### PR TITLE
MINIFICPP-1073 - Fixed the suffix computation for Regex matches.

### DIFF
--- a/libminifi/src/utils/RegexUtils.cpp
+++ b/libminifi/src/utils/RegexUtils.cpp
@@ -146,7 +146,7 @@ bool Regex::match(const std::string &pattern) {
     if ((size_t) matches_[0].rm_eo >= pattern.size()) {
       suffix_ = "";
     } else {
-      suffix_ = pattern.substr(matches_[0].rm_eo + 1);
+      suffix_ = pattern.substr(matches_[0].rm_eo);
     }
     return true;
   }

--- a/libminifi/test/unit/RegexUtilsTests.cpp
+++ b/libminifi/test/unit/RegexUtilsTests.cpp
@@ -34,7 +34,7 @@ TEST_CASE("TestRegexUtils::single_match", "[regex1]") {
     auto ret = r1.getResult();
     std::vector<std::string> ans = {"Speed limit 130", "130"};
     REQUIRE(ans == ret);
-    REQUIRE("| Speed limit 80" == r1.getSuffix());
+    REQUIRE(" | Speed limit 80" == r1.getSuffix());
 }
 
 TEST_CASE("TestRegexUtils::invalid_construction", "[regex2]") {


### PR DESCRIPTION
First char of the suffix was being cut-off.

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
