### PR TITLE
MINIFICPP-1131 fix syntax error in install script

### DIFF
--- a/bin/minifi.sh
+++ b/bin/minifi.sh
@@ -142,7 +142,7 @@ cat <<SERVICEDESCRIPTOR > ${SVC_FILE}
 export MINIFI_HOME=${MINIFI_HOME}
 bin_dir=\${MINIFI_HOME}/bin
 minifi_executable=\${bin_dir}/minifi
-pid_file=${bin_dir}/.minifi.pid
+pid_file="\${bin_dir}/.minifi.pid"
 
 # determines the pid
 get_pid() {
@@ -150,7 +150,7 @@ get_pid() {
   pid=-1
   # Check to see if we have a pid file
   if [ -f \${pid_file} ]; then
-    pid=\$(cat ${pid_file})
+    pid=\$(cat "\${pid_file}")
   fi
   echo \${pid}
 }
@@ -257,21 +257,21 @@ case "\$1" in
         ;;
     restart)
       echo "Restarting the MiNiFi service. Hit CTRL+C at any time to forcibly terminate MiNiFi"
-      ${bin_dir}/minifi.sh stop
+      "\${bin_dir}/minifi.sh" stop
       ticks=1
       printf "Waiting for process to terminate."
       trap endnow INT
-      if [ "${saved_pid}" -gt 0 ]; then
-        while [ $(active_pid ${saved_pid}) -eq 0 ]; do
+      if [ "\${saved_pid}" -gt 0 ]; then
+        while [ "\$(active_pid \${saved_pid})" -eq 0 ]; do
                 sleep 1
-                ticks=$((ticks+1))
-                numticks=$(($ticks % 5))
-                if [ "${numticks}"  -eq 0 ]; then
+                ticks="\$((ticks+1))"
+                numticks="\$((ticks % 5))"
+                if [ "\${numticks}"  -eq 0 ]; then
                         printf "."
                 fi
         done
       fi
-      ${bin_dir}/minifi.sh start
+      "\${bin_dir}/minifi.sh" start
 	;;
     *)
         echo "Usage: service minifi {start|stop|restart|status}"


### PR DESCRIPTION
Note: This PR fixes issues with installation but not with running the service. I've experienced dynamic linker errors missing `libpython3.4m.so.1.0` when trying to start the minifi service on CentOS 7/8.


Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
