### PR TITLE
MINIFICPP-1314 Fix an intermittent test failure in ConsumeWindowsEventLogTests

### DIFF
--- a/extensions/windows-event-log/tests/ConsumeWindowsEventLogTests.cpp
+++ b/extensions/windows-event-log/tests/ConsumeWindowsEventLogTests.cpp
@@ -33,6 +33,7 @@ core::Relationship Success{"success", "Everything is fine"};
 const std::string APPLICATION_CHANNEL = "Application";
 
 constexpr DWORD CWEL_TESTS_OPCODE = 14985;  // random opcode hopefully won't clash with something important
+const std::string QUERY = "Event/System/EventID=" + std::to_string(CWEL_TESTS_OPCODE);
 
 void reportEvent(const std::string& channel, const char* message, WORD log_level = EVENTLOG_INFORMATION_TYPE) {
   auto event_source = RegisterEventSourceA(nullptr, channel.c_str());
@@ -118,6 +119,7 @@ TEST_CASE("ConsumeWindowsEventLog can consume new events", "[onTrigger]") {
 
   auto cwel_processor = test_plan->addProcessor("ConsumeWindowsEventLog", "cwel");
   test_plan->setProperty(cwel_processor, ConsumeWindowsEventLog::Channel.getName(), APPLICATION_CHANNEL);
+  test_plan->setProperty(cwel_processor, ConsumeWindowsEventLog::Query.getName(), QUERY);
 
   auto logger_processor = test_plan->addProcessor("LogAttribute", "logger", Success, true);
   test_plan->setProperty(logger_processor, LogAttribute::FlowFilesToLog.getName(), "0");
@@ -162,6 +164,7 @@ TEST_CASE("ConsumeWindowsEventLog bookmarking works", "[onTrigger]") {
 
   auto cwel_processor = test_plan->addProcessor("ConsumeWindowsEventLog", "cwel");
   test_plan->setProperty(cwel_processor, ConsumeWindowsEventLog::Channel.getName(), APPLICATION_CHANNEL);
+  test_plan->setProperty(cwel_processor, ConsumeWindowsEventLog::Query.getName(), QUERY);
 
   auto logger_processor = test_plan->addProcessor("LogAttribute", "logger", Success, true);
   test_plan->setProperty(logger_processor, LogAttribute::FlowFilesToLog.getName(), "0");
@@ -208,6 +211,7 @@ TEST_CASE("ConsumeWindowsEventLog extracts some attributes by default", "[onTrig
 
   auto cwel_processor = test_plan->addProcessor("ConsumeWindowsEventLog", "cwel");
   test_plan->setProperty(cwel_processor, ConsumeWindowsEventLog::Channel.getName(), APPLICATION_CHANNEL);
+  test_plan->setProperty(cwel_processor, ConsumeWindowsEventLog::Query.getName(), QUERY);
 
   auto logger_processor = test_plan->addProcessor("LogAttribute", "logger", Success, true);
   test_plan->setProperty(logger_processor, LogAttribute::FlowFilesToLog.getName(), "0");
@@ -256,6 +260,7 @@ void outputFormatSetterTestHelper(const std::string &output_format, int expected
 
   auto cwel_processor = test_plan->addProcessor("ConsumeWindowsEventLog", "cwel");
   test_plan->setProperty(cwel_processor, ConsumeWindowsEventLog::Channel.getName(), APPLICATION_CHANNEL);
+  test_plan->setProperty(cwel_processor, ConsumeWindowsEventLog::Query.getName(), QUERY);
   test_plan->setProperty(cwel_processor, ConsumeWindowsEventLog::OutputFormat.getName(), output_format);
 
   auto logger_processor = test_plan->addProcessor("LogAttribute", "logger", Success, true);
@@ -303,6 +308,7 @@ TEST_CASE("ConsumeWindowsEventLog prints events in XML correctly", "[onTrigger]"
 
   auto cwel_processor = test_plan->addProcessor("ConsumeWindowsEventLog", "cwel");
   test_plan->setProperty(cwel_processor, ConsumeWindowsEventLog::Channel.getName(), APPLICATION_CHANNEL);
+  test_plan->setProperty(cwel_processor, ConsumeWindowsEventLog::Query.getName(), QUERY);
   test_plan->setProperty(cwel_processor, ConsumeWindowsEventLog::OutputFormat.getName(), "XML");
 
   auto logger_processor = test_plan->addProcessor("LogAttribute", "logger", Success, true);
@@ -344,6 +350,7 @@ void batchCommitSizeTestHelper(int batch_commit_size, int expected_num_commits) 
 
   auto cwel_processor = test_plan->addProcessor("ConsumeWindowsEventLog", "cwel");
   test_plan->setProperty(cwel_processor, ConsumeWindowsEventLog::Channel.getName(), APPLICATION_CHANNEL);
+  test_plan->setProperty(cwel_processor, ConsumeWindowsEventLog::Query.getName(), QUERY);
   test_plan->setProperty(cwel_processor, ConsumeWindowsEventLog::OutputFormat.getName(), "XML");
   test_plan->setProperty(cwel_processor, ConsumeWindowsEventLog::BatchCommitSize.getName(), std::to_string(batch_commit_size));
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-1314

Filter queries by opcode in ConsumeWindowsEventLogTests to make sure it only reads the events published by itself, and events published by BookmarkTests or other applications do not interfere with it.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
