### PR TITLE
MINIFICPP-1194 - Fix Table Formatting for 2 Execute.* Processors

### DIFF
--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -240,10 +240,8 @@ In the list below, the names of required properties appear in bold. Any other pr
 
 | Name | Default Value | Allowable Values | Description | 
 | - | - | - | - | 
-|Module Directory|||Comma-separated list of paths to files and/or directories which
-                                                 contain modules required by the script|
-|Script File|||Path to script file to execute.
-                                            Only one of Script File or Script Body may be used|
+|Module Directory|||Comma-separated list of paths to files and/or directories which contain modules required by the script|
+|Script File|||Path to script file to execute. Only one of Script File or Script Body may be used|
 ### Properties 
 
 | Name | Description |
@@ -285,13 +283,11 @@ In the list below, the names of required properties appear in bold. Any other pr
 
 | Name | Default Value | Allowable Values | Description | 
 | - | - | - | - | 
-|Module Directory|||Comma-separated list of paths to files and/or directories which
-                                                 contain modules required by the script|
-|Script Body|||Body of script to execute.
-                                            Only one of Script File or Script Body may be used|
+|Module Directory|||Comma-separated list of paths to files and/or directories which contain modules required by the script|
+|Script Body|||Body of script to execute. Only one of Script File or Script Body may be used|
 |Script Engine|python||The engine to execute scripts (python, lua)|
-|Script File|||Path to script file to execute.
-                                            Only one of Script File or Script Body may be used|
+|Script File|||Path to script file to execute. Only one of Script File or Script Body may be used|
+
 ### Properties 
 
 | Name | Description |


### PR DESCRIPTION
Table formatting was making it difficult to read properties for ExecutePythonProcessor and ExecuteScript. So, this change resolves the formatting issues.

Jira ticket opened for issue: https://issues.apache.org/jira/browse/MINIFICPP-1194

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
