### PR TITLE
MINIFI-189: Check log level before buffer operations

### DIFF
--- a/libminifi/include/Logger.h
+++ b/libminifi/include/Logger.h
@@ -21,6 +21,7 @@
 #ifndef __LOGGER_H__
 #define __LOGGER_H__
 
+#include <cstdio>
 #include "spdlog/spdlog.h"
 
 using spdlog::stdout_logger_mt;
@@ -31,7 +32,7 @@ using spdlog::logger;
 #define FILL_BUFFER  char buffer[LOG_BUFFER_SIZE]; \
     va_list args; \
     va_start(args, format); \
-    vsnprintf(buffer, LOG_BUFFER_SIZE,format, args); \
+    std::vsnprintf(buffer, LOG_BUFFER_SIZE,format, args); \
     va_end(args);
 
 //! 5M default log file size
@@ -79,7 +80,7 @@ public:
 	 * @warning does not check @p log or @p format for null. Caller must ensure parameters and format string lengths match
 	 */
 	void log_error(const char *const format, ...) {
-		if(_spdlog == NULL)
+		if(_spdlog == NULL || !_spdlog->should_log(spdlog::level::level_enum::err))
 			return;
 		FILL_BUFFER
 	    _spdlog->error(buffer);
@@ -90,7 +91,7 @@ public:
 	 * @warning does not check @p log or @p format for null. Caller must ensure parameters and format string lengths match
 	 */
 	void log_warn(const char *const format, ...) {
-		if(_spdlog == NULL)
+		if(_spdlog == NULL || !_spdlog->should_log(spdlog::level::level_enum::warn))
 			return;
 		FILL_BUFFER
 	    _spdlog->warn(buffer);
@@ -101,7 +102,7 @@ public:
 	 * @warning does not check @p log or @p format for null. Caller must ensure parameters and format string lengths match
 	 */
 	void log_info(const char *const format, ...) {
-		if(_spdlog == NULL)
+		if(_spdlog == NULL || !_spdlog->should_log(spdlog::level::level_enum::info))
 			return;
 		FILL_BUFFER
 	    _spdlog->info(buffer);
@@ -112,7 +113,7 @@ public:
 	 * @warning does not check @p log or @p format for null. Caller must ensure parameters and format string lengths match
 	 */
 	void log_debug(const char *const format, ...) {
-		if(_spdlog == NULL)
+		if(_spdlog == NULL || !_spdlog->should_log(spdlog::level::level_enum::debug))
 			return;
 		FILL_BUFFER
 	    _spdlog->debug(buffer);
@@ -123,7 +124,7 @@ public:
 	 * @warning does not check @p log or @p format for null. Caller must ensure parameters and format string lengths match
 	 */
 	void log_trace(const char *const format, ...) {
-		if(_spdlog == NULL)
+		if(_spdlog == NULL || !_spdlog->should_log(spdlog::level::level_enum::trace))
 			return;
 		FILL_BUFFER
 	    _spdlog->trace(buffer);


### PR DESCRIPTION
Checking the log level before attempting buffer operations has
the impact of avoiding memory and functional calls that are
unnecessary due to the configured level excluding this log
message

Trivial change that checks the log level before logging. I noticed this while
creating a test processor that logged a lot. That logging created a noticeable impact,
hence I'm submitting a PR for this low hanging fruit. 