### PR TITLE
MINIFI-193: Ensure safe UTF encoding

### DIFF
--- a/libminifi/test/unit/SerializationTests.cpp
+++ b/libminifi/test/unit/SerializationTests.cpp
@@ -17,7 +17,7 @@
  */
 
 
-
+#include "io/BaseStream.h"
 #include "Site2SitePeer.h"
 #include "Site2SiteClientProtocol.h"
 #include <uuid/uuid.h>
@@ -78,6 +78,68 @@ TEST_CASE("TestSetPortIdUppercase", "[S2S2]"){
 }
 
 
+TEST_CASE("TestWriteUTF", "[MINIFI193]"){
+
+  DataStream baseStream;
+
+  Serializable ser;
+
+  std::string stringOne = "helo world"; // yes, this has a typo.
+  std::string verifyString;
+  ser.writeUTF(stringOne,&baseStream,false);
+
+
+  ser.readUTF(verifyString,&baseStream,false);
+
+  REQUIRE(verifyString == stringOne);
 
 
 
+
+}
+
+
+
+
+TEST_CASE("TestWriteUTF2", "[MINIFI193]"){
+
+  DataStream baseStream;
+
+  Serializable ser;
+
+  std::string stringOne = "hel\xa1o world";
+  REQUIRE(11 == stringOne.length());
+  std::string verifyString;
+  ser.writeUTF(stringOne,&baseStream,false);
+
+
+  ser.readUTF(verifyString,&baseStream,false);
+
+  REQUIRE(verifyString == stringOne);
+
+
+
+
+}
+
+
+TEST_CASE("TestWriteUTF3", "[MINIFI193]"){
+
+  DataStream baseStream;
+
+  Serializable ser;
+
+  std::string stringOne = "\xe4\xbd\xa0\xe5\xa5\xbd\xe4\xb8\x96\xe7\x95\x8c";
+  REQUIRE(12 == stringOne.length());
+  std::string verifyString;
+  ser.writeUTF(stringOne,&baseStream,false);
+
+
+  ser.readUTF(verifyString,&baseStream,false);
+
+  REQUIRE(verifyString == stringOne);
+
+
+
+
+}


### PR DESCRIPTION
Since the C++ library is agnostic of UTF-8 we can safely write the bytes.
Since we won't be interpreting the UTF-8 code in the core library
we do not need any additional dependencies. Nor do we need to worry about
encoding beyond proper serialization and deserialization of the byte array.

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
