### PR TITLE
MINIFICPP-1239 Use <regex> except in gcc < 4.9

### DIFF
--- a/libminifi/include/utils/RegexUtils.h
+++ b/libminifi/include/utils/RegexUtils.h
@@ -19,15 +19,14 @@
 #ifndef LIBMINIFI_INCLUDE_IO_REGEXUTILS_H_
 #define LIBMINIFI_INCLUDE_IO_REGEXUTILS_H_
 
+#include <string>
 #include <vector>
-#include <regex>
 
-#if (__cplusplus > 201103L) || defined(_WIN32)
-#define NO_MORE_REGFREEE
-#endif
-
-#ifndef NO_MORE_REGFREEE
+#if defined(__GNUC__) && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 9))
 #include <regex.h>
+#else
+#include <regex>
+#define NO_MORE_REGFREEE
 #endif
 
 namespace org {


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

### Description of PR

We should use the regular expression implementation from the STL whenever we can, which means for all compilers except gcc versions before 4.9.


In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
