### PR TITLE
MINIFI-175 Create official Apache NiFi MiNiFi C++ Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ bin
 target
 thirdparty/**/*.o
 thirdparty/**/*.a
+
+# Ignore source files that have been placed in the docker directory during build
+docker/minificppsource
+docker/.DS_STORE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,6 @@ enable_testing(test)
 # Create a custom build target called "docker" that will invoke DockerBuild.sh and create the NiFi-MiNiFi-CPP Docker image
 add_custom_target(
     docker
-    COMMAND ${CMAKE_SOURCE_DIR}/docker/DockerBuild.sh 1000 1000 0.2.0 nifi-minifi-cpp-0.2.0-bin.tar.gz ${CMAKE_SOURCE_DIR}
+    COMMAND ${CMAKE_SOURCE_DIR}/docker/DockerBuild.sh 1000 1000 ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH} ${PROJECT_NAME}-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}-bin.tar.gz ${CMAKE_SOURCE_DIR}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docker/
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,3 +125,10 @@ enable_testing(test)
     target_include_directories(tests PRIVATE BEFORE "libminifi/include/")
     target_link_libraries(tests ${CMAKE_THREAD_LIBS_INIT} ${UUID_LIBRARIES} ${LEVELDB_LIBRARIES} ${OPENSSL_LIBRARIES} minifi yaml-cpp)
     add_test(NAME LibMinifiTests COMMAND tests)
+
+# Create a custom build target called "docker" that will invoke DockerBuild.sh and create the NiFi-MiNiFi-CPP Docker image
+add_custom_target(
+    docker
+    COMMAND ${CMAKE_SOURCE_DIR}/docker/DockerBuild.sh 1000 1000 0.2.0 nifi-minifi-cpp-0.2.0-bin.tar.gz ${CMAKE_SOURCE_DIR}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docker/
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,6 @@ enable_testing(test)
 # Create a custom build target called "docker" that will invoke DockerBuild.sh and create the NiFi-MiNiFi-CPP Docker image
 add_custom_target(
     docker
-    COMMAND ${CMAKE_SOURCE_DIR}/docker/DockerBuild.sh 1000 1000 ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH} ${PROJECT_NAME}-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}-bin.tar.gz ${CMAKE_SOURCE_DIR}
+    COMMAND ${CMAKE_SOURCE_DIR}/docker/DockerBuild.sh 1000 1000 ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH} minificppsource ${CMAKE_SOURCE_DIR}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docker/
 )

--- a/README.md
+++ b/README.md
@@ -184,6 +184,28 @@ $ brew install cmake \
   CPack: - package: ~/Development/code/apache/nifi-minifi-cpp/build/nifi-minifi-cpp-0.1.0-source.tar.gz generated.
   ```
 
+- (Optional) Create a Docker image from the resulting binary assembly output from "make package".
+```
+~/Development/code/apache/nifi-minifi-cpp/build
+$ make docker
+NiFi-MiNiFi-CPP Version: 0.2.0
+Current Working Directory: /Users/jdyer/Development/github/nifi-minifi-cpp/docker
+CMake Source Directory: /Users/jdyer/Development/github/nifi-minifi-cpp
+MiNiFi Package: nifi-minifi-cpp-0.2.0-bin.tar.gz
+Docker Command: 'docker build --build-arg UID=1000 --build-arg GID=1000 --build-arg MINIFI_VERSION=0.2.0 --build-arg MINIFI_PACKAGE=nifi-minifi-cpp-0.2.0-bin.tar.gz -t apacheminificpp:0.2.0 .'
+Sending build context to Docker daemon 777.2 kB
+Step 1 : FROM alpine:3.5
+ ---> 88e169ea8f46
+Step 2 : MAINTAINER Apache NiFi <dev@nifi.apache.org>
+
+...
+
+Step 15 : CMD $MINIFI_HOME/bin/minifi.sh run
+ ---> Using cache
+ ---> c390063d9bd1
+Successfully built c390063d9bd1
+Built target docker
+```
 
 ### Cleaning
 Remove the build directory created above.

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Place files you want to exclude from the docker build here similar to .gitignore https://docs.docker.com/engine/reference/builder/#dockerignore-file
+DockerBuild.sh

--- a/docker/DockerBuild.sh
+++ b/docker/DockerBuild.sh
@@ -22,17 +22,29 @@
 UID_ARG=$1
 GID_ARG=$2
 MINIFI_VERSION=$3
-MINIFI_PACKAGE=$4
+MINIFI_SOURCE_CODE=$4
 CMAKE_SOURCE_DIR=$5
 
 echo "NiFi-MiNiFi-CPP Version: $MINIFI_VERSION"
 echo "Current Working Directory: $(pwd)"
 echo "CMake Source Directory: $CMAKE_SOURCE_DIR"
-echo "MiNiFi Package: $MINIFI_PACKAGE"
+echo "MiNiFi Package: $MINIFI_SOURCE_CODE"
 
 # Copy the MiNiFi package to the Docker working directory before building
-cp $CMAKE_SOURCE_DIR/build/$MINIFI_PACKAGE $CMAKE_SOURCE_DIR/docker/.
+mkdir -p $CMAKE_SOURCE_DIR/docker/minificppsource
+cp -r $CMAKE_SOURCE_DIR/bin $CMAKE_SOURCE_DIR/docker/minificppsource/.
+cp -r $CMAKE_SOURCE_DIR/cmake $CMAKE_SOURCE_DIR/docker/minificppsource/.
+cp -r $CMAKE_SOURCE_DIR/conf $CMAKE_SOURCE_DIR/docker/minificppsource/.
+cp -r $CMAKE_SOURCE_DIR/examples $CMAKE_SOURCE_DIR/docker/minificppsource/.
+cp -r $CMAKE_SOURCE_DIR/include $CMAKE_SOURCE_DIR/docker/minificppsource/.
+cp -r $CMAKE_SOURCE_DIR/libminifi $CMAKE_SOURCE_DIR/docker/minificppsource/.
+cp -r $CMAKE_SOURCE_DIR/main $CMAKE_SOURCE_DIR/docker/minificppsource/.
+cp -r $CMAKE_SOURCE_DIR/thirdparty $CMAKE_SOURCE_DIR/docker/minificppsource/.
+cp -r $CMAKE_SOURCE_DIR/CMakeLists.txt $CMAKE_SOURCE_DIR/docker/minificppsource/.
+cp -r $CMAKE_SOURCE_DIR/LICENSE $CMAKE_SOURCE_DIR/docker/minificppsource/.
+cp -r $CMAKE_SOURCE_DIR/NOTICE $CMAKE_SOURCE_DIR/docker/minificppsource/.
+cp -r $CMAKE_SOURCE_DIR/README.md $CMAKE_SOURCE_DIR/docker/minificppsource/.
 
-DOCKER_COMMAND="docker build --build-arg UID=$UID_ARG --build-arg GID=$GID_ARG --build-arg MINIFI_VERSION=$MINIFI_VERSION --build-arg MINIFI_PACKAGE=$MINIFI_PACKAGE -t apacheminificpp:$MINIFI_VERSION ."
+DOCKER_COMMAND="docker build --build-arg UID=$UID_ARG --build-arg GID=$GID_ARG --build-arg MINIFI_VERSION=$MINIFI_VERSION --build-arg MINIFI_SOURCE_CODE=$MINIFI_SOURCE_CODE -t apacheminificpp:$MINIFI_VERSION ."
 echo "Docker Command: '$DOCKER_COMMAND'"
 ${DOCKER_COMMAND}

--- a/docker/DockerBuild.sh
+++ b/docker/DockerBuild.sh
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#!/bin/bash
+
+# Set env vars.
+UID_ARG=$1
+GID_ARG=$2
+MINIFI_VERSION=$3
+MINIFI_PACKAGE=$4
+CMAKE_SOURCE_DIR=$5
+
+echo "NiFi-MiNiFi-CPP Version: $MINIFI_VERSION"
+echo "Current Working Directory: $(pwd)"
+echo "CMake Source Directory: $CMAKE_SOURCE_DIR"
+echo "MiNiFi Package: $MINIFI_PACKAGE"
+
+# Copy the MiNiFi package to the Docker working directory before building
+cp $CMAKE_SOURCE_DIR/build/$MINIFI_PACKAGE $CMAKE_SOURCE_DIR/docker/.
+
+DOCKER_COMMAND="docker build --build-arg UID=$UID_ARG --build-arg GID=$GID_ARG --build-arg MINIFI_VERSION=$MINIFI_VERSION --build-arg MINIFI_PACKAGE=$MINIFI_PACKAGE -t apacheminificpp:$MINIFI_VERSION ."
+echo "Docker Command: '$DOCKER_COMMAND'"
+${DOCKER_COMMAND}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,26 +16,53 @@
 # under the License.
 #
 
-FROM alpine:3.5
+FROM ubuntu:16.10
 MAINTAINER Apache NiFi <dev@nifi.apache.org>
 
 ARG UID
 ARG GID
 ARG MINIFI_VERSION
-ARG MINIFI_PACKAGE
+ARG MINIFI_SOURCE_CODE
+
+# Install the system dependencies needed for a build
+RUN apt-get update && apt-get install -y build-essential \
+	wget \
+	gdb \
+	libboost-all-dev \
+	libxml2-dev \
+	vim \
+	uuid-dev \
+	libleveldb-dev \
+	cmake \
+	git \
+	unzip \
+	libgps-dev \
+	gpsd \
+	gpsd-clients \
+	libssl-dev
 
 ENV USER minificpp
 ENV MINIFI_BASE_DIR /opt/minifi
-ENV MINIFI_HOME $MINIFI_BASE_DIR/nifi-minifi-cpp-$MINIFI_VERSION
 
 # Setup minificpp user
-RUN adduser -u $UID -g $GID -D $USER
-RUN mkdir -p $MINIFI_HOME 
+RUN addgroup --gid $GID $USER && adduser --uid $UID --gid $GID --disabled-password --gecos "" $USER
+RUN mkdir -p $MINIFI_BASE_DIR 
 
-ADD $MINIFI_PACKAGE $MINIFI_BASE_DIR
-RUN chown -R $USER:$USER $MINIFI_HOME
+ADD $MINIFI_SOURCE_CODE $MINIFI_BASE_DIR
+RUN chown -R $USER:$USER $MINIFI_BASE_DIR
 
 USER $USER
 
-# Startup NiFi-MiNiFi-CPP
-CMD $MINIFI_HOME/bin/minifi.sh run
+ENV MINIFI_HOME $MINIFI_BASE_DIR/nifi-minifi-cpp-$MINIFI_VERSION
+
+# Perform the build
+RUN cd $MINIFI_BASE_DIR \
+	&& mkdir build \
+	&& cd build \
+	&& cmake .. \
+	&& make package \
+	&& tar -xzvf $MINIFI_BASE_DIR/build/nifi-minifi-cpp-$MINIFI_VERSION-bin.tar.gz -C $MINIFI_BASE_DIR
+
+# Start MiNiFi CPP in the foreground
+CMD cd $MINIFI_HOME && ./bin/minifi.sh run
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM alpine:3.5
+MAINTAINER Apache NiFi <dev@nifi.apache.org>
+
+ARG UID
+ARG GID
+ARG MINIFI_VERSION
+ARG MINIFI_PACKAGE
+
+ENV USER minificpp
+ENV MINIFI_BASE_DIR /opt/minifi
+ENV MINIFI_HOME $MINIFI_BASE_DIR/nifi-minifi-cpp-$MINIFI_VERSION
+
+# Setup minificpp user
+RUN adduser -u $UID -g $GID -D $USER
+RUN mkdir -p $MINIFI_HOME 
+
+ADD $MINIFI_PACKAGE $MINIFI_BASE_DIR
+RUN chown -R $USER:$USER $MINIFI_HOME
+
+USER $USER
+
+# Startup NiFi-MiNiFi-CPP
+CMD $MINIFI_HOME/bin/minifi.sh run


### PR DESCRIPTION
Created version 1 of official NiFi-MiNiFi-CPP docker image. The image
can be built by running a custom target “make docker” please note that
“make package” must first be ran to ensure the binary assembly is
present.