### PR TITLE
MINIFI-124 The active_pid() function kill -s 0 <PID> returns 0 on success (PID i…

### DIFF
--- a/bin/minifi.sh
+++ b/bin/minifi.sh
@@ -174,7 +174,7 @@ case "\$1" in
       echo Starting MiNiFi with PID \${pid} and pid file \${pid_file}
       ;;
     stop)
-      if [ \$(active_pid \${saved_pid}) -le 0 ]; then
+      if [ \$(active_pid \${saved_pid}) -ne 0 ]; then
         echo "MiNiFi is not currently running."
       else
         echo "Stopping MiNiFi (PID: \${saved_pid})."
@@ -274,7 +274,7 @@ case "$1" in
       echo Starting MiNiFi with PID ${pid} and pid file ${pid_file}
       ;;
     stop)
-      if [ $(active_pid ${saved_pid}) -le 0 ]; then
+      if [ $(active_pid ${saved_pid}) -ne 0 ]; then
         echo "MiNiFi is not currently running."
       else
         echo "Stopping MiNiFi (PID: ${saved_pid})."


### PR DESCRIPTION
MINIFI-124.  In the active_pid() function kill -s 0 <PID> returns 0 on success (the PID is currently running), yet the if statement in the stop case statement is checking for 0 as a failure condition.