### PR TITLE
MINIFICPP-1198: Fixes AWSCredentialsService Table Render Issue

### DIFF
--- a/CONTROLLERS.md
+++ b/CONTROLLERS.md
@@ -34,6 +34,6 @@ properties (not in bold) are considered optional. The table also indicates any
 default values, and whether a property supports the NiFi Expression Language.
 
 | Name | Default Value | Allowable Values | Expression Language Supported? | Description |
-| - | - | - | - |
+| - | - | - | - | - |
 | **Access Key** | | | Yes | Specifies the AWS Access Key |
 | **Secret Key** | | | Yes | Specifies the AWS Secret Key |


### PR DESCRIPTION
Under AWSCredentialsService section, the Properties markdown table was not rendering. I realized the markdown table was missing a hyphen '-' and pipe '|' for the last header. I added this missing markdown and now the table renders correctly.

Created Jira ticket associated with this PR: https://issues.apache.org/jira/browse/MINIFICPP-1198

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
