### PR TITLE
MINIFI-177 Incorporating Apache RAT to build with a custom target of

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 # Standard ignores
 .DS_Store
 
@@ -28,6 +46,7 @@ thirdparty/**/*.o
 thirdparty/**/*.a
 libminifi/test/**/*.a
 docs/generated
+thirdparty/apache-rat/apache-rat*
 
 # Ignore source files that have been placed in the docker directory during build
 docker/minificppsource

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,4 +63,4 @@ matrix:
         - package='graphviz'; [[ $(brew ls --versions ${package}) ]] && { brew outdated ${package} || brew upgrade ${package}; } || brew install ${package}
 
 script:
-  - mkdir ./build && cd ./build && cmake .. && make VERBOSE=1 && make test ARGS="--output-on-failure" && make linter && make docs
+  - mkdir ./build && cd ./build && cmake .. && make VERBOSE=1 && make test ARGS="--output-on-failure" && make linter && make apache-rat && make docs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,10 @@ include(BuildTests)
 
 include(BuildDocs)
 
+include(RunApacheRAT)
+
 include(DockerConfig)
+
 
 # Create a custom build target that will run the linter.
 add_custom_target(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,13 +148,16 @@ include(BuildTests)
 
 include(BuildDocs)
 
-include(RunApacheRAT)
-
 include(DockerConfig)
-
 
 # Create a custom build target that will run the linter.
 add_custom_target(
     linter
     COMMAND ${CMAKE_SOURCE_DIR}/thirdparty/google-styleguide/run_linter.sh ${CMAKE_SOURCE_DIR}/libminifi/include/ ${CMAKE_SOURCE_DIR}/libminifi/src/
     COMMAND ${CMAKE_SOURCE_DIR}/thirdparty/google-styleguide/run_linter.sh ${CMAKE_SOURCE_DIR}/libminifi/include/ ${CMAKE_SOURCE_DIR}/libminifi/test/ )
+
+# Custom target to download and run Apache Release Audit Tool (RAT)
+add_custom_target(
+        apache-rat
+        ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/cmake/RunApacheRAT.cmake
+        COMMAND java -jar ${CMAKE_SOURCE_DIR}/thirdparty/apache-rat/apache-rat-0.12/apache-rat-0.12.jar -E ${CMAKE_SOURCE_DIR}/thirdparty/apache-rat/.rat-excludes -d ${CMAKE_SOURCE_DIR} | grep -B 1 -A 15 Summary )

--- a/cmake/RunApacheRAT.cmake
+++ b/cmake/RunApacheRAT.cmake
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Find the preferred Apache mirror to use for the download by querying the list of mirrors and filtering out 'preferred'
+execute_process(COMMAND curl -s https://www.apache.org/dyn/closer.lua/?asjson=1
+        COMMAND grep preferred
+        COMMAND awk "{print $2}"
+        COMMAND tr -d "\""
+        TIMEOUT 10
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        OUTPUT_VARIABLE MIRROR_URL )
+
+ExternalProject_Add(
+        rat-binary
+        PREFIX "apache-rat"
+        URL "${MIRROR_URL}creadur/apache-rat-0.12/apache-rat-0.12-bin.tar.gz"
+        URL_HASH SHA1=e84dffe8b354871c29f5078b823a726508474a6c
+        DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/thirdparty/apache-rat
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ""
+)
+
+# Custom target to run Apache Release Audit Tool (RAT)
+add_custom_target(
+        apache-rat
+        COMMAND java -jar ${CMAKE_BINARY_DIR}/apache-rat/src/rat-binary/apache-rat-0.12.jar -E ${CMAKE_SOURCE_DIR}/thirdparty/apache-rat/.rat-excludes -d ${CMAKE_SOURCE_DIR} | grep -B 1 -A 15 Summary )
+
+
+add_dependencies(apache-rat rat-binary)

--- a/examples/iOSPort/iOSPortREADME.md
+++ b/examples/iOSPort/iOSPortREADME.md
@@ -1,3 +1,18 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
 1) Install XCode
 2) Build libminfi.a
 cd libminifi, mkdir lib, cd lib

--- a/libminifi/cmake/iOS.cmake
+++ b/libminifi/cmake/iOS.cmake
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # This file is based off of the Platform/Darwin.cmake and Platform/UnixPaths.cmake
 # files which are included with CMake 2.8.4
 # It has been altered for iOS development

--- a/libminifi/test/Server.cpp
+++ b/libminifi/test/Server.cpp
@@ -1,3 +1,21 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /* A simple server in the internet domain using TCP
  The port number is passed as an argument */
 #include <stdio.h>

--- a/libminifi/test/resources/TestControllerServices.yml
+++ b/libminifi/test/resources/TestControllerServices.yml
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 Flow Controller:
     name: MiNiFi Flow
     id: 2438e3c8-015a-1000-79ca-83af40ec1990

--- a/libminifi/test/resources/TestProvenanceReporting.yml
+++ b/libminifi/test/resources/TestProvenanceReporting.yml
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 Flow Controller:
     name: MiNiFi Flow
     id: 2438e3c8-015a-1000-79ca-83af40ec1990

--- a/thirdparty/apache-rat/.rat-excludes
+++ b/thirdparty/apache-rat/.rat-excludes
@@ -1,0 +1,8 @@
+thirdparty
+generated
+build
+spdlog
+cmake-build-debug
+.gitignore
+CPPLINT.cfg
+cn.pass


### PR DESCRIPTION
apache-rat.  Updating non-compliant files and/or listing exclusions
in .rat-excludes

This commit introduces a separate CMake file to manage the acquisition
of the RAT binary.