### PR TITLE
MINIFI-111 Providing explicit inclusion of cstring in ExecuteProcess

### DIFF
--- a/src/ExecuteProcess.cpp
+++ b/src/ExecuteProcess.cpp
@@ -21,6 +21,7 @@
 #include "ExecuteProcess.h"
 #include "ProcessContext.h"
 #include "ProcessSession.h"
+#include <cstring>
 
 const std::string ExecuteProcess::ProcessorName("ExecuteProcess");
 Property ExecuteProcess::Command("Command", "Specifies the command to be executed; if just the name of an executable is provided, it must be in the user's environment PATH.", "");


### PR DESCRIPTION
MINIFI-111 Providing explicit inclusion of cstring in ExecuteProcess.

This takes care of correcting the build issue on gcc based build systems from the inclusion of a new processor in #13 