### PR TITLE
MINIFICPP-1325 - Separate process group processor lookups for IDs and names, allow constructing ID-s from strings

### DIFF
--- a/extensions/coap/tests/CoapC2VerifyHeartbeat.cpp
+++ b/extensions/coap/tests/CoapC2VerifyHeartbeat.cpp
@@ -92,7 +92,7 @@ class VerifyCoAPServer : public CoapIntegrationBase {
   }
 
   void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> pg) {
-    std::shared_ptr<core::Processor> proc = pg->findProcessor("invoke");
+    std::shared_ptr<core::Processor> proc = pg->findProcessorByName("invoke");
     assert(proc != nullptr);
 
     std::shared_ptr<minifi::processors::InvokeHTTP> inv = std::dynamic_pointer_cast<minifi::processors::InvokeHTTP>(proc);

--- a/extensions/coap/tests/CoapIntegrationBase.h
+++ b/extensions/coap/tests/CoapIntegrationBase.h
@@ -61,12 +61,9 @@ class CoapIntegrationBase : public IntegrationBase {
 
     core::YamlConfiguration yaml_config(test_repo, test_repo, content_repo, stream_factory, configuration, test_file_location);
 
-    std::unique_ptr<core::ProcessGroup> ptr = yaml_config.getRoot(test_file_location);
-    std::shared_ptr<core::ProcessGroup> pg = std::shared_ptr<core::ProcessGroup>(ptr.get());
+    std::shared_ptr<core::ProcessGroup> pg{ yaml_config.getRoot(test_file_location).release() };
 
     queryRootProcessGroup(pg);
-
-    ptr.release();
 
     std::shared_ptr<TestRepository> repo = std::static_pointer_cast<TestRepository>(test_repo);
 

--- a/extensions/http-curl/tests/C2NullConfiguration.cpp
+++ b/extensions/http-curl/tests/C2NullConfiguration.cpp
@@ -65,7 +65,7 @@ public:
   }
 
   void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> pg) override {
-    std::shared_ptr<core::Processor> proc = pg->findProcessor("invoke");
+    std::shared_ptr<core::Processor> proc = pg->findProcessorByName("invoke");
     assert(proc != nullptr);
 
     std::shared_ptr<minifi::processors::InvokeHTTP> inv = std::dynamic_pointer_cast<minifi::processors::InvokeHTTP>(proc);

--- a/extensions/http-curl/tests/C2VerifyServeResults.cpp
+++ b/extensions/http-curl/tests/C2VerifyServeResults.cpp
@@ -57,7 +57,7 @@ public:
   }
 
   void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> pg) override {
-    std::shared_ptr<core::Processor> proc = pg->findProcessor("invoke");
+    std::shared_ptr<core::Processor> proc = pg->findProcessorByName("invoke");
     assert(proc != nullptr);
 
     std::shared_ptr<minifi::processors::InvokeHTTP> inv = std::dynamic_pointer_cast<minifi::processors::InvokeHTTP>(proc);

--- a/extensions/http-curl/tests/HttpGetIntegrationTest.cpp
+++ b/extensions/http-curl/tests/HttpGetIntegrationTest.cpp
@@ -99,7 +99,7 @@ int main(int argc, char **argv) {
 
   core::YamlConfiguration yaml_config(test_repo, test_repo, content_repo, stream_factory, configuration, args.test_file);
 
-  std::shared_ptr<core::Processor> proc = yaml_config.getRoot(args.test_file)->findProcessor("invoke");
+  std::shared_ptr<core::Processor> proc = yaml_config.getRoot(args.test_file)->findProcessorByName("invoke");
   assert(proc != nullptr);
 
   const auto inv = std::dynamic_pointer_cast<minifi::processors::InvokeHTTP>(proc);

--- a/extensions/standard-processors/tests/integration/SecureSocketGetTCPTest.cpp
+++ b/extensions/standard-processors/tests/integration/SecureSocketGetTCPTest.cpp
@@ -84,7 +84,7 @@ class SecureSocketTest : public IntegrationBase {
   }
 
   void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> pg) override {
-    std::shared_ptr<core::Processor> proc = pg->findProcessor("invoke");
+    std::shared_ptr<core::Processor> proc = pg->findProcessorByName("invoke");
     assert(proc != nullptr);
 
     std::shared_ptr<minifi::processors::GetTCP> inv = std::dynamic_pointer_cast<minifi::processors::GetTCP>(proc);

--- a/extensions/standard-processors/tests/unit/YamlConfigurationTests.cpp
+++ b/extensions/standard-processors/tests/unit/YamlConfigurationTests.cpp
@@ -139,19 +139,19 @@ TEST_CASE("Test YAML Config Processing", "[YamlConfiguration]") {
   std::unique_ptr<core::ProcessGroup> rootFlowConfig = yamlConfig.getYamlRoot(configYamlStream);
 
   REQUIRE(rootFlowConfig);
-  REQUIRE(rootFlowConfig->findProcessor("TailFile"));
+  REQUIRE(rootFlowConfig->findProcessorByName("TailFile"));
   utils::Identifier uuid;
-  rootFlowConfig->findProcessor("TailFile")->getUUID(uuid);
+  rootFlowConfig->findProcessorByName("TailFile")->getUUID(uuid);
   REQUIRE(uuid != nullptr);
-  REQUIRE(!rootFlowConfig->findProcessor("TailFile")->getUUIDStr().empty());
-  REQUIRE(1 == rootFlowConfig->findProcessor("TailFile")->getMaxConcurrentTasks());
+  REQUIRE(!rootFlowConfig->findProcessorByName("TailFile")->getUUIDStr().empty());
+  REQUIRE(1 == rootFlowConfig->findProcessorByName("TailFile")->getMaxConcurrentTasks());
   REQUIRE(
-      core::SchedulingStrategy::TIMER_DRIVEN == rootFlowConfig->findProcessor("TailFile")->getSchedulingStrategy());
-  REQUIRE(1 == rootFlowConfig->findProcessor("TailFile")->getMaxConcurrentTasks());
-  REQUIRE(1 * 1000 * 1000 * 1000 == rootFlowConfig->findProcessor("TailFile")->getSchedulingPeriodNano());
-  REQUIRE(30 * 1000 == rootFlowConfig->findProcessor("TailFile")->getPenalizationPeriodMsec());
-  REQUIRE(1 * 1000 == rootFlowConfig->findProcessor("TailFile")->getYieldPeriodMsec());
-  REQUIRE(0 == rootFlowConfig->findProcessor("TailFile")->getRunDurationNano());
+      core::SchedulingStrategy::TIMER_DRIVEN == rootFlowConfig->findProcessorByName("TailFile")->getSchedulingStrategy());
+  REQUIRE(1 == rootFlowConfig->findProcessorByName("TailFile")->getMaxConcurrentTasks());
+  REQUIRE(1 * 1000 * 1000 * 1000 == rootFlowConfig->findProcessorByName("TailFile")->getSchedulingPeriodNano());
+  REQUIRE(30 * 1000 == rootFlowConfig->findProcessorByName("TailFile")->getPenalizationPeriodMsec());
+  REQUIRE(1 * 1000 == rootFlowConfig->findProcessorByName("TailFile")->getYieldPeriodMsec());
+  REQUIRE(0 == rootFlowConfig->findProcessorByName("TailFile")->getRunDurationNano());
 
   std::map<std::string, std::shared_ptr<minifi::Connection>> connectionMap;
   rootFlowConfig->getConnections(connectionMap);
@@ -442,18 +442,18 @@ NiFi Properties Overrides: {}
   std::unique_ptr<core::ProcessGroup> rootFlowConfig = yamlConfig.getYamlRoot(configYamlStream);
 
   REQUIRE(rootFlowConfig);
-  REQUIRE(rootFlowConfig->findProcessor("TailFile"));
+  REQUIRE(rootFlowConfig->findProcessorByName("TailFile"));
   utils::Identifier uuid;
-  rootFlowConfig->findProcessor("TailFile")->getUUID(uuid);
+  rootFlowConfig->findProcessorByName("TailFile")->getUUID(uuid);
   REQUIRE(uuid != nullptr);
-  REQUIRE(!rootFlowConfig->findProcessor("TailFile")->getUUIDStr().empty());
-  REQUIRE(1 == rootFlowConfig->findProcessor("TailFile")->getMaxConcurrentTasks());
-  REQUIRE(core::SchedulingStrategy::TIMER_DRIVEN == rootFlowConfig->findProcessor("TailFile")->getSchedulingStrategy());
-  REQUIRE(1 == rootFlowConfig->findProcessor("TailFile")->getMaxConcurrentTasks());
-  REQUIRE(1 * 1000 * 1000 * 1000 == rootFlowConfig->findProcessor("TailFile")->getSchedulingPeriodNano());
-  REQUIRE(30 * 1000 == rootFlowConfig->findProcessor("TailFile")->getPenalizationPeriodMsec());
-  REQUIRE(1 * 1000 == rootFlowConfig->findProcessor("TailFile")->getYieldPeriodMsec());
-  REQUIRE(0 == rootFlowConfig->findProcessor("TailFile")->getRunDurationNano());
+  REQUIRE(!rootFlowConfig->findProcessorByName("TailFile")->getUUIDStr().empty());
+  REQUIRE(1 == rootFlowConfig->findProcessorByName("TailFile")->getMaxConcurrentTasks());
+  REQUIRE(core::SchedulingStrategy::TIMER_DRIVEN == rootFlowConfig->findProcessorByName("TailFile")->getSchedulingStrategy());
+  REQUIRE(1 == rootFlowConfig->findProcessorByName("TailFile")->getMaxConcurrentTasks());
+  REQUIRE(1 * 1000 * 1000 * 1000 == rootFlowConfig->findProcessorByName("TailFile")->getSchedulingPeriodNano());
+  REQUIRE(30 * 1000 == rootFlowConfig->findProcessorByName("TailFile")->getPenalizationPeriodMsec());
+  REQUIRE(1 * 1000 == rootFlowConfig->findProcessorByName("TailFile")->getYieldPeriodMsec());
+  REQUIRE(0 == rootFlowConfig->findProcessorByName("TailFile")->getRunDurationNano());
 
   std::map<std::string, std::shared_ptr<minifi::Connection>> connectionMap;
   rootFlowConfig->getConnections(connectionMap);
@@ -495,11 +495,11 @@ Processors:
   std::unique_ptr<core::ProcessGroup> rootFlowConfig = yamlConfig.getYamlRoot(configYamlStream);
 
   REQUIRE(rootFlowConfig);
-  REQUIRE(rootFlowConfig->findProcessor("PutFile"));
+  REQUIRE(rootFlowConfig->findProcessorByName("PutFile"));
   utils::Identifier uuid;
-  rootFlowConfig->findProcessor("PutFile")->getUUID(uuid);
+  rootFlowConfig->findProcessorByName("PutFile")->getUUID(uuid);
   REQUIRE(uuid != nullptr);
-  REQUIRE(!rootFlowConfig->findProcessor("PutFile")->getUUIDStr().empty());
+  REQUIRE(!rootFlowConfig->findProcessorByName("PutFile")->getUUIDStr().empty());
 
   REQUIRE(LogTestController::getInstance().contains("[warning] Unable to set the dynamic property "
                                                     "Dynamic Property with value Bad"));
@@ -536,11 +536,11 @@ Processors:
     std::unique_ptr<core::ProcessGroup> rootFlowConfig = yamlConfig.getYamlRoot(configYamlStream);
 
     REQUIRE(rootFlowConfig);
-    REQUIRE(rootFlowConfig->findProcessor("GetFile"));
+    REQUIRE(rootFlowConfig->findProcessorByName("GetFile"));
     utils::Identifier uuid;
-    rootFlowConfig->findProcessor("GetFile")->getUUID(uuid);
+    rootFlowConfig->findProcessorByName("GetFile")->getUUID(uuid);
     REQUIRE(uuid != nullptr);
-    REQUIRE(!rootFlowConfig->findProcessor("GetFile")->getUUIDStr().empty());
+    REQUIRE(!rootFlowConfig->findProcessorByName("GetFile")->getUUIDStr().empty());
   } catch (const std::exception &e) {
     caught_exception = true;
     REQUIRE("Unable to parse configuration file for component named 'XYZ' because required property "
@@ -579,11 +579,11 @@ Processors:
   std::unique_ptr<core::ProcessGroup> rootFlowConfig = yamlConfig.getYamlRoot(configYamlStream);
 
   REQUIRE(rootFlowConfig);
-  REQUIRE(rootFlowConfig->findProcessor("XYZ"));
+  REQUIRE(rootFlowConfig->findProcessorByName("XYZ"));
   utils::Identifier uuid;
-  rootFlowConfig->findProcessor("XYZ")->getUUID(uuid);
+  rootFlowConfig->findProcessorByName("XYZ")->getUUID(uuid);
   REQUIRE(uuid != nullptr);
-  REQUIRE(!rootFlowConfig->findProcessor("XYZ")->getUUIDStr().empty());
+  REQUIRE(!rootFlowConfig->findProcessorByName("XYZ")->getUUIDStr().empty());
 }
 
 class DummyComponent : public core::ConfigurableComponent {

--- a/libminifi/include/Connection.h
+++ b/libminifi/include/Connection.h
@@ -49,11 +49,11 @@ class Connection : public core::Connectable, public std::enable_shared_from_this
    * Create a new processor
    */
   explicit Connection(const std::shared_ptr<core::Repository> &flow_repository, const std::shared_ptr<core::ContentRepository> &content_repo, std::string name);
-  explicit Connection(const std::shared_ptr<core::Repository> &flow_repository, const std::shared_ptr<core::ContentRepository> &content_repo, std::string name, utils::Identifier & uuid);
-  explicit Connection(const std::shared_ptr<core::Repository> &flow_repository, const std::shared_ptr<core::ContentRepository> &content_repo, std::string name, utils::Identifier & uuid,
-                      utils::Identifier & srcUUID);
-  explicit Connection(const std::shared_ptr<core::Repository> &flow_repository, const std::shared_ptr<core::ContentRepository> &content_repo, std::string name, utils::Identifier & uuid,
-                      utils::Identifier & srcUUID, utils::Identifier & destUUID);
+  explicit Connection(const std::shared_ptr<core::Repository> &flow_repository, const std::shared_ptr<core::ContentRepository> &content_repo, std::string name, const utils::Identifier& uuid);
+  explicit Connection(const std::shared_ptr<core::Repository> &flow_repository, const std::shared_ptr<core::ContentRepository> &content_repo, std::string name, const utils::Identifier& uuid,
+                      const utils::Identifier& srcUUID);
+  explicit Connection(const std::shared_ptr<core::Repository> &flow_repository, const std::shared_ptr<core::ContentRepository> &content_repo, std::string name, const utils::Identifier& uuid,
+                      const utils::Identifier& srcUUID, const utils::Identifier& destUUID);
   // Destructor
   virtual ~Connection() = default;
 

--- a/libminifi/include/core/FlowConfiguration.h
+++ b/libminifi/include/core/FlowConfiguration.h
@@ -98,7 +98,7 @@ class FlowConfiguration : public CoreComponent {
   // Create Remote Processor Group
   std::unique_ptr<core::ProcessGroup> createRemoteProcessGroup(std::string name, utils::Identifier & uuid);
   // Create Connection
-  std::shared_ptr<minifi::Connection> createConnection(std::string name, utils::Identifier & uuid);
+  std::shared_ptr<minifi::Connection> createConnection(std::string name, const utils::Identifier& uuid) const;
   // Create Provenance Report Task
   std::shared_ptr<core::Processor> createProvenanceReportTask(void);
 

--- a/libminifi/include/core/ProcessGroup.h
+++ b/libminifi/include/core/ProcessGroup.h
@@ -201,7 +201,7 @@ class ProcessGroup {
   void addConnection(std::shared_ptr<Connection> connection);
   // Generic find
   template <typename Fun>
-  std::shared_ptr<Processor> findProcessor(Fun&& condition) const {
+  std::shared_ptr<Processor> findProcessor(Fun condition) const {
     std::lock_guard<std::recursive_mutex> lock(mutex_);
     const auto found = std::find_if(processors_.cbegin(), processors_.cend(), condition);
     if (found != processors_.cend()) {

--- a/libminifi/include/utils/Id.h
+++ b/libminifi/include/utils/Id.h
@@ -107,9 +107,12 @@ class IdentifierBase {
 typedef uint8_t UUID_FIELD[16];
 
 class Identifier : public IdentifierBase<UUID_FIELD, std::string> {
+  static const char* UUID_FORMAT_STRING;
+
  public:
   Identifier(UUID_FIELD u); // NOLINT
   Identifier();
+  explicit Identifier(const std::string& id_str);
   Identifier(const Identifier &other);
   Identifier(Identifier &&other);
 

--- a/libminifi/include/utils/Id.h
+++ b/libminifi/include/utils/Id.h
@@ -107,7 +107,7 @@ class IdentifierBase {
 typedef uint8_t UUID_FIELD[16];
 
 class Identifier : public IdentifierBase<UUID_FIELD, std::string> {
-  static const char* UUID_FORMAT_STRING;
+  static constexpr const char* UUID_FORMAT_STRING = "%02hhx%02hhx%02hhx%02hhx-%02hhx%02hhx-%02hhx%02hhx-%02hhx%02hhx-%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx";
 
  public:
   Identifier(UUID_FIELD u); // NOLINT

--- a/libminifi/src/Connection.cpp
+++ b/libminifi/src/Connection.cpp
@@ -54,7 +54,7 @@ Connection::Connection(const std::shared_ptr<core::Repository> &flow_repository,
   logger_->log_debug("Connection %s created", name_);
 }
 
-Connection::Connection(const std::shared_ptr<core::Repository> &flow_repository, const std::shared_ptr<core::ContentRepository> &content_repo, std::string name, utils::Identifier & uuid)
+Connection::Connection(const std::shared_ptr<core::Repository> &flow_repository, const std::shared_ptr<core::ContentRepository> &content_repo, std::string name, const utils::Identifier& uuid)
     : core::Connectable(name, uuid),
       flow_repository_(flow_repository),
       content_repo_(content_repo),
@@ -70,8 +70,8 @@ Connection::Connection(const std::shared_ptr<core::Repository> &flow_repository,
   logger_->log_debug("Connection %s created", name_);
 }
 
-Connection::Connection(const std::shared_ptr<core::Repository> &flow_repository, const std::shared_ptr<core::ContentRepository> &content_repo, std::string name, utils::Identifier & uuid,
-                       utils::Identifier & srcUUID)
+Connection::Connection(const std::shared_ptr<core::Repository> &flow_repository, const std::shared_ptr<core::ContentRepository> &content_repo, std::string name, const utils::Identifier& uuid,
+                       const utils::Identifier& srcUUID)
     : core::Connectable(name, uuid),
       flow_repository_(flow_repository),
       content_repo_(content_repo),
@@ -90,8 +90,8 @@ Connection::Connection(const std::shared_ptr<core::Repository> &flow_repository,
   logger_->log_debug("Connection %s created", name_);
 }
 
-Connection::Connection(const std::shared_ptr<core::Repository> &flow_repository, const std::shared_ptr<core::ContentRepository> &content_repo, std::string name, utils::Identifier & uuid,
-                       utils::Identifier & srcUUID, utils::Identifier & destUUID)
+Connection::Connection(const std::shared_ptr<core::Repository> &flow_repository, const std::shared_ptr<core::ContentRepository> &content_repo, std::string name, const utils::Identifier& uuid,
+                       const utils::Identifier& srcUUID, const utils::Identifier& destUUID)
     : core::Connectable(name, uuid),
       flow_repository_(flow_repository),
       content_repo_(content_repo),

--- a/libminifi/src/FlowController.cpp
+++ b/libminifi/src/FlowController.cpp
@@ -1015,7 +1015,7 @@ std::vector<std::shared_ptr<state::StateController>> FlowController::getComponen
     vec.push_back(shared_from_this());
   } else {
     // check processors
-    std::shared_ptr<core::Processor> processor = root_->findProcessor(name);
+    std::shared_ptr<core::Processor> processor = root_->findProcessorByName(name);
     if (processor != nullptr) {
       switch (processor->getSchedulingStrategy()) {
         case core::SchedulingStrategy::TIMER_DRIVEN:

--- a/libminifi/src/core/FlowConfiguration.cpp
+++ b/libminifi/src/core/FlowConfiguration.cpp
@@ -112,7 +112,7 @@ std::unique_ptr<core::ProcessGroup> FlowConfiguration::createRemoteProcessGroup(
   return std::unique_ptr<core::ProcessGroup>(new core::ProcessGroup(core::REMOTE_PROCESS_GROUP, name, uuid));
 }
 
-std::shared_ptr<minifi::Connection> FlowConfiguration::createConnection(std::string name, utils::Identifier & uuid) {
+std::shared_ptr<minifi::Connection> FlowConfiguration::createConnection(std::string name, const utils::Identifier& uuid) const {
   return std::make_shared<minifi::Connection>(flow_file_repo_, content_repo_, name, uuid);
 }
 

--- a/libminifi/src/core/yaml/YamlConfiguration.cpp
+++ b/libminifi/src/core/yaml/YamlConfiguration.cpp
@@ -610,7 +610,7 @@ void YamlConfiguration::parseConnectionYaml(YAML::Node *connectionsNode, core::P
           std::string connectionSrcProcName = connectionNode["source name"].as<std::string>();
           utils::Identifier tmpUUID;
           tmpUUID = connectionSrcProcName;
-          if (NULL != parent->findProcessor(tmpUUID)) {
+          if (NULL != parent->findProcessorById(tmpUUID)) {
             // the source name is a remote port id, so use that as the source id
             srcUUID = tmpUUID;
             logger_->log_debug("Using 'source name' containing a remote port id to match the source for "
@@ -618,7 +618,7 @@ void YamlConfiguration::parseConnectionYaml(YAML::Node *connectionsNode, core::P
                                name, connectionSrcProcName);
           } else {
             // lastly, look the processor up by name
-            auto srcProcessor = parent->findProcessor(connectionSrcProcName);
+            auto srcProcessor = parent->findProcessorByName(connectionSrcProcName);
             if (NULL != srcProcessor) {
               srcProcessor->getUUID(srcUUID);
               logger_->log_debug("Using 'source name' to match source with same name for "
@@ -649,7 +649,7 @@ void YamlConfiguration::parseConnectionYaml(YAML::Node *connectionsNode, core::P
           std::string connectionDestProcName = connectionNode["destination name"].as<std::string>();
           utils::Identifier tmpUUID;
           tmpUUID = connectionDestProcName;
-          if (parent->findProcessor(tmpUUID)) {
+          if (parent->findProcessorById(tmpUUID)) {
             // the destination name is a remote port id, so use that as the dest id
             destUUID = tmpUUID;
             logger_->log_debug("Using 'destination name' containing a remote port id to match the destination for "
@@ -657,7 +657,7 @@ void YamlConfiguration::parseConnectionYaml(YAML::Node *connectionsNode, core::P
                                name, connectionDestProcName);
           } else {
             // look the processor up by name
-            auto destProcessor = parent->findProcessor(connectionDestProcName);
+            auto destProcessor = parent->findProcessorByName(connectionDestProcName);
             if (NULL != destProcessor) {
               destProcessor->getUUID(destUUID);
               logger_->log_debug("Using 'destination name' to match destination with same name for "

--- a/libminifi/src/utils/Id.cpp
+++ b/libminifi/src/utils/Id.cpp
@@ -48,6 +48,8 @@ namespace nifi {
 namespace minifi {
 namespace utils {
 
+const char* Identifier::UUID_FORMAT_STRING = "%02hhx%02hhx%02hhx%02hhx-%02hhx%02hhx-%02hhx%02hhx-%02hhx%02hhx-%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx";
+
 #ifdef WIN32
 namespace {
   void windowsUuidToUuidField(UUID* uuid, UUID_FIELD out) {
@@ -81,6 +83,14 @@ Identifier::Identifier(UUID_FIELD u)
 
 Identifier::Identifier()
     : IdentifierBase() {
+}
+
+Identifier::Identifier(const std::string& id_str)
+    : IdentifierBase() {
+  sscanf(id_str.c_str(), UUID_FORMAT_STRING,
+         &id_[0], &id_[1], &id_[2], &id_[3], &id_[4], &id_[5], &id_[6], &id_[7],
+         &id_[8], &id_[9], &id_[10], &id_[11], &id_[12], &id_[13], &id_[14], &id_[15]);
+  build_string();
 }
 
 Identifier::Identifier(const Identifier &other) {
@@ -124,14 +134,7 @@ Identifier &Identifier::operator=(UUID_FIELD o) {
 }
 
 Identifier &Identifier::operator=(std::string id) {
-  sscanf(id.c_str(), "%02hhx%02hhx%02hhx%02hhx-%02hhx%02hhx-%02hhx%02hhx-%02hhx%02hhx-%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx",
-         &id_[0], &id_[1], &id_[2], &id_[3],
-         &id_[4], &id_[5],
-         &id_[6], &id_[7],
-         &id_[8], &id_[9],
-         &id_[10], &id_[11], &id_[12], &id_[13], &id_[14], &id_[15]);
-  build_string();
-  return *this;
+  return Identifier::operator=(Identifier{id});
 }
 
 bool Identifier::operator==(const std::nullptr_t nullp) const {
@@ -160,12 +163,9 @@ const unsigned char * const Identifier::toArray() const {
 
 void Identifier::build_string() {
   char uuidStr[37];
-  snprintf(uuidStr, sizeof(uuidStr), "%02hhx%02hhx%02hhx%02hhx-%02hhx%02hhx-%02hhx%02hhx-%02hhx%02hhx-%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx",
-      id_[0], id_[1], id_[2], id_[3],
-      id_[4], id_[5],
-      id_[6], id_[7],
-      id_[8], id_[9],
-      id_[10], id_[11], id_[12], id_[13], id_[14], id_[15]);
+  snprintf(uuidStr, sizeof(uuidStr), UUID_FORMAT_STRING,
+      id_[0], id_[1], id_[2], id_[3], id_[4], id_[5], id_[6], id_[7],
+      id_[8], id_[9], id_[10], id_[11], id_[12], id_[13], id_[14], id_[15]);
   converted_ = uuidStr;
 }
 

--- a/libminifi/src/utils/Id.cpp
+++ b/libminifi/src/utils/Id.cpp
@@ -48,8 +48,6 @@ namespace nifi {
 namespace minifi {
 namespace utils {
 
-const char* Identifier::UUID_FORMAT_STRING = "%02hhx%02hhx%02hhx%02hhx-%02hhx%02hhx-%02hhx%02hhx-%02hhx%02hhx-%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx";
-
 #ifdef WIN32
 namespace {
   void windowsUuidToUuidField(UUID* uuid, UUID_FIELD out) {

--- a/libminifi/test/flow-tests/CycleTest.cpp
+++ b/libminifi/test/flow-tests/CycleTest.cpp
@@ -103,9 +103,9 @@ TEST_CASE("Flow with two long cycle", "[FlowWithCycle]") {
   auto controller = testController.controller_;
   auto root = testController.root_;
 
-  auto procGenerator = std::static_pointer_cast<org::apache::nifi::minifi::processors::TestFlowFileGenerator>(root->findProcessor("Generator"));
-  auto procA = std::static_pointer_cast<org::apache::nifi::minifi::processors::TestProcessor>(root->findProcessor("A"));
-  auto procB = std::static_pointer_cast<org::apache::nifi::minifi::processors::TestProcessor>(root->findProcessor("B"));
+  auto procGenerator = std::static_pointer_cast<org::apache::nifi::minifi::processors::TestFlowFileGenerator>(root->findProcessorByName("Generator"));
+  auto procA = std::static_pointer_cast<org::apache::nifi::minifi::processors::TestProcessor>(root->findProcessorByName("A"));
+  auto procB = std::static_pointer_cast<org::apache::nifi::minifi::processors::TestProcessor>(root->findProcessorByName("B"));
 
   int tryCount = 0;
   while (tryCount++ < 10 && !(procA->trigger_count.load() >= 10 && procB->trigger_count.load() >= 10)) {

--- a/libminifi/test/flow-tests/FlowControllerTests.cpp
+++ b/libminifi/test/flow-tests/FlowControllerTests.cpp
@@ -86,7 +86,7 @@ TEST_CASE("Flow shutdown drains connections", "[TestFlow1]") {
 
   testController.configuration_->set(minifi::Configure::nifi_flowcontroller_drain_timeout, "100 ms");
 
-  auto sinkProc = std::static_pointer_cast<minifi::processors::TestProcessor>(root->findProcessor("TestProcessor"));
+  auto sinkProc = std::static_pointer_cast<minifi::processors::TestProcessor>(root->findProcessorByName("TestProcessor"));
   // prevent execution of the consumer processor
   sinkProc->yield(10000);
 
@@ -121,8 +121,8 @@ TEST_CASE("Flow shutdown waits for a while", "[TestFlow2]") {
 
   testController.configuration_->set(minifi::Configure::nifi_flowcontroller_drain_timeout, "10 s");
 
-  auto sourceProc = std::static_pointer_cast<minifi::processors::TestFlowFileGenerator>(root->findProcessor("Generator"));
-  auto sinkProc = std::static_pointer_cast<minifi::processors::TestProcessor>(root->findProcessor("TestProcessor"));
+  auto sourceProc = std::static_pointer_cast<minifi::processors::TestFlowFileGenerator>(root->findProcessorByName("Generator"));
+  auto sinkProc = std::static_pointer_cast<minifi::processors::TestProcessor>(root->findProcessorByName("TestProcessor"));
 
   std::promise<void> execSinkPromise;
   std::future<void> execSinkFuture = execSinkPromise.get_future();
@@ -155,8 +155,8 @@ TEST_CASE("Flow stopped after grace period", "[TestFlow3]") {
 
   testController.configuration_->set(minifi::Configure::nifi_flowcontroller_drain_timeout, "1000 ms");
 
-  auto sourceProc = std::static_pointer_cast<minifi::processors::TestFlowFileGenerator>(root->findProcessor("Generator"));
-  auto sinkProc = std::static_pointer_cast<minifi::processors::TestProcessor>(root->findProcessor("TestProcessor"));
+  auto sourceProc = std::static_pointer_cast<minifi::processors::TestFlowFileGenerator>(root->findProcessorByName("Generator"));
+  auto sinkProc = std::static_pointer_cast<minifi::processors::TestProcessor>(root->findProcessorByName("TestProcessor"));
 
   std::promise<void> execSinkPromise;
   std::future<void> execSinkFuture = execSinkPromise.get_future();
@@ -197,8 +197,8 @@ TEST_CASE("Extend the waiting period during shutdown", "[TestFlow4]") {
 
   testController.configuration_->set(minifi::Configure::nifi_flowcontroller_drain_timeout, std::to_string(timeout_ms) + " ms");
 
-  auto sourceProc = std::static_pointer_cast<minifi::processors::TestFlowFileGenerator>(root->findProcessor("Generator"));
-  auto sinkProc = std::static_pointer_cast<minifi::processors::TestProcessor>(root->findProcessor("TestProcessor"));
+  auto sourceProc = std::static_pointer_cast<minifi::processors::TestFlowFileGenerator>(root->findProcessorByName("Generator"));
+  auto sinkProc = std::static_pointer_cast<minifi::processors::TestProcessor>(root->findProcessorByName("TestProcessor"));
 
   std::promise<void> execSinkPromise;
   std::future<void> execSinkFuture = execSinkPromise.get_future();

--- a/libminifi/test/flow-tests/LoopTest.cpp
+++ b/libminifi/test/flow-tests/LoopTest.cpp
@@ -81,8 +81,8 @@ TEST_CASE("Flow with a single loop", "[SingleLoopFlow]") {
   auto controller = testController.controller_;
   auto root = testController.root_;
 
-  auto procGenerator = std::static_pointer_cast<org::apache::nifi::minifi::processors::TestFlowFileGenerator>(root->findProcessor("Generator"));
-  auto procA = std::static_pointer_cast<org::apache::nifi::minifi::processors::TestProcessor>(root->findProcessor("A"));
+  auto procGenerator = std::static_pointer_cast<org::apache::nifi::minifi::processors::TestFlowFileGenerator>(root->findProcessorByName("Generator"));
+  auto procA = std::static_pointer_cast<org::apache::nifi::minifi::processors::TestProcessor>(root->findProcessorByName("A"));
 
   int tryCount = 0;
   // wait for the procA to get triggered 15 times

--- a/libminifi/test/flow-tests/MultiLoopTest.cpp
+++ b/libminifi/test/flow-tests/MultiLoopTest.cpp
@@ -90,8 +90,8 @@ TEST_CASE("Flow with two loops", "[MultiLoopFlow]") {
   auto controller = testController.controller_;
   auto root = testController.root_;
 
-  auto procGenerator = std::static_pointer_cast<org::apache::nifi::minifi::processors::TestFlowFileGenerator>(root->findProcessor("Generator"));
-  auto procA = std::static_pointer_cast<org::apache::nifi::minifi::processors::TestProcessor>(root->findProcessor("A"));
+  auto procGenerator = std::static_pointer_cast<org::apache::nifi::minifi::processors::TestFlowFileGenerator>(root->findProcessorByName("Generator"));
+  auto procA = std::static_pointer_cast<org::apache::nifi::minifi::processors::TestProcessor>(root->findProcessorByName("A"));
 
   int tryCount = 0;
   while (tryCount++ < 10 && !(procA->trigger_count.load() > 15)) {

--- a/libminifi/test/sensors-tests/SensorTests.cpp
+++ b/libminifi/test/sensors-tests/SensorTests.cpp
@@ -70,7 +70,7 @@ class PcapTestHarness : public IntegrationBase {
   }
 
   void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> pg) {
-    std::shared_ptr<core::Processor> proc = pg->findProcessor("pcap");
+    std::shared_ptr<core::Processor> proc = pg->findProcessorByName("pcap");
     assert(proc != nullptr);
 
     auto inv = std::dynamic_pointer_cast<minifi::processors::GetEnvironmentalSensors>(proc);


### PR DESCRIPTION
This is a cleanup PR before I start a refactor on configuration parsing, IDs and names lookups.