### PR TITLE
MINIFICPP-1282 Use GNUInstallDirs for more reliable determination of installed lib/lib64 directories

### DIFF
--- a/cmake/BundledLibSSH2.cmake
+++ b/cmake/BundledLibSSH2.cmake
@@ -22,15 +22,11 @@ function(use_bundled_libssh2 SOURCE_DIR BINARY_DIR)
     set(PC "${Patch_EXECUTABLE}" -p1 -i "${SOURCE_DIR}/thirdparty/libssh2/libssh2-CMAKE_MODULE_PATH.patch")
 
     # Define byproducts
-    get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
-    if ("${LIB64}" STREQUAL "TRUE" AND (NOT WIN32 AND NOT APPLE))
-        set(LIBSUFFIX 64)
-    endif()
-
     if (WIN32)
         set(BYPRODUCT "lib/libssh2.lib")
     else()
-        set(BYPRODUCT "lib${LIBSUFFIX}/libssh2.a")
+        include(GNUInstallDirs)
+        set(BYPRODUCT "${CMAKE_INSTALL_LIBDIR}/libssh2.a")
     endif()
 
     # Set build options

--- a/cmake/BundledLibcURL.cmake
+++ b/cmake/BundledLibcURL.cmake
@@ -22,16 +22,11 @@ function(use_bundled_curl SOURCE_DIR BINARY_DIR)
     endif()
 
     # Define byproducts
-    get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
-
-    if ("${LIB64}" STREQUAL "TRUE" AND (NOT WIN32 AND NOT APPLE))
-        set(LIBSUFFIX 64)
-    endif()
-
     if (WIN32)
         set(BYPRODUCT "lib/libcurl.lib")
     else()
-        set(BYPRODUCT "lib${LIBSUFFIX}/libcurl.a")
+        include(GNUInstallDirs)
+        set(BYPRODUCT "${CMAKE_INSTALL_LIBDIR}/libcurl.a")
     endif()
 
     # Set build options

--- a/cmake/BundledOpen62541.cmake
+++ b/cmake/BundledOpen62541.cmake
@@ -20,16 +20,11 @@ function(use_bundled_open62541 SOURCE_DIR BINARY_DIR)
     set(PC "${Patch_EXECUTABLE}" -p1 -i "${SOURCE_DIR}/thirdparty/open62541/open62541.patch")
 
     # Define byproducts
-    get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
-
-    if ("${LIB64}" STREQUAL "TRUE" AND (NOT WIN32 AND NOT APPLE))
-        set(LIBSUFFIX 64)
-    endif()
-
     if (WIN32)
         set(BYPRODUCT "lib/open62541.lib")
     else()
-        set(BYPRODUCT "lib${LIBSUFFIX}/libopen62541.a")
+        include(GNUInstallDirs)
+        set(BYPRODUCT "${CMAKE_INSTALL_LIBDIR}/libopen62541.a")
     endif()
 
     # Set build options

--- a/cmake/BundledPahoMqttC.cmake
+++ b/cmake/BundledPahoMqttC.cmake
@@ -20,15 +20,11 @@ function(use_bundled_pahomqttc SOURCE_DIR BINARY_DIR)
     set(PC "${Patch_EXECUTABLE}" -p1 -i "${SOURCE_DIR}/thirdparty/paho.mqtt.c/paho.mqtt.c.patch")
 
     # Define byproducts
-    get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
-    if ("${LIB64}" STREQUAL "TRUE" AND (NOT WIN32 AND NOT APPLE))
-        set(LIBSUFFIX 64)
-    endif()
-
     if (WIN32)
         set(BYPRODUCT "lib/libpaho-mqtt3cs-static.lib")
     else()
-        set(BYPRODUCT "lib${LIBSUFFIX}/libpaho-mqtt3cs-static.a")
+        include(GNUInstallDirs)
+        set(BYPRODUCT "${CMAKE_INSTALL_LIBDIR}/libpaho-mqtt3cs-static.a")
     endif()
 
     # Set build options

--- a/cmake/BundledRocksDB.cmake
+++ b/cmake/BundledRocksDB.cmake
@@ -22,15 +22,11 @@ function(use_bundled_rocksdb SOURCE_DIR BINARY_DIR)
     set(PC "${Patch_EXECUTABLE}" -p1 -i "${SOURCE_DIR}/thirdparty/rocksdb/rocksdb-BUILD.patch" && "${Patch_EXECUTABLE}" -p1 -i "${SOURCE_DIR}/thirdparty/rocksdb/channel-mutex-mutable.patch")
 
     # Define byproducts
-    get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
-    if ("${LIB64}" STREQUAL "TRUE" AND (NOT WIN32 AND NOT APPLE))
-        set(LIBSUFFIX 64)
-    endif()
-
     if (WIN32)
         set(BYPRODUCT "lib/rocksdb.lib")
     else()
-        set(BYPRODUCT "lib${LIBSUFFIX}/librocksdb.a")
+        include(GNUInstallDirs)
+        set(BYPRODUCT "${CMAKE_INSTALL_LIBDIR}/librocksdb.a")
     endif()
 
     # Set build options

--- a/extensions/sql/CMakeLists.txt
+++ b/extensions/sql/CMakeLists.txt
@@ -30,17 +30,15 @@ file(GLOB SOURCES  "*.cpp" "services/*.cpp" "processors/*.cpp"  "data/*.cpp")
 add_library(minifi-sql STATIC ${SOURCES})
 set_property(TARGET minifi-sql PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-# Get whether we should use lib64/ library paths
-get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
-
 if(WIN32)
 	find_package(ODBC REQUIRED)
 else()
 	# Build iODBC
 
 	# Define byproducts
-	if(LIB64 AND NOT APPLE)
-		set(IODBC_BYPRODUCT "lib64/libiodbc.a")
+	if(NOT APPLE)
+		include(GNUInstallDirs)
+		set(IODBC_BYPRODUCT "${CMAKE_INSTALL_LIBDIR}/libiodbc.a")
 	else()
 		set(IODBC_BYPRODUCT "lib/libiodbc.a")
 	endif()
@@ -92,7 +90,10 @@ set(PC "${Patch_EXECUTABLE}" -p1 -i "${CMAKE_CURRENT_SOURCE_DIR}/patch/soci.patc
 
 # Define byproducts
 if(NOT APPLE AND CMAKE_SIZEOF_VOID_P EQUAL 8)
-	set(LIBSUFFIX 64)
+	include(GNUInstallDirs)
+	set(LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+else()
+	set(LIBDIR "lib")
 endif()
 
 if (WIN32)
@@ -102,8 +103,8 @@ else()
 endif()
 
 set(SOCI_BYPRODUCTS
-		"lib${LIBSUFFIX}/libsoci_core${BYPRODUCT_SUFFIX}"
-		"lib${LIBSUFFIX}/libsoci_odbc${BYPRODUCT_SUFFIX}"
+		"${LIBDIR}/libsoci_core${BYPRODUCT_SUFFIX}"
+		"${LIBDIR}/libsoci_odbc${BYPRODUCT_SUFFIX}"
 		)
 
 set(SOCI_BYPRODUCT_DIR "${CMAKE_CURRENT_BINARY_DIR}/thirdparty/soci-install")


### PR DESCRIPTION
Use `GNUInstallDirs` for more reliable determination of installed lib/lib64 directories.

This fixes a bug :beetle:  I ran into when attempting to build on Arch Linux. According to https://cmake.org/cmake/help/v3.4/module/GNUInstallDirs.html `GNUInstallDirs` `CMAKE_INSTALL_LIBDIR` will give the correct dir: "object code libraries (lib or lib64 or lib/<multiarch-tuple> on Debian)"

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

