### PR TITLE
MINIFICPP-254: Resolve odd naming of isRunning variable so that it's …

### DIFF
--- a/libminifi/src/core/Connectable.cpp
+++ b/libminifi/src/core/Connectable.cpp
@@ -65,9 +65,11 @@ bool Connectable::setSupportedRelationships(std::set<core::Relationship> relatio
 
 // Whether the relationship is supported
 bool Connectable::isSupportedRelationship(core::Relationship relationship) {
-  const bool requiresLock = isRunning();
+  // if we are running we do not need a lock since the function to change relationships_ ( setSupportedRelationships)
+  // cannot be executed while we are running
+  const bool isConnectableRunning = isRunning();
 
-  const auto conditionalLock = !requiresLock ? std::unique_lock<std::mutex>() : std::unique_lock<std::mutex>(relationship_mutex_);
+  const auto conditionalLock = isConnectableRunning ? std::unique_lock<std::mutex>() : std::unique_lock<std::mutex>(relationship_mutex_);
 
   const auto &it = relationships_.find(relationship.getName());
   if (it != relationships_.end()) {
@@ -95,9 +97,11 @@ bool Connectable::setAutoTerminatedRelationships(std::set<Relationship> relation
 
 // Check whether the relationship is auto terminated
 bool Connectable::isAutoTerminated(core::Relationship relationship) {
-  const bool requiresLock = isRunning();
+  // if we are running we do not need a lock since the function to change relationships_ ( setSupportedRelationships)
+    // cannot be executed while we are running
+  const bool isConnectableRunning = isRunning();
 
-  const auto conditionalLock = !requiresLock ? std::unique_lock<std::mutex>() : std::unique_lock<std::mutex>(relationship_mutex_);
+  const auto conditionalLock = isConnectableRunning ? std::unique_lock<std::mutex>() : std::unique_lock<std::mutex>(relationship_mutex_);
 
   const auto &it = auto_terminated_relationships_.find(relationship.getName());
   if (it != auto_terminated_relationships_.end()) {


### PR DESCRIPTION
…clear we do not lock when we are running

Originally identified by Fredrick Stakem.

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
