### PR TITLE
Update WindowsEventLog.cpp - NO JIRA - Hour math bug 

### DIFF
--- a/extensions/windows-event-log/wel/WindowsEventLog.cpp
+++ b/extensions/windows-event-log/wel/WindowsEventLog.cpp
@@ -78,7 +78,7 @@ void WindowsEventLogMetadataImpl::renderMetadata() {
   auto hour = st.wHour;
   if (hour >= 12 && hour < 24)
     period = "PM";
-  if (hour >= 12)
+  if (hour > 12)
     hour -= 12;
   datestr << st.wMonth << "/" << st.wDay << "/" << st.wYear << " " << std::setfill('0') << std::setw(2) << hour << ":" << std::setfill('0') << std::setw(2) << st.wMinute << ":" << std::setfill('0') << std::setw(2) << st.wSecond << " " << period;
   event_timestamp_str_ = datestr.str();

--- a/extensions/windows-event-log/wel/WindowsEventLog.cpp
+++ b/extensions/windows-event-log/wel/WindowsEventLog.cpp
@@ -80,6 +80,8 @@ void WindowsEventLogMetadataImpl::renderMetadata() {
     period = "PM";
   if (hour > 12)
     hour -= 12;
+  if (hour = 0)
+    hour = 12;
   datestr << st.wMonth << "/" << st.wDay << "/" << st.wYear << " " << std::setfill('0') << std::setw(2) << hour << ":" << std::setfill('0') << std::setw(2) << st.wMinute << ":" << std::setfill('0') << std::setw(2) << st.wSecond << " " << period;
   event_timestamp_str_ = datestr.str();
   auto level = static_cast<PEVT_VARIANT>(rendered_values.get())[EvtSystemLevel];

--- a/extensions/windows-event-log/wel/WindowsEventLog.cpp
+++ b/extensions/windows-event-log/wel/WindowsEventLog.cpp
@@ -80,7 +80,7 @@ void WindowsEventLogMetadataImpl::renderMetadata() {
     period = "PM";
   if (hour > 12)
     hour -= 12;
-  if (hour = 0)
+  if (hour == 0)
     hour = 12;
   datestr << st.wMonth << "/" << st.wDay << "/" << st.wYear << " " << std::setfill('0') << std::setw(2) << hour << ":" << std::setfill('0') << std::setw(2) << st.wMinute << ":" << std::setfill('0') << std::setw(2) << st.wSecond << " " << period;
   event_timestamp_str_ = datestr.str();


### PR DESCRIPTION
Line 81 is incorrect, results in an hour containing "00:00:00 PM"

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
