### PR TITLE
MINIFI-139 - Resolved OS X 10.12 build failures by introducing Cmake

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -3,3 +3,9 @@ Copyright 2016 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+This includes derived works from the Apache Celix (ASLv2 licensed) project (https://github.com/apache/celix):
+Copyright 2015 The Apache Software Foundation
+The derived work is adapted from
+  celix/cmake/FindUUID.cmake
+and can be found in cmake/FindUUID.cmake

--- a/cmake/FindLeveldb.cmake
+++ b/cmake/FindLeveldb.cmake
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless qrequired by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+# Find module for Leveldb library and includes
+#  LEVELDB_FOUND - if system found LEVELDB library
+#  LEVELDB_INCLUDE_DIRS - The LEVELDB include directories
+#  LEVELDB_LIBRARIES - The libraries needed to use LEVELDB
+#  LEVELDB_DEFINITIONS - Compiler switches required for using LEVELDB
+
+# For OS X do not attempt to use the OS X application frameworks or bundles.
+set (CMAKE_FIND_FRAMEWORK NEVER)
+set (CMAKE_FIND_APPBUNDLE NEVER)
+
+find_path(LEVELDB_INCLUDE_DIR
+    NAMES leveldb/db.h
+    PATHS /usr/local/include /usr/include
+    DOC "LevelDB include header"
+)
+
+find_library(LEVELDB_LIBRARY 
+    NAMES libleveldb.dylib libleveldb.so
+    PATHS /usr/local/lib /usr/lib/x86_64-linux-gnu
+    DOC "LevelDB library"
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LEVELDB DEFAULT_MSG LEVELDB_INCLUDE_DIR LEVELDB_LIBRARY)
+
+if (LEVELDB_FOUND)
+    set(LEVELDB_LIBRARIES ${LEVELDB_LIBRARY} )
+    set(LEVELDB_INCLUDE_DIRS ${LEVELDB_INCLUDE_DIR} )
+    set(LEVELDB_DEFINITIONS )
+endif()
+
+mark_as_advanced(LEVELDB_ROOT_DIR LEVELDB_INCLUDE_DIR LEVELDB_LIBRARY)

--- a/cmake/FindUUID.cmake
+++ b/cmake/FindUUID.cmake
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+find_path(UUID_INCLUDE_DIR
+	NAMES uuid/uuid.h
+	HINTS ${UUID_DIR}/include
+			$ENV{UUID_DIR}/include
+	PATHS /usr/include
+          /usr/local/include )
+
+find_library(UUID_LIBRARY NAMES uuid
+             PATHS /usr/lib /usr/local/lib /usr/local/lib64 /lib/i386-linux-gnu /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu)
+
+set(UUID_INCLUDE_DIRS ${UUID_INCLUDE_DIR})
+set(UUID_LIBRARIES ${UUID_LIBRARY})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(UUID  DEFAULT_MSG
+                                  UUID_LIBRARY UUID_INCLUDE_DIR)
+
+
+mark_as_advanced(UUID_INCLUDE_DIRS UUID_LIBRARIES)

--- a/libminifi/CMakeLists.txt
+++ b/libminifi/CMakeLists.txt
@@ -39,7 +39,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include_directories(../include)
 include_directories(../thirdparty/yaml-cpp-yaml-cpp-0.5.3/include)
 include_directories(include)
-include_directories(/usr/local/include)
 
 file(GLOB SOURCES "src/*.cpp")
 file(GLOB SPD_SOURCES "../include/spdlog/*")

--- a/libminifi/CMakeLists.txt
+++ b/libminifi/CMakeLists.txt
@@ -39,6 +39,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include_directories(../include)
 include_directories(../thirdparty/yaml-cpp-yaml-cpp-0.5.3/include)
 include_directories(include)
+include_directories(/usr/local/include)
 
 file(GLOB SOURCES "src/*.cpp")
 file(GLOB SPD_SOURCES "../include/spdlog/*")
@@ -56,3 +57,13 @@ if (LIBXML2_FOUND)
 else ()
     # Build from our local version
 endif (LIBXML2_FOUND)
+
+# Include LevelDB
+find_package (Leveldb REQUIRED)
+if (LEVELDB_FOUND)
+	include_directories(${LEVELDB_INCLUDE_DIRS})
+	target_link_libraries (minifi ${LEVELDB_LIBRARIES})
+else ()
+    message( FATAL_ERROR "LevelDB was not found. Please install LevelDB" )
+endif (LEVELDB_FOUND)
+

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -23,7 +23,10 @@ IF(POLICY CMP0048)
   CMAKE_POLICY(SET CMP0048 OLD)
 ENDIF(POLICY CMP0048)
 
-include_directories(../include ../libminifi/include ../thirdparty/yaml-cpp-yaml-cpp-0.5.3/include ../thirdparty/leveldb-1.18/include ../thirdparty/ /usr/local/include)
+include_directories(../include ../libminifi/include ../thirdparty/yaml-cpp-yaml-cpp-0.5.3/include ../thirdparty/leveldb-1.18/include ../thirdparty/)
+
+find_package(Boost REQUIRED)
+include_directories(${Boost_INCLUDE_DIRS})
 
 # Include libxml2
 find_package(LibXml2)

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -23,7 +23,7 @@ IF(POLICY CMP0048)
   CMAKE_POLICY(SET CMP0048 OLD)
 ENDIF(POLICY CMP0048)
 
-include_directories(../include ../libminifi/include ../thirdparty/yaml-cpp-yaml-cpp-0.5.3/include ../thirdparty/leveldb-1.18/include ../thirdparty/)
+include_directories(../include ../libminifi/include ../thirdparty/yaml-cpp-yaml-cpp-0.5.3/include ../thirdparty/leveldb-1.18/include ../thirdparty/ /usr/local/include)
 
 # Include libxml2
 find_package(LibXml2)
@@ -41,8 +41,11 @@ if(CMAKE_THREAD_LIBS_INIT)
   target_link_libraries(minifiexe "${CMAKE_THREAD_LIBS_INIT}")
 endif()
 
-# Link against minifi, yaml-cpp and uuid
-target_link_libraries(minifiexe minifi yaml-cpp uuid leveldb)
+# Include UUID
+find_package(UUID REQUIRED)
+
+# Link against minifi, yaml-cpp, uuid, and leveldb
+target_link_libraries(minifiexe minifi yaml-cpp ${UUID_LIBRARIES} ${LEVELDB_LIBRARIES})
 set_target_properties(minifiexe
         PROPERTIES OUTPUT_NAME minifi)
 


### PR DESCRIPTION
find modules for LevelDB and UUID for both includes and libraries.