### PR TITLE
MINIFICPP-597 Convert error log statement to info.

### DIFF
--- a/libminifi/src/processors/ListenSyslog.cpp
+++ b/libminifi/src/processors/ListenSyslog.cpp
@@ -121,7 +121,7 @@ void ListenSyslog::runThread() {
       if (_protocol == "TCP")
         listen(sockfd, 5);
       _serverSocket = sockfd;
-      logger_->log_error("ListenSysLog Server socket %d bind OK to port %d", _serverSocket, portno);
+      logger_->log_info("ListenSysLog Server socket %d bind OK to port %d", _serverSocket, portno);
     }
     FD_ZERO(&_readfds);
     FD_SET(_serverSocket, &_readfds);


### PR DESCRIPTION
MINIFICPP-597: Log level was wrongly set to error although it should reflect successful socket binding. Set the level to info instead.