### PR TITLE
MiNiFCPP-1195: Updates Outdated README Bootstrapping Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,10 +323,10 @@ $ # It is recommended that you install bison from source as HomeBrew now uses an
 
 ### Bootstrapping
 
-- MiNiFi C++ offers a bootstrap script in the root of our github repo that will boot strap the cmake and build process for you without the need to install dependencies yourself. To use this process, please run the command boostrap.sh from the root of the MiNiFi C++ source tree.
+- MiNiFi C++ offers a bootstrap script in the root of our github repo that will boot strap the cmake and build process for you without the need to install dependencies yourself. To use this process, please run the command `boostrap.sh` from the root of the MiNiFi C++ source tree.
 
 
-- Per the table, below, you will be presented with a menu guided bootstrap process. You may enable and disable extensions ( further defined below ). Once you are finished selecting the features you wish to build, enter N to continue with the process. CMAKE dependencies will be resolved for your distro. You may enter command line options -n to force yes to all prompts ( including the package installation prompts ) and -b to automatically run make once the cmake process is complete. Alternatively, you may include the package argument to boostrap, -p, which will run make package.
+- Per the table, below, you will be presented with a menu guided bootstrap process. You may enable and disable extensions ( further defined below ). Once you are finished selecting the features you wish to build, enter P to continue with the process. CMAKE dependencies will be resolved for your distro. You may enter command line options -n to force yes to all prompts ( including the package installation prompts ) and -b to automatically run make once the cmake process is complete. Alternatively, you may include the package argument to boostrap, -p, which will run make package.
 
 - If you provide -b or -p to bootstrap.sh, you do not need to follow the Building section, below. If you do not provide these arguments you may skip the cmake .. section from Building.
 
@@ -335,9 +335,9 @@ $ # It is recommended that you install bison from source as HomeBrew now uses an
   $ ./bootstrap.sh
   # CMAKE Build dir exists, should we overwrite your build directory before we begin?
     If you have already bootstrapped, bootstrapping again isn't necessary to run make [ Y/N ] Y
-  $  ****************************************
+  $ *****************************************
      Select MiNiFi C++ Features to toggle.
-    ****************************************
+    *****************************************
     A. Persistent Repositories .....Enabled
     B. Lib Curl Features ...........Enabled
     C. Lib Archive Features ........Enabled
@@ -348,15 +348,31 @@ $ # It is recommended that you install bison from source as HomeBrew now uses an
     H. USB Camera support ..........Disabled
     I. GPS support .................Disabled
     J. TensorFlow Support ..........Disabled
-    K. Enable all extensions
-    L. Portable Build ..............Enabled
-    M. Build with Debug symbols ....Disabled
-    N. Continue with these options
-    Q. Exit
+    K. Bustache Support ............Disabled
+    L. MQTT Support ................Disabled
+    M. SQLite Support ..............Disabled
+    N. Python Support ..............Disabled
+    O. COAP Support ................Enabled
+    S. SFTP Support ................Disabled
+    V. AWS Support .................Disabled
+    T. OpenCV Support ..............Disabled
+    U. OPC-UA Support ..............Disabled
+    W. SQL Support .................Disabled
+    ****************************************
+                Build Options.
+    ****************************************
+    1. Disable Tests ...............Disabled
+    2. Enable all extensions
+    3. Enable JNI Support ..........Disabled
+    4. Use Shared Dependency Links .Enabled
+    5. Build Profile ...............RelWithDebInfo Debug MinSizeRel Release
+    P. Continue with these options
+    Q. Quit
     * Extension cannot be installed due to
-      version of cmake or other software
+      version of cmake or other software, or
+      incompatibility with other extensions
     
-    Enter choice [ A - N ] 
+    Enter choice [ A - W or 1-4 ] 
   ```
 
 - Boostrap now saves state between runs. State will automatically be saved. Provide -c or --clear to clear this state. The -i option provides a guided menu install with the ability to change 


### PR DESCRIPTION
The paragraph in the Getting Started: Bootstrapping section originally told the user to enter N to continue the build process, but with the updated menu guided bootstrap process displayed in the console, P is what one must enter to continue the build process. I updated that info. 

The previous menu guided bootstrap process was outdated and did not show the new features Bustache Support to SQL Support and the Build Options. So, I updated it to show that information.

Here is the Jira Ticket: https://issues.apache.org/jira/browse/MINIFICPP-1195

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
