### PR TITLE
MINIFICPP-1281 - Improve test performance by using event polling instead of sleep by sync

### DIFF
--- a/extensions/coap/tests/CoapC2VerifyHeartbeat.cpp
+++ b/extensions/coap/tests/CoapC2VerifyHeartbeat.cpp
@@ -53,6 +53,7 @@
 #include "CoapServer.h"
 #include "io/BaseStream.h"
 #include "concurrentqueue.h"
+#include "utils/IntegrationTestUtils.h"
 
 class VerifyCoAPServer : public CoapIntegrationBase {
  public:
@@ -82,12 +83,11 @@ class VerifyCoAPServer : public CoapIntegrationBase {
   }
 
   void runAssertions() {
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
-    assert(LogTestController::getInstance().contains("Received ack. version 3. number of operations 1") == true);
-    assert(LogTestController::getInstance().contains("Received ack. version 3. number of operations 0") == true);
-    assert(LogTestController::getInstance().contains("Received error event from protocol") == true);
-    assert(LogTestController::getInstance().contains("Received op 1, with id id and operand operand") == true);
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::seconds(3), "Received ack. version 3. number of operations 1"));
+    assert(verifyLogLinePresenceInPollTime(std::chrono::seconds(3), "Received ack. version 3. number of operations 0"));
+    assert(verifyLogLinePresenceInPollTime(std::chrono::seconds(3), "Received error event from protocol"));
+    assert(verifyLogLinePresenceInPollTime(std::chrono::seconds(3), "Received op 1, with id id and operand operand"));
   }
 
   void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> pg) {

--- a/extensions/coap/tests/CoapC2VerifyHeartbeat.cpp
+++ b/extensions/coap/tests/CoapC2VerifyHeartbeat.cpp
@@ -84,10 +84,11 @@ class VerifyCoAPServer : public CoapIntegrationBase {
 
   void runAssertions() {
     using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
-    assert(verifyLogLinePresenceInPollTime(std::chrono::seconds(3), "Received ack. version 3. number of operations 1"));
-    assert(verifyLogLinePresenceInPollTime(std::chrono::seconds(3), "Received ack. version 3. number of operations 0"));
-    assert(verifyLogLinePresenceInPollTime(std::chrono::seconds(3), "Received error event from protocol"));
-    assert(verifyLogLinePresenceInPollTime(std::chrono::seconds(3), "Received op 1, with id id and operand operand"));
+    assert(verifyLogLinePresenceInPollTime(std::chrono::seconds(3),
+        "Received ack. version 3. number of operations 1",
+        "Received ack. version 3. number of operations 0",
+        "Received error event from protocol",
+        "Received op 1, with id id and operand operand"));
   }
 
   void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> pg) {

--- a/extensions/coap/tests/CoapIntegrationBase.h
+++ b/extensions/coap/tests/CoapIntegrationBase.h
@@ -74,12 +74,12 @@ class CoapIntegrationBase : public IntegrationBase {
 
     controller->load();
     controller->start();
-    waitToVerifyProcessor();
+
+    runAssertions();
 
     shutdownBeforeFlowController();
     controller->waitUnload(wait_time_);
     controller->stopC2();
-    runAssertions();
 
     cleanup();
   }

--- a/extensions/coap/tests/CoapIntegrationBase.h
+++ b/extensions/coap/tests/CoapIntegrationBase.h
@@ -51,6 +51,7 @@ class CoapIntegrationBase : public IntegrationBase {
     std::shared_ptr<core::Repository> test_flow_repo = std::make_shared<TestFlowRepository>();
 
     configuration->set(minifi::Configure::nifi_flow_configuration_file, test_file_location);
+    configuration->set("c2.agent.heartbeat.period", "200");
 
     std::shared_ptr<core::ContentRepository> content_repo = std::make_shared<core::repository::VolatileContentRepository>();
     content_repo->initialize(configuration);

--- a/extensions/expression-language/tests/integration/UpdateAttributeIntegrationTest.cpp
+++ b/extensions/expression-language/tests/integration/UpdateAttributeIntegrationTest.cpp
@@ -33,6 +33,7 @@
 #include "integration/IntegrationBase.h"
 #include "ProcessContextExpr.h"
 #include "TestBase.h"
+#include "utils/IntegrationTestUtils.h"
 
 class TestHarness : public IntegrationBase {
  public:
@@ -46,9 +47,11 @@ class TestHarness : public IntegrationBase {
   void cleanup() override {}
 
   void runAssertions() override {
-    assert(LogTestController::getInstance().contains("key:route_check_attr value:good"));
-    assert(LogTestController::getInstance().contains("key:variable_attribute value:replacement_value"));
-    assert(LogTestController::getInstance().contains("ProcessSession rollback", std::chrono::seconds(1)) == false);  // No rollback happened
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_),
+        "key:route_check_attr value:good",
+        "key:variable_attribute value:replacement_value"));
+    assert(false == verifyLogLinePresenceInPollTime(std::chrono::milliseconds(200), "ProcessSession rollback"));  // No rollback happened
   }
 
   void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> pg) override {

--- a/extensions/http-curl/tests/C2FailedUpdateTest.cpp
+++ b/extensions/http-curl/tests/C2FailedUpdateTest.cpp
@@ -19,6 +19,7 @@
 #undef NDEBUG
 #include "HTTPIntegrationBase.h"
 #include "HTTPHandlers.h"
+#include "utils/IntegrationTestUtils.h"
 
 int main(int argc, char **argv) {
   const cmd_args args = parse_cmdline_args(argc, argv, "update");

--- a/extensions/http-curl/tests/C2JstackTest.cpp
+++ b/extensions/http-curl/tests/C2JstackTest.cpp
@@ -21,11 +21,13 @@
 #include "TestBase.h"
 #include "HTTPIntegrationBase.h"
 #include "HTTPHandlers.h"
+#include "utils/IntegrationTestUtils.h"
 
 class VerifyC2DescribeJstack : public VerifyC2Describe {
  public:
   void runAssertions() override {
-    assert(LogTestController::getInstance().contains("SchedulingAgent"));
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_), "SchedulingAgent"));
   }
 };
 

--- a/extensions/http-curl/tests/C2NullConfiguration.cpp
+++ b/extensions/http-curl/tests/C2NullConfiguration.cpp
@@ -30,6 +30,7 @@
 #include "c2/C2Agent.h"
 #include "processors/LogAttribute.h"
 #include "HTTPIntegrationBase.h"
+#include "utils/IntegrationTestUtils.h"
 
 class VerifyC2Server : public HTTPIntegrationBase {
 public:
@@ -57,8 +58,10 @@ public:
   }
 
   void runAssertions() override {
-    assert(LogTestController::getInstance().contains("C2Agent] [debug] Could not instantiate null"));
-    assert(LogTestController::getInstance().contains("Class is RESTSender"));
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_),
+        "C2Agent] [debug] Could not instantiate null",
+        "Class is RESTSender"));
   }
 
   void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> pg) override {

--- a/extensions/http-curl/tests/C2UpdateAgentTest.cpp
+++ b/extensions/http-curl/tests/C2UpdateAgentTest.cpp
@@ -34,6 +34,6 @@ int main(int argc, char **argv) {
 
   const auto then = std::chrono::system_clock::now();
   const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(then - start).count();
-  assert(handler.calls_ <= (seconds) + 1);
+  assert(handler.calls_ <= (seconds) + 2);
   return 0;
 }

--- a/extensions/http-curl/tests/C2UpdateTest.cpp
+++ b/extensions/http-curl/tests/C2UpdateTest.cpp
@@ -19,6 +19,7 @@
 #undef NDEBUG
 #include "HTTPIntegrationBase.h"
 #include "HTTPHandlers.h"
+#include "utils/IntegrationTestUtils.h"
 
 int main(int argc, char **argv) {
   const cmd_args args = parse_cmdline_args(argc, argv, "update");

--- a/extensions/http-curl/tests/C2VerifyHeartbeatAndStop.cpp
+++ b/extensions/http-curl/tests/C2VerifyHeartbeatAndStop.cpp
@@ -24,6 +24,7 @@
 #include "protocols/RESTReceiver.h"
 #include "HTTPIntegrationBase.h"
 #include "HTTPHandlers.h"
+#include "utils/IntegrationTestUtils.h"
 
 class LightWeightC2Handler : public HeartbeatHandler {
  public:
@@ -51,9 +52,11 @@ class VerifyC2Heartbeat : public VerifyC2Base {
   }
 
   void runAssertions() override {
-    assert(LogTestController::getInstance().contains("Received Ack from Server"));
-    assert(LogTestController::getInstance().contains("C2Agent] [debug] Stopping component invoke"));
-    assert(LogTestController::getInstance().contains("C2Agent] [debug] Stopping component FlowController"));
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_),
+        "Received Ack from Server",
+        "C2Agent] [debug] Stopping component invoke",
+        "C2Agent] [debug] Stopping component FlowController"));
   }
 
   void configureFullHeartbeat() override {
@@ -62,7 +65,7 @@ class VerifyC2Heartbeat : public VerifyC2Base {
 };
 
 class VerifyLightWeightC2Heartbeat : public VerifyC2Heartbeat {
-public:
+ public:
   void configureFullHeartbeat() override {
     configuration->set("nifi.c2.full.heartbeat", "false");
   }

--- a/extensions/http-curl/tests/C2VerifyServeResults.cpp
+++ b/extensions/http-curl/tests/C2VerifyServeResults.cpp
@@ -26,6 +26,7 @@
 #include "properties/Configure.h"
 #include "TestServer.h"
 #include "HTTPIntegrationBase.h"
+#include "utils/IntegrationTestUtils.h"
 
 class VerifyC2Server : public HTTPIntegrationBase {
 public:
@@ -49,8 +50,10 @@ public:
   }
 
   void runAssertions() override {
-    assert(LogTestController::getInstance().contains("Import offset 0"));
-    assert(LogTestController::getInstance().contains("Outputting success and response"));
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_),
+        "Import offset 0",
+        "Outputting success and response"));
   }
 
   void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> pg) override {

--- a/extensions/http-curl/tests/ControllerServiceIntegrationTests.cpp
+++ b/extensions/http-curl/tests/ControllerServiceIntegrationTests.cpp
@@ -15,23 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- *
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 #undef NDEBUG
 #include <cassert>

--- a/extensions/http-curl/tests/HTTPIntegrationBase.h
+++ b/extensions/http-curl/tests/HTTPIntegrationBase.h
@@ -24,6 +24,7 @@
 #include "protocols/RESTSender.h"
 #include "ServerAwareHandler.h"
 #include "TestBase.h"
+#include "utils/IntegrationTestUtils.h"
 #include "TestServer.h"
 
 int log_message(const struct mg_connection *conn, const char *message) {
@@ -158,7 +159,8 @@ public:
   }
 
   void runAssertions() override {
-    assert(LogTestController::getInstance().contains("Starting to reload Flow Controller with flow control name MiNiFi Flow, version"));
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::seconds(10), "Starting to reload Flow Controller with flow control name MiNiFi Flow, version"));
   }
 };
 
@@ -179,8 +181,8 @@ class VerifyC2UpdateAgent : public VerifyC2Update {
   }
 
   void runAssertions() override {
-    assert(LogTestController::getInstance().contains("removing file"));
-    assert(LogTestController::getInstance().contains("May not have command processor"));
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::seconds(10), "removing file", "May not have command processor"));
   }
 };
 
@@ -197,8 +199,8 @@ public:
   }
 
   void runAssertions() override {
-    assert(LogTestController::getInstance().contains("Invalid configuration payload"));
-    assert(LogTestController::getInstance().contains("update failed"));
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::seconds(10), "Invalid configuration payload", "update failed."));
   }
 
   void cleanup() override {

--- a/extensions/http-curl/tests/HTTPIntegrationBase.h
+++ b/extensions/http-curl/tests/HTTPIntegrationBase.h
@@ -131,6 +131,9 @@ class VerifyC2Describe : public VerifyC2Base {
   }
 
   void runAssertions() override {
+    // This class is never used for running assertions, but we are forced to wait for DescribeManifestHandler to verifyJsonHasAgentManifest
+    // if we were to log something on finished verification, we could poll on finding it 
+    std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_));
   }
 };
 

--- a/extensions/http-curl/tests/HTTPSiteToSiteTests.cpp
+++ b/extensions/http-curl/tests/HTTPSiteToSiteTests.cpp
@@ -65,7 +65,10 @@ public:
 
   void cleanup() override {}
 
-  void runAssertions() override {}
+  void runAssertions() override {
+    // There is nothing to verify here, but we are expected to wait for all paralell events to execute 
+    std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_));
+  }
 
  protected:
   bool isSecure;

--- a/extensions/http-curl/tests/HttpPostIntegrationTest.cpp
+++ b/extensions/http-curl/tests/HttpPostIntegrationTest.cpp
@@ -28,6 +28,7 @@
 #include "core/ProcessGroup.h"
 #include "FlowController.h"
 #include "HTTPIntegrationBase.h"
+#include "utils/IntegrationTestUtils.h"
 
 class HttpTestHarness : public HTTPIntegrationBase {
 public:
@@ -65,9 +66,11 @@ public:
   }
 
   void runAssertions() override {
-    assert(LogTestController::getInstance().contains("curl performed"));
-    assert(LogTestController::getInstance().contains("Size:1024 Offset:0"));
-    assert(!LogTestController::getInstance().contains("Size:0 Offset:0"));
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_),
+      "curl performed",
+      "Size:1024 Offset:0"));
+    assert(false == verifyLogLinePresenceInPollTime(std::chrono::milliseconds(200), "Size:0 Offset:0"));
   }
 
  protected:

--- a/extensions/http-curl/tests/SiteToSiteRestTest.cpp
+++ b/extensions/http-curl/tests/SiteToSiteRestTest.cpp
@@ -30,6 +30,7 @@
 #include "core/ConfigurableComponent.h"
 #include "controllers/SSLContextService.h"
 #include "HTTPIntegrationBase.h"
+#include "utils/IntegrationTestUtils.h"
 
 class Responder : public ServerAwareHandler {
  public:
@@ -86,12 +87,13 @@ public:
   }
 
   void runAssertions() override {
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
     if (isSecure) {
-      assert(LogTestController::getInstance().contains("process group remote site2site port 10001, is secure 1"));
+      assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_), "process group remote site2site port 10001, is secure 1"));
     } else {
-      assert(LogTestController::getInstance().contains("process group remote site2site port 10001, is secure 0"));
+      assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_), "process group remote site2site port 10001, is secure 0"));
     }
-    assert(LogTestController::getInstance().contains("ProcessGroup::refreshRemoteSite2SiteInfo -- curl_easy_perform() failed "));
+    assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_), "ProcessGroup::refreshRemoteSite2SiteInfo -- curl_easy_perform() failed "));
   }
 
  protected:

--- a/extensions/http-curl/tests/ThreadPoolAdjust.cpp
+++ b/extensions/http-curl/tests/ThreadPoolAdjust.cpp
@@ -28,6 +28,7 @@
 #include "FlowController.h"
 #include "HTTPIntegrationBase.h"
 #include "processors/LogAttribute.h"
+#include "utils/IntegrationTestUtils.h"
 
 class HttpTestHarness : public IntegrationBase {
  public:
@@ -64,9 +65,11 @@ class HttpTestHarness : public IntegrationBase {
   }
 
   void runAssertions() override {
-    assert(LogTestController::getInstance().contains("curl performed"));
-    assert(LogTestController::getInstance().contains("Size:1024 Offset:0"));
-    assert(!LogTestController::getInstance().contains("Size:0 Offset:0"));
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_),
+      "curl performed",
+      "Size:1024 Offset:0"));
+    assert(false == verifyLogLinePresenceInPollTime(std::chrono::milliseconds(200), "Size:0 Offset:0"));
   }
 
  protected:

--- a/extensions/http-curl/tests/TimeoutHTTPSiteToSiteTests.cpp
+++ b/extensions/http-curl/tests/TimeoutHTTPSiteToSiteTests.cpp
@@ -66,7 +66,10 @@ public:
 
   void cleanup() override {}
 
-  void runAssertions() override {}
+  void runAssertions() override {
+    // There is nothing to verify here, but we are expected to wait for all paralell events to execute 
+    std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_));
+  }
 
 protected:
   bool isSecure;

--- a/extensions/http-curl/tests/VerifyInvokeHTTPTest.cpp
+++ b/extensions/http-curl/tests/VerifyInvokeHTTPTest.cpp
@@ -193,7 +193,7 @@ int main(int argc, char ** argv) {
   }
 
   {
-    TimeoutingHTTPHandler handler({std::chrono::milliseconds(2000)});
+    TimeoutingHTTPHandler handler({std::chrono::seconds(2)});
     VerifyRWTimeoutInvokeHTTP harness;
     run(harness, args.url, args.test_file, args.key_dir, &handler);
   }

--- a/extensions/http-curl/tests/VerifyInvokeHTTPTest.cpp
+++ b/extensions/http-curl/tests/VerifyInvokeHTTPTest.cpp
@@ -56,7 +56,7 @@ class VerifyInvokeHTTP : public HTTPIntegrationBase {
     std::shared_ptr<core::Repository> test_flow_repo = std::make_shared<TestFlowRepository>();
 
     configuration->set(minifi::Configure::nifi_flow_configuration_file, flow_yml_path);
-
+    configuration->set("c2.agent.heartbeat.period", "200");
     std::shared_ptr<core::ContentRepository> content_repo = std::make_shared<core::repository::VolatileContentRepository>();
     content_repo->initialize(configuration);
     std::shared_ptr<minifi::io::StreamFactory> stream_factory = minifi::io::StreamFactory::getInstance(configuration);

--- a/extensions/http-curl/tests/VerifyInvokeHTTPTest.cpp
+++ b/extensions/http-curl/tests/VerifyInvokeHTTPTest.cpp
@@ -26,9 +26,10 @@
 
 #include "CivetServer.h"
 #include "HTTPIntegrationBase.h"
+#include "utils/IntegrationTestUtils.h"
 
 class VerifyInvokeHTTP : public HTTPIntegrationBase {
-public:
+ public:
   VerifyInvokeHTTP()
       : HTTPIntegrationBase(6000) {
   }
@@ -79,7 +80,8 @@ public:
     setupFlow(flow_yml_path);
     startFlowController();
 
-    waitToVerifyProcessor();
+    runAssertions();
+
     shutdownBeforeFlowController();
     stopFlowController();
   }
@@ -92,47 +94,55 @@ public:
     flowController_->unload();
     flowController_->stopC2();
 
-    runAssertions();
     cleanup();
   }
 };
 
 class VerifyInvokeHTTPOKResponse : public VerifyInvokeHTTP {
-public:
+ public:
   void runAssertions() override {
-    assert(LogTestController::getInstance().contains("key:invokehttp.status.code value:201"));
-    assert(LogTestController::getInstance().contains("response code 201"));
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::seconds(6),
+        "key:invokehttp.status.code value:201",
+        "response code 201"));
   }
 };
 
 class VerifyCouldNotConnectInvokeHTTP : public VerifyInvokeHTTP {
-public:
+ public:
   void runAssertions() override {
-    assert(LogTestController::getInstance().contains("key:invoke_http value:failure"));
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::seconds(6), "key:invoke_http value:failure"));
   }
 };
 
 class VerifyNoRetryInvokeHTTP : public VerifyInvokeHTTP {
-public:
+ public:
   void runAssertions() override {
-    assert(LogTestController::getInstance().contains("key:invokehttp.status.message value:HTTP/1.1 404 Not Found"));
-    assert(LogTestController::getInstance().contains("isSuccess: 0, response code 404"));
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::seconds(6),
+        "key:invokehttp.status.message value:HTTP/1.1 404 Not Found",
+        "isSuccess: 0, response code 404"));
   }
 };
 
 class VerifyRetryInvokeHTTP : public VerifyInvokeHTTP {
-public:
+ public:
   void runAssertions() override {
-    assert(LogTestController::getInstance().contains("key:invokehttp.status.message value:HTTP/1.1 501 Not Implemented"));
-    assert(LogTestController::getInstance().contains("isSuccess: 0, response code 501"));
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::seconds(6),
+        "key:invokehttp.status.message value:HTTP/1.1 501 Not Implemented",
+        "isSuccess: 0, response code 501"));
   }
 };
 
 class VerifyRWTimeoutInvokeHTTP : public VerifyInvokeHTTP {
-public:
+ public:
   void runAssertions() override {
-    assert(LogTestController::getInstance().contains("key:invoke_http value:failure"));
-    assert(LogTestController::getInstance().contains("limit (1000ms) reached, terminating connection"));
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::seconds(6),
+        "key:invoke_http value:failure",
+        "limit (1000ms) reached, terminating connection"));
   }
 };
 
@@ -160,7 +170,7 @@ int main(int argc, char ** argv) {
     harness.setupFlow(args.test_file);
     harness.shutdownBeforeFlowController();
     harness.startFlowController();
-    harness.waitToVerifyProcessor();
+    harness.runAssertions();
     harness.stopFlowController();
   }
 
@@ -183,7 +193,7 @@ int main(int argc, char ** argv) {
   }
 
   {
-    TimeoutingHTTPHandler handler({std::chrono::seconds(4)});
+    TimeoutingHTTPHandler handler({std::chrono::milliseconds(2000)});
     VerifyRWTimeoutInvokeHTTP harness;
     run(harness, args.url, args.test_file, args.key_dir, &handler);
   }

--- a/extensions/librdkafka/tests/PublishKafkaOnScheduleTests.cpp
+++ b/extensions/librdkafka/tests/PublishKafkaOnScheduleTests.cpp
@@ -33,10 +33,7 @@ class PublishKafkaOnScheduleTests : public IntegrationBase {
         const std::string logs = LogTestController::getInstance().log_output.str();
         const auto result = utils::StringUtils::countOccurrences(logs, "value 1 is outside allowed range 1000..1000000000");
         const int occurrences = result.second;
-        if (occurrences <= 1) {  // Verify retry of onSchedule and onUnSchedule calls
-          return false;
-        }
-        return true;
+        return 1 < occurrences;
       }));
       flowController_->updatePropertyValue("kafka", minifi::processors::PublishKafka::MaxMessageSize.getName(), "1999");
       const std::vector<std::string> must_appear_byorder_msgs = {"notifyStop called",

--- a/extensions/standard-processors/tests/integration/SecureSocketGetTCPTest.cpp
+++ b/extensions/standard-processors/tests/integration/SecureSocketGetTCPTest.cpp
@@ -49,6 +49,7 @@
 #include "processors/LogAttribute.h"
 #include "io/tls/TLSSocket.h"
 #include "io/tls/TLSServerSocket.h"
+#include "utils/IntegrationTestUtils.h"
 
 class SecureSocketTest : public IntegrationBase {
  public:
@@ -76,9 +77,10 @@ class SecureSocketTest : public IntegrationBase {
   }
 
   void runAssertions() override {
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
     isRunning_ = false;
     server_socket_.reset();
-    assert(LogTestController::getInstance().contains("send succeed 20"));
+    assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_), "send succeed 20"));
   }
 
   void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> pg) override {

--- a/extensions/standard-processors/tests/integration/TailFileTest.cpp
+++ b/extensions/standard-processors/tests/integration/TailFileTest.cpp
@@ -41,6 +41,7 @@
 #include "processors/LogAttribute.h"
 #include "state/ProcessorController.h"
 #include "integration/IntegrationBase.h"
+#include "utils/IntegrationTestUtils.h"
 
 class TailFileTestHarness : public IntegrationBase {
  public:
@@ -69,9 +70,11 @@ class TailFileTestHarness : public IntegrationBase {
   }
 
   void runAssertions() override {
-    assert(LogTestController::getInstance().contains("5 flowfiles were received from TailFile input") == true);
-    assert(LogTestController::getInstance().contains("Looking for delimiter 0xA") == true);
-    assert(LogTestController::getInstance().contains("li\\ne5") == true);
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_),
+        "5 flowfiles were received from TailFile input",
+        "Looking for delimiter 0xA",
+        "li\\ne5"));
   }
 
  protected:

--- a/extensions/standard-processors/tests/unit/GetFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/GetFileTests.cpp
@@ -66,8 +66,6 @@ TEST_CASE("GetFile: MaxSize", "[getFileFifo]") {  // NOLINT
   in_file_stream << "The quick brown fox jumps over the lazy dog" << std::endl;
   in_file_stream.close();
 
-  std::this_thread::sleep_for(std::chrono::seconds(2));
-
   in_file_stream.open(in_file + "2");
   in_file_stream << "The quick brown fox jumps over the lazy dog who is 2 legit to quit" << std::endl;
   in_file_stream.close();

--- a/libminifi/include/utils/IntegrationTestUtils.h
+++ b/libminifi/include/utils/IntegrationTestUtils.h
@@ -51,12 +51,10 @@ bool verifyLogLinePresenceInPollTime(const std::chrono::duration<Rep, Period>& w
   std::initializer_list<int> {(pattern_list.push_back(patterns), 0)...};
   auto check = [&] {
     const std::string logs = LogTestController::getInstance().log_output.str();
-    for (const std::string& pattern : pattern_list) {
-        if (logs.find(pattern) == std::string::npos) {
-            return false;
-        }
+    if (std::all_of(pattern_list.cbegin(), pattern_list.cend(), [&logs] (const std::string& pattern) { return logs.find(pattern) != std::string::npos; })) {
+      return true;
     }
-    return true;
+    return false;
   };
   return verifyEventHappenedInPollTime(wait_duration, check);
 }

--- a/libminifi/include/utils/IntegrationTestUtils.h
+++ b/libminifi/include/utils/IntegrationTestUtils.h
@@ -44,6 +44,8 @@ bool verifyEventHappenedInPollTime(const std::chrono::duration<Rep, Period>& wai
 
 template <class Rep, class Period, typename ...String>
 bool verifyLogLinePresenceInPollTime(const std::chrono::duration<Rep, Period>& wait_duration, String... patterns) {
+  // This function contains an extra copy on the parameter pack unpacking
+  // However, since we gcc 4.9 does not support forwarding parameter packs we are pretty much forced to do this
   // This helper is to be removed once we upgrade to support gcc 4.9+ only
   std::vector<std::string> pattern_list;
   std::initializer_list<int> {(pattern_list.push_back(patterns), 0)...};

--- a/libminifi/include/utils/IntegrationTestUtils.h
+++ b/libminifi/include/utils/IntegrationTestUtils.h
@@ -49,10 +49,7 @@ bool verifyLogLinePresenceInPollTime(const std::chrono::duration<Rep, Period>& w
   std::vector<std::string> pattern_list{std::forward<String>(patterns)...};
   auto check = [&] {
     const std::string logs = LogTestController::getInstance().log_output.str();
-    if (std::all_of(pattern_list.cbegin(), pattern_list.cend(), [&logs] (const std::string& pattern) { return logs.find(pattern) != std::string::npos; })) {
-      return true;
-    }
-    return false;
+    return std::all_of(pattern_list.cbegin(), pattern_list.cend(), [&logs] (const std::string& pattern) { return logs.find(pattern) != std::string::npos; });
   };
   return verifyEventHappenedInPollTime(wait_duration, check);
 }

--- a/libminifi/include/utils/IntegrationTestUtils.h
+++ b/libminifi/include/utils/IntegrationTestUtils.h
@@ -1,0 +1,66 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <utility>
+#include <string>
+#include <vector>
+
+#include "../../../libminifi/test/TestBase.h"
+
+namespace org {
+namespace apache {
+namespace nifi {
+namespace minifi {
+namespace utils {
+
+template <class Rep, class Period, typename Fun>
+bool verifyEventHappenedInPollTime(const std::chrono::duration<Rep, Period>& wait_duration, Fun&& check) {
+  std::chrono::system_clock::time_point wait_end = std::chrono::system_clock::now() + wait_duration;
+  do {
+    if (std::forward<Fun>(check)()) {
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  } while (std::chrono::system_clock::now() < wait_end);
+  return false;
+}
+
+template <class Rep, class Period, typename ...String>
+bool verifyLogLinePresenceInPollTime(const std::chrono::duration<Rep, Period>& wait_duration, String... patterns) {
+  // This helper is to be removed once we upgrade to support gcc 4.9+ only
+  std::vector<std::string> pattern_list;
+  std::initializer_list<int> {(pattern_list.push_back(patterns), 0)...};
+  auto check = [&] {
+    const std::string logs = LogTestController::getInstance().log_output.str();
+    for (const std::string& pattern : pattern_list) {
+        if (logs.find(pattern) == std::string::npos) {
+            return false;
+        }
+    }
+    return true;
+  };
+  return verifyEventHappenedInPollTime(wait_duration, check);
+}
+
+}  // namespace utils
+}  // namespace minifi
+}  // namespace nifi
+}  // namespace apache
+}  // namespace org

--- a/libminifi/test/integration/IntegrationBase.h
+++ b/libminifi/test/integration/IntegrationBase.h
@@ -55,10 +55,6 @@ class IntegrationBase {
 
   virtual void runAssertions() = 0;
 
-  virtual void waitToVerifyProcessor() {
-    std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_));
-  }
-
  protected:
 
   virtual void configureC2() {
@@ -134,13 +130,13 @@ void IntegrationBase::run(std::string test_file_location) {
   flowController_->load();
   updateProperties(flowController_);
   flowController_->start();
-  waitToVerifyProcessor();
+
+  runAssertions();
 
   shutdownBeforeFlowController();
   flowController_->unload();
   flowController_->stopC2();
 
-  runAssertions();
   cleanup();
 }
 

--- a/libminifi/test/integration/OnScheduleErrorHandlingTests.cpp
+++ b/libminifi/test/integration/OnScheduleErrorHandlingTests.cpp
@@ -38,10 +38,7 @@ class KamikazeErrorHandlingTests : public IntegrationBase {
       const std::string logs = LogTestController::getInstance().log_output.str();
       const auto result = utils::StringUtils::countOccurrences(logs, minifi::processors::KamikazeProcessor::OnScheduleExceptionStr);
       const int occurrences = result.second;
-      if (occurrences <= 1) {  // Verify retry of onSchedule and onUnSchedule calls
-        return false;
-      }
-      return true;
+      return 1 < occurrences;
     }));
     flowController_->updatePropertyValue("kamikaze", minifi::processors::KamikazeProcessor::ThrowInOnSchedule.getName(), "false");
 

--- a/libminifi/test/integration/ProvenanceReportingTest.cpp
+++ b/libminifi/test/integration/ProvenanceReportingTest.cpp
@@ -38,12 +38,11 @@
 #include "../unit/ProvenanceTestHelper.h"
 #include "io/StreamFactory.h"
 #include "../TestBase.h"
-
-void waitToVerifyProcessor() {
-  std::this_thread::sleep_for(std::chrono::seconds(2));
-}
+#include "utils/IntegrationTestUtils.h"
 
 int main(int argc, char **argv) {
+  using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+
   std::string test_file_location;
   if (argc > 1) {
     test_file_location = argv[1];
@@ -80,11 +79,10 @@ int main(int argc, char **argv) {
 
   controller->load();
   controller->start();
-  waitToVerifyProcessor();
+
+  assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(std::chrono::seconds(2)), "Add processor SiteToSiteProvenanceReportingTask into process group MiNiFi Flow"));
 
   controller->waitUnload(60000);
-  std::string logs = LogTestController::getInstance().log_output.str();
-  assert(logs.find("Add processor SiteToSiteProvenanceReportingTask into process group MiNiFi Flow") != std::string::npos);
   LogTestController::getInstance().reset();
   rmdir("./content_repository");
   rmdir("/tmp/aljs39/");

--- a/libminifi/test/pcap-tests/PcapTest.cpp
+++ b/libminifi/test/pcap-tests/PcapTest.cpp
@@ -43,6 +43,7 @@
 #include "core/state/ProcessorController.h"
 #include "../integration/IntegrationBase.h"
 #include "CapturePacket.h"
+#include "utils/IntegrationTestUtils.h"
 
 class PcapTestHarness : public IntegrationBase {
  public:
@@ -66,10 +67,13 @@ class PcapTestHarness : public IntegrationBase {
   }
 
   void runAssertions() {
-    assert(LogTestController::getInstance().contains("Starting capture") == true);
-    assert(LogTestController::getInstance().contains("Stopping capture") == true);
-    assert(LogTestController::getInstance().contains("Stopped device capture. clearing queues") == true);
-    assert(LogTestController::getInstance().contains("Accepting ") == true && LogTestController::getInstance().contains("because it matches .*") );
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_),
+        "Starting capture",
+        "Stopping capture",
+        "Stopped device capture. clearing queues",
+        "Accepting ",
+        "because it matches .*"));
   }
 
   void updateProperties(std::shared_ptr<minifi::FlowController> fc) {

--- a/libminifi/test/sensors-tests/SensorTests.cpp
+++ b/libminifi/test/sensors-tests/SensorTests.cpp
@@ -42,6 +42,7 @@
 #include "core/ConfigurableComponent.h"
 #include "../integration/IntegrationBase.h"
 #include "GetEnvironmentalSensors.h"
+#include "utils/IntegrationTestUtils.h"
 
 class PcapTestHarness : public IntegrationBase {
  public:
@@ -64,7 +65,9 @@ class PcapTestHarness : public IntegrationBase {
   }
 
   void runAssertions() {
-    assert(LogTestController::getInstance().contains("Initializing EnvironmentalSensors") == true);
+    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    
+    assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_), "Initializing EnvironmentalSensors"));
   }
 
   void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> pg) {

--- a/libminifi/test/sensors-tests/SensorTests.cpp
+++ b/libminifi/test/sensors-tests/SensorTests.cpp
@@ -66,7 +66,6 @@ class PcapTestHarness : public IntegrationBase {
 
   void runAssertions() {
     using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
-    
     assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_), "Initializing EnvironmentalSensors"));
   }
 

--- a/libminifi/test/unit/BackTraceTests.cpp
+++ b/libminifi/test/unit/BackTraceTests.cpp
@@ -75,7 +75,7 @@ TEST_CASE("BT1", "[TPT1]") {
 std::atomic<int> counter;
 
 int counterFunction() {
-  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  std::this_thread::sleep_for(std::chrono::milliseconds(150));
   return ++counter;
 }
 
@@ -83,7 +83,7 @@ TEST_CASE("BT2", "[TPT2]") {
   counter = 0;
   utils::ThreadPool<int> pool(4);
   pool.start();
-  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  std::this_thread::sleep_for(std::chrono::milliseconds(150));
   for (int i = 0; i < 3; i++) {
     std::function<int()> f_ex = counterFunction;
     std::unique_ptr<utils::AfterExecute<int>> after_execute = std::unique_ptr<utils::AfterExecute<int>>(new WorkerNumberExecutions(5));

--- a/libminifi/test/unit/MinifiConcurrentQueueTests.cpp
+++ b/libminifi/test/unit/MinifiConcurrentQueueTests.cpp
@@ -75,7 +75,7 @@ namespace MinifiConcurrentQueueTestProducersConsumers {
 
   std::thread getSimpleTryDequeConsumerThread(utils::ConcurrentQueue<std::string>& queue, std::vector<std::string>& results) {
     return std::thread([&queue, &results] {
-      constexpr std::size_t max_read_attempts = 1000;
+      constexpr std::size_t max_read_attempts = 300;
       for (std::size_t attempt_num = 0; results.size() < 3 && attempt_num < max_read_attempts; ++attempt_num) {
         std::string s;
         if (queue.tryDequeue(s)) {
@@ -89,7 +89,7 @@ namespace MinifiConcurrentQueueTestProducersConsumers {
 
   std::thread getSimpleConsumeConsumerThread(utils::ConcurrentQueue<std::string>& queue, std::vector<std::string>& results) {
     return std::thread([&queue, &results] {
-      constexpr std::size_t max_read_attempts = 1000;
+      constexpr std::size_t max_read_attempts = 300;
       for (std::size_t attempt_num = 0; results.size() < 3 && attempt_num < max_read_attempts; ++attempt_num) {
         if (!queue.consume([&results] (const std::string& s) { results.push_back(s); })) {
           std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -146,7 +146,7 @@ namespace MinifiConcurrentQueueTestProducersConsumers {
 
   std::thread getDequeueWaitForConsumerThread(utils::ConditionConcurrentQueue<std::string>& queue, std::vector<std::string>& results) {
     return std::thread([&queue, &results] {
-      constexpr std::size_t max_read_attempts = 1000;
+      constexpr std::size_t max_read_attempts = 300;
       for (std::size_t attempt_num = 0; results.size() < 3 && attempt_num < max_read_attempts; ++attempt_num) {
         std::string s;
         if (queue.dequeueWaitFor(s, std::chrono::milliseconds(1))) {
@@ -158,7 +158,7 @@ namespace MinifiConcurrentQueueTestProducersConsumers {
 
   std::thread getDequeueWaitUntilConsumerThread(utils::ConditionConcurrentQueue<std::string>& queue, std::vector<std::string>& results) {
     return std::thread([&queue, &results] {
-      constexpr std::size_t max_read_attempts = 1000;
+      constexpr std::size_t max_read_attempts = 300;
       for (std::size_t attempt_num = 0; results.size() < 3 && attempt_num < max_read_attempts; ++attempt_num) {
         std::string s;
         const std::chrono::system_clock::time_point timeout_point = std::chrono::system_clock::now() + std::chrono::milliseconds(1);
@@ -171,7 +171,7 @@ namespace MinifiConcurrentQueueTestProducersConsumers {
 
   std::thread getConsumeWaitForConsumerThread(utils::ConditionConcurrentQueue<std::string>& queue, std::vector<std::string>& results) {
     return std::thread([&queue, &results]() {
-      constexpr std::size_t max_read_attempts = 1000;
+      constexpr std::size_t max_read_attempts = 300;
       for (std::size_t attempt_num = 0; results.size() < 3 && attempt_num < max_read_attempts; ++attempt_num) {
         queue.consumeWaitFor([&results] (const std::string& s) { results.push_back(s); }, std::chrono::milliseconds(1));
       }
@@ -366,7 +366,7 @@ TEST_CASE("TestConcurrentQueues::highLoad", "[TestConcurrentQueuesHighLoad]") {
   std::mt19937 rng(dev());
   std::uniform_int_distribution<std::mt19937::result_type> dist(1, std::numeric_limits<int>::max());
 
-  std::vector<int> source(1000000);
+  std::vector<int> source(50000);
   std::vector<int> target;
 
   generate(source.begin(), source.end(), [&rng, &dist](){ return dist(rng); });
@@ -380,7 +380,7 @@ TEST_CASE("TestConcurrentQueues::highLoad", "[TestConcurrentQueuesHighLoad]") {
 
   std::thread relay([&queue, &cqueue]() {
     size_t cnt = 0;
-    while (cnt < 1000000) {
+    while (cnt < 50000) {
       int i;
       if (queue.tryDequeue(i)) {
         cnt++;


### PR DESCRIPTION
**Decreases the avg. test execution time by 57% (from 326 seconds to 139 seconds).**

Measurements on test times of master (on MacBook Pro 16-inch, 2019):
```
➜ for repetition in {1..5}; do; time ninja test 2>&1 >> test_logs.txt; done;
ninja test 2>&1 >> test_logs.txt  46.05s user 19.32s system 18% cpu 5:58.81 total
ninja test 2>&1 >> test_logs.txt  45.81s user 13.33s system 18% cpu 5:16.95 total
ninja test 2>&1 >> test_logs.txt  46.10s user 13.22s system 18% cpu 5:18.84 total
ninja test 2>&1 >> test_logs.txt  46.08s user 13.39s system 18% cpu 5:17.21 total
ninja test 2>&1 >> test_logs.txt  46.16s user 13.51s system 18% cpu 5:16.61 total
➜ grep "Total Test time" test_logs.txt
Total Test time (real) = 358.74 sec
Total Test time (real) = 316.88 sec
Total Test time (real) = 318.78 sec
Total Test time (real) = 317.14 sec
Total Test time (real) = 316.57 sec
```
On the source branch of this PR:
```
➜ for repetition in {1..5}; do; time ninja test 2>&1 >> test_logs.txt; done;
ninja test 2>&1 >> test_logs.txt  24.04s user 9.62s system 24% cpu 2:19.84 total
ninja test 2>&1 >> test_logs.txt  23.98s user 9.17s system 24% cpu 2:17.74 total
ninja test 2>&1 >> test_logs.txt  23.89s user 9.44s system 24% cpu 2:18.17 total
ninja test 2>&1 >> test_logs.txt  23.82s user 9.53s system 24% cpu 2:18.72 total
ninja test 2>&1 >> test_logs.txt  24.04s user 9.56s system 23% cpu 2:20.81 total
➜ grep "Total Test time" test_logs.txt
Total Test time (real) = 139.77 sec
Total Test time (real) = 137.68 sec
Total Test time (real) = 138.10 sec
Total Test time (real) = 138.66 sec
Total Test time (real) = 140.75 sec
```