### PR TITLE
MINIFICPP-1262 Fix the MinifiConcurrentQueueTests unit tests

### DIFF
--- a/libminifi/test/unit/MinifiConcurrentQueueTests.cpp
+++ b/libminifi/test/unit/MinifiConcurrentQueueTests.cpp
@@ -331,7 +331,7 @@ TEST_CASE("TestConcurrentQueue: test the readding dequeue consumer", "[ProducerC
   utils::ConditionConcurrentQueue<std::string> queue(true);
   std::vector<std::string> results;
 
-  std::atomic_int results_size;
+  std::atomic_int results_size{0};
   std::thread consumer { getReaddingDequeueConsumerThread(queue, results, results_size) };
   std::this_thread::sleep_for(std::chrono::milliseconds(1));
   std::thread producer { getSimpleProducerThread(queue) };

--- a/libminifi/test/unit/MinifiConcurrentQueueTests.cpp
+++ b/libminifi/test/unit/MinifiConcurrentQueueTests.cpp
@@ -31,8 +31,8 @@ namespace utils = org::apache::nifi::minifi::utils;
 
 namespace {
 
-  template <typename Function, typename Duration>
-  bool becomesTrueWithinTimeout(const Function &condition, Duration timeout) {
+  template<typename Function, typename Rep, typename Period>
+  bool becomesTrueWithinTimeout(const Function &condition, std::chrono::duration<Rep, Period> timeout) {
     auto start_time = std::chrono::steady_clock::now();
     while (std::chrono::steady_clock::now() < start_time + timeout) {
       if (condition()) {


### PR DESCRIPTION
### Description of the changes

* Move the timed and untimed waiting consumer tests into separate test cases, as the timed consumers do not need a sleep in the test (they wait and retry internally) and they do not need to stop the queue, but the untimed consumers do.
* In the untimed consumer case, change the fixed 10 ms wait to a wait until the queue is empty (but not more than 1 second).
* Change possibly infinite loops in two other tests to also wait for the condition with a 1 second timeout.
* Move some other independent tests, which used to be sections within a single test, into separate test cases.
* Minor cleanup

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
