### PR TITLE
MINIFI-367 port tests to use boost::filesystem vs. stat.h for better portability

### DIFF
--- a/libminifi/CMakeLists.txt
+++ b/libminifi/CMakeLists.txt
@@ -80,9 +80,10 @@ target_link_libraries (minifi ${ZLIB_LIBRARIES})
 
 if (NOT IOS)
 # Include Boost System
-find_package(Boost COMPONENTS system REQUIRED)
+find_package(Boost COMPONENTS system filesystem REQUIRED)
 find_package(CURL)
 target_link_libraries(minifi ${Boost_SYSTEM_LIBRARY})
+target_link_libraries(minifi ${Boost_FILESYSTEM_LIBRARY})
 
 if (CURL_FOUND)
         include_directories(${CURL_INCLUDE_DIRS})


### PR DESCRIPTION
This closes MINIFI-367.