### PR TITLE
MINIFI-123 Pthreads linker fix

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -34,6 +34,12 @@ else ()
 endif (LIBXML2_FOUND)
 
 add_executable(minifiexe MiNiFiMain.cpp)
+if(THREADS_HAVE_PTHREAD_ARG)
+  target_compile_options(PUBLIC minifiexe "-pthread")
+endif()
+if(CMAKE_THREAD_LIBS_INIT)
+  target_link_libraries(minifiexe "${CMAKE_THREAD_LIBS_INIT}")
+endif()
 
 # Link against minifi, yaml-cpp and uuid
 target_link_libraries(minifiexe minifi yaml-cpp uuid)


### PR DESCRIPTION
MINIFI-123.  On the Raspbian platform (Debian based) the linker is unsuccessful in linking pthreads with the MiNiFi executable because CMake does not specify -lpthreads.  The following change should create a platform agnostic way of making sure posix threads are linked correctly.  This change should be compatible with CMake 2.8.x and above.
