### PR TITLE
MINIFICPP-965 Add other supported relationships to InvokeHTTP processor.

### DIFF
--- a/extensions/http-curl/client/HTTPClient.cpp
+++ b/extensions/http-curl/client/HTTPClient.cpp
@@ -268,7 +268,7 @@ bool HTTPClient::submit() {
   if (keep_alive_probe_.count() > 0) {
     const auto keepAlive = std::chrono::duration_cast<std::chrono::seconds>(keep_alive_probe_);
     const auto keepIdle = std::chrono::duration_cast<std::chrono::seconds>(keep_alive_idle_);
-    logger_->log_debug("Setting keep alive to %" PRIu64 " seconds", keepAlive.count());
+    logger_->log_debug("Setting keep alive to %" PRId64 " seconds", keepAlive.count());
     curl_easy_setopt(http_session_, CURLOPT_TCP_KEEPALIVE, 1L);
     curl_easy_setopt(http_session_, CURLOPT_TCP_KEEPINTVL, keepAlive.count());
     curl_easy_setopt(http_session_, CURLOPT_TCP_KEEPIDLE, keepIdle.count());

--- a/extensions/http-curl/client/HTTPClient.cpp
+++ b/extensions/http-curl/client/HTTPClient.cpp
@@ -36,48 +36,17 @@ namespace utils {
 HTTPClient::HTTPClient(const std::string &url, const std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service)
     : core::Connectable("HTTPClient"),
       ssl_context_service_(ssl_context_service),
-      url_(url),
-      content_type_str_(nullptr),
-      headers_(nullptr),
-      callback(nullptr),
-      write_callback_(nullptr),
-      http_code(0),
-      read_callback_(INT_MAX),
-      header_response_(-1),
-      res(CURLE_OK),
-      logger_(logging::LoggerFactory<HTTPClient>::getLogger()) {
+      url_(url) {
   http_session_ = curl_easy_init();
 }
 
 HTTPClient::HTTPClient(std::string name, utils::Identifier uuid)
-    : core::Connectable(name, uuid),
-      ssl_context_service_(nullptr),
-      url_(),
-      content_type_str_(nullptr),
-      headers_(nullptr),
-      callback(nullptr),
-      write_callback_(nullptr),
-      http_code(0),
-      read_callback_(INT_MAX),
-      header_response_(-1),
-      res(CURLE_OK),
-      logger_(logging::LoggerFactory<HTTPClient>::getLogger()) {
+    : core::Connectable(name, uuid) {
   http_session_ = curl_easy_init();
 }
 
 HTTPClient::HTTPClient()
-    : core::Connectable("HTTPClient"),
-      ssl_context_service_(nullptr),
-      url_(),
-      content_type_str_(nullptr),
-      headers_(nullptr),
-      callback(nullptr),
-      write_callback_(nullptr),
-      http_code(0),
-      read_callback_(INT_MAX),
-      header_response_(-1),
-      res(CURLE_OK),
-      logger_(logging::LoggerFactory<HTTPClient>::getLogger()) {
+    : core::Connectable("HTTPClient") {
   http_session_ = curl_easy_init();
 }
 
@@ -297,8 +266,8 @@ bool HTTPClient::submit() {
   curl_easy_setopt(http_session_, CURLOPT_HEADERFUNCTION, &utils::HTTPHeaderResponse::receive_headers);
   curl_easy_setopt(http_session_, CURLOPT_HEADERDATA, static_cast<void*>(&header_response_));
   if (keep_alive_probe_.count() > 0) {
-    const auto keepAlive = std::chrono::duration_cast<std::chrono::duration<uint64_t>>(keep_alive_probe_);
-    const auto keepIdle = std::chrono::duration_cast<std::chrono::duration<uint64_t>>(keep_alive_idle_);
+    const auto keepAlive = std::chrono::duration_cast<std::chrono::seconds>(keep_alive_probe_);
+    const auto keepIdle = std::chrono::duration_cast<std::chrono::seconds>(keep_alive_idle_);
     logger_->log_debug("Setting keep alive to %" PRIu64 " seconds", keepAlive.count());
     curl_easy_setopt(http_session_, CURLOPT_TCP_KEEPALIVE, 1L);
     curl_easy_setopt(http_session_, CURLOPT_TCP_KEEPINTVL, keepAlive.count());

--- a/extensions/http-curl/client/HTTPClient.h
+++ b/extensions/http-curl/client/HTTPClient.h
@@ -39,6 +39,7 @@
 #include <regex.h>
 #endif
 #include <vector>
+#include <chrono>
 
 #include "utils/ByteArrayCallback.h"
 #include "controllers/SSLContextService.h"
@@ -80,9 +81,19 @@ class HTTPClient : public BaseHTTPClient, public core::Connectable {
 
   virtual void initialize(const std::string &method, const std::string url = "", const std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service = nullptr) override;
 
-  virtual void setConnectionTimeout(int64_t timeout) override;
+  // This is a bad API and deprecated. Use the std::chrono variant of this
+  // It is assumed that the value of timeout provided to this function
+  // is in seconds units
+  DEPRECATED(/*deprecated in*/ 0.7.0, /*will remove in */ 2.0) virtual void setConnectionTimeout(int64_t timeout) override;
 
-  virtual void setReadTimeout(int64_t timeout) override;
+  // This is a bad API and deprecated. Use the std::chrono variant of this
+  // It is assumed that the value of timeout provided to this function
+  // is in seconds units
+  DEPRECATED(/*deprecated in*/ 0.7.0, /*will remove in */ 2.0) virtual void setReadTimeout(int64_t timeout) override;
+
+  virtual void setConnectionTimeout(std::chrono::milliseconds timeout) override;
+
+  virtual void setReadTimeout(std::chrono::milliseconds timeout) override;
 
   virtual void setUploadCallback(HTTPUploadCallback *callbackObj) override;
 
@@ -124,11 +135,11 @@ class HTTPClient : public BaseHTTPClient, public core::Connectable {
 
   bool setMinimumSSLVersion(SSLVersion minimum_version) override;
 
-  void setKeepAliveProbe(long probe){
+  void setKeepAliveProbe(std::chrono::milliseconds probe){
     keep_alive_probe_ = probe;
   }
 
-  void setKeepAliveIdle(long idle){
+  void setKeepAliveIdle(std::chrono::milliseconds idle){
     keep_alive_idle_= idle;
   }
 
@@ -229,9 +240,9 @@ class HTTPClient : public BaseHTTPClient, public core::Connectable {
 
   std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service_;
   std::string url_;
-  int64_t connect_timeout_;
+  std::chrono::milliseconds connect_timeout_ms_{0};
   // read timeout.
-  int64_t read_timeout_;
+  std::chrono::milliseconds read_timeout_ms_{0};
   char *content_type_str_;
   std::string content_type_;
   struct curl_slist *headers_;
@@ -247,9 +258,9 @@ class HTTPClient : public BaseHTTPClient, public core::Connectable {
 
   std::string method_;
 
-  long keep_alive_probe_;
+  std::chrono::milliseconds keep_alive_probe_{0};
 
-  long keep_alive_idle_;
+  std::chrono::milliseconds keep_alive_idle_{0};
 
   std::shared_ptr<logging::Logger> logger_;
 

--- a/extensions/http-curl/client/HTTPClient.h
+++ b/extensions/http-curl/client/HTTPClient.h
@@ -84,12 +84,12 @@ class HTTPClient : public BaseHTTPClient, public core::Connectable {
   // This is a bad API and deprecated. Use the std::chrono variant of this
   // It is assumed that the value of timeout provided to this function
   // is in seconds units
-  DEPRECATED(/*deprecated in*/ 0.7.0, /*will remove in */ 2.0) virtual void setConnectionTimeout(int64_t timeout) override;
+  DEPRECATED(/*deprecated in*/ 0.8.0, /*will remove in */ 2.0) virtual void setConnectionTimeout(int64_t timeout) override;
 
   // This is a bad API and deprecated. Use the std::chrono variant of this
   // It is assumed that the value of timeout provided to this function
   // is in seconds units
-  DEPRECATED(/*deprecated in*/ 0.7.0, /*will remove in */ 2.0) virtual void setReadTimeout(int64_t timeout) override;
+  DEPRECATED(/*deprecated in*/ 0.8.0, /*will remove in */ 2.0) virtual void setReadTimeout(int64_t timeout) override;
 
   virtual void setConnectionTimeout(std::chrono::milliseconds timeout) override;
 

--- a/extensions/http-curl/client/HTTPClient.h
+++ b/extensions/http-curl/client/HTTPClient.h
@@ -38,8 +38,8 @@
 #else
 #include <regex.h>
 #endif
-#include <vector>
 #include <chrono>
+#include <limits>
 
 #include "utils/ByteArrayCallback.h"
 #include "controllers/SSLContextService.h"
@@ -134,6 +134,14 @@ class HTTPClient : public BaseHTTPClient, public core::Connectable {
   bool setSpecificSSLVersion(SSLVersion specific_version) override;
 
   bool setMinimumSSLVersion(SSLVersion minimum_version) override;
+
+  DEPRECATED(/*deprecated in*/ 0.8.0, /*will remove in */ 2.0) void setKeepAliveProbe(long probe) {
+    keep_alive_probe_ = std::chrono::milliseconds(probe * 1000);
+  }
+
+  DEPRECATED(/*deprecated in*/ 0.8.0, /*will remove in */ 2.0) void setKeepAliveIdle(long idle) {
+    keep_alive_idle_ = std::chrono::milliseconds(idle * 1000);
+  }
 
   void setKeepAliveProbe(std::chrono::milliseconds probe){
     keep_alive_probe_ = probe;
@@ -243,27 +251,26 @@ class HTTPClient : public BaseHTTPClient, public core::Connectable {
   std::chrono::milliseconds connect_timeout_ms_{0};
   // read timeout.
   std::chrono::milliseconds read_timeout_ms_{0};
-  char *content_type_str_;
+  char *content_type_str_{nullptr};
   std::string content_type_;
-  struct curl_slist *headers_;
-  HTTPReadCallback *callback;
-  HTTPUploadCallback *write_callback_;
-  int64_t http_code;
-  ByteOutputCallback read_callback_;
-  utils::HTTPHeaderResponse header_response_;
+  struct curl_slist *headers_{nullptr};
+  HTTPReadCallback *callback{nullptr};
+  HTTPUploadCallback *write_callback_{nullptr};
+  int64_t http_code{0};
+  ByteOutputCallback read_callback_{std::numeric_limits<int>::max()};
+  utils::HTTPHeaderResponse header_response_{-1};
 
-  CURLcode res;
+  CURLcode res{CURLE_OK};
 
   CURL *http_session_;
 
   std::string method_;
 
-  std::chrono::milliseconds keep_alive_probe_{0};
+  std::chrono::milliseconds keep_alive_probe_{-1};
 
-  std::chrono::milliseconds keep_alive_idle_{0};
+  std::chrono::milliseconds keep_alive_idle_{-1};
 
-  std::shared_ptr<logging::Logger> logger_;
-
+  std::shared_ptr<logging::Logger> logger_{logging::LoggerFactory<HTTPClient>::getLogger()};
 };
 
 } /* namespace utils */

--- a/extensions/http-curl/client/HTTPClient.h
+++ b/extensions/http-curl/client/HTTPClient.h
@@ -39,7 +39,6 @@
 #include <regex.h>
 #endif
 #include <chrono>
-#include <limits>
 
 #include "utils/ByteArrayCallback.h"
 #include "controllers/SSLContextService.h"
@@ -257,7 +256,7 @@ class HTTPClient : public BaseHTTPClient, public core::Connectable {
   HTTPReadCallback *callback{nullptr};
   HTTPUploadCallback *write_callback_{nullptr};
   int64_t http_code{0};
-  ByteOutputCallback read_callback_{std::numeric_limits<int>::max()};
+  ByteOutputCallback read_callback_{INT_MAX};
   utils::HTTPHeaderResponse header_response_{-1};
 
   CURLcode res{CURLE_OK};

--- a/extensions/http-curl/processors/InvokeHTTP.cpp
+++ b/extensions/http-curl/processors/InvokeHTTP.cpp
@@ -274,16 +274,15 @@ void InvokeHTTP::onTrigger(const std::shared_ptr<core::ProcessContext> &context,
       return;
     }
   } else {
-    context->getProperty(URL, url, flowFile);
     logger_->log_debug("InvokeHTTP -- Received flowfile");
   }
 
-  logger_->log_debug("onTrigger InvokeHTTP with %s to %s", method_, url);
+  logger_->log_debug("onTrigger InvokeHTTP with %s to %s", method_, url_);
 
   // create a transaction id
   std::string tx_id = generateId();
 
-  utils::HTTPClient client(url, ssl_context_service_);
+  utils::HTTPClient client(url_, ssl_context_service_);
 
   client.initialize(method_);
   client.setConnectionTimeout(connect_timeout_ms_);
@@ -343,7 +342,7 @@ void InvokeHTTP::onTrigger(const std::shared_ptr<core::ProcessContext> &context,
     flowFile->addAttribute(STATUS_CODE, std::to_string(http_code));
     if (!response_headers.empty())
       flowFile->addAttribute(STATUS_MESSAGE, response_headers.at(0));
-    flowFile->addAttribute(REQUEST_URL, url);
+    flowFile->addAttribute(REQUEST_URL, url_);
     flowFile->addAttribute(TRANSACTION_ID, tx_id);
 
     bool isSuccess = ((int32_t) (http_code / 100)) == 2;

--- a/extensions/http-curl/processors/InvokeHTTP.h
+++ b/extensions/http-curl/processors/InvokeHTTP.h
@@ -142,9 +142,9 @@ class InvokeHTTP : public core::Processor {
   // attribute to send regex
   std::string attribute_to_send_regex_;
   // connection timeout
-  std::chrono::milliseconds connect_timeout_ms_{DEFAULT_TIMEOUT_MS};
+  std::chrono::milliseconds connect_timeout_ms_{20000};
   // read timeout.
-  std::chrono::milliseconds read_timeout_ms_{DEFAULT_TIMEOUT_MS};
+  std::chrono::milliseconds read_timeout_ms_{20000};
   // attribute in which response body will be added
   std::string put_attribute_name_;
   // determine if we always output a response.
@@ -159,7 +159,6 @@ class InvokeHTTP : public core::Processor {
   bool disable_peer_verification_{false};
  private:
   std::shared_ptr<logging::Logger> logger_{logging::LoggerFactory<InvokeHTTP>::getLogger()};
-  const std::chrono::milliseconds DEFAULT_TIMEOUT_MS{20000};
 };
 
 REGISTER_RESOURCE(InvokeHTTP,"An HTTP client processor which can interact with a configurable HTTP Endpoint. "

--- a/extensions/http-curl/processors/InvokeHTTP.h
+++ b/extensions/http-curl/processors/InvokeHTTP.h
@@ -50,16 +50,7 @@ class InvokeHTTP : public core::Processor {
    * Create a new processor
    */
   InvokeHTTP(std::string name, utils::Identifier uuid = utils::Identifier())
-      : Processor(name, uuid),
-        ssl_context_service_(nullptr),
-        date_header_include_(true),
-        connect_timeout_(20000),
-        read_timeout_(20000),
-        always_output_response_(false),
-        use_chunked_encoding_(false),
-        penalize_no_retry_(false),
-        disable_peer_verification_(false),
-        logger_(logging::LoggerFactory<InvokeHTTP>::getLogger()) {
+      : Processor(name, uuid) {
   }
   // Destructor
   virtual ~InvokeHTTP();
@@ -140,35 +131,35 @@ class InvokeHTTP : public core::Processor {
    */
   bool emitFlowFile(const std::string &method);
 
-  std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service_;
+  std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service_{nullptr};
 
   // http method
   std::string method_;
   // url
   std::string url_;
   // include date in the header
-  bool date_header_include_;
+  bool date_header_include_{true};
   // attribute to send regex
   std::string attribute_to_send_regex_;
   // connection timeout
-  int64_t connect_timeout_;
+  std::chrono::milliseconds connect_timeout_ms_{DEFAULT_TIMEOUT_MS};
   // read timeout.
-  int64_t read_timeout_;
+  std::chrono::milliseconds read_timeout_ms_{DEFAULT_TIMEOUT_MS};
   // attribute in which response body will be added
   std::string put_attribute_name_;
   // determine if we always output a response.
-  bool always_output_response_;
+  bool always_output_response_{false};
   // content type.
   std::string content_type_;
   // use chunked encoding.
-  bool use_chunked_encoding_;
+  bool use_chunked_encoding_{false};
   // penalize on no retry
-  bool penalize_no_retry_;
+  bool penalize_no_retry_{false};
   // disable peer verification ( makes susceptible for MITM attacks )
-  bool disable_peer_verification_;
+  bool disable_peer_verification_{false};
  private:
-  std::shared_ptr<logging::Logger> logger_;
-  static std::shared_ptr<utils::IdGenerator> id_generator_;
+  std::shared_ptr<logging::Logger> logger_{logging::LoggerFactory<InvokeHTTP>::getLogger()};
+  const std::chrono::milliseconds DEFAULT_TIMEOUT_MS{20000};
 };
 
 REGISTER_RESOURCE(InvokeHTTP,"An HTTP client processor which can interact with a configurable HTTP Endpoint. "

--- a/extensions/http-curl/protocols/RESTSender.cpp
+++ b/extensions/http-curl/protocols/RESTSender.cpp
@@ -104,9 +104,9 @@ const C2Payload RESTSender::sendPayload(const std::string url, const Direction d
 
   // Client declared last to make sure calbacks are still available when client is destructed
   utils::HTTPClient client(url, ssl_context_service_);
-  client.setKeepAliveProbe(2);
-  client.setKeepAliveIdle(2);
-  client.setConnectionTimeout(2);
+  client.setKeepAliveProbe(std::chrono::milliseconds(2000));
+  client.setKeepAliveIdle(std::chrono::milliseconds(2000));
+  client.setConnectionTimeout(std::chrono::milliseconds(2000));
   if (direction == Direction::TRANSMIT) {
     input = std::unique_ptr<utils::ByteInputCallBack>(new utils::ByteInputCallBack());
     callback = std::unique_ptr<utils::HTTPUploadCallback>(new utils::HTTPUploadCallback());

--- a/extensions/http-curl/sitetosite/HTTPProtocol.cpp
+++ b/extensions/http-curl/sitetosite/HTTPProtocol.cpp
@@ -55,7 +55,7 @@ std::shared_ptr<Transaction> HttpSiteToSiteClient::createTransaction(std::string
   uri << getBaseURI() << "data-transfer/" << dir_str << "/" << getPortId() << "/transactions";
   auto client = create_http_client(uri.str(), "POST");
   client->appendHeader(PROTOCOL_VERSION_HEADER, "1");
-  client->setConnectionTimeout(5);
+  client->setConnectionTimeout(std::chrono::milliseconds(5000));
   client->setContentType("application/json");
   client->appendHeader("Accept: application/json");
   client->setUseChunkedEncoding();
@@ -282,7 +282,7 @@ void HttpSiteToSiteClient::closeTransaction(const std::string &transactionID) {
 
   client->appendHeader(PROTOCOL_VERSION_HEADER, "1");
 
-  client->setConnectionTimeout(5);
+  client->setConnectionTimeout(std::chrono::milliseconds(5000));
 
   client->appendHeader("Accept", "application/json");
 

--- a/extensions/http-curl/tests/CMakeLists.txt
+++ b/extensions/http-curl/tests/CMakeLists.txt
@@ -79,6 +79,7 @@ add_test(NAME C2NullConfiguration COMMAND C2NullConfiguration "${TEST_RESOURCES}
 if(NOT OPENSSL_OFF)
 add_test(NAME HttpGetIntegrationTestSecure COMMAND HttpGetIntegrationTest "${TEST_RESOURCES}/TestHTTPGetSecure.yml"  "${TEST_RESOURCES}/")
 add_test(NAME C2VerifyHeartbeatAndStopSecure COMMAND C2VerifyHeartbeatAndStop "${TEST_RESOURCES}/C2VerifyHeartbeatAndStopSecure.yml" "${TEST_RESOURCES}/")
+add_test(NAME VerifyInvokeHTTPTestSecure COMMAND VerifyInvokeHTTPTest "${TEST_RESOURCES}/TestInvokeHTTPPostSecure.yml" "${TEST_RESOURCES}/")
 endif()
 add_test(NAME HttpPostIntegrationTest COMMAND HttpPostIntegrationTest "${TEST_RESOURCES}/TestHTTPPost.yml" "${TEST_RESOURCES}/")
 if (NOT APPLE)

--- a/extensions/http-curl/tests/CMakeLists.txt
+++ b/extensions/http-curl/tests/CMakeLists.txt
@@ -90,3 +90,4 @@ add_test(NAME HTTPSiteToSiteTests COMMAND HTTPSiteToSiteTests "${TEST_RESOURCES}
 add_test(NAME SiteToSiteRestTest COMMAND SiteToSiteRestTest "${TEST_RESOURCES}/TestSite2SiteRest.yml" "${TEST_RESOURCES}/" "http://localhost:8077/nifi-api/site-to-site")
 add_test(NAME ControllerServiceIntegrationTests COMMAND ControllerServiceIntegrationTests "${TEST_RESOURCES}/TestControllerServices.yml" "${TEST_RESOURCES}/")
 add_test(NAME ThreadPoolAdjust COMMAND ThreadPoolAdjust "${TEST_RESOURCES}/ThreadPoolAdjust.yml" "${TEST_RESOURCES}/")
+add_test(NAME VerifyInvokeHTTPTest COMMAND VerifyInvokeHTTPTest "${TEST_RESOURCES}/TestInvokeHTTPPost.yml")

--- a/extensions/http-curl/tests/HTTPHandlers.h
+++ b/extensions/http-curl/tests/HTTPHandlers.h
@@ -477,12 +477,17 @@ public:
 
 class InvokeHTTPResponseTimeoutHandler : public CivetHandler {
 public:
+    InvokeHTTPResponseTimeoutHandler(std::chrono::milliseconds wait_ms)
+        : wait_(wait_ms) {
+    }
   bool handlePost(CivetServer *, struct mg_connection *conn) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(5500));
+    std::this_thread::sleep_for(wait_);
     std::stringstream headers;
     headers << "HTTP/1.1 201 OK\r\nContent-Type: text/plain\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
     mg_printf(conn, headers.str().c_str());
     return true;
   }
+protected:
+  std::chrono::milliseconds wait_;
 };
 #endif /* LIBMINIFI_TEST_CURL_TESTS_SITETOSITEHTTP_HTTPHANDLERS_H_ */

--- a/extensions/http-curl/tests/HTTPHandlers.h
+++ b/extensions/http-curl/tests/HTTPHandlers.h
@@ -474,4 +474,15 @@ public:
     return true;
   }
 };
+
+class InvokeHTTPResponseTimeoutHandler : public CivetHandler {
+public:
+  bool handlePost(CivetServer *, struct mg_connection *conn) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(5500));
+    std::stringstream headers;
+    headers << "HTTP/1.1 201 OK\r\nContent-Type: text/plain\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+    mg_printf(conn, headers.str().c_str());
+    return true;
+  }
+};
 #endif /* LIBMINIFI_TEST_CURL_TESTS_SITETOSITEHTTP_HTTPHANDLERS_H_ */

--- a/extensions/http-curl/tests/HTTPHandlers.h
+++ b/extensions/http-curl/tests/HTTPHandlers.h
@@ -445,12 +445,13 @@ class HeartbeatHandler : public CivetHandler {
   bool isSecure;
 };
 
+class InvokeHTTPCouldNotConnectHandler : public CivetHandler {
+};
+
 class InvokeHTTPResponseOKHandler : public CivetHandler {
 public:
   bool handlePost(CivetServer *, struct mg_connection *conn) {
-    std::stringstream headers;
-    headers << "HTTP/1.1 201 OK\r\nContent-Type: text/plain\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
-    mg_printf(conn, headers.str().c_str());
+    mg_printf(conn, "HTTP/1.1 201 OK\r\nContent-Type: text/plain\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
     return true;
   }
 };
@@ -458,9 +459,7 @@ public:
 class InvokeHTTPResponse404Handler : public CivetHandler {
 public:
   bool handlePost(CivetServer *, struct mg_connection *conn) {
-    std::stringstream headers;
-    headers << "HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
-    mg_printf(conn, headers.str().c_str());
+    mg_printf(conn, "HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
     return true;
   }
 };
@@ -468,9 +467,7 @@ public:
 class InvokeHTTPResponse501Handler : public CivetHandler {
 public:
   bool handlePost(CivetServer *, struct mg_connection *conn) {
-    std::stringstream headers;
-    headers << "HTTP/1.1 501 Not Implemented\r\nContent-Type: text/plain\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
-    mg_printf(conn, headers.str().c_str());
+    mg_printf(conn, "HTTP/1.1 501 Not Implemented\r\nContent-Type: text/plain\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
     return true;
   }
 };
@@ -482,9 +479,7 @@ public:
     }
   bool handlePost(CivetServer *, struct mg_connection *conn) {
     std::this_thread::sleep_for(wait_);
-    std::stringstream headers;
-    headers << "HTTP/1.1 201 OK\r\nContent-Type: text/plain\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
-    mg_printf(conn, headers.str().c_str());
+    mg_printf(conn, "HTTP/1.1 201 OK\r\nContent-Type: text/plain\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
     return true;
   }
 protected:

--- a/extensions/http-curl/tests/HTTPHandlers.h
+++ b/extensions/http-curl/tests/HTTPHandlers.h
@@ -445,4 +445,33 @@ class HeartbeatHandler : public CivetHandler {
   bool isSecure;
 };
 
+class InvokeHTTPResponseOKHandler : public CivetHandler {
+public:
+  bool handlePost(CivetServer *, struct mg_connection *conn) {
+    std::stringstream headers;
+    headers << "HTTP/1.1 201 OK\r\nContent-Type: text/plain\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+    mg_printf(conn, headers.str().c_str());
+    return true;
+  }
+};
+
+class InvokeHTTPResponse404Handler : public CivetHandler {
+public:
+  bool handlePost(CivetServer *, struct mg_connection *conn) {
+    std::stringstream headers;
+    headers << "HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+    mg_printf(conn, headers.str().c_str());
+    return true;
+  }
+};
+
+class InvokeHTTPResponse501Handler : public CivetHandler {
+public:
+  bool handlePost(CivetServer *, struct mg_connection *conn) {
+    std::stringstream headers;
+    headers << "HTTP/1.1 501 Not Implemented\r\nContent-Type: text/plain\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+    mg_printf(conn, headers.str().c_str());
+    return true;
+  }
+};
 #endif /* LIBMINIFI_TEST_CURL_TESTS_SITETOSITEHTTP_HTTPHANDLERS_H_ */

--- a/extensions/http-curl/tests/VerifyInvokeHTTPTest.cpp
+++ b/extensions/http-curl/tests/VerifyInvokeHTTPTest.cpp
@@ -165,6 +165,14 @@ public:
   }
 };
 
+class VerifyRWTimeoutInvokeHTTP : public VerifyInvokeHTTP {
+public:
+  virtual void runAssertions() {
+    assert(LogTestController::getInstance().contains("key:invoke_http value:failure"));
+    assert(LogTestController::getInstance().contains("failed Timeout was reached"));
+  }
+};
+
 void run(VerifyInvokeHTTP& harness,
     const std::string& test_file_location,
     const std::string& key_dir,
@@ -214,6 +222,12 @@ int main(int argc, char ** argv) {
   {
     InvokeHTTPResponse501Handler handler;
     VerifyRetryInvokeHTTP harness;
+    run(harness, test_file_location, key_dir, &handler);
+  }
+
+  {
+    InvokeHTTPResponseTimeoutHandler handler;
+    VerifyRWTimeoutInvokeHTTP harness;
     run(harness, test_file_location, key_dir, &handler);
   }
   return 0;

--- a/extensions/http-curl/tests/VerifyInvokeHTTPTest.cpp
+++ b/extensions/http-curl/tests/VerifyInvokeHTTPTest.cpp
@@ -1,0 +1,220 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#undef NDEBUG
+#include "TestBase.h"
+#include "HTTPHandlers.h"
+#include "HTTPClient.h"
+#include "InvokeHTTP.h"
+#include "processors/LogAttribute.h"
+
+#include "../tests/TestServer.h"
+#include "CivetServer.h"
+#include "HTTPIntegrationBase.h"
+
+class VerifyInvokeHTTP : public IntegrationBase {
+public:
+  VerifyInvokeHTTP()
+      : IntegrationBase(6000),
+        server(nullptr) {
+  }
+
+  virtual void testSetup() {
+    LogTestController::getInstance().setDebug<utils::HTTPClient>();
+    LogTestController::getInstance().setDebug<LogTestController>();
+    LogTestController::getInstance().setTrace<minifi::processors::InvokeHTTP>();
+    LogTestController::getInstance().setTrace<minifi::processors::LogAttribute>();
+  }
+
+  virtual void shutdownBeforeFlowController() {
+    stop_webserver(server);
+  }
+
+  virtual void cleanup() {
+  }
+
+  virtual void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> pg) {
+    std::shared_ptr<core::Processor> proc = pg->findProcessor("InvokeHTTP");
+    assert(proc);
+    std::shared_ptr<minifi::processors::InvokeHTTP> inv = std::dynamic_pointer_cast<minifi::processors::InvokeHTTP>(proc);
+    assert(inv);
+    std::string url = "";
+    inv->getProperty(minifi::processors::InvokeHTTP::URL.getName(), url);
+    assert(!url.empty());
+    parse_http_components(url, port, scheme, path);
+  }
+
+  void setupFlow(const std::string& flow_yml_path) {
+    testSetup();
+
+    std::shared_ptr<core::Repository> test_repo = std::make_shared<TestRepository>();
+    std::shared_ptr<core::Repository> test_flow_repo = std::make_shared<TestFlowRepository>();
+
+    configuration->set(minifi::Configure::nifi_flow_configuration_file, flow_yml_path);
+
+    std::shared_ptr<core::ContentRepository> content_repo = std::make_shared<core::repository::VolatileContentRepository>();
+    content_repo->initialize(configuration);
+    std::shared_ptr<minifi::io::StreamFactory> stream_factory = minifi::io::StreamFactory::getInstance(configuration);
+    std::unique_ptr<core::FlowConfiguration> yaml_ptr = std::unique_ptr<core::YamlConfiguration>(
+        new core::YamlConfiguration(test_repo, test_repo, content_repo, stream_factory, configuration, flow_yml_path));
+
+    core::YamlConfiguration yaml_config(test_repo, test_repo, content_repo, stream_factory, configuration, flow_yml_path);
+
+    std::unique_ptr<core::ProcessGroup> ptr = yaml_config.getRoot(flow_yml_path);
+    std::shared_ptr<core::ProcessGroup> pg = std::shared_ptr<core::ProcessGroup>(ptr.get());
+
+    queryRootProcessGroup(pg);
+
+    configureFullHeartbeat();
+
+    ptr.release();
+
+    std::shared_ptr<TestRepository> repo = std::static_pointer_cast<TestRepository>(test_repo);
+
+    flowController_ = std::make_shared<minifi::FlowController>(test_repo, test_flow_repo, configuration, std::move(yaml_ptr), content_repo, DEFAULT_ROOT_GROUP_NAME, true);
+  }
+
+  void startFlow() {
+    updateProperties(flowController_);
+    flowController_->load();
+    flowController_->start();
+  }
+
+  void stopFlowAndVerify() {
+    flowController_->unload();
+    flowController_->stopC2();
+
+    runAssertions();
+    cleanup();
+  }
+
+  void startCivetServer(CivetHandler * handler) {
+    if (server != nullptr) {
+      server->addHandler(path, handler);
+      return;
+    }
+    struct mg_callbacks callback;
+    if (scheme == "https" && !key_dir.empty()) {
+      std::string cert = "";
+      cert = key_dir + "nifi-cert.pem";
+      memset(&callback, 0, sizeof(callback));
+      callback.init_ssl = ssl_enable;
+      port += "s";
+      callback.log_message = log_message;
+      server = start_webserver(port, path, handler, &callback, cert, cert);
+    } else {
+      server = start_webserver(port, path, handler);
+    }
+    if (port == "0" || port == "0s") {
+      bool secure = (port == "0s");
+      port = std::to_string(server->getListeningPorts()[0]);
+      if (secure) {
+        port += "s";
+      }
+    }
+  }
+
+protected:
+  CivetServer *server;
+  bool isSecure;
+};
+
+class VerifyInvokeHTTPOKResponse : public VerifyInvokeHTTP {
+public:
+  virtual void runAssertions() {
+    assert(LogTestController::getInstance().contains("key:invokehttp.status.code value:201"));
+    assert(LogTestController::getInstance().contains("response code 201"));
+  }
+};
+
+class VerifyCouldNotConnectInvokeHTTP : public VerifyInvokeHTTP {
+public:
+  virtual void runAssertions() {
+    assert(LogTestController::getInstance().contains("key:invoke_http value:failure"));
+  }
+};
+
+class VerifyNoRetryInvokeHTTP : public VerifyInvokeHTTP {
+public:
+  virtual void runAssertions() {
+    assert(LogTestController::getInstance().contains("key:invokehttp.status.message value:HTTP/1.1 404 Not Found"));
+    assert(LogTestController::getInstance().contains("isSuccess: 0, response code 404"));
+  }
+};
+
+class VerifyRetryInvokeHTTP : public VerifyInvokeHTTP {
+public:
+  virtual void runAssertions() {
+    assert(LogTestController::getInstance().contains("key:invokehttp.status.message value:HTTP/1.1 501 Not Implemented"));
+    assert(LogTestController::getInstance().contains("isSuccess: 0, response code 501"));
+  }
+};
+
+void run(VerifyInvokeHTTP& harness,
+    const std::string& test_file_location,
+    const std::string& key_dir,
+    CivetHandler * handler) {
+
+  harness.setKeyDir(key_dir);
+  harness.setupFlow(test_file_location);
+  harness.startCivetServer(handler);
+  harness.startFlow();
+  harness.waitToVerifyProcessor();
+  harness.shutdownBeforeFlowController();
+  harness.stopFlowAndVerify();
+}
+
+int main(int argc, char ** argv) {
+  std::string key_dir, test_file_location;
+  if (argc > 1) {
+    test_file_location = argv[1];
+    if (argc > 2) {
+      key_dir = argv[2];
+    }
+  }
+
+  // Do not start the civet server to simulate
+  // unreachable remote end point
+  {
+    VerifyCouldNotConnectInvokeHTTP harness;
+    harness.setKeyDir(key_dir);
+    harness.setupFlow(test_file_location);
+    harness.startFlow();
+    harness.waitToVerifyProcessor();
+    harness.stopFlowAndVerify();
+  }
+
+  {
+    InvokeHTTPResponseOKHandler handler;
+    VerifyInvokeHTTPOKResponse harness;
+    run(harness, test_file_location, key_dir, &handler);
+  }
+
+  {
+    InvokeHTTPResponse404Handler handler;
+    VerifyNoRetryInvokeHTTP harness;
+    run(harness, test_file_location, key_dir, &handler);
+  }
+
+  {
+    InvokeHTTPResponse501Handler handler;
+    VerifyRetryInvokeHTTP harness;
+    run(harness, test_file_location, key_dir, &handler);
+  }
+  return 0;
+}

--- a/extensions/http-curl/tests/VerifyInvokeHTTPTest.cpp
+++ b/extensions/http-curl/tests/VerifyInvokeHTTPTest.cpp
@@ -34,14 +34,14 @@ public:
       : CoapIntegrationBase(6000) {
   }
 
-  virtual void testSetup() {
+  virtual void testSetup() override {
     LogTestController::getInstance().setDebug<utils::HTTPClient>();
     LogTestController::getInstance().setDebug<LogTestController>();
     LogTestController::getInstance().setTrace<minifi::processors::InvokeHTTP>();
     LogTestController::getInstance().setTrace<minifi::processors::LogAttribute>();
   }
 
-  virtual void cleanup() {
+  virtual void cleanup() override {
   }
 
   void setProperties(std::shared_ptr<core::Processor> proc) {
@@ -100,7 +100,7 @@ public:
 
 class VerifyInvokeHTTPOKResponse : public VerifyInvokeHTTP {
 public:
-  virtual void runAssertions() {
+  virtual void runAssertions() override {
     assert(LogTestController::getInstance().contains("key:invokehttp.status.code value:201"));
     assert(LogTestController::getInstance().contains("response code 201"));
   }
@@ -108,14 +108,14 @@ public:
 
 class VerifyCouldNotConnectInvokeHTTP : public VerifyInvokeHTTP {
 public:
-  virtual void runAssertions() {
+  virtual void runAssertions() override {
     assert(LogTestController::getInstance().contains("key:invoke_http value:failure"));
   }
 };
 
 class VerifyNoRetryInvokeHTTP : public VerifyInvokeHTTP {
 public:
-  virtual void runAssertions() {
+  virtual void runAssertions() override {
     assert(LogTestController::getInstance().contains("key:invokehttp.status.message value:HTTP/1.1 404 Not Found"));
     assert(LogTestController::getInstance().contains("isSuccess: 0, response code 404"));
   }
@@ -123,7 +123,7 @@ public:
 
 class VerifyRetryInvokeHTTP : public VerifyInvokeHTTP {
 public:
-  virtual void runAssertions() {
+  virtual void runAssertions() override {
     assert(LogTestController::getInstance().contains("key:invokehttp.status.message value:HTTP/1.1 501 Not Implemented"));
     assert(LogTestController::getInstance().contains("isSuccess: 0, response code 501"));
   }
@@ -131,7 +131,7 @@ public:
 
 class VerifyRWTimeoutInvokeHTTP : public VerifyInvokeHTTP {
 public:
-  virtual void runAssertions() {
+  virtual void runAssertions() override {
     assert(LogTestController::getInstance().contains("key:invoke_http value:failure"));
     assert(LogTestController::getInstance().contains("failed Timeout was reached"));
   }

--- a/extensions/http-curl/tests/VerifyInvokeHTTPTest.cpp
+++ b/extensions/http-curl/tests/VerifyInvokeHTTPTest.cpp
@@ -226,9 +226,10 @@ int main(int argc, char ** argv) {
   }
 
   {
-    InvokeHTTPResponseTimeoutHandler handler;
+    InvokeHTTPResponseTimeoutHandler handler(std::chrono::milliseconds(4000));
     VerifyRWTimeoutInvokeHTTP harness;
     run(harness, test_file_location, key_dir, &handler);
   }
+
   return 0;
 }

--- a/extensions/mqtt/processors/ConvertUpdate.cpp
+++ b/extensions/mqtt/processors/ConvertUpdate.cpp
@@ -19,6 +19,7 @@
 #include "utils/HTTPClient.h"
 #include "io/BaseStream.h"
 #include "io/DataStream.h"
+
 namespace org {
 namespace apache {
 namespace nifi {
@@ -62,8 +63,8 @@ void ConvertUpdate::onTrigger(const std::shared_ptr<core::ProcessContext> &conte
       }
       std::unique_ptr<utils::BaseHTTPClient> client = std::unique_ptr<utils::BaseHTTPClient>(dynamic_cast<utils::BaseHTTPClient*>(client_ptr));
       client->initialize("GET");
-      client->setConnectionTimeout(2000);
-      client->setReadTimeout(2000);
+      client->setConnectionTimeout(std::chrono::milliseconds(2000));
+      client->setReadTimeout(std::chrono::milliseconds(2000));
 
       if (client->submit()) {
         auto data = client->getResponseBody();

--- a/libminifi/include/core/Property.h
+++ b/libminifi/include/core/Property.h
@@ -412,6 +412,18 @@ class Property {
     return true;
   }
 
+  static bool getTimeMSFromString(const std::string& str, uint64_t& valInt) {
+    core::TimeUnit unit;
+    return !str.empty() && StringToTime(str, valInt, unit)
+        && ConvertTimeUnitToMS(valInt, unit, valInt);
+  }
+
+  static bool getTimeMSFromString(const std::string& str, int64_t& valInt) {
+    core::TimeUnit unit;
+    return !str.empty() && StringToTime(str, valInt, unit)
+        && ConvertTimeUnitToMS(valInt, unit, valInt);
+  }
+
   // Convert String to Integer
   template<typename T>
   static bool StringToInt(std::string input, T &output) {

--- a/libminifi/include/utils/HTTPClient.h
+++ b/libminifi/include/utils/HTTPClient.h
@@ -283,10 +283,10 @@ public:
   virtual void initialize(const std::string &method, const std::string url = "", const std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service = nullptr) {
   }
 
-  DEPRECATED(/*deprecated in*/ 0.7.0, /*will remove in */ 2.0) virtual void setConnectionTimeout(int64_t timeout) {
+  DEPRECATED(/*deprecated in*/ 0.8.0, /*will remove in */ 2.0) virtual void setConnectionTimeout(int64_t timeout) {
   }
 
-  DEPRECATED(/*deprecated in*/ 0.7.0, /*will remove in */ 2.0) virtual void setReadTimeout(int64_t timeout) {
+  DEPRECATED(/*deprecated in*/ 0.8.0, /*will remove in */ 2.0) virtual void setReadTimeout(int64_t timeout) {
   }
 
   virtual void setConnectionTimeout(std::chrono::milliseconds timeout) {

--- a/libminifi/include/utils/HTTPClient.h
+++ b/libminifi/include/utils/HTTPClient.h
@@ -283,10 +283,16 @@ public:
   virtual void initialize(const std::string &method, const std::string url = "", const std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service = nullptr) {
   }
 
-  virtual void setConnectionTimeout(int64_t timeout) {
+  DEPRECATED(/*deprecated in*/ 0.7.0, /*will remove in */ 2.0) virtual void setConnectionTimeout(int64_t timeout) {
   }
 
-  virtual void setReadTimeout(int64_t timeout) {
+  DEPRECATED(/*deprecated in*/ 0.7.0, /*will remove in */ 2.0) virtual void setReadTimeout(int64_t timeout) {
+  }
+
+  virtual void setConnectionTimeout(std::chrono::milliseconds timeout) {
+  }
+
+  virtual void setReadTimeout(std::chrono::milliseconds timeout) {
   }
 
   virtual void setUploadCallback(HTTPUploadCallback *callbackObj) {

--- a/libminifi/src/RemoteProcessorGroupPort.cpp
+++ b/libminifi/src/RemoteProcessorGroupPort.cpp
@@ -305,7 +305,7 @@ std::pair<std::string, int> RemoteProcessorGroupPort::refreshRemoteSite2SiteInfo
       client->initialize("GET", loginUrl.str(), ssl_service);
       // use a connection timeout. if this times out we will simply attempt re-connection
       // so no need for configuration parameter that isn't already defined in Processor
-      client->setConnectionTimeout(10);
+      client->setConnectionTimeout(std::chrono::milliseconds(10000));
 
       token = utils::get_token(client.get(), this->rest_user_name_, this->rest_password_);
       logger_->log_debug("Token from NiFi REST Api endpoint %s,  %s", loginUrl.str(), token);
@@ -323,7 +323,7 @@ std::pair<std::string, int> RemoteProcessorGroupPort::refreshRemoteSite2SiteInfo
     client->initialize("GET", fullUrl.str().c_str(), ssl_service);
     // use a connection timeout. if this times out we will simply attempt re-connection
     // so no need for configuration parameter that isn't already defined in Processor
-    client->setConnectionTimeout(10);
+    client->setConnectionTimeout(std::chrono::milliseconds(10000));
     if (!proxy_.host.empty()) {
       client->setHTTPProxy(proxy_);
     }

--- a/libminifi/test/resources/C2VerifyServeResults.yml
+++ b/libminifi/test/resources/C2VerifyServeResults.yml
@@ -30,6 +30,10 @@ Processors:
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
+          - failure
+          - retry
+          - no retry
+          - response
       Properties:
           HTTP Method: GET
           Remote URL: http://localhost:10013/geturl

--- a/libminifi/test/resources/TestHTTPGet.yml
+++ b/libminifi/test/resources/TestHTTPGet.yml
@@ -30,6 +30,10 @@ Processors:
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
+          - retry
+          - no retry
+          - response
+          - failure
       Properties:
           HTTP Method: GET
           Remote URL: http://localhost:10003/geturl

--- a/libminifi/test/resources/TestHTTPGetSecure.yml
+++ b/libminifi/test/resources/TestHTTPGetSecure.yml
@@ -30,6 +30,10 @@ Processors:
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
+          - failure
+          - retry
+          - no retry
+          - response
       Properties:
           SSL Context Service: SSLContextService
           HTTP Method: GET

--- a/libminifi/test/resources/TestHTTPPost.yml
+++ b/libminifi/test/resources/TestHTTPPost.yml
@@ -53,7 +53,11 @@ Processors:
       penalization period: 30 sec
       yield period: 1 sec
       run duration nanos: 0
-      auto-terminated relationships list: 
+      auto-terminated relationships list:
+         - retry
+         - no retry
+         - failure
+         - response
       Properties:
           HTTP Method: POST
           Content-type: text/html

--- a/libminifi/test/resources/TestHTTPPostChunkedEncoding.yml
+++ b/libminifi/test/resources/TestHTTPPostChunkedEncoding.yml
@@ -55,6 +55,10 @@ Processors:
       run duration nanos: 0
       auto-terminated relationships list: 
           - success
+          - retry
+          - failure
+          - response
+          - no retry
       Properties:
           HTTP Method: POST
           Use Chunked Encoding: true

--- a/libminifi/test/resources/TestInvokeHTTPPost.yml
+++ b/libminifi/test/resources/TestInvokeHTTPPost.yml
@@ -48,7 +48,7 @@ Processors:
   class: org.apache.nifi.minifi.processors.GenerateFlowFile
   max concurrent tasks: 1
   scheduling strategy: TIMER_DRIVEN
-  scheduling period: 4000 ms
+  scheduling period: 15000 ms
   penalization period: 1000 ms
   yield period: 1000 ms
   run duration nanos: 0
@@ -100,7 +100,7 @@ Processors:
   class: org.apache.nifi.minifi.processors.UpdateAttribute
   max concurrent tasks: 1
   scheduling strategy: TIMER_DRIVEN
-  scheduling period: 1000 ms
+  scheduling period: 200 ms
   penalization period: 1000 ms
   yield period: 1000 ms
   run duration nanos: 0

--- a/libminifi/test/resources/TestInvokeHTTPPost.yml
+++ b/libminifi/test/resources/TestInvokeHTTPPost.yml
@@ -1,0 +1,161 @@
+MiNiFi Config Version: 3
+Flow Controller:
+  name: c++lw
+  comment: Created by MiNiFi C2 Flow Designer
+Core Properties:
+  flow controller graceful shutdown period: 10 sec
+  flow service write delay interval: 500 ms
+  administrative yield duration: 30 sec
+  bored yield duration: 10 millis
+  max concurrent threads: 1
+  variable registry properties: ''
+FlowFile Repository:
+  partitions: 256
+  checkpoint interval: 2 mins
+  always sync: false
+  Swap:
+    threshold: 20000
+    in period: 5 sec
+    in threads: 1
+    out period: 5 sec
+    out threads: 4
+Content Repository:
+  content claim max appendable size: 10 MB
+  content claim max flow files: 100
+  always sync: false
+Provenance Repository:
+  provenance rollover time: 1 min
+  implementation: org.apache.nifi.provenance.MiNiFiPersistentProvenanceRepository
+Component Status Repository:
+  buffer size: 1440
+  snapshot frequency: 1 min
+Security Properties:
+  keystore: ''
+  keystore type: ''
+  keystore password: ''
+  key password: ''
+  truststore: ''
+  truststore type: ''
+  truststore password: ''
+  ssl protocol: ''
+  Sensitive Props:
+    key:
+    algorithm: PBEWITHMD5AND256BITAES-CBC-OPENSSL
+    provider: BC
+Processors:
+- id: 4ed2d51d-076a-49b0-88de-5cf5adf52a7e
+  name: GenerateFlowFile
+  class: org.apache.nifi.minifi.processors.GenerateFlowFile
+  max concurrent tasks: 1
+  scheduling strategy: TIMER_DRIVEN
+  scheduling period: 4000 ms
+  penalization period: 1000 ms
+  yield period: 1000 ms
+  run duration nanos: 0
+  auto-terminated relationships list: []
+  Properties:
+    Batch Size: '1'
+    Data Format: Binary
+    File Size: 1 kB
+    Unique FlowFiles: 'true'
+- id: 1d51724d-dd76-46a0-892d-a7c7408d58dd
+  name: InvokeHTTP
+  class: org.apache.nifi.minifi.processors.InvokeHTTP
+  max concurrent tasks: 1
+  scheduling strategy: TIMER_DRIVEN
+  scheduling period: 1000 ms
+  penalization period: 1000 ms
+  yield period: 1000 ms
+  run duration nanos: 0
+  auto-terminated relationships list: []
+  Properties:
+    Always Output Response: 'false'
+    Connection Timeout: 5 s
+    Content-type: application/octet-stream
+    Disable Peer Verification: 'false'
+    HTTP Method: POST
+    Include Date Header: 'true'
+    Read Timeout: 15 s
+    Remote URL: http://localhost:10033/minifi
+    Use Chunked Encoding: 'false'
+    send-message-body: 'true'
+- id: 8543b2e2-a373-4d8d-8710-ac314666696b
+  name: LogAttribute
+  class: org.apache.nifi.minifi.processors.LogAttribute
+  max concurrent tasks: 1
+  scheduling strategy: TIMER_DRIVEN
+  scheduling period: 1000 ms
+  penalization period: 30000 ms
+  yield period: 1000 ms
+  run duration nanos: 0
+  auto-terminated relationships list:
+  - success
+  Properties:
+    FlowFiles To Log: '1'
+    Hexencode Payload: 'false'
+    Log Payload: 'false'
+    Maximum Payload Line Length: '80'
+- id: 4f8a0c9b-6f7c-458f-9b4d-480addb2e0af
+  name: UpdateAttribute
+  class: org.apache.nifi.minifi.processors.UpdateAttribute
+  max concurrent tasks: 1
+  scheduling strategy: TIMER_DRIVEN
+  scheduling period: 1000 ms
+  penalization period: 1000 ms
+  yield period: 1000 ms
+  run duration nanos: 0
+  auto-terminated relationships list:
+  - failure
+  Properties:
+    invoke_http: failure
+Controller Services: []
+Process Groups: []
+Input Ports: []
+Output Ports: []
+Funnels: []
+Connections:
+- id: 189bee81-3e56-45ac-b6bb-aa70b7180dc8
+  name: GenerateFlowFile/success/InvokeHTTP
+  source id: 4ed2d51d-076a-49b0-88de-5cf5adf52a7e
+  source relationship names:
+  - success
+  destination id: 1d51724d-dd76-46a0-892d-a7c7408d58dd
+  max work queue size: 0
+  max work queue data size: 10000 B
+  flowfile expiration: 0 seconds
+  queue prioritizer class: ''
+- id: f5d1dd2d-f675-41bd-bf1b-b571aa23ebfb
+  name: InvokeHTTP/failure/UpdateAttribute
+  source id: 1d51724d-dd76-46a0-892d-a7c7408d58dd
+  source relationship names:
+  - failure
+  destination id: 4f8a0c9b-6f7c-458f-9b4d-480addb2e0af
+  max work queue size: 0
+  max work queue data size: 10000 B
+  flowfile expiration: 0 seconds
+  queue prioritizer class: ''
+- id: 000035d8-46a0-460a-809c-f0c6320d532e
+  name: InvokeHTTP/response/LogAttribute
+  source id: 1d51724d-dd76-46a0-892d-a7c7408d58dd
+  source relationship names:
+  - no retry
+  - response
+  - retry
+  - success
+  destination id: 8543b2e2-a373-4d8d-8710-ac314666696b
+  max work queue size: 0
+  max work queue data size: 10000 B
+  flowfile expiration: 0 seconds
+  queue prioritizer class: ''
+- id: 0f292c74-cdbb-4e69-8a26-c834569366c1
+  name: UpdateAttribute/success/LogAttribute
+  source id: 4f8a0c9b-6f7c-458f-9b4d-480addb2e0af
+  source relationship names:
+  - success
+  destination id: 8543b2e2-a373-4d8d-8710-ac314666696b
+  max work queue size: 0
+  max work queue data size: 10000 B
+  flowfile expiration: 0 seconds
+  queue prioritizer class: ''
+Remote Process Groups: []
+NiFi Properties Overrides: {}

--- a/libminifi/test/resources/TestInvokeHTTPPost.yml
+++ b/libminifi/test/resources/TestInvokeHTTPPost.yml
@@ -76,7 +76,7 @@ Processors:
     HTTP Method: POST
     Include Date Header: 'true'
     Read Timeout: 4 s
-    Remote URL: http://localhost:10033/minifi
+    Remote URL: http://localhost:0/minifi
     Use Chunked Encoding: 'false'
     send-message-body: 'true'
 - id: 8543b2e2-a373-4d8d-8710-ac314666696b

--- a/libminifi/test/resources/TestInvokeHTTPPost.yml
+++ b/libminifi/test/resources/TestInvokeHTTPPost.yml
@@ -70,12 +70,12 @@ Processors:
   auto-terminated relationships list: []
   Properties:
     Always Output Response: 'false'
-    Connection Timeout: 5 s
+    Connection Timeout: 3 s
     Content-type: application/octet-stream
     Disable Peer Verification: 'false'
     HTTP Method: POST
     Include Date Header: 'true'
-    Read Timeout: 15 s
+    Read Timeout: 4 s
     Remote URL: http://localhost:10033/minifi
     Use Chunked Encoding: 'false'
     send-message-body: 'true'

--- a/libminifi/test/resources/TestInvokeHTTPPostSecure.yml
+++ b/libminifi/test/resources/TestInvokeHTTPPostSecure.yml
@@ -75,7 +75,7 @@ Processors:
     Disable Peer Verification: 'true'
     HTTP Method: POST
     Read Timeout: 3 s
-    Remote URL: https://localhost:30468/minifi
+    Remote URL: https://localhost:0/minifi
     Use Chunked Encoding: 'false'
     send-message-body: 'true'
     SSL Context Service: SSLContextService

--- a/libminifi/test/resources/TestInvokeHTTPPostSecure.yml
+++ b/libminifi/test/resources/TestInvokeHTTPPostSecure.yml
@@ -48,7 +48,7 @@ Processors:
   class: org.apache.nifi.minifi.processors.GenerateFlowFile
   max concurrent tasks: 1
   scheduling strategy: TIMER_DRIVEN
-  scheduling period: 4000 ms
+  scheduling period: 15000 ms
   penalization period: 1000 ms
   yield period: 1000 ms
   run duration nanos: 0
@@ -70,11 +70,11 @@ Processors:
   auto-terminated relationships list: []
   Properties:
     Always Output Response: 'false'
-    Connection Timeout: 3 s
+    Connection Timeout: 2 s
     Content-type: application/octet-stream
     Disable Peer Verification: 'true'
     HTTP Method: POST
-    Read Timeout: 4 s
+    Read Timeout: 3 s
     Remote URL: https://localhost:30468/minifi
     Use Chunked Encoding: 'false'
     send-message-body: 'true'
@@ -100,7 +100,7 @@ Processors:
   class: org.apache.nifi.minifi.processors.UpdateAttribute
   max concurrent tasks: 1
   scheduling strategy: TIMER_DRIVEN
-  scheduling period: 1000 ms
+  scheduling period: 200 ms
   penalization period: 1000 ms
   yield period: 1000 ms
   run duration nanos: 0

--- a/libminifi/test/resources/TestInvokeHTTPPostSecure.yml
+++ b/libminifi/test/resources/TestInvokeHTTPPostSecure.yml
@@ -1,0 +1,175 @@
+MiNiFi Config Version: 3
+Flow Controller:
+  name: c++lw
+  comment: Created by MiNiFi C2 Flow Designer
+Core Properties:
+  flow controller graceful shutdown period: 10 sec
+  flow service write delay interval: 500 ms
+  administrative yield duration: 30 sec
+  bored yield duration: 10 millis
+  max concurrent threads: 1
+  variable registry properties: ''
+FlowFile Repository:
+  partitions: 256
+  checkpoint interval: 2 mins
+  always sync: false
+  Swap:
+    threshold: 20000
+    in period: 5 sec
+    in threads: 1
+    out period: 5 sec
+    out threads: 4
+Content Repository:
+  content claim max appendable size: 10 MB
+  content claim max flow files: 100
+  always sync: false
+Provenance Repository:
+  provenance rollover time: 1 min
+  implementation: org.apache.nifi.provenance.MiNiFiPersistentProvenanceRepository
+Component Status Repository:
+  buffer size: 1440
+  snapshot frequency: 1 min
+Security Properties:
+  keystore: ''
+  keystore type: ''
+  keystore password: ''
+  key password: ''
+  truststore: ''
+  truststore type: ''
+  truststore password: ''
+  ssl protocol: ''
+  Sensitive Props:
+    key:
+    algorithm: PBEWITHMD5AND256BITAES-CBC-OPENSSL
+    provider: BC
+Processors:
+- id: 4ed2d51d-076a-49b0-88de-5cf5adf52a7e
+  name: GenerateFlowFile
+  class: org.apache.nifi.minifi.processors.GenerateFlowFile
+  max concurrent tasks: 1
+  scheduling strategy: TIMER_DRIVEN
+  scheduling period: 4000 ms
+  penalization period: 1000 ms
+  yield period: 1000 ms
+  run duration nanos: 0
+  auto-terminated relationships list: []
+  Properties:
+    Batch Size: '1'
+    Data Format: Binary
+    File Size: 1 kB
+    Unique FlowFiles: 'true'
+- id: 1d51724d-dd76-46a0-892d-a7c7408d58dd
+  name: InvokeHTTP
+  class: org.apache.nifi.minifi.processors.InvokeHTTP
+  max concurrent tasks: 1
+  scheduling strategy: TIMER_DRIVEN
+  scheduling period: 1000 ms
+  penalization period: 1000 ms
+  yield period: 1000 ms
+  run duration nanos: 0
+  auto-terminated relationships list: []
+  Properties:
+    Always Output Response: 'false'
+    Connection Timeout: 5 s
+    Content-type: application/octet-stream
+    Disable Peer Verification: 'true'
+    HTTP Method: POST
+    Read Timeout: 15 s
+    Remote URL: https://localhost:30468/minifi
+    Use Chunked Encoding: 'false'
+    send-message-body: 'true'
+    SSL Context Service: SSLContextService
+- id: 8543b2e2-a373-4d8d-8710-ac314666696b
+  name: LogAttribute
+  class: org.apache.nifi.minifi.processors.LogAttribute
+  max concurrent tasks: 1
+  scheduling strategy: TIMER_DRIVEN
+  scheduling period: 1000 ms
+  penalization period: 30000 ms
+  yield period: 1000 ms
+  run duration nanos: 0
+  auto-terminated relationships list:
+  - success
+  Properties:
+    FlowFiles To Log: '1'
+    Hexencode Payload: 'false'
+    Log Payload: 'false'
+    Maximum Payload Line Length: '80'
+- id: 4f8a0c9b-6f7c-458f-9b4d-480addb2e0af
+  name: UpdateAttribute
+  class: org.apache.nifi.minifi.processors.UpdateAttribute
+  max concurrent tasks: 1
+  scheduling strategy: TIMER_DRIVEN
+  scheduling period: 1000 ms
+  penalization period: 1000 ms
+  yield period: 1000 ms
+  run duration nanos: 0
+  auto-terminated relationships list:
+  - failure
+  Properties:
+    invoke_http: failure
+Controller Services: []
+Process Groups: []
+Input Ports: []
+Output Ports: []
+Funnels: []
+Connections:
+- id: 189bee81-3e56-45ac-b6bb-aa70b7180dc8
+  name: GenerateFlowFile/success/InvokeHTTP
+  source id: 4ed2d51d-076a-49b0-88de-5cf5adf52a7e
+  source relationship names:
+  - success
+  destination id: 1d51724d-dd76-46a0-892d-a7c7408d58dd
+  max work queue size: 0
+  max work queue data size: 10000 B
+  flowfile expiration: 0 seconds
+  queue prioritizer class: ''
+- id: f5d1dd2d-f675-41bd-bf1b-b571aa23ebfb
+  name: InvokeHTTP/failure/UpdateAttribute
+  source id: 1d51724d-dd76-46a0-892d-a7c7408d58dd
+  source relationship names:
+  - failure
+  destination id: 4f8a0c9b-6f7c-458f-9b4d-480addb2e0af
+  max work queue size: 0
+  max work queue data size: 10000 B
+  flowfile expiration: 0 seconds
+  queue prioritizer class: ''
+- id: 000035d8-46a0-460a-809c-f0c6320d532e
+  name: InvokeHTTP/response/LogAttribute
+  source id: 1d51724d-dd76-46a0-892d-a7c7408d58dd
+  source relationship names:
+  - no retry
+  - response
+  - retry
+  - success
+  destination id: 8543b2e2-a373-4d8d-8710-ac314666696b
+  max work queue size: 0
+  max work queue data size: 10000 B
+  flowfile expiration: 0 seconds
+  queue prioritizer class: ''
+- id: 0f292c74-cdbb-4e69-8a26-c834569366c1
+  name: UpdateAttribute/success/LogAttribute
+  source id: 4f8a0c9b-6f7c-458f-9b4d-480addb2e0af
+  source relationship names:
+  - success
+  destination id: 8543b2e2-a373-4d8d-8710-ac314666696b
+  max work queue size: 0
+  max work queue data size: 10000 B
+  flowfile expiration: 0 seconds
+  queue prioritizer class: ''
+  
+Controller Services:
+  - name: SSLContextService
+    id: 2438e3c8-015a-1000-79ca-83af40ec1994
+    class: SSLContextService
+    Properties:
+      Client Certificate:
+          - value: cn.crt.pem
+      Private Key:
+          - value: cn.ckey.pem
+      Passphrase:
+          - value: cn.pass
+      CA Certificate:
+          - value: nifi-cert.pem
+Remote Process Groups: []
+NiFi Properties Overrides: {}

--- a/libminifi/test/resources/TestInvokeHTTPPostSecure.yml
+++ b/libminifi/test/resources/TestInvokeHTTPPostSecure.yml
@@ -70,11 +70,11 @@ Processors:
   auto-terminated relationships list: []
   Properties:
     Always Output Response: 'false'
-    Connection Timeout: 5 s
+    Connection Timeout: 3 s
     Content-type: application/octet-stream
     Disable Peer Verification: 'true'
     HTTP Method: POST
-    Read Timeout: 15 s
+    Read Timeout: 4 s
     Remote URL: https://localhost:30468/minifi
     Use Chunked Encoding: 'false'
     send-message-body: 'true'


### PR DESCRIPTION
Added response, retry, no retry, failure relationships.
Transfer request and response flow files appropriately.
Overloaded virtual functions to set connection timeout and read timeout
using std chrono
Deprecated the old set timeout functions that use int64_t

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
