### PR TITLE
MINIFICPP-1288 - Remove unused stop() args, clean whitespaces and stop method in FlowController

### DIFF
--- a/controller/Controller.h
+++ b/controller/Controller.h
@@ -331,7 +331,7 @@ void printManifest(const std::shared_ptr<minifi::Configure> &configuration) {
   controller->load();
   controller->start();
   std::this_thread::sleep_for(std::chrono::milliseconds(10000));
-  controller->stop(true);
+  controller->stop();
 }
 
 #endif /* CONTROLLER_CONTROLLER_H_ */

--- a/libminifi/include/FlowController.h
+++ b/libminifi/include/FlowController.h
@@ -117,7 +117,7 @@ class FlowController : public core::controller::ControllerServiceProvider, publi
     return -1;
   }
   // Unload the current flow YAML, clean the root process group and all its children
-  int16_t stop(bool force, uint64_t timeToWait = 0) override;
+  int16_t stop() override;
   int16_t applyUpdate(const std::string &source, const std::string &configuration) override;
   int16_t drainRepositories() override {
     return -1;

--- a/libminifi/include/FlowController.h
+++ b/libminifi/include/FlowController.h
@@ -327,6 +327,7 @@ class FlowController : public core::controller::ControllerServiceProvider, publi
 
   void loadC2ResponseConfiguration(const std::string &prefix);
 
+
   std::shared_ptr<state::response::ResponseNode> loadC2ResponseConfiguration(const std::string &prefix, std::shared_ptr<state::response::ResponseNode>);
 
   // function to load the flow file repo.
@@ -338,6 +339,8 @@ class FlowController : public core::controller::ControllerServiceProvider, publi
    * Initializes flow controller paths.
    */
   virtual void initializePaths(const std::string &adjustedFilename);
+
+  utils::optional<std::chrono::milliseconds> loadShutdownTimeoutFromConfiguration();
 
   // flow controller mutex
   std::recursive_mutex mutex_;

--- a/libminifi/include/FlowController.h
+++ b/libminifi/include/FlowController.h
@@ -319,20 +319,15 @@ class FlowController : public core::controller::ControllerServiceProvider, publi
   std::vector<BackTrace> getTraces() override;
 
   void initializeC2();
-
   void stopC2();
 
  protected:
   void loadC2ResponseConfiguration();
-
   void loadC2ResponseConfiguration(const std::string &prefix);
-
-
   std::shared_ptr<state::response::ResponseNode> loadC2ResponseConfiguration(const std::string &prefix, std::shared_ptr<state::response::ResponseNode>);
 
   // function to load the flow file repo.
   void loadFlowRepo();
-
   void initializeExternalComponents();
 
   /**
@@ -345,10 +340,6 @@ class FlowController : public core::controller::ControllerServiceProvider, publi
   // flow controller mutex
   std::recursive_mutex mutex_;
 
-  // Configuration File Name
-  std::string configuration_file_name_;
-  // NiFi property File Name
-  std::string properties_file_name_;
   // Root Process Group
   std::shared_ptr<core::ProcessGroup> root_;
   // Whether it is running
@@ -357,7 +348,6 @@ class FlowController : public core::controller::ControllerServiceProvider, publi
 
   // conifiguration filename
   std::string configuration_filename_;
-
   std::atomic<bool> c2_initialized_;
   std::atomic<bool> flow_update_;
   std::atomic<bool> c2_enabled_;
@@ -365,61 +355,41 @@ class FlowController : public core::controller::ControllerServiceProvider, publi
   std::atomic<bool> initialized_;
   // Provenance Repo
   std::shared_ptr<core::Repository> provenance_repo_;
-
   // FlowFile Repo
   std::shared_ptr<core::Repository> flow_file_repo_;
-
   std::shared_ptr<core::ContentRepository> content_repo_;
-
   // Thread pool for schedulers
   utils::ThreadPool<utils::TaskRescheduleInfo> thread_pool_;
-  // Flow Engines
   // Flow Timer Scheduler
   std::shared_ptr<TimerDrivenSchedulingAgent> timer_scheduler_;
   // Flow Event Scheduler
   std::shared_ptr<EventDrivenSchedulingAgent> event_scheduler_;
   // Cron Schedule
   std::shared_ptr<CronDrivenSchedulingAgent> cron_scheduler_;
-  // Controller Service
-  // Config
-  // Site to Site Server Listener
-  // Heart Beat
   // FlowControl Protocol
   std::unique_ptr<FlowControlProtocol> protocol_;
-
   std::shared_ptr<Configure> configuration_;
-
   std::shared_ptr<core::controller::ControllerServiceMap> controller_service_map_;
-
   std::shared_ptr<core::controller::ControllerServiceProvider> controller_service_provider_;
   // flow configuration object.
   std::unique_ptr<core::FlowConfiguration> flow_configuration_;
-
   // metrics information
-
   std::chrono::steady_clock::time_point start_time_;
-
   mutable std::mutex metrics_mutex_;
   // root_nodes cache
   std::map<std::string, std::shared_ptr<state::response::ResponseNode>> root_response_nodes_;
-
   // metrics cache
   std::map<std::string, std::shared_ptr<state::response::ResponseNode>> device_information_;
-
   // metrics cache
   std::map<std::string, std::shared_ptr<state::response::ResponseNode>> component_metrics_;
-
   std::map<uint8_t, std::vector<std::shared_ptr<state::response::ResponseNode>>> component_metrics_by_id_;
-
   // metrics last run
   std::chrono::steady_clock::time_point last_metrics_capture_;
 
  private:
   std::chrono::milliseconds shutdown_check_interval_{1000};
-
   std::shared_ptr<logging::Logger> logger_;
   std::string serial_number_;
-
   std::unique_ptr<state::UpdateController> c2_agent_;
 };
 

--- a/libminifi/include/core/state/ProcessorController.h
+++ b/libminifi/include/core/state/ProcessorController.h
@@ -60,7 +60,7 @@ class ProcessorController : public StateController {
   /**
    * Stop the client
    */
-  virtual int16_t stop(bool force, uint64_t timeToWait = 0);
+  virtual int16_t stop();
 
   virtual bool isRunning();
 

--- a/libminifi/include/core/state/UpdateController.h
+++ b/libminifi/include/core/state/UpdateController.h
@@ -162,7 +162,7 @@ class StateController {
   /**
    * Stop the client
    */
-  virtual int16_t stop(bool force, uint64_t timeToWait = 0) = 0;
+  virtual int16_t stop() = 0;
 
   virtual bool isRunning() = 0;
 

--- a/libminifi/src/FlowControlProtocol.cpp
+++ b/libminifi/src/FlowControlProtocol.cpp
@@ -361,7 +361,7 @@ int FlowControlProtocol::sendReportReq() {
     return 0;
   } else if (hdr.status == RESP_STOP_FLOW_CONTROLLER && hdr.seqNumber == this->_seqNumber) {
     logger_->log_trace("Flow Control Protocol stop flow controller");
-    this->_controller->stop(true);
+    this->_controller->stop();
     this->_seqNumber++;
     close(_socket);
     _socket = 0;

--- a/libminifi/src/c2/C2Agent.cpp
+++ b/libminifi/src/c2/C2Agent.cpp
@@ -449,7 +449,7 @@ void C2Agent::handle_c2_server_response(const C2ContentResponse &resp) {
             logger_->log_debug("Clearing state for component %s", component->getComponentName());
             auto state_manager = state_manager_provider->getCoreComponentStateManager(component->getComponentUUID());
             if (state_manager != nullptr) {
-              component->stop(true);
+              component->stop();
               state_manager->clear();
               state_manager->persist();
               component->start();
@@ -476,7 +476,7 @@ void C2Agent::handle_c2_server_response(const C2ContentResponse &resp) {
       handle_describe(resp);
       break;
     case Operation::RESTART: {
-      update_sink_->stop(true);
+      update_sink_->stop();
       C2Payload response(Operation::ACKNOWLEDGE, resp.ident, false, true);
       protocol_.load()->consumePayload(std::move(response));
       restart_agent();
@@ -493,7 +493,7 @@ void C2Agent::handle_c2_server_response(const C2ContentResponse &resp) {
       for (auto &component : components) {
         logger_->log_debug("Stopping component %s", component->getComponentName());
         if (resp.op == Operation::STOP)
-          component->stop(true);
+          component->stop();
         else
           component->start();
       }

--- a/libminifi/src/c2/ControllerSocketProtocol.cpp
+++ b/libminifi/src/c2/ControllerSocketProtocol.cpp
@@ -103,7 +103,7 @@ void ControllerSocketProtocol::initialize(const std::shared_ptr<core::controller
           int size = stream->readUTF(componentStr);
           if ( size != -1 ) {
             auto components = update_sink_->getComponents(componentStr);
-            for (auto component : components) {
+            for (const auto& component : components) {
               component->start();
             }
           } else {
@@ -117,8 +117,8 @@ void ControllerSocketProtocol::initialize(const std::shared_ptr<core::controller
           int size = stream->readUTF(componentStr);
           if ( size != -1 ) {
             auto components = update_sink_->getComponents(componentStr);
-            for (auto component : components) {
-              component->stop(true, 1000);
+            for (const auto& component : components) {
+              component->stop();
             }
           } else {
             logger_->log_debug("Connection broke");

--- a/libminifi/src/core/state/ProcessorController.cpp
+++ b/libminifi/src/core/state/ProcessorController.cpp
@@ -42,7 +42,7 @@ int16_t ProcessorController::start() {
 /**
  * Stop the client
  */
-int16_t ProcessorController::stop(bool force, uint64_t timeToWait) {
+int16_t ProcessorController::stop() {
   scheduler_->unschedule(processor_);
   return 0;
 }

--- a/libminifi/test/flow-tests/FlowControllerTests.cpp
+++ b/libminifi/test/flow-tests/FlowControllerTests.cpp
@@ -105,7 +105,7 @@ TEST_CASE("Flow shutdown drains connections", "[TestFlow1]") {
     REQUIRE(it.second->getQueueSize() > 10);
   }
 
-  controller->stop(true);
+  controller->stop();
 
   REQUIRE(sinkProc->trigger_count == 0);
 
@@ -142,7 +142,7 @@ TEST_CASE("Flow shutdown waits for a while", "[TestFlow2]") {
   REQUIRE(sourceProc->trigger_count.load() == 1);
 
   execSinkPromise.set_value();
-  controller->stop(true);
+  controller->stop();
 
   REQUIRE(sourceProc->trigger_count.load() == 1);
   REQUIRE(sinkProc->trigger_count.load() == 3);
@@ -182,7 +182,7 @@ TEST_CASE("Flow stopped after grace period", "[TestFlow3]") {
   REQUIRE(sourceProc->trigger_count.load() == 1);
 
   execSinkPromise.set_value();
-  controller->stop(true);
+  controller->stop();
 
   REQUIRE(sourceProc->trigger_count.load() == 1);
   REQUIRE(sinkProc->trigger_count.load() == 1);
@@ -225,7 +225,7 @@ TEST_CASE("Extend the waiting period during shutdown", "[TestFlow4]") {
 
   std::thread shutdownThread([&]{
     execSinkPromise.set_value();
-    controller->stop(true);
+    controller->stop();
   });
 
   while (controller->isRunning()) {

--- a/libminifi/test/flow-tests/TestControllerWithFlow.h
+++ b/libminifi/test/flow-tests/TestControllerWithFlow.h
@@ -56,7 +56,7 @@ class TestControllerWithFlow: public TestController{
   }
 
   ~TestControllerWithFlow() {
-    controller_->stop(true);
+    controller_->stop();
     controller_->unload();
     LogTestController::getInstance().reset();
   }

--- a/libminifi/test/unit/ControllerTests.cpp
+++ b/libminifi/test/unit/ControllerTests.cpp
@@ -52,7 +52,7 @@ class TestStateController : public minifi::state::StateController {
   /**
    * Stop the client
    */
-  virtual int16_t stop(bool force, uint64_t timeToWait = 0) {
+  virtual int16_t stop() {
     is_running = false;
     return 0;
   }
@@ -105,7 +105,7 @@ class TestUpdateSink : public minifi::state::StateMonitor {
   /**
    * Stop the client
    */
-  virtual int16_t stop(bool force, uint64_t timeToWait = 0) {
+  virtual int16_t stop() {
     is_running = false;
     return 0;
   }

--- a/libminifi/test/unit/ProvenanceTestHelper.h
+++ b/libminifi/test/unit/ProvenanceTestHelper.h
@@ -254,12 +254,12 @@ class TestFlowController : public minifi::FlowController {
     return 0;
   }
 
-  int16_t stop(bool force, uint64_t timeToWait = 0) override {
+  int16_t stop() override {
     running_.store(false);
     return 0;
   }
   void waitUnload(const uint64_t timeToWaitMs) override {
-    stop(true);
+    stop();
   }
 
   int16_t pause() override {
@@ -267,7 +267,7 @@ class TestFlowController : public minifi::FlowController {
   }
 
   void unload() override {
-    stop(true);
+    stop();
   }
 
   bool isRunning() override {


### PR DESCRIPTION
The only change in logic in this PR should be that FlowControlProtocol now loses its default one second timeout. However, this method of communicating with minifi is not supported either way, so the change is fine.

This is part of several cleanup PRs for FlowController, before the implementation of configuration validation.