### PR TITLE
MINIFI-171  Dynamic Properties support for processors

### DIFF
--- a/conf/minifi.properties
+++ b/conf/minifi.properties
@@ -16,6 +16,7 @@
 # Core Properties #
 nifi.version=0.2.0
 nifi.flow.configuration.file=./conf/config.yml
+nifi.accept.dynamic.properties=true
 nifi.administrative.yield.duration=30 sec
 # If a component has no work to do (is "bored"), how long should we wait before checking again for work?
 nifi.bored.yield.duration=10 millis

--- a/libminifi/include/Configure.h
+++ b/libminifi/include/Configure.h
@@ -42,6 +42,7 @@ public:
 	}
 	//! nifi.flow.configuration.file
 	static const char *nifi_flow_configuration_file;
+	static const char *nifi_accept_dynamic_properties;
 	static const char *nifi_administrative_yield_duration;
 	static const char *nifi_bored_yield_duration;
 	static const char *nifi_server_name;

--- a/libminifi/include/Processor.h
+++ b/libminifi/include/Processor.h
@@ -47,6 +47,9 @@ class ProcessSession;
 //! Default penalization period in second
 #define DEFAULT_PENALIZATION_PERIOD_SECONDS 30
 
+//! Description given to Dynamic Property since they have no definition
+#define DEFAULT_DYNAMIC_PROPERTY_DESC "Dynamic Property"
+
 /*!
  * Indicates the valid values for the state of a entity
  * with respect to scheduling the entity to run.
@@ -122,8 +125,12 @@ public:
 	bool setSupportedRelationships(std::set<Relationship> relationships);
 	//! Get the supported property value by name
 	bool getProperty(std::string name, std::string &value);
-	//! Set the supported property value by name wile the process is not running
+	//! Get the dynamic property value by name
+	bool getDynamicProperty(std::string name, std::string &value);
+	//! Set the supported property value by name wile the process is not running.
 	bool setProperty(std::string name, std::string value);
+	//! Set dynamic property if the property received is not a suppoted property
+	bool setDynamicProperty(std::string name, std::string value);
 	//! Whether the relationship is supported
 	bool isSupportedRelationship(Relationship relationship);
 	//! Set the auto terminated relationships while the process is not running
@@ -295,6 +302,8 @@ protected:
 	std::string _name;
 	//! Supported properties
 	std::map<std::string, Property> _properties;
+	//! Dynamic properties
+	std::map<std::string, Property> _dynamicProperties;
 	//! Supported relationships
 	std::map<std::string, Relationship> _relationships;
 	//! Autoterminated relationships

--- a/libminifi/src/Configure.cpp
+++ b/libminifi/src/Configure.cpp
@@ -21,6 +21,7 @@
 
 Configure *Configure::_configure(NULL);
 const char *Configure::nifi_flow_configuration_file = "nifi.flow.configuration.file";
+const char *Configure::nifi_accept_dynamic_properties = "nifi.accept.dynamic.properties";
 const char *Configure::nifi_administrative_yield_duration = "nifi.administrative.yield.duration";
 const char *Configure::nifi_bored_yield_duration = "nifi.bored.yield.duration";
 const char *Configure::nifi_server_name = "nifi.server.name";

--- a/libminifi/src/FlowController.cpp
+++ b/libminifi/src/FlowController.cpp
@@ -1095,7 +1095,14 @@ void FlowController::parsePropertiesNodeYaml(YAML::Node *propertiesNode, Process
             std::string rawValueString = propertyValueNode.as<std::string>();
             if (!processor->setProperty(propertyName, rawValueString))
             {
-                _logger->log_warn("Received property %s with value %s but is not one of the properties for %s", propertyName.c_str(), rawValueString.c_str(), processor->getName().c_str());
+                _logger->log_warn("Received property %s with value %s but is not one of the properties for %s. Attempting to add as dynamic property.", 
+                    propertyName.c_str(), rawValueString.c_str(), processor->getName().c_str());
+
+                if (!processor->setDynamicProperty(propertyName, rawValueString)) {
+                    _logger->log_warn("Unable to set the dynamic property %s with value %s", propertyName.c_str(), rawValueString.c_str());
+                } else {
+                    _logger->log_warn("Dynamic property %s with value %s set", propertyName.c_str(), rawValueString.c_str());
+                }
             }
         }
     }

--- a/libminifi/src/Processor.cpp
+++ b/libminifi/src/Processor.cpp
@@ -207,25 +207,23 @@ bool Processor::getProperty(std::string name, std::string &value)
 	}
 }
 
+int dyn_prop = 0;
+std::mutex dyn_prop_mutex;
+
 bool Processor::getDynamicProperty(std::string name, std::string &value)
 {
-	if (isRunning())
-		// Because set property only allowed in non running state, we need to obtain lock avoid rack condition
-		_mtx.lock();
+	std::lock_guard<std::mutex> lock(dyn_prop_mutex);
 
-	std::map<std::string, Property>::iterator it = _dynamicProperties.find(name);
+	//std::map<std::string, Property>::iterator it = _dynamicProperties.find(name);
+	auto it = _dynamicProperties.find(name);
 	if (it != _dynamicProperties.end())
 	{
 		Property item = it->second;
 		value = item.getValue();
-		if (!isRunning())
-			_mtx.unlock();
 		return true;
 	}
 	else
 	{
-		if (!isRunning())
-			_mtx.unlock();
 		return false;
 	}
 }


### PR DESCRIPTION
Added support in Processor.cpp to both set and get dynamic properties.
The logic will first attempt to set the parsed Property from the .yml
file as a supported property. IF that parsed Property is not in the
whitelisted supported list AND if the “nifi.accept.dynamic.properties”
configuration is set to true then the Property will be added to a
Map<String, Property> of dynamic properties that can be accessed in a
manner similar to the supported properties from any processor logic
that extends Processor.cpp