### PR TITLE
MINIFI-84 Performing explicit checking on values of processor Properties YAML

### DIFF
--- a/inc/FlowController.h
+++ b/inc/FlowController.h
@@ -234,6 +234,8 @@ private:
 	void parseConnectionYaml(YAML::Node *node, ProcessGroup *parent);
 	//! Process Remote Process Group YAML
 	void parseRemoteProcessGroupYaml(YAML::Node *node, ProcessGroup *parent);
+	//! Parse Properties Node YAML for a processor
+	void parsePropertiesNodeYaml(YAML::Node *propertiesNode, Processor *processor);
 
 	// Prevent default copy constructor and assignment operation
 	// Only support pass by reference or pointer

--- a/inc/GetFile.h
+++ b/inc/GetFile.h
@@ -42,7 +42,7 @@ public:
 		_minAge = 0;
 		_maxAge = 0;
 		_minSize = 0;
-		_maxSize = 0;;
+		_maxSize = 0;
 		_ignoreHiddenFile = true;
 		_pollInterval = 0;
 		_batchSize = 10;


### PR DESCRIPTION
MINIFI-84 Performing explicit checking on values of processor Properties YAML. An empty value is treated as a YAML node in lieu of being null and would lead to conversion errors.