### PR TITLE
MINIFI-195: Convert uuid_unparse usage to uuid_unparse_lower

### DIFF
--- a/libminifi/include/Processor.h
+++ b/libminifi/include/Processor.h
@@ -105,7 +105,7 @@ public:
 	void setUUID(uuid_t uuid) {
 		uuid_copy(_uuid, uuid);
 		char uuidStr[37];
-		uuid_unparse(_uuid, uuidStr);
+		uuid_unparse_lower(_uuid, uuidStr);
 		_uuidStr = uuidStr;
 	}
 	//! Get UUID

--- a/libminifi/include/Provenance.h
+++ b/libminifi/include/Provenance.h
@@ -171,7 +171,7 @@ public:
 		char eventIdStr[37];
 		// Generate the global UUID for th event
 		uuid_generate(_eventId);
-		uuid_unparse(_eventId, eventIdStr);
+		uuid_unparse_lower(_eventId, eventIdStr);
 		_eventIdStr = eventIdStr;
 		_logger = Logger::getLogger();
 	}

--- a/libminifi/include/Site2SiteClientProtocol.h
+++ b/libminifi/include/Site2SiteClientProtocol.h
@@ -307,7 +307,7 @@ public:
 
 		// Generate the global UUID for the transaction
 		uuid_generate(_uuid);
-		uuid_unparse(_uuid, uuidStr);
+		uuid_unparse_lower(_uuid, uuidStr);
 		_uuidStr = uuidStr;
 	}
 	//! Destructor
@@ -454,17 +454,27 @@ public:
 			_peer->setTimeOut(time);
 
 	}
-	//! getTimeout
-	uint64_t getTimeOut()
-	{
+	/**
+	 * Provides a reference to the time out
+	 * @returns timeout
+	 */
+	const uint64_t getTimeOut() const {
 		return _timeOut;
+	}
+
+	/**
+	 * Provides a reference to the port identifier
+	 * @returns port identifier
+	 */
+	const std::string getPortId() const {
+		return _portIdStr;
 	}
 	//! setPortId
 	void setPortId(uuid_t id)
 	{
 		uuid_copy(_portId, id);
 		char idStr[37];
-		uuid_unparse(id, idStr);
+		uuid_unparse_lower(id, idStr);
 		_portIdStr = idStr;
 	}
 	//! getResourceName

--- a/libminifi/src/FlowController.cpp
+++ b/libminifi/src/FlowController.cpp
@@ -320,7 +320,7 @@ void FlowControllerImpl::parseRootProcessGroupYaml(YAML::Node rootFlowNode) {
 	std::string flowName = rootFlowNode["name"].as<std::string>();
 
 	char uuidStr[37];
-	uuid_unparse(_uuid, uuidStr);
+	uuid_unparse_lower(_uuid, uuidStr);
 	_logger->log_debug("parseRootProcessGroup: id => [%s]", uuidStr);
 	_logger->log_debug("parseRootProcessGroup: name => [%s]", flowName.c_str());
 	group = this->createRootProcessGroup(flowName, uuid);
@@ -361,7 +361,7 @@ void FlowControllerImpl::parseProcessorNodeYaml(YAML::Node processorsNode,
 						procCfg.javaClass.c_str());
 
 				char uuidStr[37];
-				uuid_unparse(_uuid, uuidStr);
+				uuid_unparse_lower(_uuid, uuidStr);
 
 				// generate the random UUID
 				uuid_generate(uuid);
@@ -571,7 +571,7 @@ void FlowControllerImpl::parseRemoteProcessGroupYaml(YAML::Node *rpgNode,
 				uuid_generate(uuid);
 
 				char uuidStr[37];
-				uuid_unparse(_uuid, uuidStr);
+				uuid_unparse_lower(_uuid, uuidStr);
 
 				int64_t timeoutValue = -1;
 				int64_t yieldPeriodValue = -1;
@@ -654,7 +654,7 @@ void FlowControllerImpl::parseConnectionYaml(YAML::Node *connectionsNode,
 						std::string>();
 
 				char uuidStr[37];
-				uuid_unparse(_uuid, uuidStr);
+				uuid_unparse_lower(_uuid, uuidStr);
 
 				_logger->log_debug(
 						"Created connection with UUID %s and name %s", uuidStr,

--- a/libminifi/src/FlowFileRecord.cpp
+++ b/libminifi/src/FlowFileRecord.cpp
@@ -51,7 +51,7 @@ FlowFileRecord::FlowFileRecord(std::map<std::string, std::string> attributes, Re
 	uuid_generate(_uuid);
 	// Increase the local ID for the flow record
 	++_localFlowSeqNumber;
-	uuid_unparse(_uuid, uuidStr);
+	uuid_unparse_lower(_uuid, uuidStr);
 	_uuidStr = uuidStr;
 
 	// Populate the default attributes

--- a/libminifi/src/Processor.cpp
+++ b/libminifi/src/Processor.cpp
@@ -40,7 +40,7 @@ Processor::Processor(std::string name, uuid_t uuid)
 		uuid_copy(_uuid, uuid);
 
 	char uuidStr[37];
-	uuid_unparse(_uuid, uuidStr);
+	uuid_unparse_lower(_uuid, uuidStr);
 	_uuidStr = uuidStr;
 	_hasWork.store(false);
 	// Setup the default values

--- a/libminifi/src/PutFile.cpp
+++ b/libminifi/src/PutFile.cpp
@@ -88,7 +88,7 @@ void PutFile::onTrigger(ProcessContext *context, ProcessSession *session)
 	char tmpFileUuidStr[37];
 	uuid_t tmpFileUuid;
 	uuid_generate(tmpFileUuid);
-	uuid_unparse(tmpFileUuid, tmpFileUuidStr);
+	uuid_unparse_lower(tmpFileUuid, tmpFileUuidStr);
 	std::stringstream tmpFileSs;
 	tmpFileSs << directory << "/." << filename << "." << tmpFileUuidStr;
 	std::string tmpFile = tmpFileSs.str();

--- a/libminifi/src/ResourceClaim.cpp
+++ b/libminifi/src/ResourceClaim.cpp
@@ -39,7 +39,7 @@ ResourceClaim::ResourceClaim(const std::string contentDirectory)
 	uuid_generate(_uuid);
 	// Increase the local ID for the resource claim
 	++_localResourceClaimNumber;
-	uuid_unparse(_uuid, uuidStr);
+	uuid_unparse_lower(_uuid, uuidStr);
 	// Create the full content path for the content
 	_contentFullPath = contentDirectory + "/" + uuidStr;
 

--- a/libminifi/src/Site2SiteClientProtocol.cpp
+++ b/libminifi/src/Site2SiteClientProtocol.cpp
@@ -224,7 +224,7 @@ bool Site2SiteClientProtocol::handShake()
 	// Generate the global UUID for the com identify
 	uuid_generate(uuid);
 	char uuidStr[37];
-	uuid_unparse(uuid, uuidStr);
+	uuid_unparse_lower(uuid, uuidStr);
 	_commsIdentifier = uuidStr;
 
 	int ret = _peer->writeUTF(_commsIdentifier);

--- a/libminifi/test/unit/SerializationTests.h
+++ b/libminifi/test/unit/SerializationTests.h
@@ -1,0 +1,87 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef DERSER_TESTS
+#define DERSER_TESTS
+
+#include "Site2SitePeer.h"
+#include "Site2SiteClientProtocol.h"
+#include <uuid/uuid.h>
+#include <algorithm>
+#include <string>
+
+#define FMT_DEFAULT fmt_lower
+
+
+
+TEST_CASE("TestSetPortId", "[S2S1]"){
+
+
+	Site2SitePeer peer("fake_host",65433);
+
+	Site2SiteClientProtocol protocol(&peer);
+
+
+	std::string uuid_str = "c56a4180-65aa-42ec-a945-5fd21dec0538";
+
+	uuid_t fakeUUID;
+
+	uuid_parse(uuid_str.c_str(),fakeUUID);
+
+	protocol.setPortId(fakeUUID);
+
+	REQUIRE( uuid_str == protocol.getPortId() );
+
+
+
+}
+
+TEST_CASE("TestSetPortIdUppercase", "[S2S2]"){
+
+
+	Site2SitePeer peer("fake_host",65433);
+
+	Site2SiteClientProtocol protocol(&peer);
+
+
+	std::string uuid_str = "C56A4180-65AA-42EC-A945-5FD21DEC0538";
+
+	uuid_t fakeUUID;
+
+	uuid_parse(uuid_str.c_str(),fakeUUID);
+
+	protocol.setPortId(fakeUUID);
+
+	REQUIRE( uuid_str != protocol.getPortId() );
+
+	std::transform(uuid_str.begin(),uuid_str.end(),uuid_str.begin(),::tolower);
+
+	REQUIRE( uuid_str == protocol.getPortId() );
+
+
+
+}
+
+
+
+
+
+
+
+#endif

--- a/libminifi/test/unit/Tests.cpp
+++ b/libminifi/test/unit/Tests.cpp
@@ -21,3 +21,4 @@
 
 #include "ProvenanceTests.h"
 #include "ProcessorTests.h"
+#include "SerializationTests.h"


### PR DESCRIPTION
This will ensure that we use lower case UUIDs. Undefining
the macro won't work and we likely don't want to change
the default behavior.