### PR TITLE
MINIFICPP-1188 move test repos to /var/tmp

### DIFF
--- a/libminifi/test/rocksdb-tests/DBContentRepositoryTests.cpp
+++ b/libminifi/test/rocksdb-tests/DBContentRepositoryTests.cpp
@@ -27,13 +27,13 @@
 
 TEST_CASE("Write Claim", "[TestDBCR1]") {
   TestController testController;
-  char format[] = "/tmp/testRepo.XXXXXX";
-auto dir = testController.createTempDirectory(format);
+  char format[] = "/var/tmp/testRepo.XXXXXX";
+  auto dir = testController.createTempDirectory(format);
   auto content_repo = std::make_shared<core::repository::DatabaseContentRepository>();
 
   auto configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
   configuration->set(minifi::Configure::nifi_dbcontent_repository_directory_default, dir);
-  REQUIRE(true == content_repo->initialize(configuration));
+  REQUIRE(content_repo->initialize(configuration));
 
 
   auto claim = std::make_shared<minifi::ResourceClaim>(content_repo);
@@ -51,7 +51,7 @@ auto dir = testController.createTempDirectory(format);
 
   configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
   configuration->set(minifi::Configure::nifi_dbcontent_repository_directory_default, dir);
-  REQUIRE(true == content_repo->initialize(configuration));
+  REQUIRE(content_repo->initialize(configuration));
 
   auto read_stream = content_repo->read(claim);
 
@@ -68,13 +68,13 @@ auto dir = testController.createTempDirectory(format);
 
 TEST_CASE("Delete Claim", "[TestDBCR2]") {
   TestController testController;
-  char format[] = "/tmp/testRepo.XXXXXX";
-auto dir = testController.createTempDirectory(format);
+  char format[] = "/var/tmp/testRepo.XXXXXX";
+  auto dir = testController.createTempDirectory(format);
   auto content_repo = std::make_shared<core::repository::DatabaseContentRepository>();
 
   auto configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
   configuration->set(minifi::Configure::nifi_dbcontent_repository_directory_default, dir);
-  REQUIRE(true == content_repo->initialize(configuration));
+  REQUIRE(content_repo->initialize(configuration));
 
 
   auto claim = std::make_shared<minifi::ResourceClaim>(content_repo);
@@ -93,7 +93,7 @@ auto dir = testController.createTempDirectory(format);
 
   configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
   configuration->set(minifi::Configure::nifi_dbcontent_repository_directory_default, dir);
-  REQUIRE(true == content_repo->initialize(configuration));
+  REQUIRE(content_repo->initialize(configuration));
 
   content_repo->remove(claim);
 
@@ -107,13 +107,13 @@ auto dir = testController.createTempDirectory(format);
 
 TEST_CASE("Test Empty Claim", "[TestDBCR3]") {
   TestController testController;
-  char format[] = "/tmp/testRepo.XXXXXX";
-auto dir = testController.createTempDirectory(format);
+  char format[] = "/var/tmp/testRepo.XXXXXX";
+  auto dir = testController.createTempDirectory(format);
   auto content_repo = std::make_shared<core::repository::DatabaseContentRepository>();
 
   auto configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
   configuration->set(minifi::Configure::nifi_dbcontent_repository_directory_default, dir);
-  REQUIRE(true == content_repo->initialize(configuration));
+  REQUIRE(content_repo->initialize(configuration));
 
   auto claim = std::make_shared<minifi::ResourceClaim>(content_repo);
   auto stream = content_repo->write(claim);
@@ -131,7 +131,7 @@ auto dir = testController.createTempDirectory(format);
 
   configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
   configuration->set(minifi::Configure::nifi_dbcontent_repository_directory_default, dir);
-  REQUIRE(true == content_repo->initialize(configuration));
+  REQUIRE(content_repo->initialize(configuration));
 
   auto read_stream = content_repo->read(claim);
 
@@ -143,13 +143,13 @@ auto dir = testController.createTempDirectory(format);
 
 TEST_CASE("Test Null Claim", "[TestDBCR4]") {
   TestController testController;
-  char format[] = "/tmp/testRepo.XXXXXX";
-auto dir = testController.createTempDirectory(format);
+  char format[] = "/var/tmp/testRepo.XXXXXX";
+  auto dir = testController.createTempDirectory(format);
   auto content_repo = std::make_shared<core::repository::DatabaseContentRepository>();
 
   auto configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
   configuration->set(minifi::Configure::nifi_dbcontent_repository_directory_default, dir);
-  REQUIRE(true == content_repo->initialize(configuration));
+  REQUIRE(content_repo->initialize(configuration));
 
 
   auto claim = std::make_shared<minifi::ResourceClaim>(content_repo);
@@ -164,13 +164,13 @@ auto dir = testController.createTempDirectory(format);
 
 TEST_CASE("Delete Null Claim", "[TestDBCR5]") {
   TestController testController;
-  char format[] = "/tmp/testRepo.XXXXXX";
-auto dir = testController.createTempDirectory(format);
+  char format[] = "/var/tmp/testRepo.XXXXXX";
+  auto dir = testController.createTempDirectory(format);
   auto content_repo = std::make_shared<core::repository::DatabaseContentRepository>();
 
   auto configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
   configuration->set(minifi::Configure::nifi_dbcontent_repository_directory_default, dir);
-  REQUIRE(true == content_repo->initialize(configuration));
+  REQUIRE(content_repo->initialize(configuration));
 
   auto claim = std::make_shared<minifi::ResourceClaim>(content_repo);
   auto stream = content_repo->write(claim);
@@ -188,9 +188,9 @@ auto dir = testController.createTempDirectory(format);
 
   configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
   configuration->set(minifi::Configure::nifi_dbcontent_repository_directory_default, dir);
-  REQUIRE(true == content_repo->initialize(configuration));
+  REQUIRE(content_repo->initialize(configuration));
 
-  REQUIRE(false == content_repo->remove(nullptr));
+  REQUIRE(!content_repo->remove(nullptr));
 
   auto read_stream = content_repo->read(claim);
 
@@ -204,13 +204,13 @@ auto dir = testController.createTempDirectory(format);
 
 TEST_CASE("Delete NonExistent Claim", "[TestDBCR5]") {
   TestController testController;
-  char format[] = "/tmp/testRepo.XXXXXX";
-auto dir = testController.createTempDirectory(format);
+  char format[] = "/var/tmp/testRepo.XXXXXX";
+  auto dir = testController.createTempDirectory(format);
   auto content_repo = std::make_shared<core::repository::DatabaseContentRepository>();
 
   auto configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
   configuration->set(minifi::Configure::nifi_dbcontent_repository_directory_default, dir);
-  REQUIRE(true == content_repo->initialize(configuration));
+  REQUIRE(content_repo->initialize(configuration));
 
   auto claim = std::make_shared<minifi::ResourceClaim>(content_repo);
   auto claim2 = std::make_shared<minifi::ResourceClaim>(content_repo);
@@ -229,10 +229,10 @@ auto dir = testController.createTempDirectory(format);
 
   configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
   configuration->set(minifi::Configure::nifi_dbcontent_repository_directory_default, dir);
-  REQUIRE(true == content_repo->initialize(configuration));
+  REQUIRE(content_repo->initialize(configuration));
 
   // we won't complain if it does not exist
-  REQUIRE(true == content_repo->remove(claim2));
+  REQUIRE(content_repo->remove(claim2));
 
   auto read_stream = content_repo->read(claim);
 
@@ -246,13 +246,13 @@ auto dir = testController.createTempDirectory(format);
 
 TEST_CASE("Delete Remove Count Claim", "[TestDBCR6]") {
   TestController testController;
-  char format[] = "/tmp/testRepo.XXXXXX";
-auto dir = testController.createTempDirectory(format);
+  char format[] = "/var/tmp/testRepo.XXXXXX";
+  auto dir = testController.createTempDirectory(format);
   auto content_repo = std::make_shared<core::repository::DatabaseContentRepository>();
 
   auto configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
   configuration->set(minifi::Configure::nifi_dbcontent_repository_directory_default, dir);
-  REQUIRE(true == content_repo->initialize(configuration));
+  REQUIRE(content_repo->initialize(configuration));
 
   auto claim = std::make_shared<minifi::ResourceClaim>(content_repo);
   auto claim2 = std::make_shared<minifi::ResourceClaim>(content_repo);
@@ -271,7 +271,7 @@ auto dir = testController.createTempDirectory(format);
 
   configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
   configuration->set(minifi::Configure::nifi_dbcontent_repository_directory_default, dir);
-  REQUIRE(true == content_repo->initialize(configuration));
+  REQUIRE(content_repo->initialize(configuration));
 
   // increment twice. verify we have 2 for the stream count
   // and then test the removal and verify that the claim was removed by virtue of obtaining
@@ -281,7 +281,7 @@ auto dir = testController.createTempDirectory(format);
   REQUIRE(content_repo->getStreamCount(claim2) == 2);
   content_repo->decrementStreamCount(claim2);
   content_repo->decrementStreamCount(claim2);
-  REQUIRE(true == content_repo->removeIfOrphaned(claim2));
+  REQUIRE(content_repo->removeIfOrphaned(claim2));
   REQUIRE(content_repo->getStreamCount(claim2) == 0);
   auto read_stream = content_repo->read(claim);
 

--- a/libminifi/test/rocksdb-tests/DBProvenanceRepositoryTests.cpp
+++ b/libminifi/test/rocksdb-tests/DBProvenanceRepositoryTests.cpp
@@ -62,7 +62,7 @@ void verifyMaxKeyCount(const minifi::provenance::ProvenanceRepository& repo, uin
 TEST_CASE("Test size limit", "[sizeLimitTest]") {
   TestController testController;
 
-  char dirtemplate[] = "/tmp/db.XXXXXX";
+  char dirtemplate[] = "/var/tmp/db.XXXXXX";
   auto temp_dir = testController.createTempDirectory(dirtemplate);
   REQUIRE(!temp_dir.empty());
 
@@ -85,7 +85,7 @@ TEST_CASE("Test size limit", "[sizeLimitTest]") {
 TEST_CASE("Test time limit", "[timeLimitTest]") {
   TestController testController;
 
-  char dirtemplate[] = "/tmp/db.XXXXXX";
+  char dirtemplate[] = "/var/tmp/db.XXXXXX";
   auto temp_dir = testController.createTempDirectory(dirtemplate);
   REQUIRE(!temp_dir.empty());
 

--- a/libminifi/test/rocksdb-tests/RepoTests.cpp
+++ b/libminifi/test/rocksdb-tests/RepoTests.cpp
@@ -43,7 +43,7 @@ TEST_CASE("Test Repo Empty Value Attribute", "[TestFFR1]") {
   LogTestController::getInstance().setDebug<core::repository::FileSystemRepository>();
   LogTestController::getInstance().setDebug<core::repository::FlowFileRepository>();
   TestController testController;
-  char format[] = "/tmp/testRepo.XXXXXX";
+  char format[] = "/var/tmp/testRepo.XXXXXX";
   auto dir = testController.createTempDirectory(format);
   std::shared_ptr<core::repository::FlowFileRepository> repository = std::make_shared<core::repository::FlowFileRepository>("ff", dir, 0, 0, 1);
 
@@ -66,7 +66,7 @@ TEST_CASE("Test Repo Empty Key Attribute ", "[TestFFR2]") {
   LogTestController::getInstance().setDebug<core::repository::FileSystemRepository>();
   LogTestController::getInstance().setDebug<core::repository::FlowFileRepository>();
   TestController testController;
-  char format[] = "/tmp/testRepo.XXXXXX";
+  char format[] = "/var/tmp/testRepo.XXXXXX";
   auto dir = testController.createTempDirectory(format);
   std::shared_ptr<core::repository::FlowFileRepository> repository = std::make_shared<core::repository::FlowFileRepository>("ff", dir, 0, 0, 1);
 
@@ -90,7 +90,7 @@ TEST_CASE("Test Repo Key Attribute Verify ", "[TestFFR3]") {
   LogTestController::getInstance().setDebug<core::repository::FileSystemRepository>();
   LogTestController::getInstance().setDebug<core::repository::FlowFileRepository>();
   TestController testController;
-  char format[] = "/tmp/testRepo.XXXXXX";
+  char format[] = "/var/tmp/testRepo.XXXXXX";
   auto dir = testController.createTempDirectory(format);
   std::shared_ptr<core::repository::FlowFileRepository> repository = std::make_shared<core::repository::FlowFileRepository>("ff", dir, 0, 0, 1);
 
@@ -113,30 +113,30 @@ TEST_CASE("Test Repo Key Attribute Verify ", "[TestFFR3]") {
 
   record.addAttribute("", "sdgsdg");
 
-  REQUIRE(true == record.Serialize());
+  REQUIRE(record.Serialize());
 
   repository->stop();
 
   record2.DeSerialize(uuid);
 
   std::string value;
-  REQUIRE(true == record2.getAttribute("", value));
+  REQUIRE(record2.getAttribute("", value));
 
   REQUIRE("hasdgasdgjsdgasgdsgsadaskgasd2" == value);
 
-  REQUIRE(false == record2.getAttribute("key", value));
-  REQUIRE(true == record2.getAttribute("keyA", value));
+  REQUIRE(!record2.getAttribute("key", value));
+  REQUIRE(record2.getAttribute("keyA", value));
   REQUIRE("hasdgasdgjsdgasgdsgsadaskgasd" == value);
 
-  REQUIRE(true == record2.getAttribute("keyB", value));
-  REQUIRE("" == value);
+  REQUIRE(record2.getAttribute("keyB", value));
+  REQUIRE(value.empty());
 
   utils::file::FileUtils::delete_dir(FLOWFILE_CHECKPOINT_DIRECTORY, true);
 }
 
 TEST_CASE("Test Delete Content ", "[TestFFR4]") {
   TestController testController;
-  char format[] = "/tmp/testRepo.XXXXXX";
+  char format[] = "/var/tmp/testRepo.XXXXXX";
   LogTestController::getInstance().setDebug<core::ContentRepository>();
   LogTestController::getInstance().setDebug<core::repository::FileSystemRepository>();
   LogTestController::getInstance().setDebug<core::repository::FlowFileRepository>();
@@ -168,7 +168,7 @@ TEST_CASE("Test Delete Content ", "[TestFFR4]") {
 
   record.addAttribute("", "hasdgasdgjsdgasgdsgsadaskgasd");
 
-  REQUIRE(true == record.Serialize());
+  REQUIRE(record.Serialize());
 
   claim->decreaseFlowFileRecordOwnedCount();
 
@@ -181,7 +181,7 @@ TEST_CASE("Test Delete Content ", "[TestFFR4]") {
   repository->stop();
 
   std::ifstream fileopen(ss.str(), std::ios::in);
-  REQUIRE(false == fileopen.good());
+  REQUIRE(!fileopen.good());
 
   utils::file::FileUtils::delete_dir(FLOWFILE_CHECKPOINT_DIRECTORY, true);
 
@@ -191,7 +191,7 @@ TEST_CASE("Test Delete Content ", "[TestFFR4]") {
 TEST_CASE("Test Validate Checkpoint ", "[TestFFR5]") {
   TestController testController;
   utils::file::FileUtils::delete_dir(FLOWFILE_CHECKPOINT_DIRECTORY, true);
-  char format[] = "/tmp/testRepo.XXXXXX";
+  char format[] = "/var/tmp/testRepo.XXXXXX";
   LogTestController::getInstance().setDebug<core::ContentRepository>();
   LogTestController::getInstance().setTrace<core::repository::FileSystemRepository>();
   LogTestController::getInstance().setTrace<minifi::ResourceClaim>();
@@ -224,7 +224,7 @@ TEST_CASE("Test Validate Checkpoint ", "[TestFFR5]") {
 
     record.addAttribute("", "hasdgasdgjsdgasgdsgsadaskgasd");
 
-    REQUIRE(true == record.Serialize());
+    REQUIRE(record.Serialize());
 
     repository->flush();
 
@@ -243,7 +243,7 @@ TEST_CASE("Test Validate Checkpoint ", "[TestFFR5]") {
   }
 
   std::ifstream fileopen(ss.str(), std::ios::in);
-  REQUIRE(true == fileopen.fail());
+  REQUIRE(fileopen.fail());
 
   utils::file::FileUtils::delete_dir(FLOWFILE_CHECKPOINT_DIRECTORY, true);
 


### PR DESCRIPTION
[[MINIFICPP-1188] Fix repo tests on linux systems with tmpfs /tmp](https://issues.apache.org/jira/browse/MINIFICPP-1188)

Repo tests use /tmp for temporary repos. Many linux distros (e.g. Arch, Gentoo) mount /tmp as tmpfs, which is the page cache mounted as a filesystem. Since we use RocksDB repositories with direct IO (i.e. send IO directly to disk, avoid page cache), the integration tests that try to open repositories under /tmp fail on the affected systems.

Fix: Place the temporary test repositories under /var/tmp instead.

------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
