### PR TITLE
MINIFICPP-435: Use NSS when libcurl-openssl is not available. Bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ or greater is recommended.
 #### Libraries / Development Headers
 * libboost and boost-devel
   * 1.48.0 or greater
-* libcurl-openssl
+* libcurl-openssl (If not available or desired, NSS will be used by applying -DUSE_CURL_NSS)
 * librocksdb4.1 and librocksdb-dev
 * libuuid and uuid-dev
 * openssl
@@ -157,7 +157,7 @@ Finally, it is required to add the `-lrt` compiler flag by using the
 #### Libraries
 * libuuid
 * librocksdb *** IF NOT INSTALLED, WILL BE BUILT FROM THIRD PARTY DIRECTORY ***
-* libcurl-openssl
+* libcurl-openssl (If not available or desired, NSS will be used by applying -DUSE_CURL_NSS)
 * libssl and libcrypto from openssl 
 * libarchive
 * librdkafka
@@ -201,7 +201,8 @@ $ yum install docker python-virtualenv
 $ yum install gpsd-devel
 $ # (Optional) for PacketCapture Processor
 $ yum install libpcap-devel
-$ #depending on your yum repo you may need to manually build libcurl-openssl if you do not have it.
+$ #depending on your yum repo you may need to manually build libcurl-openssl if you do not wish to use
+  libcurl with NSS support. By default we will use NSS when libcurl-openssl is not available.
 ```
 
 ##### Aptitude based Linux Distributions

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -450,7 +450,6 @@ CMAKE_REVISION=`echo $CMAKE_VERSION | cut -d. -f3`
 
 CMAKE_BUILD_COMMAND="${CMAKE_COMMAND} "
 
-
 build_cmake_command(){
 
   for option in "${OPTIONS[@]}" ; do
@@ -500,7 +499,15 @@ build_cmake_command(){
 
   add_os_flags
 
+  curl -V | grep OpenSSL &> /dev/null
+  if [ $? == 0 ]; then
+    echo "Using libcurl-openssl..."
+  else
+    CMAKE_BUILD_COMMAND="${CMAKE_BUILD_COMMAND} -DUSE_CURL_NSS=true .."
+  fi
+
   CMAKE_BUILD_COMMAND="${CMAKE_BUILD_COMMAND} .."
+
   continue_with_plan="Y"
   if [ ! "$NO_PROMPT" = "true" ]; then
     read -p "Command will be '${CMAKE_BUILD_COMMAND}', run this? [ Y/N ] " continue_with_plan
@@ -513,8 +520,6 @@ build_cmake_command(){
 
 
 build_cmake_command
-
-
 
 ### run the cmake command
 ${CMAKE_BUILD_COMMAND}

--- a/extensions/http-curl/CMakeLists.txt
+++ b/extensions/http-curl/CMakeLists.txt
@@ -27,6 +27,11 @@ include_directories(protocols client processors sitetosite)
 
 file(GLOB SOURCES  "*.cpp" "protocols/*.cpp" "client/*.cpp" "processors/*.cpp" "sitetosite/*.cpp")
 
+if (USE_CURL_NSS)
+    message("okay use nss")
+	add_definitions(-DUSE_CURL_NSS)
+endif()
+
 add_library(minifi-http-curl STATIC ${SOURCES})
 set_property(TARGET minifi-http-curl PROPERTY POSITION_INDEPENDENT_CODE ON)
 if(THREADS_HAVE_PTHREAD_ARG)

--- a/extensions/http-curl/client/HTTPClient.cpp
+++ b/extensions/http-curl/client/HTTPClient.cpp
@@ -331,8 +331,8 @@ bool HTTPClient::matches(const std::string &value, const std::string &sregex) {
 }
 
 void HTTPClient::configure_secure_connection(CURL *http_session) {
-  logger_->log_debug("Using certificate file %s", ssl_context_service_->getCertificateFile());
 #ifdef USE_CURL_NSS
+  logger_->log_debug("Using NSS and certificate file %s", ssl_context_service_->getCertificateFile());
   curl_easy_setopt(http_session, CURLOPT_CAINFO, 0);
   curl_easy_setopt(http_session, CURLOPT_SSLCERTTYPE, "PEM");
   curl_easy_setopt(http_session, CURLOPT_SSLCERT, ssl_context_service_->getCertificateFile().c_str());
@@ -340,6 +340,7 @@ void HTTPClient::configure_secure_connection(CURL *http_session) {
   curl_easy_setopt(http_session, CURLOPT_KEYPASSWD, ssl_context_service_->getPassphrase().c_str());
   curl_easy_setopt(http_session, CURLOPT_CAINFO, ssl_context_service_->getCACertificate().c_str());
 #else
+  logger_->log_debug("Using OpenSSL and certificate file %s", ssl_context_service_->getCertificateFile());
   curl_easy_setopt(http_session, CURLOPT_SSL_CTX_FUNCTION, &configure_ssl_context);
   curl_easy_setopt(http_session, CURLOPT_SSL_CTX_DATA, static_cast<void*>(ssl_context_service_.get()));
   curl_easy_setopt(http_session, CURLOPT_CAINFO, 0);

--- a/extensions/http-curl/client/HTTPClient.cpp
+++ b/extensions/http-curl/client/HTTPClient.cpp
@@ -332,10 +332,19 @@ bool HTTPClient::matches(const std::string &value, const std::string &sregex) {
 
 void HTTPClient::configure_secure_connection(CURL *http_session) {
   logger_->log_debug("Using certificate file %s", ssl_context_service_->getCertificateFile());
+#ifdef USE_CURL_NSS
+  curl_easy_setopt(http_session, CURLOPT_CAINFO, 0);
+  curl_easy_setopt(http_session, CURLOPT_SSLCERTTYPE, "PEM");
+  curl_easy_setopt(http_session, CURLOPT_SSLCERT, ssl_context_service_->getCertificateFile().c_str());
+  curl_easy_setopt(http_session, CURLOPT_SSLKEY, ssl_context_service_->getPrivateKeyFile().c_str());
+  curl_easy_setopt(http_session, CURLOPT_KEYPASSWD, ssl_context_service_->getPassphrase().c_str());
+  curl_easy_setopt(http_session, CURLOPT_CAINFO, ssl_context_service_->getCACertificate().c_str());
+#else
   curl_easy_setopt(http_session, CURLOPT_SSL_CTX_FUNCTION, &configure_ssl_context);
   curl_easy_setopt(http_session, CURLOPT_SSL_CTX_DATA, static_cast<void*>(ssl_context_service_.get()));
   curl_easy_setopt(http_session, CURLOPT_CAINFO, 0);
   curl_easy_setopt(http_session, CURLOPT_CAPATH, 0);
+#endif
 }
 
 bool HTTPClient::isSecure(const std::string &url) {


### PR DESCRIPTION
should default to using NSS when curl is not built with OpenSSL, such as
the case for CENTOS 7

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
