### PR TITLE
MINIFICPP-1153 Make the CTailFile tests thread-safe

### DIFF
--- a/nanofi/include/core/file_utils.h
+++ b/nanofi/include/core/file_utils.h
@@ -71,6 +71,13 @@ int make_dir(const char * path);
  */
 char * get_current_working_directory();
 
+/**
+ * Change the current working directory.
+ * @path can be relative or absolute
+ * @return 0 on success, non-zero on error
+ */
+int change_current_working_directory(const char *path);
+
 #ifdef __cplusplus
 }
 #endif

--- a/nanofi/src/core/file_utils.c
+++ b/nanofi/src/core/file_utils.c
@@ -139,3 +139,11 @@ char * get_current_working_directory() {
     free(cwd);
     return NULL;
 }
+
+int change_current_working_directory(const char *path) {
+#ifdef WIN32
+  return _chdir(path);
+#else
+  return chdir(path);
+#endif
+}

--- a/nanofi/tests/CTailFileChunkTests.cpp
+++ b/nanofi/tests/CTailFileChunkTests.cpp
@@ -35,7 +35,7 @@
  */
 
 TEST_CASE("Test tailfile chunk size 4096, file size 8KB", "[tailfileChunk8KBFileSize]") {
-
+    TestControllerWithTemporaryWorkingDirectory test_controller;
     TailFileTestResourceManager mgr("TailFileChunk", on_trigger_tailfilechunk);
     const char * file = "./e.txt";
     const char * chunksize = "4096";
@@ -67,7 +67,7 @@ TEST_CASE("Test tailfile chunk size 4096, file size 8KB", "[tailfileChunk8KBFile
 }
 
 TEST_CASE("Test tailfile chunk size 4096, file size less than 8KB", "[tailfileChunkFileSizeLessThan8KB]") {
-
+    TestControllerWithTemporaryWorkingDirectory test_controller;
     TailFileTestResourceManager mgr("TailFileChunk", on_trigger_tailfilechunk);
     const char * file = "./e.txt";
     const char * chunksize = "4096";
@@ -103,7 +103,7 @@ TEST_CASE("Test tailfile chunk size 4096, file size less than 8KB", "[tailfileCh
 }
 
 TEST_CASE("Test tailfile chunk size 512, file size equal to 4608B", "[tailfileChunkFileSize8KB]") {
-
+    TestControllerWithTemporaryWorkingDirectory test_controller;
     TailFileTestResourceManager mgr("TailFileChunk", on_trigger_tailfilechunk);
     const char * file = "./e.txt";
     const char * chunksize = "512";

--- a/nanofi/tests/CTailFileDelimitedTests.cpp
+++ b/nanofi/tests/CTailFileDelimitedTests.cpp
@@ -27,7 +27,7 @@
  */
 
 TEST_CASE("Test tailfile delimited. Empty file", "[tailfileDelimitedEmptyFileTest]") {
-
+    TestControllerWithTemporaryWorkingDirectory test_controller;
     TailFileTestResourceManager mgr("TailFileDelimited", on_trigger_tailfiledelimited);
     const char * file = "./e.txt";
     const char * delimiter = ";";
@@ -43,7 +43,7 @@ TEST_CASE("Test tailfile delimited. Empty file", "[tailfileDelimitedEmptyFileTes
 }
 
 TEST_CASE("Test tailfile delimited. File has less than 4096 chars", "[tailfileDelimitedLessThan4096Chars]") {
-
+    TestControllerWithTemporaryWorkingDirectory test_controller;
     TailFileTestResourceManager mgr("TailFileDelimited", on_trigger_tailfiledelimited);
     const char * file = "./e.txt";
     const char * delimiter = ";";
@@ -65,7 +65,7 @@ TEST_CASE("Test tailfile delimited. File has less than 4096 chars", "[tailfileDe
 }
 
 TEST_CASE("Test tailfile delimited. Simple test", "[tailfileDelimitedSimpleTest]") {
-
+    TestControllerWithTemporaryWorkingDirectory test_controller;
     TailFileTestResourceManager mgr("TailFileDelimited", on_trigger_tailfiledelimited);
     const char * file = "./e.txt";
     const char * delimiter = ";";
@@ -105,7 +105,7 @@ TEST_CASE("Test tailfile delimited. Simple test", "[tailfileDelimitedSimpleTest]
 }
 
 TEST_CASE("Test tailfile delimited. trailing non delimited string", "[tailfileNonDelimitedTest]") {
-
+    TestControllerWithTemporaryWorkingDirectory test_controller;
     TailFileTestResourceManager mgr("TailFileDelimited", on_trigger_tailfiledelimited);
     const char * file = "./e.txt";
     const char * delimiter = ";";
@@ -148,7 +148,7 @@ TEST_CASE("Test tailfile delimited. trailing non delimited string", "[tailfileNo
 }
 
 TEST_CASE("Test tailfile delimited 4096 chars non delimited", "[tailfileDelimitedSimpleTest]") {
-
+    TestControllerWithTemporaryWorkingDirectory test_controller;
     TailFileTestResourceManager mgr("TailFileDelimited", on_trigger_tailfiledelimited);
     const char * file = "./e.txt";
     const char * delimiter = ";";
@@ -212,7 +212,7 @@ TEST_CASE("Test tailfile delimited 4096 chars non delimited", "[tailfileDelimite
 }
 
 TEST_CASE("Test tailfile delimited. string starting with delimiter", "[tailfileDelimiterStartStringTest]") {
-
+    TestControllerWithTemporaryWorkingDirectory test_controller;
     TailFileTestResourceManager mgr("TailFileDelimited", on_trigger_tailfiledelimited);
     const char * file = "./e.txt";
     const char * delimiter = ";";

--- a/nanofi/tests/CTestsBase.h
+++ b/nanofi/tests/CTestsBase.h
@@ -29,6 +29,7 @@
 #include "core/file_utils.h"
 #include "api/ecu.h"
 #include "api/nanofi.h"
+#include "TestBase.h"
 
 class FileManager {
 public:
@@ -122,6 +123,30 @@ public:
 private:
     nifi_instance * instance_;
     standalone_processor * processor_;
+};
+
+class TestControllerWithTemporaryWorkingDirectory {
+public:
+  TestControllerWithTemporaryWorkingDirectory()
+    : old_cwd_(get_current_working_directory())
+  {
+    char format[] = "/tmp/ctest_temp_dir.XXXXXX";
+    std::string temp_dir = test_controller_.createTempDirectory(format);
+    int result = change_current_working_directory(temp_dir.c_str());
+    if (result != 0) {
+      throw std::runtime_error("Could not change to temporary directory " + temp_dir);
+    }
+  }
+
+  ~TestControllerWithTemporaryWorkingDirectory()
+  {
+    chdir(old_cwd_);
+    free(old_cwd_);
+  }
+
+private:
+  TestController test_controller_;
+  char *old_cwd_;
 };
 
 struct processor_params * invoke_processor(TailFileTestResourceManager& mgr, const char * filePath) {


### PR DESCRIPTION
### Description of the changes

Before each test in CTailFile tests, change the current working directory to a temporary directory not used by any other test.

This is a mix of C and C++, but that was already true of these tests.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
