### PR TITLE
MINIFICPP-409 Removing unused constants relating to Configuration Listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ Each of the repositories can be configured to be volatile ( state kept in memory
 
  The content repository has a default option for "minimal.locking" set to true. This will attempt to use lock free structures. This may or may not be optimal as this requires additional additional searching of the underlying vector. This may be optimal for cases where max.count is not excessively high. In cases where object permanence is low within the repositories, minimal locking will result in better performance. If there are many processors and/or timing is such that the content repository fills up quickly, performance may be reduced. In all cases a locking cache is used to avoid the worst case complexity of O(n) for the content repository; however, this caching is more heavily used when "minimal.locking" is set to false.
 
-### Provenance Report
+### Provenance Reporter
 
     Add Provenance Reporting to config.yml
     Provenance Reporting:
@@ -611,24 +611,6 @@ Each of the repositories can be configured to be volatile ( state kept in memory
       url: http://localhost:8080/nifi
       port uuid: 471deef6-2a6e-4a7d-912a-81cc17e3a204
       batch size: 100
-
-### Http Configuration Listener
-
-    Http Configuration Listener will pull flow file configuration from the remote command control server,
-    validate and apply the new flow configuration
-
-    in minifi.properties
-
-    nifi.configuration.listener.type=http
-    nifi.configuration.listener.http.url=https://localhost:8080
-    nifi.configuration.listener.pull.interval=1 sec
-
-    if you want to enable client certificate
-    nifi.https.need.ClientAuth=true
-    nifi.https.client.certificate=./conf/client.pem
-    nifi.https.client.private.key=./conf/client.key
-    nifi.https.client.pass.phrase=./conf/password
-    nifi.https.client.ca.certificate=./conf/nifi-cert.pem
 
 ### REST API access
 

--- a/conf/minifi.properties
+++ b/conf/minifi.properties
@@ -19,20 +19,24 @@ nifi.flow.configuration.file=./conf/config.yml
 nifi.administrative.yield.duration=30 sec
 # If a component has no work to do (is "bored"), how long should we wait before checking again for work?
 nifi.bored.yield.duration=10 millis
+
 # Provenance Repository #
 nifi.provenance.repository.directory.default=${MINIFI_HOME}/provenance_repository
 nifi.provenance.repository.max.storage.time=1 MIN
 nifi.provenance.repository.max.storage.size=1 MB
 nifi.flowfile.repository.directory.default=${MINIFI_HOME}/flowfile_repository
 nifi.database.content.repository.directory.default=${MINIFI_HOME}/content_repository
+
 #nifi.remote.input.secure=true
-nifi.https.need.ClientAuth=true
-nifi.https.client.certificate=./conf/client.pem
-nifi.https.client.private.key=./conf/client.key
-nifi.https.client.pass.phrase=./conf/password
-nifi.https.client.ca.certificate=./conf/nifi-cert.pem
+#nifi.security.need.ClientAuth=
+#nifi.security.client.certificate=
+#nifi.security.client.private.key=
+#nifi.security.client.pass.phrase=
+#nifi.security.client.ca.certificate=
+
 #nifi.rest.api.user.name=admin
 #nifi.rest.api.password=password
+
 ## enable the controller socket provider on port 9998
 controller.socket.host=localhost
 controller.socket.port=9998

--- a/libminifi/include/properties/Configure.h
+++ b/libminifi/include/properties/Configure.h
@@ -65,16 +65,7 @@ class Configure : public Properties {
   static const char *nifi_security_client_ca_certificate;
   static const char *nifi_security_client_disable_host_verification;
   static const char *nifi_security_client_disable_peer_verification;
-  static const char *nifi_configuration_listener_pull_interval;
-  static const char *nifi_configuration_listener_http_url;
-  static const char *nifi_configuration_listener_rest_url;
-  static const char *nifi_configuration_listener_type;  // http or rest
-  // security config for all https service
-  static const char *nifi_https_need_ClientAuth;
-  static const char *nifi_https_client_certificate;
-  static const char *nifi_https_client_private_key;
-  static const char *nifi_https_client_pass_phrase;
-  static const char *nifi_https_client_ca_certificate;
+
   // nifi rest api user name and password
   static const char *nifi_rest_api_user_name;
   static const char *nifi_rest_api_password;

--- a/libminifi/src/Configure.cpp
+++ b/libminifi/src/Configure.cpp
@@ -54,15 +54,6 @@ const char *Configure::nifi_security_client_pass_phrase = "nifi.security.client.
 const char *Configure::nifi_security_client_ca_certificate = "nifi.security.client.ca.certificate";
 const char *Configure::nifi_security_client_disable_host_verification = "nifi.security.client.disable.host.verification";
 const char *Configure::nifi_security_client_disable_peer_verification = "nifi.security.client.disable.peer.verification";
-const char *Configure::nifi_configuration_listener_pull_interval = "nifi.configuration.listener.pull.interval";
-const char *Configure::nifi_configuration_listener_http_url = "nifi.configuration.listener.http.url";
-const char *Configure::nifi_configuration_listener_rest_url = "nifi.configuration.listener.rest.url";
-const char *Configure::nifi_configuration_listener_type = "nifi.configuration.listener.type";
-const char *Configure::nifi_https_need_ClientAuth = "nifi.https.need.ClientAuth";
-const char *Configure::nifi_https_client_certificate = "nifi.https.client.certificate";
-const char *Configure::nifi_https_client_private_key = "nifi.https.client.private.key";
-const char *Configure::nifi_https_client_pass_phrase = "nifi.https.client.pass.phrase";
-const char *Configure::nifi_https_client_ca_certificate = "nifi.https.client.ca.certificate";
 const char *Configure::nifi_rest_api_user_name = "nifi.rest.api.user.name";
 const char *Configure::nifi_rest_api_password = "nifi.rest.api.password";
 


### PR DESCRIPTION
MINIFICPP-409 Removing unused constants relating to Configuration Listener and its security.

Removing these items from the README.
Replacing stubbed out values in minifi.properties to reflect currently
used keys.