### PR TITLE
MINIFICPP-302 Correct USB camera createExtension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,18 +146,14 @@ endif(ENABLE_GPS)
 ## Scripting extensions
 option(DISABLE_SCRIPTING "Disables the scripting extensions." OFF)
 if (NOT DISABLE_SCRIPTING)
-createExtension(SCRIPTING-EXTENSIONS "SCRIPTING EXTENSIONS" "This enables scripting" "extensions/script" "${TEST_DIR}/script-tests")
+    createExtension(SCRIPTING-EXTENSIONS "SCRIPTING EXTENSIONS" "This enables scripting" "extensions/script" "${TEST_DIR}/script-tests")
 endif()
 
 ## USB camera extensions
-createExtension(DISABLE_USB_CAMERA
-				USB-CAMERA-EXTENSIONS
-				"USB CAMERA EXTENSIONS"
-				"This enables USB camera support"
-				"extensions/usb-camera"
-				"${TEST_DIR}/usb-camera-tests"
-				"TRUE"
-				"thirdparty/libuvc-0.0.6")
+option(ENABLE_USB_CAMERA "Enables USB camera support." OFF)
+if (ENABLE_USB_CAMERA)
+    createExtension(USB-CAMERA-EXTENSIONS "USB CAMERA EXTENSIONS" "This enables USB camera support" "extensions/usb-camera" "${TEST_DIR}/usb-camera-tests" "TRUE" "thirdparty/libuvc-0.0.6")
+endif()
 
 ## NOW WE CAN ADD LIBRARIES AND EXTENSIONS TO MAIN
 


### PR DESCRIPTION
Configuration fails because the USB camera extension's createExtension in the top-level CMakeLists wasn't updated to match the changes to that macro in the GetGPS processor patch.

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
