### PR TITLE
MINIFICPP-1288 - Remove FlowController::reload() as it is both flawed and unused

### DIFF
--- a/libminifi/include/FlowController.h
+++ b/libminifi/include/FlowController.h
@@ -134,8 +134,6 @@ class FlowController : public core::controller::ControllerServiceProvider, publi
   virtual void waitUnload(uint64_t timeToWaitMs);
   // Unload the current flow xml, clean the root process group and all its children
   virtual void unload();
-  // Load new xml
-  virtual void reload(std::string yamlFile);
   // update property value
   void updatePropertyValue(std::string processorName, std::string propertyName, std::string propertyValue) {
     if (root_ != nullptr)

--- a/libminifi/src/FlowController.cpp
+++ b/libminifi/src/FlowController.cpp
@@ -382,25 +382,6 @@ void FlowController::load(const std::shared_ptr<core::ProcessGroup> &root, bool 
   }
 }
 
-void FlowController::reload(std::string yamlFile) {
-  std::lock_guard<std::recursive_mutex> flow_lock(mutex_);
-  logger_->log_info("Starting to reload Flow Controller with yaml %s", yamlFile);
-  stop(true);
-  unload();
-  std::string oldYamlFile = this->configuration_filename_;
-  this->configuration_filename_ = yamlFile;
-  load();
-  start();
-  if (this->root_ != nullptr) {
-    this->configuration_filename_ = oldYamlFile;
-    logger_->log_info("Rollback Flow Controller to YAML %s", oldYamlFile);
-    stop(true);
-    unload();
-    load();
-    start();
-  }
-}
-
 void FlowController::loadFlowRepo() {
   if (this->flow_file_repo_ != nullptr) {
     logger_->log_debug("Getting connection map");

--- a/libminifi/test/unit/ProvenanceTestHelper.h
+++ b/libminifi/test/unit/ProvenanceTestHelper.h
@@ -270,10 +270,6 @@ class TestFlowController : public minifi::FlowController {
     stop(true);
   }
 
-  void reload(std::string file) override {
-
-  }
-
   bool isRunning() override {
     return true;
   }


### PR DESCRIPTION
Move FlowController::reload() where it belongs. 🚮 
