### PR TITLE
MINIFI-198: Update root CMAKE so testing can occur

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,15 +56,31 @@ else()
 set(OPENSSL_ROOT_DIR "/usr/lib/x86_64-linux-gnu")
 endif()
 
+# Include OpenSSL 
+find_package (OpenSSL REQUIRED)
+if (OPENSSL_FOUND)
+	include_directories(${OPENSSL_INCLUDE_DIR})
+else ()
+    message( FATAL_ERROR "OpenSSL was not found. Please install OpenSSL" )
+endif (OPENSSL_FOUND)
+
 # Provide custom modules for the project
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+# Include LevelDB
+find_package (Leveldb REQUIRED)
+if (LEVELDB_FOUND)
+        include_directories(${LEVELDB_INCLUDE_DIRS})
+else ()
+    message( FATAL_ERROR "LevelDB was not found. Please install LevelDB" )
+endif (LEVELDB_FOUND)
 find_package(UUID REQUIRED)
 file(GLOB SPD_SOURCES "include/spdlog/*")
 
 add_subdirectory(thirdparty/yaml-cpp-yaml-cpp-0.5.3)
 add_subdirectory(libminifi)
 add_subdirectory(main)
+
 
 # Generate source assembly
 set(ASSEMBLY_BASE_NAME "${CMAKE_PROJECT_NAME}-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
@@ -104,7 +120,8 @@ enable_testing(test)
     add_executable(tests ${LIBMINIFI_TEST_SOURCES} ${SPD_SOURCES})
     target_include_directories(tests PRIVATE BEFORE "thirdparty/catch")
     target_include_directories(tests PRIVATE BEFORE "thirdparty/yaml-cpp-yaml-cpp-0.5.3/include")
+    target_include_directories(tests PRIVATE BEFORE ${LEVELDB_INCLUDE_DIRS})
     target_include_directories(tests PRIVATE BEFORE "include")
     target_include_directories(tests PRIVATE BEFORE "libminifi/include/")
-    target_link_libraries(tests ${CMAKE_THREAD_LIBS_INIT} ${UUID_LIBRARIES} minifi yaml-cpp)
+    target_link_libraries(tests ${CMAKE_THREAD_LIBS_INIT} ${UUID_LIBRARIES} ${LEVELDB_LIBRARIES} ${OPENSSL_LIBRARIES} minifi yaml-cpp)
     add_test(NAME LibMinifiTests COMMAND tests)


### PR DESCRIPTION
Update root CMake to bring OpenSSL location to top level. Keeping find_package(...) in libminifi CMakeLists.txt to avoid issues building only libminifi. 