### PR TITLE
MINIFI-368 exclude hidden files when scanning for src files

### DIFF
--- a/cmake/BuildTests.cmake
+++ b/cmake/BuildTests.cmake
@@ -21,7 +21,7 @@ MACRO(GETSOURCEFILES result curdir)
   FILE(GLOB children RELATIVE ${curdir} ${curdir}/*)
   SET(dirlist "")
   FOREACH(child ${children})
-    IF( "${curdir}/${child}" MATCHES .*\\.cpp)
+    IF( "${child}" MATCHES ^[^.].*\\.cpp)
   
       LIST(APPEND dirlist ${child})
     ENDIF()


### PR DESCRIPTION
Updated regex matching when scanning for source files so that we don't pick up hidden files such as vim swap files.
