### PR TITLE
MINIFICPP-1072 - Fixed temporary path for GetFileTests on Windows

### DIFF
--- a/extensions/standard-processors/tests/unit/GetFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/GetFileTests.cpp
@@ -49,11 +49,8 @@ TEST_CASE("GetFile: MaxSize", "[getFileFifo]") {  // NOLINT
   REQUIRE(!temp_path.empty());
 
   // Define test input file
-  std::string in_file = temp_path + utils::file::FileUtils::get_separator() + "testfifo";
-
-  // Define test input file
-  std::string hidden_in_file(in_dir);
-  hidden_in_file.append("/.testfifo");  // hidden
+  std::string in_file(temp_path + utils::file::FileUtils::get_separator() + "testfifo");
+  std::string hidden_in_file(temp_path + utils::file::FileUtils::get_separator() + ".testfifo");
 
   // Build MiNiFi processing graph
 


### PR DESCRIPTION
Temp dir path was invalid on Windows, causing tests to fail.

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
