### PR TITLE
MINIFI-264 Remove libxml2 from travis build as it is no longer needed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ matrix:
           - libboost-all-dev
           - uuid-dev
           - doxygen
-          - libxml2-dev
           - libleveldb-dev
           - openssl
       before_install:


### PR DESCRIPTION
MINIFI-264 Remove libxml2 from travis build as it is no longer needed.

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [X] Does your PR title start with MINIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [X] Is your initial contribution a single, squashed commit?
