### PR TITLE
MINIFICPP-1203 - Remove extra spaces around parentheses according to linter recommendation

### DIFF
--- a/controller/MiNiFiController.cpp
+++ b/controller/MiNiFiController.cpp
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
     auto result = options.parse(argc, argv);
 
     if (result.count("help")) {
-      std::cout << options.help( { "", "Group" }) << std::endl;
+      std::cout << options.help({ "", "Group" }) << std::endl;
       exit(0);
     }
 
@@ -221,7 +221,7 @@ int main(int argc, char **argv) {
     // catch anything thrown within try block that derives from std::exception
     std::cerr << exc.what() << std::endl;
   } catch (...) {
-    std::cout << options.help( { "", "Group" }) << std::endl;
+    std::cout << options.help({ "", "Group" }) << std::endl;
     exit(0);
   }
   return 0;

--- a/extensions/bootstrap/bootstrap.cpp
+++ b/extensions/bootstrap/bootstrap.cpp
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
     auto result = options.parse(argc, argv);
 
     if (result.count("help")) {
-      std::cout << options.help( { "", "Group" }) << std::endl;
+      std::cout << options.help({ "", "Group" }) << std::endl;
       exit(0);
     }
 
@@ -52,7 +52,7 @@ int main(int argc, char **argv) {
       // catch anything thrown within try block that derives from std::exception
       std::cerr << exc.what() << std::endl;
   } catch (...) {
-    std::cout << options.help( { "", "Group" }) << std::endl;
+    std::cout << options.help({ "", "Group" }) << std::endl;
     exit(0);
   }
   return 0;

--- a/extensions/coap/server/CoapServer.h
+++ b/extensions/coap/server/CoapServer.h
@@ -124,7 +124,7 @@ class CoapServer : public core::Connectable {
     future = std::async(std::launch::async, [&]() -> uint64_t {
       while (running_) {
         int res = coap_run_once(server_->ctx, 100);
-        if (res < 0 ) {
+        if (res < 0) {
           break;
         }
         coap_check_notify(server_->ctx);

--- a/extensions/expression-language/Expression.cpp
+++ b/extensions/expression-language/Expression.cpp
@@ -86,7 +86,7 @@ Expression make_dynamic_attr(const std::string &attribute_id) {
       return Value(result);
     } else {
       auto registry = params.registry_.lock();
-      if ( registry && registry->getConfigurationProperty( attribute_id , result) ) {
+      if (registry && registry->getConfigurationProperty(attribute_id , result)) {
         return Value(result);
       }
     }

--- a/extensions/expression-language/tests/ExpressionLanguageTests.cpp
+++ b/extensions/expression-language/tests/ExpressionLanguageTests.cpp
@@ -44,30 +44,30 @@ class MockFlowFile : public core::FlowFile {
 };
 
 TEST_CASE("Trivial static expression", "[expressionLanguageTestTrivialStaticExpr]") {  // NOLINT
-  REQUIRE("a" == expression::make_static("a")( { }).asString());
+  REQUIRE("a" == expression::make_static("a")({ }).asString());
 }
 
 TEST_CASE("Text expression", "[expressionLanguageTestTextExpression]") {  // NOLINT
   auto expr = expression::compile("text");
-  REQUIRE("text" == expr( { }).asString());
+  REQUIRE("text" == expr({ }).asString());
 }
 
 TEST_CASE("Text expression with escaped dollar", "[expressionLanguageTestEscapedDollar]") {  // NOLINT
   auto expr = expression::compile("te$$xt");
-  REQUIRE("te$xt" == expr( { }).asString());
+  REQUIRE("te$xt" == expr({ }).asString());
 }
 
 TEST_CASE("Attribute expression", "[expressionLanguageTestAttributeExpression]") {  // NOLINT
   auto flow_file = std::make_shared<MockFlowFile>();
   flow_file->addAttribute("attr_a", "__attr_value_a__");
   auto expr = expression::compile("text_before${attr_a}text_after");
-  REQUIRE("text_before__attr_value_a__text_after" == expr( { flow_file }).asString());
+  REQUIRE("text_before__attr_value_a__text_after" == expr({ flow_file }).asString());
 }
 
 TEST_CASE("Attribute expression (Null)", "[expressionLanguageTestAttributeExpressionNull]") {  // NOLINT
   auto expr = expression::compile("text_before${attr_a}text_after");
   std::shared_ptr<MockFlowFile> flow_file = nullptr;
-  REQUIRE("text_beforetext_after" == expr( { flow_file }).asString());
+  REQUIRE("text_beforetext_after" == expr({ flow_file }).asString());
 }
 
 TEST_CASE("Multi-attribute expression", "[expressionLanguageTestMultiAttributeExpression]") {  // NOLINT
@@ -75,7 +75,7 @@ TEST_CASE("Multi-attribute expression", "[expressionLanguageTestMultiAttributeEx
   flow_file->addAttribute("attr_a", "__attr_value_a__");
   flow_file->addAttribute("attr_b", "__attr_value_b__");
   auto expr = expression::compile("text_before${attr_a}text_between${attr_b}text_after");
-  REQUIRE("text_before__attr_value_a__text_between__attr_value_b__text_after" == expr( { flow_file }).asString());
+  REQUIRE("text_before__attr_value_a__text_between__attr_value_b__text_after" == expr({ flow_file }).asString());
 }
 
 TEST_CASE("Multi-flowfile attribute expression",
@@ -84,18 +84,18 @@ TEST_CASE("Multi-flowfile attribute expression",
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr_a", "__flow_a_attr_value_a__");
-  REQUIRE("text_before__flow_a_attr_value_a__text_after" == expr( { flow_file_a }).asString());
+  REQUIRE("text_before__flow_a_attr_value_a__text_after" == expr({ flow_file_a }).asString());
 
   auto flow_file_b = std::make_shared<MockFlowFile>();
   flow_file_b->addAttribute("attr_a", "__flow_b_attr_value_a__");
-  REQUIRE("text_before__flow_b_attr_value_a__text_after" == expr( { flow_file_b }).asString());
+  REQUIRE("text_before__flow_b_attr_value_a__text_after" == expr({ flow_file_b }).asString());
 }
 
 TEST_CASE("Attribute expression with whitespace", "[expressionLanguageTestAttributeExpressionWhitespace]") {  // NOLINT
   auto flow_file = std::make_shared<MockFlowFile>();
   flow_file->addAttribute("attr_a", "__attr_value_a__");
   auto expr = expression::compile("text_before${\n\tattr_a \r}text_after");
-  REQUIRE("text_before__attr_value_a__text_after" == expr( { flow_file }).asString());
+  REQUIRE("text_before__attr_value_a__text_after" == expr({ flow_file }).asString());
 }
 
 TEST_CASE("Special characters expression", "[expressionLanguageTestSpecialCharactersExpression]") {  // NOLINT
@@ -103,7 +103,7 @@ TEST_CASE("Special characters expression", "[expressionLanguageTestSpecialCharac
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr_a", "__flow_a_attr_value_a__");
-  REQUIRE("text_before|{}()[],:;\\/*#'\" \t\r\n__flow_a_attr_value_a__}()text_after" == expr( { flow_file_a }).asString());
+  REQUIRE("text_before|{}()[],:;\\/*#'\" \t\r\n__flow_a_attr_value_a__}()text_after" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("UTF-8 characters expression", "[expressionLanguageTestUTF8Expression]") {  // NOLINT
@@ -111,7 +111,7 @@ TEST_CASE("UTF-8 characters expression", "[expressionLanguageTestUTF8Expression]
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr_a", "__flow_a_attr_value_a__");
-  REQUIRE("text_before¥£€¢₡₢₣₤₥₦₧₨₩₪₫₭₮₯₹__flow_a_attr_value_a__text_after" == expr( { flow_file_a }).asString());
+  REQUIRE("text_before¥£€¢₡₢₣₤₥₦₧₨₩₪₫₭₮₯₹__flow_a_attr_value_a__text_after" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("UTF-8 characters attribute", "[expressionLanguageTestUTF8Attribute]") {  // NOLINT
@@ -119,7 +119,7 @@ TEST_CASE("UTF-8 characters attribute", "[expressionLanguageTestUTF8Attribute]")
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr_a", "__¥£€¢₡₢₣₤₥₦₧₨₩₪₫₭₮₯₹__");
-  REQUIRE("text_before__¥£€¢₡₢₣₤₥₦₧₨₩₪₫₭₮₯₹__text_after" == expr( { flow_file_a }).asString());
+  REQUIRE("text_before__¥£€¢₡₢₣₤₥₦₧₨₩₪₫₭₮₯₹__text_after" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Single quoted attribute expression", "[expressionLanguageTestSingleQuotedAttributeExpression]") {  // NOLINT
@@ -127,7 +127,7 @@ TEST_CASE("Single quoted attribute expression", "[expressionLanguageTestSingleQu
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("|{}()[],:;\\/*# \t\r\n$", "__flow_a_attr_value_a__");
-  REQUIRE("text_before__flow_a_attr_value_a__text_after" == expr( { flow_file_a }).asString());
+  REQUIRE("text_before__flow_a_attr_value_a__text_after" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Double quoted attribute expression", "[expressionLanguageTestDoubleQuotedAttributeExpression]") {  // NOLINT
@@ -135,7 +135,7 @@ TEST_CASE("Double quoted attribute expression", "[expressionLanguageTestDoubleQu
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("|{}()[],:;\\/*# \t\r\n$", "__flow_a_attr_value_a__");
-  REQUIRE("text_before__flow_a_attr_value_a__text_after" == expr( { flow_file_a }).asString());
+  REQUIRE("text_before__flow_a_attr_value_a__text_after" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Hostname function", "[expressionLanguageTestHostnameFunction]") {  // NOLINT
@@ -149,7 +149,7 @@ TEST_CASE("Hostname function", "[expressionLanguageTestHostnameFunction]") {  //
   expected.append("text_after");
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
-  REQUIRE(expected == expr( { flow_file_a }).asString());
+  REQUIRE(expected == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("ToUpper function", "[expressionLanguageTestToUpperFunction]") {  // NOLINT
@@ -158,14 +158,14 @@ TEST_CASE("ToUpper function", "[expressionLanguageTestToUpperFunction]") {  // N
                                      }text_after)");
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr_a", "__flow_a_attr_value_a__");
-  REQUIRE("text_before__FLOW_A_ATTR_VALUE_A__text_after" == expr( { flow_file_a }).asString());
+  REQUIRE("text_before__FLOW_A_ATTR_VALUE_A__text_after" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("ToUpper function w/o whitespace", "[expressionLanguageTestToUpperFunctionWithoutWhitespace]") {  // NOLINT
   auto expr = expression::compile(R"(text_before${attr_a:toUpper()}text_after)");
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr_a", "__flow_a_attr_value_a__");
-  REQUIRE("text_before__FLOW_A_ATTR_VALUE_A__text_after" == expr( { flow_file_a }).asString());
+  REQUIRE("text_before__FLOW_A_ATTR_VALUE_A__text_after" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("ToLower function", "[expressionLanguageTestToLowerFunction]") {  // NOLINT
@@ -174,7 +174,7 @@ TEST_CASE("ToLower function", "[expressionLanguageTestToLowerFunction]") {  // N
                                      }text_after)");
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr_a", "__FLOW_A_ATTR_VALUE_A__");
-  REQUIRE("text_before__flow_a_attr_value_a__text_after" == expr( { flow_file_a }).asString());
+  REQUIRE("text_before__flow_a_attr_value_a__text_after" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("GetFile PutFile dynamic attribute", "[expressionLanguageTestGetFilePutFileDynamicAttribute]") {  // NOLINT
@@ -252,7 +252,7 @@ TEST_CASE("Substring 2 arg", "[expressionLanguageSubstring2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "__flow_a_attr_value_a__");
-  REQUIRE("text_before_a_attr_text_after" == expr( { flow_file_a }).asString());
+  REQUIRE("text_before_a_attr_text_after" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Substring 1 arg", "[expressionLanguageSubstring1]") {  // NOLINT
@@ -260,7 +260,7 @@ TEST_CASE("Substring 1 arg", "[expressionLanguageSubstring1]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "__flow_a_attr_value_a__");
-  REQUIRE("text_before_a_attr_value_a__text_after" == expr( { flow_file_a }).asString());
+  REQUIRE("text_before_a_attr_value_a__text_after" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Substring Before", "[expressionLanguageSubstringBefore]") {  // NOLINT
@@ -268,7 +268,7 @@ TEST_CASE("Substring Before", "[expressionLanguageSubstringBefore]") {  // NOLIN
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "__flow_a_attr_value_a__");
-  REQUIRE("__flow_a_" == expr( { flow_file_a }).asString());
+  REQUIRE("__flow_a_" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Substring Before Last", "[expressionLanguageSubstringBeforeLast]") {  // NOLINT
@@ -276,7 +276,7 @@ TEST_CASE("Substring Before Last", "[expressionLanguageSubstringBeforeLast]") { 
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "__flow_a_attr_value_a__");
-  REQUIRE("__flow_a_attr_value" == expr( { flow_file_a }).asString());
+  REQUIRE("__flow_a_attr_value" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Substring After", "[expressionLanguageSubstringAfter]") {  // NOLINT
@@ -284,7 +284,7 @@ TEST_CASE("Substring After", "[expressionLanguageSubstringAfter]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "__flow_a_attr_value_a__");
-  REQUIRE("_attr_value_a__" == expr( { flow_file_a }).asString());
+  REQUIRE("_attr_value_a__" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Substring After Last", "[expressionLanguageSubstringAfterLast]") {  // NOLINT
@@ -292,7 +292,7 @@ TEST_CASE("Substring After Last", "[expressionLanguageSubstringAfterLast]") {  /
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "__flow_a_attr_value_a__");
-  REQUIRE("__" == expr( { flow_file_a }).asString());
+  REQUIRE("__" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Get Delimited", "[expressionLanguageGetDelimited]") {  // NOLINT
@@ -300,7 +300,7 @@ TEST_CASE("Get Delimited", "[expressionLanguageGetDelimited]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "\"Jacobson, John\", 32, Mr.");
-  REQUIRE(" 32" == expr( { flow_file_a }).asString());
+  REQUIRE(" 32" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Get Delimited 2", "[expressionLanguageGetDelimited2]") {  // NOLINT
@@ -308,7 +308,7 @@ TEST_CASE("Get Delimited 2", "[expressionLanguageGetDelimited2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "\"Jacobson, John\", 32, Mr.");
-  REQUIRE("\"Jacobson, John\"" == expr( { flow_file_a }).asString());
+  REQUIRE("\"Jacobson, John\"" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Get Delimited 3", "[expressionLanguageGetDelimited3]") {  // NOLINT
@@ -316,7 +316,7 @@ TEST_CASE("Get Delimited 3", "[expressionLanguageGetDelimited3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "\"Jacobson, John\", 32, Mr.");
-  REQUIRE("Jacobson, John" == expr( { flow_file_a }).asString());
+  REQUIRE("Jacobson, John" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Starts With", "[expressionLanguageStartsWith]") {  // NOLINT
@@ -324,7 +324,7 @@ TEST_CASE("Starts With", "[expressionLanguageStartsWith]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "A BRAND TEST");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Starts With 2", "[expressionLanguageStartsWith2]") {  // NOLINT
@@ -332,7 +332,7 @@ TEST_CASE("Starts With 2", "[expressionLanguageStartsWith2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand TEST");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Ends With", "[expressionLanguageEndsWith]") {  // NOLINT
@@ -340,7 +340,7 @@ TEST_CASE("Ends With", "[expressionLanguageEndsWith]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.TXT");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Ends With 2", "[expressionLanguageEndsWith2]") {  // NOLINT
@@ -348,7 +348,7 @@ TEST_CASE("Ends With 2", "[expressionLanguageEndsWith2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.TXT");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Contains", "[expressionLanguageContains]") {  // NOLINT
@@ -356,7 +356,7 @@ TEST_CASE("Contains", "[expressionLanguageContains]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Contains 2", "[expressionLanguageContains2]") {  // NOLINT
@@ -364,7 +364,7 @@ TEST_CASE("Contains 2", "[expressionLanguageContains2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("In", "[expressionLanguageIn]") {  // NOLINT
@@ -372,7 +372,7 @@ TEST_CASE("In", "[expressionLanguageIn]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "JOHN");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("In 2", "[expressionLanguageIn2]") {  // NOLINT
@@ -380,7 +380,7 @@ TEST_CASE("In 2", "[expressionLanguageIn2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "JOHN");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Substring Before No Args", "[expressionLanguageSubstringBeforeNoArgs]") {  // NOLINT
@@ -401,7 +401,7 @@ TEST_CASE("Replace", "[expressionLanguageReplace]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("a brand new filename_txt" == expr( { flow_file_a }).asString());
+  REQUIRE("a brand new filename_txt" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Replace 2", "[expressionLanguageReplace2]") {  // NOLINT
@@ -409,7 +409,7 @@ TEST_CASE("Replace 2", "[expressionLanguageReplace2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("a.brand.new.filename.txt" == expr( { flow_file_a }).asString());
+  REQUIRE("a.brand.new.filename.txt" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Replace First", "[expressionLanguageReplaceFirst]") {  // NOLINT
@@ -417,7 +417,7 @@ TEST_CASE("Replace First", "[expressionLanguageReplaceFirst]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("the brand new filename.txt" == expr( { flow_file_a }).asString());
+  REQUIRE("the brand new filename.txt" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Replace First Regex", "[expressionLanguageReplaceFirstRegex]") {  // NOLINT
@@ -425,7 +425,7 @@ TEST_CASE("Replace First Regex", "[expressionLanguageReplaceFirstRegex]") {  // 
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("a grand new filename.txt" == expr( { flow_file_a }).asString());
+  REQUIRE("a grand new filename.txt" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Replace All", "[expressionLanguageReplaceAll]") {  // NOLINT
@@ -433,7 +433,7 @@ TEST_CASE("Replace All", "[expressionLanguageReplaceAll]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("a brand new filename" == expr( { flow_file_a }).asString());
+  REQUIRE("a brand new filename" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Replace All 2", "[expressionLanguageReplaceAll2]") {  // NOLINT
@@ -441,7 +441,7 @@ TEST_CASE("Replace All 2", "[expressionLanguageReplaceAll2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("new filename.txt" == expr( { flow_file_a }).asString());
+  REQUIRE("new filename.txt" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Replace All 3", "[expressionLanguageReplaceAll3]") {  // NOLINT
@@ -449,7 +449,7 @@ TEST_CASE("Replace All 3", "[expressionLanguageReplaceAll3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("a brand new filename.txt" == expr( { flow_file_a }).asString());
+  REQUIRE("a brand new filename.txt" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Replace Null", "[expressionLanguageReplaceNull]") {  // NOLINT
@@ -457,7 +457,7 @@ TEST_CASE("Replace Null", "[expressionLanguageReplaceNull]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("a brand new filename.txt" == expr( { flow_file_a }).asString());
+  REQUIRE("a brand new filename.txt" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Replace Null 2", "[expressionLanguageReplaceNull2]") {  // NOLINT
@@ -465,7 +465,7 @@ TEST_CASE("Replace Null 2", "[expressionLanguageReplaceNull2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr2", "a brand new filename.txt");
-  REQUIRE("abc" == expr( { flow_file_a }).asString());
+  REQUIRE("abc" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Replace Empty", "[expressionLanguageReplaceEmpty]") {  // NOLINT
@@ -473,7 +473,7 @@ TEST_CASE("Replace Empty", "[expressionLanguageReplaceEmpty]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("a brand new filename.txt" == expr( { flow_file_a }).asString());
+  REQUIRE("a brand new filename.txt" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Replace Empty 2", "[expressionLanguageReplaceEmpty2]") {  // NOLINT
@@ -481,7 +481,7 @@ TEST_CASE("Replace Empty 2", "[expressionLanguageReplaceEmpty2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "  \t  \r  \n  ");
-  REQUIRE("abc" == expr( { flow_file_a }).asString());
+  REQUIRE("abc" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Replace Empty 3", "[expressionLanguageReplaceEmpty2]") {  // NOLINT
@@ -489,7 +489,7 @@ TEST_CASE("Replace Empty 3", "[expressionLanguageReplaceEmpty2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr2", "test");
-  REQUIRE("abc" == expr( { flow_file_a }).asString());
+  REQUIRE("abc" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Matches", "[expressionLanguageMatches]") {  // NOLINT
@@ -497,7 +497,7 @@ TEST_CASE("Matches", "[expressionLanguageMatches]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "At:est");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Matches 2", "[expressionLanguageMatches2]") {  // NOLINT
@@ -505,7 +505,7 @@ TEST_CASE("Matches 2", "[expressionLanguageMatches2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "At:something");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Matches 3", "[expressionLanguageMatches3]") {  // NOLINT
@@ -513,7 +513,7 @@ TEST_CASE("Matches 3", "[expressionLanguageMatches3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", " At:est");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Find", "[expressionLanguageFind]") {  // NOLINT
@@ -521,7 +521,7 @@ TEST_CASE("Find", "[expressionLanguageFind]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Find 2", "[expressionLanguageFind2]") {  // NOLINT
@@ -529,7 +529,7 @@ TEST_CASE("Find 2", "[expressionLanguageFind2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Find 3", "[expressionLanguageFind3]") {  // NOLINT
@@ -537,7 +537,7 @@ TEST_CASE("Find 3", "[expressionLanguageFind3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("IndexOf", "[expressionLanguageIndexOf]") {  // NOLINT
@@ -545,7 +545,7 @@ TEST_CASE("IndexOf", "[expressionLanguageIndexOf]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("-1" == expr( { flow_file_a }).asString());
+  REQUIRE("-1" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("IndexOf2", "[expressionLanguageIndexOf2]") {  // NOLINT
@@ -553,7 +553,7 @@ TEST_CASE("IndexOf2", "[expressionLanguageIndexOf2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("20" == expr( { flow_file_a }).asString());
+  REQUIRE("20" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("IndexOf3", "[expressionLanguageIndexOf3]") {  // NOLINT
@@ -561,7 +561,7 @@ TEST_CASE("IndexOf3", "[expressionLanguageIndexOf3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("0" == expr( { flow_file_a }).asString());
+  REQUIRE("0" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("IndexOf4", "[expressionLanguageIndexOf4]") {  // NOLINT
@@ -569,7 +569,7 @@ TEST_CASE("IndexOf4", "[expressionLanguageIndexOf4]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("1" == expr( { flow_file_a }).asString());
+  REQUIRE("1" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("LastIndexOf", "[expressionLanguageLastIndexOf]") {  // NOLINT
@@ -577,7 +577,7 @@ TEST_CASE("LastIndexOf", "[expressionLanguageLastIndexOf]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("-1" == expr( { flow_file_a }).asString());
+  REQUIRE("-1" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("LastIndexOf2", "[expressionLanguageLastIndexOf2]") {  // NOLINT
@@ -585,7 +585,7 @@ TEST_CASE("LastIndexOf2", "[expressionLanguageLastIndexOf2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("20" == expr( { flow_file_a }).asString());
+  REQUIRE("20" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("LastIndexOf3", "[expressionLanguageLastIndexOf3]") {  // NOLINT
@@ -593,7 +593,7 @@ TEST_CASE("LastIndexOf3", "[expressionLanguageLastIndexOf3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("17" == expr( { flow_file_a }).asString());
+  REQUIRE("17" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("LastIndexOf4", "[expressionLanguageLastIndexOf4]") {  // NOLINT
@@ -601,7 +601,7 @@ TEST_CASE("LastIndexOf4", "[expressionLanguageLastIndexOf4]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "a brand new filename.txt");
-  REQUIRE("11" == expr( { flow_file_a }).asString());
+  REQUIRE("11" == expr({ flow_file_a }).asString());
 }
 
 #endif  // EXPRESSION_LANGUAGE_USE_REGEX
@@ -611,7 +611,7 @@ TEST_CASE("Plus Integer", "[expressionLanguagePlusInteger]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "11");
-  REQUIRE("24" == expr( { flow_file_a }).asString());
+  REQUIRE("24" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Plus Decimal", "[expressionLanguagePlusDecimal]") {  // NOLINT
@@ -619,7 +619,7 @@ TEST_CASE("Plus Decimal", "[expressionLanguagePlusDecimal]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "11.1");
-  REQUIRE("-2.24567" == expr( { flow_file_a }).asString());
+  REQUIRE("-2.24567" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Plus Exponent", "[expressionLanguagePlusExponent]") {  // NOLINT
@@ -627,7 +627,7 @@ TEST_CASE("Plus Exponent", "[expressionLanguagePlusExponent]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "11");
-  REQUIRE("10000011" == expr( { flow_file_a }).asString());
+  REQUIRE("10000011" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Plus Exponent 2", "[expressionLanguagePlusExponent2]") {  // NOLINT
@@ -635,7 +635,7 @@ TEST_CASE("Plus Exponent 2", "[expressionLanguagePlusExponent2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "11.345678901234");
-  REQUIRE("10000011.345678901234351" == expr( { flow_file_a }).asString());
+  REQUIRE("10000011.345678901234351" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Minus Integer", "[expressionLanguageMinusInteger]") {  // NOLINT
@@ -643,7 +643,7 @@ TEST_CASE("Minus Integer", "[expressionLanguageMinusInteger]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "11");
-  REQUIRE("-2" == expr( { flow_file_a }).asString());
+  REQUIRE("-2" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Minus Decimal", "[expressionLanguageMinusDecimal]") {  // NOLINT
@@ -651,7 +651,7 @@ TEST_CASE("Minus Decimal", "[expressionLanguageMinusDecimal]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "11.1");
-  REQUIRE("24.44567" == expr( { flow_file_a }).asString());
+  REQUIRE("24.44567" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Multiply Integer", "[expressionLanguageMultiplyInteger]") {  // NOLINT
@@ -659,7 +659,7 @@ TEST_CASE("Multiply Integer", "[expressionLanguageMultiplyInteger]") {  // NOLIN
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "11");
-  REQUIRE("143" == expr( { flow_file_a }).asString());
+  REQUIRE("143" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Multiply Decimal", "[expressionLanguageMultiplyDecimal]") {  // NOLINT
@@ -667,7 +667,7 @@ TEST_CASE("Multiply Decimal", "[expressionLanguageMultiplyDecimal]") {  // NOLIN
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "11.1");
-  REQUIRE("-148.136937" == expr( { flow_file_a }).asString());
+  REQUIRE("-148.136937" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Divide Integer", "[expressionLanguageDivideInteger]") {  // NOLINT
@@ -675,7 +675,7 @@ TEST_CASE("Divide Integer", "[expressionLanguageDivideInteger]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "11");
-  REQUIRE("0.846153846153846" == expr( { flow_file_a }).asString());
+  REQUIRE("0.846153846153846" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Divide Decimal", "[expressionLanguageDivideDecimal]") {  // NOLINT
@@ -683,7 +683,7 @@ TEST_CASE("Divide Decimal", "[expressionLanguageDivideDecimal]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "11.1");
-  REQUIRE("-0.831730441409086" == expr( { flow_file_a }).asString());
+  REQUIRE("-0.831730441409086" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("To Radix", "[expressionLanguageToRadix]") {  // NOLINT
@@ -691,7 +691,7 @@ TEST_CASE("To Radix", "[expressionLanguageToRadix]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "10");
-  REQUIRE("0000000000001010" == expr( { flow_file_a }).asString());
+  REQUIRE("0000000000001010" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("To Radix 2", "[expressionLanguageToRadix2]") {  // NOLINT
@@ -699,7 +699,7 @@ TEST_CASE("To Radix 2", "[expressionLanguageToRadix2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "13");
-  REQUIRE("d" == expr( { flow_file_a }).asString());
+  REQUIRE("d" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("To Radix 3", "[expressionLanguageToRadix3]") {  // NOLINT
@@ -707,7 +707,7 @@ TEST_CASE("To Radix 3", "[expressionLanguageToRadix3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "-2347");
-  REQUIRE("-000004a1" == expr( { flow_file_a }).asString());
+  REQUIRE("-000004a1" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("From Radix", "[expressionLanguageFromRadix]") {  // NOLINT
@@ -715,7 +715,7 @@ TEST_CASE("From Radix", "[expressionLanguageFromRadix]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "0000000000001010");
-  REQUIRE("10" == expr( { flow_file_a }).asString());
+  REQUIRE("10" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("From Radix 2", "[expressionLanguageFromRadix2]") {  // NOLINT
@@ -723,7 +723,7 @@ TEST_CASE("From Radix 2", "[expressionLanguageFromRadix2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "d");
-  REQUIRE("13" == expr( { flow_file_a }).asString());
+  REQUIRE("13" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("From Radix 3", "[expressionLanguageFromRadix3]") {  // NOLINT
@@ -731,14 +731,14 @@ TEST_CASE("From Radix 3", "[expressionLanguageFromRadix3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "-000004a1");
-  REQUIRE("-2347" == expr( { flow_file_a }).asString());
+  REQUIRE("-2347" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Random", "[expressionLanguageRandom]") {  // NOLINT
   auto expr = expression::compile("${random()}");
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
-  auto result = expr( { flow_file_a }).asSignedLong();
+  auto result = expr({ flow_file_a }).asSignedLong();
   REQUIRE(result > 0);
 }
 
@@ -747,14 +747,14 @@ TEST_CASE("Chained call", "[expressionChainedCall]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "7");
-  REQUIRE("22" == expr( { flow_file_a }).asString());
+  REQUIRE("22" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Chained call 2", "[expressionChainedCall2]") {  // NOLINT
   auto expr = expression::compile("${literal(10):multiply(2):plus(1):multiply(2)}");
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
-  REQUIRE(42 == expr( { flow_file_a }).asSignedLong());
+  REQUIRE(42 == expr({ flow_file_a }).asSignedLong());
 }
 
 TEST_CASE("Chained call 3", "[expressionChainedCall3]") {  // NOLINT
@@ -762,7 +762,7 @@ TEST_CASE("Chained call 3", "[expressionChainedCall3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "7");
-  REQUIRE("238" == expr( { flow_file_a }).asString());
+  REQUIRE("238" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("LiteralBool", "[expressionLiteralBool]") {  // NOLINT
@@ -770,7 +770,7 @@ TEST_CASE("LiteralBool", "[expressionLiteralBool]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "7");
-  REQUIRE(true == expr( { flow_file_a }).asBoolean());
+  REQUIRE(true == expr({ flow_file_a }).asBoolean());
 }
 
 TEST_CASE("LiteralBool 2", "[expressionLiteralBool2]") {  // NOLINT
@@ -778,7 +778,7 @@ TEST_CASE("LiteralBool 2", "[expressionLiteralBool2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "7");
-  REQUIRE(false == expr( { flow_file_a }).asBoolean());
+  REQUIRE(false == expr({ flow_file_a }).asBoolean());
 }
 
 TEST_CASE("Is Null", "[expressionIsNull]") {  // NOLINT
@@ -786,7 +786,7 @@ TEST_CASE("Is Null", "[expressionIsNull]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "7");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Is Null 2", "[expressionIsNull2]") {  // NOLINT
@@ -794,7 +794,7 @@ TEST_CASE("Is Null 2", "[expressionIsNull2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("filename", "7");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Not Null", "[expressionNotNull]") {  // NOLINT
@@ -802,7 +802,7 @@ TEST_CASE("Not Null", "[expressionNotNull]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "7");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Not Null 2", "[expressionNotNull2]") {  // NOLINT
@@ -810,7 +810,7 @@ TEST_CASE("Not Null 2", "[expressionNotNull2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("filename", "7");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Is Empty", "[expressionIsEmpty]") {  // NOLINT
@@ -818,7 +818,7 @@ TEST_CASE("Is Empty", "[expressionIsEmpty]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "7");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Is Empty 2", "[expressionIsEmpty2]") {  // NOLINT
@@ -826,7 +826,7 @@ TEST_CASE("Is Empty 2", "[expressionIsEmpty2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "7");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Is Empty 3", "[expressionIsEmpty3]") {  // NOLINT
@@ -834,7 +834,7 @@ TEST_CASE("Is Empty 3", "[expressionIsEmpty3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", " \t\r\n ");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Is Empty 4", "[expressionIsEmpty4]") {  // NOLINT
@@ -842,7 +842,7 @@ TEST_CASE("Is Empty 4", "[expressionIsEmpty4]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Is Empty 5", "[expressionIsEmpty5]") {  // NOLINT
@@ -850,7 +850,7 @@ TEST_CASE("Is Empty 5", "[expressionIsEmpty5]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", " \t\r\n a \t\r\n ");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Equals", "[expressionEquals]") {  // NOLINT
@@ -858,7 +858,7 @@ TEST_CASE("Equals", "[expressionEquals]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "hello.txt");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Equals 2", "[expressionEquals2]") {  // NOLINT
@@ -866,7 +866,7 @@ TEST_CASE("Equals 2", "[expressionEquals2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "helllo.txt");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Equals 3", "[expressionEquals3]") {  // NOLINT
@@ -874,7 +874,7 @@ TEST_CASE("Equals 3", "[expressionEquals3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "1");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Equals Ignore Case", "[expressionEqualsIgnoreCase]") {  // NOLINT
@@ -882,7 +882,7 @@ TEST_CASE("Equals Ignore Case", "[expressionEqualsIgnoreCase]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "hello.txt");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Equals Ignore Case 2", "[expressionEqualsIgnoreCase2]") {  // NOLINT
@@ -890,7 +890,7 @@ TEST_CASE("Equals Ignore Case 2", "[expressionEqualsIgnoreCase2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "1");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("GT", "[expressionGT]") {  // NOLINT
@@ -898,7 +898,7 @@ TEST_CASE("GT", "[expressionGT]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "1");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("GT2", "[expressionGT2]") {  // NOLINT
@@ -906,7 +906,7 @@ TEST_CASE("GT2", "[expressionGT2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "1");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("GT3", "[expressionGT3]") {  // NOLINT
@@ -914,7 +914,7 @@ TEST_CASE("GT3", "[expressionGT3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "1");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("GE", "[expressionGE]") {  // NOLINT
@@ -922,7 +922,7 @@ TEST_CASE("GE", "[expressionGE]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "1");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("GE2", "[expressionGE2]") {  // NOLINT
@@ -930,7 +930,7 @@ TEST_CASE("GE2", "[expressionGE2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "1");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("GE3", "[expressionGE3]") {  // NOLINT
@@ -938,7 +938,7 @@ TEST_CASE("GE3", "[expressionGE3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "1");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("LT", "[expressionLT]") {  // NOLINT
@@ -946,7 +946,7 @@ TEST_CASE("LT", "[expressionLT]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "1");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("LT2", "[expressionLT2]") {  // NOLINT
@@ -954,7 +954,7 @@ TEST_CASE("LT2", "[expressionLT2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "1");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("LT3", "[expressionLT3]") {  // NOLINT
@@ -962,7 +962,7 @@ TEST_CASE("LT3", "[expressionLT3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "1");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("LE", "[expressionLE]") {  // NOLINT
@@ -970,7 +970,7 @@ TEST_CASE("LE", "[expressionLE]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "1");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("LE2", "[expressionLE2]") {  // NOLINT
@@ -978,7 +978,7 @@ TEST_CASE("LE2", "[expressionLE2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "1");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("LE3", "[expressionLE3]") {  // NOLINT
@@ -986,7 +986,7 @@ TEST_CASE("LE3", "[expressionLE3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("attr", "1");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("And", "[expressionAnd]") {  // NOLINT
@@ -994,7 +994,7 @@ TEST_CASE("And", "[expressionAnd]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("filename", "an example file.txt");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("And 2", "[expressionAnd2]") {  // NOLINT
@@ -1002,7 +1002,7 @@ TEST_CASE("And 2", "[expressionAnd2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("filename", "an example file.txt");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Or", "[expressionOr]") {  // NOLINT
@@ -1010,7 +1010,7 @@ TEST_CASE("Or", "[expressionOr]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("filename", "an example file.txt");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Or 2", "[expressionOr2]") {  // NOLINT
@@ -1018,7 +1018,7 @@ TEST_CASE("Or 2", "[expressionOr2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("filename", "an example file.txt");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Not", "[expressionNot]") {  // NOLINT
@@ -1026,7 +1026,7 @@ TEST_CASE("Not", "[expressionNot]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("filename", "an example file.txt");
-  REQUIRE("false" == expr( { flow_file_a }).asString());
+  REQUIRE("false" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Not 2", "[expressionNot2]") {  // NOLINT
@@ -1034,7 +1034,7 @@ TEST_CASE("Not 2", "[expressionNot2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("filename", "an example file.txt");
-  REQUIRE("true" == expr( { flow_file_a }).asString());
+  REQUIRE("true" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("If Else", "[expressionIfElse]") {  // NOLINT
@@ -1042,7 +1042,7 @@ TEST_CASE("If Else", "[expressionIfElse]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("filename", "an example file.txt");
-  REQUIRE("yes" == expr( { flow_file_a }).asString());
+  REQUIRE("yes" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("If Else 2", "[expressionIfElse2]") {  // NOLINT
@@ -1050,7 +1050,7 @@ TEST_CASE("If Else 2", "[expressionIfElse2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("filename", "An example file.txt");
-  REQUIRE("no" == expr( { flow_file_a }).asString());
+  REQUIRE("no" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Encode JSON", "[expressionEncodeJSON]") {  // NOLINT
@@ -1058,7 +1058,7 @@ TEST_CASE("Encode JSON", "[expressionEncodeJSON]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "This is a \"test!\"");
-  REQUIRE("This is a \\\"test!\\\"" == expr( { flow_file_a }).asString());
+  REQUIRE("This is a \\\"test!\\\"" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Decode JSON", "[expressionDecodeJSON]") {  // NOLINT
@@ -1066,7 +1066,7 @@ TEST_CASE("Decode JSON", "[expressionDecodeJSON]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "This is a \\\"test!\\\"");
-  REQUIRE("This is a \"test!\"" == expr( { flow_file_a }).asString());
+  REQUIRE("This is a \"test!\"" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Encode Decode JSON", "[expressionEncodeDecodeJSON]") {  // NOLINT
@@ -1074,7 +1074,7 @@ TEST_CASE("Encode Decode JSON", "[expressionEncodeDecodeJSON]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "This is a \"test!\"");
-  REQUIRE("This is a \"test!\"" == expr( { flow_file_a }).asString());
+  REQUIRE("This is a \"test!\"" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Encode XML", "[expressionEncodeXML]") {  // NOLINT
@@ -1082,7 +1082,7 @@ TEST_CASE("Encode XML", "[expressionEncodeXML]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "Zero > One < \"two!\" & 'true'");
-  REQUIRE("Zero &gt; One &lt; &quot;two!&quot; &amp; &apos;true&apos;" == expr( { flow_file_a }).asString());
+  REQUIRE("Zero &gt; One &lt; &quot;two!&quot; &amp; &apos;true&apos;" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Decode XML", "[expressionDecodeXML]") {  // NOLINT
@@ -1090,7 +1090,7 @@ TEST_CASE("Decode XML", "[expressionDecodeXML]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "Zero &gt; One &lt; &quot;two!&quot; &amp; &apos;true&apos;");
-  REQUIRE("Zero > One < \"two!\" & 'true'" == expr( { flow_file_a }).asString());
+  REQUIRE("Zero > One < \"two!\" & 'true'" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Encode Decode XML", "[expressionEncodeDecodeXML]") {  // NOLINT
@@ -1098,7 +1098,7 @@ TEST_CASE("Encode Decode XML", "[expressionEncodeDecodeXML]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "Zero > One < \"two!\" & 'true'");
-  REQUIRE("Zero > One < \"two!\" & 'true'" == expr( { flow_file_a }).asString());
+  REQUIRE("Zero > One < \"two!\" & 'true'" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Encode HTML3", "[expressionEncodeHTML3]") {  // NOLINT
@@ -1106,7 +1106,7 @@ TEST_CASE("Encode HTML3", "[expressionEncodeHTML3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "¥ & < «");
-  REQUIRE("&yen; &amp; &lt; &laquo;" == expr( { flow_file_a }).asString());
+  REQUIRE("&yen; &amp; &lt; &laquo;" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Decode HTML3", "[expressionDecodeHTML3]") {  // NOLINT
@@ -1114,7 +1114,7 @@ TEST_CASE("Decode HTML3", "[expressionDecodeHTML3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "&yen; &amp; &lt; &laquo;");
-  REQUIRE("¥ & < «" == expr( { flow_file_a }).asString());
+  REQUIRE("¥ & < «" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Encode Decode HTML3", "[expressionEncodeDecodeHTML3]") {  // NOLINT
@@ -1122,7 +1122,7 @@ TEST_CASE("Encode Decode HTML3", "[expressionEncodeDecodeHTML3]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "&yen; &amp; &lt; &laquo;");
-  REQUIRE("&yen; &amp; &lt; &laquo;" == expr( { flow_file_a }).asString());
+  REQUIRE("&yen; &amp; &lt; &laquo;" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Encode HTML4", "[expressionEncodeHTML4]") {  // NOLINT
@@ -1130,7 +1130,7 @@ TEST_CASE("Encode HTML4", "[expressionEncodeHTML4]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "¥ & Φ < «");
-  REQUIRE("&yen; &amp; &Phi; &lt; &laquo;" == expr( { flow_file_a }).asString());
+  REQUIRE("&yen; &amp; &Phi; &lt; &laquo;" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Decode HTML4", "[expressionDecodeHTML4]") {  // NOLINT
@@ -1138,7 +1138,7 @@ TEST_CASE("Decode HTML4", "[expressionDecodeHTML4]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "&yen; &iota; &amp; &lt; &laquo;");
-  REQUIRE("¥ ι & < «" == expr( { flow_file_a }).asString());
+  REQUIRE("¥ ι & < «" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Encode Decode HTML4", "[expressionEncodeDecodeHTML4]") {  // NOLINT
@@ -1146,7 +1146,7 @@ TEST_CASE("Encode Decode HTML4", "[expressionEncodeDecodeHTML4]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "&yen; &amp; &lt; &Pi; &laquo;");
-  REQUIRE("&yen; &amp; &lt; &Pi; &laquo;" == expr( { flow_file_a }).asString());
+  REQUIRE("&yen; &amp; &lt; &Pi; &laquo;" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Encode CSV", "[expressionEncodeCSV]") {  // NOLINT
@@ -1154,7 +1154,7 @@ TEST_CASE("Encode CSV", "[expressionEncodeCSV]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "Zero > One < \"two!\" & 'true'");
-  REQUIRE("\"Zero > One < \"\"two!\"\" & 'true'\"" == expr( { flow_file_a }).asString());
+  REQUIRE("\"Zero > One < \"\"two!\"\" & 'true'\"" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Decode CSV", "[expressionDecodeCSV]") {  // NOLINT
@@ -1162,7 +1162,7 @@ TEST_CASE("Decode CSV", "[expressionDecodeCSV]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", R"("Zero > One < ""two!"" & 'true'")");
-  REQUIRE("Zero > One < \"two!\" & 'true'" == expr( { flow_file_a }).asString());
+  REQUIRE("Zero > One < \"two!\" & 'true'" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Decode CSV 2", "[expressionDecodeCSV2]") {  // NOLINT
@@ -1170,7 +1170,7 @@ TEST_CASE("Decode CSV 2", "[expressionDecodeCSV2]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", R"("quoted")");
-  REQUIRE("\"quoted\"" == expr( { flow_file_a }).asString());
+  REQUIRE("\"quoted\"" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Encode Decode CSV", "[expressionEncodeDecodeCSV]") {  // NOLINT
@@ -1178,7 +1178,7 @@ TEST_CASE("Encode Decode CSV", "[expressionEncodeDecodeCSV]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "Zero > One < \"two!\" & 'true'");
-  REQUIRE("Zero > One < \"two!\" & 'true'" == expr( { flow_file_a }).asString());
+  REQUIRE("Zero > One < \"two!\" & 'true'" == expr({ flow_file_a }).asString());
 }
 
 #ifndef WIN32
@@ -1188,7 +1188,7 @@ TEST_CASE("Encode URL", "[expressionEncodeURL]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "some value with spaces");
-  REQUIRE("some%20value%20with%20spaces" == expr( { flow_file_a }).asString());
+  REQUIRE("some%20value%20with%20spaces" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Decode URL", "[expressionDecodeURL]") {  // NOLINT
@@ -1196,7 +1196,7 @@ TEST_CASE("Decode URL", "[expressionDecodeURL]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "some%20value%20with%20spaces");
-  REQUIRE("some value with spaces" == expr( { flow_file_a }).asString());
+  REQUIRE("some value with spaces" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Encode Decode URL", "[expressionEncodeDecodeURL]") {  // NOLINT
@@ -1204,7 +1204,7 @@ TEST_CASE("Encode Decode URL", "[expressionEncodeDecodeURL]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "some value with spaces");
-  REQUIRE("some value with spaces" == expr( { flow_file_a }).asString());
+  REQUIRE("some value with spaces" == expr({ flow_file_a }).asString());
 }
 #else
 TEST_CASE("Encode URL", "[expressionEncodeURLExcept]") {  // NOLINT
@@ -1212,7 +1212,7 @@ TEST_CASE("Encode URL", "[expressionEncodeURLExcept]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "some value with spaces");
-  REQUIRE_THROWS(expr( {flow_file_a}).asString());
+  REQUIRE_THROWS(expr({flow_file_a}).asString());
 }
 
 TEST_CASE("Decode URL", "[expressionDecodeURLExcept]") {  // NOLINT
@@ -1220,7 +1220,7 @@ TEST_CASE("Decode URL", "[expressionDecodeURLExcept]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "some%20value%20with%20spaces");
-  REQUIRE_THROWS(expr( {flow_file_a}).asString());
+  REQUIRE_THROWS(expr({flow_file_a}).asString());
 }
 
 TEST_CASE("Encode Decode URL", "[expressionEncodeDecodeURLExcept]") {  // NOLINT
@@ -1228,7 +1228,7 @@ TEST_CASE("Encode Decode URL", "[expressionEncodeDecodeURLExcept]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "some value with spaces");
-  REQUIRE_THROWS(expr( {flow_file_a}).asString());
+  REQUIRE_THROWS(expr({flow_file_a}).asString());
 }
 #endif
 #endif
@@ -1240,7 +1240,7 @@ TEST_CASE("Parse Date", "[expressionParseDate]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "2014/04/30");
-  REQUIRE("1398841200000" == expr( { flow_file_a }).asString());
+  REQUIRE("1398841200000" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Format Date", "[expressionFormatDate]") {  // NOLINT
@@ -1248,7 +1248,7 @@ TEST_CASE("Format Date", "[expressionFormatDate]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "1394755200000");
-  REQUIRE("03-14-2014" == expr( { flow_file_a }).asString());
+  REQUIRE("03-14-2014" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Reformat Date", "[expressionReformatDate]") {  // NOLINT
@@ -1256,7 +1256,7 @@ TEST_CASE("Reformat Date", "[expressionReformatDate]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "2014/03/14");
-  REQUIRE("03-13-2014" == expr( { flow_file_a }).asString());
+  REQUIRE("03-13-2014" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Now Date", "[expressionNowDate]") {  // NOLINT
@@ -1268,7 +1268,7 @@ TEST_CASE("Now Date", "[expressionNowDate]") {  // NOLINT
   struct tm lt;
   localtime_r(&t, &lt);
 
-  REQUIRE((lt.tm_year + 1900) == expr( { flow_file_a }).asUnsignedLong());
+  REQUIRE((lt.tm_year + 1900) == expr({ flow_file_a }).asUnsignedLong());
 }
 
 #endif  // EXPRESSION_LANGUAGE_USE_DATE
@@ -1277,21 +1277,21 @@ TEST_CASE("IP", "[expressionIP]") {  // NOLINT
   auto expr = expression::compile("${ip()}");
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
-  REQUIRE("" != expr( { flow_file_a }).asString());
+  REQUIRE("" != expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Full Hostname", "[expressionFullHostname]") {  // NOLINT
   auto expr = expression::compile("${hostname('true')}");
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
-  REQUIRE("" != expr( { flow_file_a }).asString());
+  REQUIRE("" != expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("UUID", "[expressionUuid]") {  // NOLINT
   auto expr = expression::compile("${UUID()}");
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
-  REQUIRE(36 == expr( { flow_file_a }).asString().length());
+  REQUIRE(36 == expr({ flow_file_a }).asString().length());
 }
 
 TEST_CASE("Trim", "[expressionTrim]") {  // NOLINT
@@ -1299,7 +1299,7 @@ TEST_CASE("Trim", "[expressionTrim]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", " 1 2 3 ");
-  REQUIRE("1 2 3" == expr( { flow_file_a }).asString());
+  REQUIRE("1 2 3" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Append", "[expressionAppend]") {  // NOLINT
@@ -1307,7 +1307,7 @@ TEST_CASE("Append", "[expressionAppend]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "a brand new filename.txt");
-  REQUIRE("a brand new filename.txt.gz" == expr( { flow_file_a }).asString());
+  REQUIRE("a brand new filename.txt.gz" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Prepend", "[expressionPrepend]") {  // NOLINT
@@ -1315,7 +1315,7 @@ TEST_CASE("Prepend", "[expressionPrepend]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "filename.txt");
-  REQUIRE("a brand new filename.txt" == expr( { flow_file_a }).asString());
+  REQUIRE("a brand new filename.txt" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Length", "[expressionLength]") {  // NOLINT
@@ -1323,7 +1323,7 @@ TEST_CASE("Length", "[expressionLength]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "a brand new filename.txt");
-  REQUIRE(24 == expr( { flow_file_a }).asUnsignedLong());
+  REQUIRE(24 == expr({ flow_file_a }).asUnsignedLong());
 }
 
 TEST_CASE("Encode B64", "[expressionEncodeB64]") {  // NOLINT
@@ -1331,7 +1331,7 @@ TEST_CASE("Encode B64", "[expressionEncodeB64]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "admin:admin");
-  REQUIRE("YWRtaW46YWRtaW4=" == expr( { flow_file_a }).asString());
+  REQUIRE("YWRtaW46YWRtaW4=" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Decode B64", "[expressionDecodeB64]") {  // NOLINT
@@ -1339,7 +1339,7 @@ TEST_CASE("Decode B64", "[expressionDecodeB64]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "YWRtaW46YWRtaW4=");
-  REQUIRE("admin:admin" == expr( { flow_file_a }).asString());
+  REQUIRE("admin:admin" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Encode Decode B64", "[expressionEncodeDecodeB64]") {  // NOLINT
@@ -1347,7 +1347,7 @@ TEST_CASE("Encode Decode B64", "[expressionEncodeDecodeB64]") {  // NOLINT
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("message", "Zero > One < \"two!\" & 'true'");
-  REQUIRE("Zero > One < \"two!\" & 'true'" == expr( { flow_file_a }).asString());
+  REQUIRE("Zero > One < \"two!\" & 'true'" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("All Contains", "[expressionAllContains]") {  // NOLINT
@@ -1356,7 +1356,7 @@ TEST_CASE("All Contains", "[expressionAllContains]") {  // NOLINT
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("a", "hello 1");
   flow_file_a->addAttribute("b", "hello 2");
-  REQUIRE(expr( { flow_file_a }).asBoolean());
+  REQUIRE(expr({ flow_file_a }).asBoolean());
 }
 
 TEST_CASE("All Contains 2", "[expressionAllContains2]") {  // NOLINT
@@ -1365,7 +1365,7 @@ TEST_CASE("All Contains 2", "[expressionAllContains2]") {  // NOLINT
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("a", "hello 1");
   flow_file_a->addAttribute("b", "mello 2");
-  REQUIRE(!expr( { flow_file_a }).asBoolean());
+  REQUIRE(!expr({ flow_file_a }).asBoolean());
 }
 
 TEST_CASE("Any Contains", "[expressionAnyContains]") {  // NOLINT
@@ -1374,7 +1374,7 @@ TEST_CASE("Any Contains", "[expressionAnyContains]") {  // NOLINT
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("a", "hello 1");
   flow_file_a->addAttribute("b", "mello 2");
-  REQUIRE(expr( { flow_file_a }).asBoolean());
+  REQUIRE(expr({ flow_file_a }).asBoolean());
 }
 
 TEST_CASE("Any Contains 2", "[expressionAnyContains2]") {  // NOLINT
@@ -1383,7 +1383,7 @@ TEST_CASE("Any Contains 2", "[expressionAnyContains2]") {  // NOLINT
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("a", "mello 1");
   flow_file_a->addAttribute("b", "mello 2");
-  REQUIRE(!expr( { flow_file_a }).asBoolean());
+  REQUIRE(!expr({ flow_file_a }).asBoolean());
 }
 
 #ifdef EXPRESSION_LANGUAGE_USE_REGEX
@@ -1394,7 +1394,7 @@ TEST_CASE("All Matching Contains", "[expressionAllMatchingContains]") {  // NOLI
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("xyz_1", "hello 1");
   flow_file_a->addAttribute("xyz_2", "hello 2");
-  REQUIRE(expr( { flow_file_a }).asBoolean());
+  REQUIRE(expr({ flow_file_a }).asBoolean());
 }
 
 TEST_CASE("All Matching Contains 2", "[expressionAllMatchingContains2]") {  // NOLINT
@@ -1403,7 +1403,7 @@ TEST_CASE("All Matching Contains 2", "[expressionAllMatchingContains2]") {  // N
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("xyz_1", "hello 1");
   flow_file_a->addAttribute("xyz_2", "hello 2");
-  REQUIRE(!expr( { flow_file_a }).asBoolean());
+  REQUIRE(!expr({ flow_file_a }).asBoolean());
 }
 
 TEST_CASE("All Matching Contains 3", "[expressionAllMatchingContains3]") {  // NOLINT
@@ -1412,7 +1412,7 @@ TEST_CASE("All Matching Contains 3", "[expressionAllMatchingContains3]") {  // N
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("xyz_1", "hello 1");
   flow_file_a->addAttribute("abc_2", "hello 2");
-  REQUIRE(expr( { flow_file_a }).asBoolean());
+  REQUIRE(expr({ flow_file_a }).asBoolean());
 }
 
 TEST_CASE("All Matching Contains 4", "[expressionAllMatchingContains4]") {  // NOLINT
@@ -1421,7 +1421,7 @@ TEST_CASE("All Matching Contains 4", "[expressionAllMatchingContains4]") {  // N
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("xyz_1", "hello 1");
   flow_file_a->addAttribute("xyz_2", "2");
-  REQUIRE(!expr( { flow_file_a }).asBoolean());
+  REQUIRE(!expr({ flow_file_a }).asBoolean());
 }
 
 TEST_CASE("Any Matching Contains", "[expressionAnyMatchingContains]") {  // NOLINT
@@ -1430,7 +1430,7 @@ TEST_CASE("Any Matching Contains", "[expressionAnyMatchingContains]") {  // NOLI
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("xyz_1", "hello 1");
   flow_file_a->addAttribute("xyz_2", "mello 2");
-  REQUIRE(expr( { flow_file_a }).asBoolean());
+  REQUIRE(expr({ flow_file_a }).asBoolean());
 }
 
 TEST_CASE("Any Matching Contains 2", "[expressionAnyMatchingContains2]") {  // NOLINT
@@ -1439,7 +1439,7 @@ TEST_CASE("Any Matching Contains 2", "[expressionAnyMatchingContains2]") {  // N
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("xyz_1", "hello 1");
   flow_file_a->addAttribute("xyz_2", "mello 2");
-  REQUIRE(!expr( { flow_file_a }).asBoolean());
+  REQUIRE(!expr({ flow_file_a }).asBoolean());
 }
 
 TEST_CASE("Any Matching Contains 3", "[expressionAnyMatchingContains3]") {  // NOLINT
@@ -1448,7 +1448,7 @@ TEST_CASE("Any Matching Contains 3", "[expressionAnyMatchingContains3]") {  // N
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("abc_1", "hello 1");
   flow_file_a->addAttribute("xyz_2", "mello 2");
-  REQUIRE(expr( { flow_file_a }).asBoolean());
+  REQUIRE(expr({ flow_file_a }).asBoolean());
 }
 
 TEST_CASE("Any Matching Contains 4", "[expressionAnyMatchingContains4]") {  // NOLINT
@@ -1457,7 +1457,7 @@ TEST_CASE("Any Matching Contains 4", "[expressionAnyMatchingContains4]") {  // N
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("xyz_1", "mello 1");
   flow_file_a->addAttribute("xyz_2", "mello 2");
-  REQUIRE(!expr( { flow_file_a }).asBoolean());
+  REQUIRE(!expr({ flow_file_a }).asBoolean());
 }
 
 #endif  // EXPRESSION_LANGUAGE_USE_REGEX
@@ -1467,7 +1467,7 @@ TEST_CASE("All Delineated Contains", "[expressionAllDelineatedContains]") {  // 
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("word_list", "hello_1,hello_2");
-  REQUIRE(expr( { flow_file_a }).asBoolean());
+  REQUIRE(expr({ flow_file_a }).asBoolean());
 }
 
 TEST_CASE("All Delineated Contains 2", "[expressionAllDelineatedContains2]") {  // NOLINT
@@ -1475,7 +1475,7 @@ TEST_CASE("All Delineated Contains 2", "[expressionAllDelineatedContains2]") {  
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("word_list", "hello_1,mello_2");
-  REQUIRE(!expr( { flow_file_a }).asBoolean());
+  REQUIRE(!expr({ flow_file_a }).asBoolean());
 }
 
 TEST_CASE("All Delineated Contains 3", "[expressionAllDelineatedContains3]") {  // NOLINT
@@ -1483,7 +1483,7 @@ TEST_CASE("All Delineated Contains 3", "[expressionAllDelineatedContains3]") {  
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("word_list", "hello_1,hello_2");
-  REQUIRE(expr( { flow_file_a }).asBoolean());
+  REQUIRE(expr({ flow_file_a }).asBoolean());
 }
 
 TEST_CASE("Any Delineated Contains", "[expressionAnyDelineatedContains]") {  // NOLINT
@@ -1491,7 +1491,7 @@ TEST_CASE("Any Delineated Contains", "[expressionAnyDelineatedContains]") {  // 
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("word_list", "hello_1,mello_2");
-  REQUIRE(expr( { flow_file_a }).asBoolean());
+  REQUIRE(expr({ flow_file_a }).asBoolean());
 }
 
 TEST_CASE("Any Delineated Contains 2", "[expressionAnyDelineatedContains2]") {  // NOLINT
@@ -1499,7 +1499,7 @@ TEST_CASE("Any Delineated Contains 2", "[expressionAnyDelineatedContains2]") {  
 
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("word_list", "mello_1,mello_2");
-  REQUIRE(!expr( { flow_file_a }).asBoolean());
+  REQUIRE(!expr({ flow_file_a }).asBoolean());
 }
 
 TEST_CASE("Count", "[expressionCount]") {  // NOLINT
@@ -1508,7 +1508,7 @@ TEST_CASE("Count", "[expressionCount]") {  // NOLINT
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("a", "hello 1");
   flow_file_a->addAttribute("b", "mello 2");
-  REQUIRE(1 == expr( { flow_file_a }).asUnsignedLong());
+  REQUIRE(1 == expr({ flow_file_a }).asUnsignedLong());
 }
 
 TEST_CASE("Count 2", "[expressionCount2]") {  // NOLINT
@@ -1518,7 +1518,7 @@ TEST_CASE("Count 2", "[expressionCount2]") {  // NOLINT
   flow_file_a->addAttribute("a", "mello 1");
   flow_file_a->addAttribute("b", "mello 2");
   flow_file_a->addAttribute("c", "hello 3");
-  REQUIRE(2 == expr( { flow_file_a }).asUnsignedLong());
+  REQUIRE(2 == expr({ flow_file_a }).asUnsignedLong());
 }
 
 TEST_CASE("Count 3", "[expressionCount3]") {  // NOLINT
@@ -1528,7 +1528,7 @@ TEST_CASE("Count 3", "[expressionCount3]") {  // NOLINT
   flow_file_a->addAttribute("a", "mello 1");
   flow_file_a->addAttribute("b", "mello 2");
   flow_file_a->addAttribute("c", "hello 3");
-  REQUIRE("abc2xyz" == expr( { flow_file_a }).asString());
+  REQUIRE("abc2xyz" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Join", "[expressionJoin]") {  // NOLINT
@@ -1537,7 +1537,7 @@ TEST_CASE("Join", "[expressionJoin]") {  // NOLINT
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("a", "hello");
   flow_file_a->addAttribute("b", "mello");
-  REQUIRE("abc_def_hello_ghi|def_mello_ghi_xyz" == expr( { flow_file_a }).asString());
+  REQUIRE("abc_def_hello_ghi|def_mello_ghi_xyz" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("Join 2", "[expressionJoin2]") {  // NOLINT
@@ -1546,7 +1546,7 @@ TEST_CASE("Join 2", "[expressionJoin2]") {  // NOLINT
   auto flow_file_a = std::make_shared<MockFlowFile>();
   flow_file_a->addAttribute("a", "hello");
   flow_file_a->addAttribute("b", "mello");
-  REQUIRE("abc_def_hello|mello_ghi_xyz" == expr( { flow_file_a }).asString());
+  REQUIRE("abc_def_hello|mello_ghi_xyz" == expr({ flow_file_a }).asString());
 }
 
 TEST_CASE("resolve_user_id_test", "[resolve_user_id tests]") {  // NOLINT
@@ -1556,17 +1556,17 @@ TEST_CASE("resolve_user_id_test", "[resolve_user_id tests]") {  // NOLINT
 
   SECTION("TEST 0"){
   flow_file_a->addAttribute("attribute_sid", "0");
-  REQUIRE("0" == expr( {flow_file_a}).asString());
+  REQUIRE("0" == expr({flow_file_a}).asString());
 }
 
   SECTION("TEST abcd"){
   flow_file_a->addAttribute("attribute_sid", "abcd");
-  REQUIRE("abcd" == expr( {flow_file_a}).asString());
+  REQUIRE("abcd" == expr({flow_file_a}).asString());
 }
 
   SECTION("TEST empty"){
   flow_file_a->addAttribute("attribute_sid", "");
-  REQUIRE("" == expr( {flow_file_a}).asString());
+  REQUIRE("" == expr({flow_file_a}).asString());
 }
 }
 

--- a/extensions/http-curl/sitetosite/HTTPTransaction.h
+++ b/extensions/http-curl/sitetosite/HTTPTransaction.h
@@ -42,7 +42,7 @@ class HttpTransaction : public sitetosite::Transaction {
   }
 
   ~HttpTransaction(){
-    auto stream = dynamic_cast< org::apache::nifi::minifi::io::HttpStream*>(  dynamic_cast<SiteToSitePeer*>(crcStream.getstream())->getStream() );
+    auto stream = dynamic_cast< org::apache::nifi::minifi::io::HttpStream*>(dynamic_cast<SiteToSitePeer*>(crcStream.getstream())->getStream() );
   if (stream)
     stream->forceClose();
   }

--- a/extensions/jni/ExecuteJavaControllerService.h
+++ b/extensions/jni/ExecuteJavaControllerService.h
@@ -123,10 +123,10 @@ class ExecuteJavaControllerService : public ConfigurationContext, public std::en
   static JavaSignatures &getJniConfigurationContext() {
     static JavaSignatures methodSignatures;
     if (methodSignatures.empty()) {
-      methodSignatures.addSignature( { "getName", "()Ljava/lang/String;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniConfigurationContext_getName) });
-      methodSignatures.addSignature( { "getComponent", "()Lorg/apache/nifi/components/AbstractConfigurableComponent;",
+      methodSignatures.addSignature({ "getName", "()Ljava/lang/String;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniConfigurationContext_getName) });
+      methodSignatures.addSignature({ "getComponent", "()Lorg/apache/nifi/components/AbstractConfigurableComponent;",
           reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniConfigurationContext_getComponent) });
-      methodSignatures.addSignature( { "getPropertyNames", "()Ljava/util/List;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniConfigurationContext_getPropertyNames) });
+      methodSignatures.addSignature({ "getPropertyNames", "()Ljava/util/List;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniConfigurationContext_getPropertyNames) });
       methodSignatures.addSignature(
           { "getPropertyValue", "(Ljava/lang/String;)Ljava/lang/String;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniConfigurationContext_getPropertyValue) });
     }
@@ -136,9 +136,9 @@ class ExecuteJavaControllerService : public ConfigurationContext, public std::en
   static JavaSignatures &getJniInitializationContextSignatures() {
     static JavaSignatures methodSignatures;
     if (methodSignatures.empty()) {
-      methodSignatures.addSignature( { "getControllerServiceLookup", "()Lorg/apache/nifi/controller/ControllerServiceLookup;",
+      methodSignatures.addSignature({ "getControllerServiceLookup", "()Lorg/apache/nifi/controller/ControllerServiceLookup;",
           reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniInitializationContext_getControllerServiceLookup) });
-      methodSignatures.addSignature( { "getIdentifier", "()Ljava/lang/String;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniInitializationContext_getIdentifier) });
+      methodSignatures.addSignature({ "getIdentifier", "()Ljava/lang/String;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniInitializationContext_getIdentifier) });
     }
     return methodSignatures;
   }

--- a/extensions/jni/ExecuteJavaProcessor.h
+++ b/extensions/jni/ExecuteJavaProcessor.h
@@ -86,17 +86,17 @@ class ExecuteJavaProcessor : public core::Processor {
   static JavaSignatures &getLoggerSignatures() {
     static JavaSignatures loggersignatures;
     if (loggersignatures.empty()) {
-      loggersignatures.addSignature( { "isWarnEnabled", "()Z", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_isWarnEnabled) });
-      loggersignatures.addSignature( { "isTraceEnabled", "()Z", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_isTraceEnabled) });
-      loggersignatures.addSignature( { "isInfoEnabled", "()Z", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_isInfoEnabled) });
-      loggersignatures.addSignature( { "isErrorEnabled", "()Z", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_isErrorEnabled) });
-      loggersignatures.addSignature( { "isDebugEnabled", "()Z", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_isDebugEnabled) });
+      loggersignatures.addSignature({ "isWarnEnabled", "()Z", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_isWarnEnabled) });
+      loggersignatures.addSignature({ "isTraceEnabled", "()Z", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_isTraceEnabled) });
+      loggersignatures.addSignature({ "isInfoEnabled", "()Z", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_isInfoEnabled) });
+      loggersignatures.addSignature({ "isErrorEnabled", "()Z", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_isErrorEnabled) });
+      loggersignatures.addSignature({ "isDebugEnabled", "()Z", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_isDebugEnabled) });
 
-      loggersignatures.addSignature( { "info", "(Ljava/lang/String;)V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_info) });
-      loggersignatures.addSignature( { "warn", "(Ljava/lang/String;)V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_warn) });
-      loggersignatures.addSignature( { "error", "(Ljava/lang/String;)V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_error) });
-      loggersignatures.addSignature( { "debug", "(Ljava/lang/String;)V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_debug) });
-      loggersignatures.addSignature( { "trace", "(Ljava/lang/String;)V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_trace) });
+      loggersignatures.addSignature({ "info", "(Ljava/lang/String;)V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_info) });
+      loggersignatures.addSignature({ "warn", "(Ljava/lang/String;)V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_warn) });
+      loggersignatures.addSignature({ "error", "(Ljava/lang/String;)V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_error) });
+      loggersignatures.addSignature({ "debug", "(Ljava/lang/String;)V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_debug) });
+      loggersignatures.addSignature({ "trace", "(Ljava/lang/String;)V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniLogger_trace) });
     }
     return loggersignatures;
   }
@@ -104,11 +104,11 @@ class ExecuteJavaProcessor : public core::Processor {
   static JavaSignatures &getProcessContextSignatures() {
     static JavaSignatures methodSignatures;
     if (methodSignatures.empty()) {
-      methodSignatures.addSignature( { "getComponent", "()Lorg/apache/nifi/components/AbstractConfigurableComponent;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessContext_getComponent) });
-      methodSignatures.addSignature( { "getPropertyNames", "()Ljava/util/List;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessContext_getPropertyNames) });
-      methodSignatures.addSignature( { "getPropertyValue", "(Ljava/lang/String;)Ljava/lang/String;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessContext_getPropertyValue) });
-      methodSignatures.addSignature( { "getName", "()Ljava/lang/String;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessContext_getName) });
-      methodSignatures.addSignature( { "getControllerServiceLookup", "()Lorg/apache/nifi/controller/ControllerServiceLookup;",
+      methodSignatures.addSignature({ "getComponent", "()Lorg/apache/nifi/components/AbstractConfigurableComponent;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessContext_getComponent) });
+      methodSignatures.addSignature({ "getPropertyNames", "()Ljava/util/List;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessContext_getPropertyNames) });
+      methodSignatures.addSignature({ "getPropertyValue", "(Ljava/lang/String;)Ljava/lang/String;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessContext_getPropertyValue) });
+      methodSignatures.addSignature({ "getName", "()Ljava/lang/String;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessContext_getName) });
+      methodSignatures.addSignature({ "getControllerServiceLookup", "()Lorg/apache/nifi/controller/ControllerServiceLookup;",
           reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessContext_getControllerServiceLookup) });
     }
     return methodSignatures;
@@ -117,8 +117,8 @@ class ExecuteJavaProcessor : public core::Processor {
   static JavaSignatures &getInputStreamSignatures() {
     static JavaSignatures methodSignatures;
     if (methodSignatures.empty()) {
-      methodSignatures.addSignature( { "read", "()I", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniInputStream_read) });
-      methodSignatures.addSignature( { "readWithOffset", "([BII)I", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniInputStream_readWithOffset) });
+      methodSignatures.addSignature({ "read", "()I", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniInputStream_read) });
+      methodSignatures.addSignature({ "readWithOffset", "([BII)I", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniInputStream_readWithOffset) });
 
     }
     return methodSignatures;
@@ -127,15 +127,15 @@ class ExecuteJavaProcessor : public core::Processor {
   static JavaSignatures &getFlowFileSignatures() {
     static JavaSignatures methodSignatures;
     if (methodSignatures.empty()) {
-      methodSignatures.addSignature( { "getAttributes", "()Ljava/util/Map;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getAttributes) });
-      methodSignatures.addSignature( { "getAttribute", "(Ljava/lang/String;)Ljava/lang/String;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getAttribute) });
-      methodSignatures.addSignature( { "getSize", "()J", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getSize) });
-      methodSignatures.addSignature( { "getEntryDate", "()J", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getEntryDate) });
-      methodSignatures.addSignature( { "getLineageStartDate", "()J", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getLineageStartDate) });
-      methodSignatures.addSignature( { "getLastQueueDatePrim", "()J", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getLastQueueDatePrim) });
-      methodSignatures.addSignature( { "getQueueDateIndex", "()J", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getQueueDateIndex) });
-      methodSignatures.addSignature( { "getId", "()J", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getId) });
-      methodSignatures.addSignature( { "getUUIDStr", "()Ljava/lang/String;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getUUIDStr) });
+      methodSignatures.addSignature({ "getAttributes", "()Ljava/util/Map;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getAttributes) });
+      methodSignatures.addSignature({ "getAttribute", "(Ljava/lang/String;)Ljava/lang/String;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getAttribute) });
+      methodSignatures.addSignature({ "getSize", "()J", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getSize) });
+      methodSignatures.addSignature({ "getEntryDate", "()J", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getEntryDate) });
+      methodSignatures.addSignature({ "getLineageStartDate", "()J", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getLineageStartDate) });
+      methodSignatures.addSignature({ "getLastQueueDatePrim", "()J", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getLastQueueDatePrim) });
+      methodSignatures.addSignature({ "getQueueDateIndex", "()J", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getQueueDateIndex) });
+      methodSignatures.addSignature({ "getId", "()J", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getId) });
+      methodSignatures.addSignature({ "getUUIDStr", "()Ljava/lang/String;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniFlowFile_getUUIDStr) });
     }
     return methodSignatures;
   }
@@ -143,28 +143,28 @@ class ExecuteJavaProcessor : public core::Processor {
   static JavaSignatures &getProcessSessionSignatures() {
     static JavaSignatures methodSignatures;
     if (methodSignatures.empty()) {
-      methodSignatures.addSignature( { "remove", "(Lorg/apache/nifi/flowfile/FlowFile;)V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_remove) });
-      methodSignatures.addSignature( { "create", "()Lorg/apache/nifi/flowfile/FlowFile;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_create) });
-      methodSignatures.addSignature( { "penalize", "(Lorg/apache/nifi/flowfile/FlowFile;)Lorg/apache/nifi/flowfile/FlowFile;",
+      methodSignatures.addSignature({ "remove", "(Lorg/apache/nifi/flowfile/FlowFile;)V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_remove) });
+      methodSignatures.addSignature({ "create", "()Lorg/apache/nifi/flowfile/FlowFile;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_create) });
+      methodSignatures.addSignature({ "penalize", "(Lorg/apache/nifi/flowfile/FlowFile;)Lorg/apache/nifi/flowfile/FlowFile;",
           reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_penalize) });
-      methodSignatures.addSignature( { "createWithParent", "(Lorg/apache/nifi/flowfile/FlowFile;)Lorg/apache/nifi/flowfile/FlowFile;",
+      methodSignatures.addSignature({ "createWithParent", "(Lorg/apache/nifi/flowfile/FlowFile;)Lorg/apache/nifi/flowfile/FlowFile;",
           reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_createWithParent) });
-      methodSignatures.addSignature( { "rollback", "()V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_rollback) });
-      methodSignatures.addSignature( { "commit", "()V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_commit) });
-      methodSignatures.addSignature( { "get", "()Lorg/apache/nifi/flowfile/FlowFile;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_get) });
-      methodSignatures.addSignature( { "write", "(Lorg/apache/nifi/flowfile/FlowFile;[B)Z", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_write) });
-      methodSignatures.addSignature( { "append", "(Lorg/apache/nifi/flowfile/FlowFile;[B)Z", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_append) });
-      methodSignatures.addSignature( { "putAttribute", "(Lorg/apache/nifi/flowfile/FlowFile;Ljava/lang/String;Ljava/lang/String;)Lorg/apache/nifi/flowfile/FlowFile;",
+      methodSignatures.addSignature({ "rollback", "()V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_rollback) });
+      methodSignatures.addSignature({ "commit", "()V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_commit) });
+      methodSignatures.addSignature({ "get", "()Lorg/apache/nifi/flowfile/FlowFile;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_get) });
+      methodSignatures.addSignature({ "write", "(Lorg/apache/nifi/flowfile/FlowFile;[B)Z", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_write) });
+      methodSignatures.addSignature({ "append", "(Lorg/apache/nifi/flowfile/FlowFile;[B)Z", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_append) });
+      methodSignatures.addSignature({ "putAttribute", "(Lorg/apache/nifi/flowfile/FlowFile;Ljava/lang/String;Ljava/lang/String;)Lorg/apache/nifi/flowfile/FlowFile;",
           reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_putAttribute) });
-      methodSignatures.addSignature( { "removeAttribute", "(Lorg/apache/nifi/flowfile/FlowFile;Ljava/lang/String;)Lorg/apache/nifi/flowfile/FlowFile;",
+      methodSignatures.addSignature({ "removeAttribute", "(Lorg/apache/nifi/flowfile/FlowFile;Ljava/lang/String;)Lorg/apache/nifi/flowfile/FlowFile;",
           reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_removeAttribute) });
-      methodSignatures.addSignature( { "clone", "(Lorg/apache/nifi/flowfile/FlowFile;)Lorg/apache/nifi/flowfile/FlowFile;",
+      methodSignatures.addSignature({ "clone", "(Lorg/apache/nifi/flowfile/FlowFile;)Lorg/apache/nifi/flowfile/FlowFile;",
           reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_clone) });
-      methodSignatures.addSignature( { "clonePortion", "(Lorg/apache/nifi/flowfile/FlowFile;JJ)Lorg/apache/nifi/flowfile/FlowFile;",
+      methodSignatures.addSignature({ "clonePortion", "(Lorg/apache/nifi/flowfile/FlowFile;JJ)Lorg/apache/nifi/flowfile/FlowFile;",
           reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_clonePortion) });
-      methodSignatures.addSignature( { "readFlowFile", "(Lorg/apache/nifi/flowfile/FlowFile;)Lorg/apache/nifi/processor/JniInputStream;",
+      methodSignatures.addSignature({ "readFlowFile", "(Lorg/apache/nifi/flowfile/FlowFile;)Lorg/apache/nifi/processor/JniInputStream;",
           reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_readFlowFile) });
-      methodSignatures.addSignature( { "transfer", "(Lorg/apache/nifi/flowfile/FlowFile;Ljava/lang/String;)V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_transfer) });
+      methodSignatures.addSignature({ "transfer", "(Lorg/apache/nifi/flowfile/FlowFile;Ljava/lang/String;)V", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniProcessSession_transfer) });
     }
     return methodSignatures;
   }
@@ -172,9 +172,9 @@ class ExecuteJavaProcessor : public core::Processor {
   static JavaSignatures &getJniInitializationContextSignatures() {
     static JavaSignatures methodSignatures;
     if (methodSignatures.empty()) {
-      methodSignatures.addSignature( { "getControllerServiceLookup", "()Lorg/apache/nifi/controller/ControllerServiceLookup;",
+      methodSignatures.addSignature({ "getControllerServiceLookup", "()Lorg/apache/nifi/controller/ControllerServiceLookup;",
           reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniInitializationContext_getControllerServiceLookup) });
-      methodSignatures.addSignature( { "getIdentifier", "()Ljava/lang/String;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniInitializationContext_getIdentifier) });
+      methodSignatures.addSignature({ "getIdentifier", "()Ljava/lang/String;", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniInitializationContext_getIdentifier) });
     }
     return methodSignatures;
   }
@@ -182,13 +182,13 @@ class ExecuteJavaProcessor : public core::Processor {
   static JavaSignatures &getJniControllerServiceLookupSignatures() {
     static JavaSignatures methodSignatures;
     if (methodSignatures.empty()) {
-      methodSignatures.addSignature( { "getControllerService", "(Ljava/lang/String;)Lorg/apache/nifi/controller/ControllerService;",
+      methodSignatures.addSignature({ "getControllerService", "(Ljava/lang/String;)Lorg/apache/nifi/controller/ControllerService;",
           reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniControllerServiceLookup_getControllerService) });
-      methodSignatures.addSignature( { "isControllerServiceEnabled", "(Ljava/lang/String;)Z",
+      methodSignatures.addSignature({ "isControllerServiceEnabled", "(Ljava/lang/String;)Z",
           reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniControllerServiceLookup_isControllerServiceEnabled) });
-      methodSignatures.addSignature( { "isControllerServiceEnabling", "(Ljava/lang/String;)Z",
+      methodSignatures.addSignature({ "isControllerServiceEnabling", "(Ljava/lang/String;)Z",
           reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniControllerServiceLookup_isControllerServiceEnabling) });
-      methodSignatures.addSignature( { "getControllerServiceName", "(Ljava/lang/String;)Ljava/lang/String;",
+      methodSignatures.addSignature({ "getControllerServiceName", "(Ljava/lang/String;)Ljava/lang/String;",
           reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniControllerServiceLookup_getControllerServiceName) });
     }
     return methodSignatures;

--- a/extensions/jni/jvm/JVMLoader.h
+++ b/extensions/jni/jvm/JVMLoader.h
@@ -349,7 +349,7 @@ class JVMLoader {
     }
 
 #ifdef _MSC_VER
-#pragma warning( suppress: 4054 )
+#pragma warning(suppress: 4054)
 #endif
     return (void*)symbol;
   }

--- a/extensions/libarchive/CompressContent.h
+++ b/extensions/libarchive/CompressContent.h
@@ -438,7 +438,7 @@ private:
   std::map<std::string, std::string> fileExtension_;
 };
 
-REGISTER_RESOURCE (CompressContent, "Compresses or decompresses the contents of FlowFiles using a user-specified compression algorithm and updates the mime.type attribute as appropriate");
+REGISTER_RESOURCE(CompressContent, "Compresses or decompresses the contents of FlowFiles using a user-specified compression algorithm and updates the mime.type attribute as appropriate");
 
 } /* namespace processors */
 } /* namespace minifi */

--- a/extensions/opc/include/opc.h
+++ b/extensions/opc/include/opc.h
@@ -74,7 +74,7 @@ class Client {
                                               const std::vector<std::vector<char>>& trustBuffers);
 
  private:
-  Client (std::shared_ptr<core::logging::Logger> logger, const std::string& applicationURI,
+  Client(std::shared_ptr<core::logging::Logger> logger, const std::string& applicationURI,
       const std::vector<char>& certBuffer, const std::vector<char>& keyBuffer,
       const std::vector<std::vector<char>>& trustBuffers);
 

--- a/extensions/opc/src/opc.cpp
+++ b/extensions/opc/src/opc.cpp
@@ -340,7 +340,7 @@ UA_StatusCode Client::translateBrowsePathsToNodeIdsRequest(const std::string& pa
   auto tokens = utils::StringUtils::split(path, "/");
   std::vector<UA_UInt32> ids;
   for(size_t i = 0; i < tokens.size(); ++i) {
-    UA_UInt32 val = (i ==0 ) ? UA_NS0ID_ORGANIZES : UA_NS0ID_HASCOMPONENT;
+    UA_UInt32 val = (i ==0) ? UA_NS0ID_ORGANIZES : UA_NS0ID_HASCOMPONENT;
     ids.push_back(val);
   }
 
@@ -485,7 +485,7 @@ std::string nodeValue2String(const NodeData& nd) {
     case UA_TYPES_STRING:
     case UA_TYPES_LOCALIZEDTEXT:
     case UA_TYPES_BYTESTRING: {
-      UA_String value = *(UA_String * )(nd.var_->data);
+      UA_String value = *(UA_String *)(nd.var_->data);
       ret_val = std::string(reinterpret_cast<const char *>(value.data), value.length);
       break;
     }

--- a/extensions/sftp/client/SFTPClient.cpp
+++ b/extensions/sftp/client/SFTPClient.cpp
@@ -563,7 +563,7 @@ bool SFTPClient::putFile(const std::string& path, io::BaseStream& input, bool ov
       logger_->log_error("Failed to open remote file \"%s\" due to an underlying SSH error: %s", path.c_str(), err_msg);
     }
   }
-  const auto guard = gsl::finally ([this, &file_handle, &path]() {
+  const auto guard = gsl::finally([this, &file_handle, &path]() {
     logger_->log_trace("Closing remote file \"%s\"", path.c_str());
     libssh2_sftp_close(file_handle);
   });

--- a/extensions/sql/processors/ExecuteSQL.cpp
+++ b/extensions/sql/processors/ExecuteSQL.cpp
@@ -74,10 +74,10 @@ ExecuteSQL::~ExecuteSQL() = default;
 
 void ExecuteSQL::initialize() {
   //! Set the supported properties
-  setSupportedProperties( { dbControllerService(), outputFormat(), s_sqlSelectQuery, s_maxRowsPerFlowFile});
+  setSupportedProperties({ dbControllerService(), outputFormat(), s_sqlSelectQuery, s_maxRowsPerFlowFile});
 
   //! Set the supported relationships
-  setSupportedRelationships( { s_success });
+  setSupportedRelationships({ s_success });
 }
 
 void ExecuteSQL::processOnSchedule(core::ProcessContext &context) {

--- a/extensions/sql/processors/PutSQL.cpp
+++ b/extensions/sql/processors/PutSQL.cpp
@@ -66,10 +66,10 @@ PutSQL::~PutSQL() = default;
 
 void PutSQL::initialize() {
   //! Set the supported properties
-  setSupportedProperties( { dbControllerService(), s_sqlStatements });
+  setSupportedProperties({ dbControllerService(), s_sqlStatements });
 
   //! Set the supported relationships
-  setSupportedRelationships( { s_success });
+  setSupportedRelationships({ s_success });
 }
 
 void PutSQL::processOnSchedule(core::ProcessContext& context) {

--- a/extensions/sql/processors/QueryDatabaseTable.cpp
+++ b/extensions/sql/processors/QueryDatabaseTable.cpp
@@ -220,10 +220,10 @@ QueryDatabaseTable::~QueryDatabaseTable() = default;
 
 void QueryDatabaseTable::initialize() {
   //! Set the supported properties
-  setSupportedProperties( { dbControllerService(), outputFormat(), s_tableName, s_columnNames, s_maxValueColumnNames, s_whereClause, s_sqlQuery, s_maxRowsPerFlowFile, s_stateDirectory});
+  setSupportedProperties({ dbControllerService(), outputFormat(), s_tableName, s_columnNames, s_maxValueColumnNames, s_whereClause, s_sqlQuery, s_maxRowsPerFlowFile, s_stateDirectory});
 
   //! Set the supported relationships
-  setSupportedRelationships( { s_success });
+  setSupportedRelationships({ s_success });
 }
 
 void QueryDatabaseTable::processOnSchedule(core::ProcessContext &context) {

--- a/extensions/sql/services/DatabaseService.cpp
+++ b/extensions/sql/services/DatabaseService.cpp
@@ -58,7 +58,7 @@ void DatabaseService::onEnable() {
 }
 
 void DatabaseService::initializeProperties() {
-  setSupportedProperties( { ConnectionString });
+  setSupportedProperties({ ConnectionString });
 }
 
 } /* namespace controllers */

--- a/extensions/windows-event-log/CollectorInitiatedSubscription.h
+++ b/extensions/windows-event-log/CollectorInitiatedSubscription.h
@@ -71,7 +71,7 @@ protected:
   bool subscribe(const std::shared_ptr<core::ProcessContext> &context);
   void unsubscribe();
   int processQueue(const std::shared_ptr<core::ProcessSession> &session);
-  void logError(int line, const std::string& error );
+  void logError(int line, const std::string& error);
   void logWindowsError(int line, const std::string& info);
   void logInvalidSubscriptionPropertyType(int line, DWORD type);
   bool getSubscriptionProperty(EC_HANDLE hSubscription, EC_SUBSCRIPTION_PROPERTY_ID propID, DWORD flags, std::vector<BYTE>& buffer, PEC_VARIANT& vProperty);

--- a/extensions/windows-event-log/TailEventLog.cpp
+++ b/extensions/windows-event-log/TailEventLog.cpp
@@ -110,7 +110,7 @@ void TailEventLog::onTrigger(const std::shared_ptr<core::ProcessContext> &contex
           strlen(source) + 1);
 
       flowFile->addAttribute("source", source);
-      flowFile->addAttribute("record_number", std::to_string( event_record->RecordNumber));
+      flowFile->addAttribute("record_number", std::to_string(event_record->RecordNumber));
       flowFile->addAttribute("computer_name", computer_name);
       
       flowFile->addAttribute("event_time", getTimeStamp(event_record->TimeGenerated));

--- a/extensions/windows-event-log/wel/WindowsEventLog.cpp
+++ b/extensions/windows-event-log/wel/WindowsEventLog.cpp
@@ -64,7 +64,7 @@ void WindowsEventLogMetadataImpl::renderMetadata() {
     }
   }
 
-  event_timestamp_ = static_cast<PEVT_VARIANT>( rendered_values.get())[EvtSystemTimeCreated].FileTimeVal;
+  event_timestamp_ = static_cast<PEVT_VARIANT>(rendered_values.get())[EvtSystemTimeCreated].FileTimeVal;
 
   SYSTEMTIME st;
   FILETIME ft;

--- a/main/AgentDocs.cpp
+++ b/main/AgentDocs.cpp
@@ -129,7 +129,7 @@ void AgentDocs::generate(const std::string &docsdir, std::ostream &genStream) {
 
   auto fileFind = [&fileList,this](const std::string& base_path, const std::string& file) -> bool {
     if (file.find(".extra") == std::string::npos)
-      fileList.insert( std::make_pair(file, base_path + utils::file::FileUtils::get_separator() + file) );
+      fileList.insert(std::make_pair(file, base_path + utils::file::FileUtils::get_separator() + file));
     return true;
   };
 

--- a/main/MiNiFiMain.cpp
+++ b/main/MiNiFiMain.cpp
@@ -162,7 +162,7 @@ int main(int argc, char **argv) {
     return -1;
   }
 
-  if (signal(SIGINT, sigHandler) == SIG_ERR || signal(SIGTERM, sigHandler) == SIG_ERR ) {
+  if (signal(SIGINT, sigHandler) == SIG_ERR || signal(SIGTERM, sigHandler) == SIG_ERR) {
     logger->log_error("Cannot install signal handler");
     return -1;
   }

--- a/nanofi/examples/hash_file.c
+++ b/nanofi/examples/hash_file.c
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
 
   char *file = argv[1];
 
-  if(access( file, F_OK ) == -1) {
+  if(access(file, F_OK) == -1) {
     printf("Error: %s doesn't exist!\n", file);
     exit(1);
   }

--- a/nanofi/examples/terminate_handler.c
+++ b/nanofi/examples/terminate_handler.c
@@ -51,7 +51,7 @@ int main(int argc, char **argv) {
   set_property(put_proc, "Directory", "/tmp/never_existed");
   set_property(put_proc, "Create Missing Directories", "false");
 
-  flow_file_record *record = get_next_flow_file(instance, new_flow );
+  flow_file_record *record = get_next_flow_file(instance, new_flow);
 
   // Here be dragons - nothing below this line gets executed
   fprintf(stderr, "Dragons!!!");

--- a/nanofi/include/sitetosite/CRawSocketProtocol.h
+++ b/nanofi/include/sitetosite/CRawSocketProtocol.h
@@ -86,7 +86,7 @@ static const char * getCodecResourceName(const struct CRawSiteToSiteClient * c) 
 
 static RespondCodeContext *getRespondCodeContext(RespondCode code) {
   unsigned int i;
-  for ( i = 0; i < sizeof(respondCodeContext) / sizeof(RespondCodeContext); i++) {
+  for (i = 0; i < sizeof(respondCodeContext) / sizeof(RespondCodeContext); i++) {
     if (respondCodeContext[i].code == code) {
       return &respondCodeContext[i];
     }

--- a/nanofi/src/cxx/Plan.cpp
+++ b/nanofi/src/cxx/Plan.cpp
@@ -344,7 +344,7 @@ bool ExecutionPlan::addCustomProcessor(custom_processor_args in) {
     return false;  // This name cannot be registered
   }
 
-  if (custom_processors.count(in.name) > 0 ) {
+  if (custom_processors.count(in.name) > 0) {
     return false;  // Already exists
   }
   custom_processors[in.name] = in;

--- a/nanofi/tests/CSite2SiteTests.cpp
+++ b/nanofi/tests/CSite2SiteTests.cpp
@@ -178,7 +178,7 @@ TEST_CASE("TestSiteToBootStrap", "[S2S3]") {
     uint16_t port = sckt->getPort();
 
     sckt->registerCallback([]() -> bool { return true; },  [&bootstrap_func, &transfer_state, &received_data](minifi::io::BaseStream* stream)
-      {bootstrap_func(stream, transfer_state, received_data); accept_transfer(stream, PAYLOAD_CRC, transfer_state, received_data); } );
+      {bootstrap_func(stream, transfer_state, received_data); accept_transfer(stream, PAYLOAD_CRC, transfer_state, received_data); });
 
     bool c_handshake_ok = false;
     bool c_transfer_ok = false;


### PR DESCRIPTION
Automatic fixes done using:

```zsh
➜ make linter |& egrep -v '^Done processing|^Ignoring' |& tee errors.txt | less
➜ cat errors.txt | grep "Extra space before (" | tr ":" " " | cut -d" " -f1,2 | sort -rn -k1 -k2 | xargs -n 2 sh -c 'sed -i "" "$2s/ (/(/g" $1' sh
➜ cat errors.txt | grep "Extra space before )" | tr ":" " " | cut -d" " -f1,2 | sort -rn -k1 -k2 | xargs -n 2 sh -c 'sed -i "" "$2s/ )/)/g" $1' sh
➜ cat errors.txt | grep "Extra space after (" | tr ":" " " | cut -d" " -f1,2 | sort -rn -k1 -k2 | xargs -n 2 sh -c 'sed -i "" "$2s/( /(/g" $1' sh
➜ cat errors.txt | grep "Extra space after )" | tr ":" " " | cut -d" " -f1,2 | sort -rn -k1 -k2 | xargs -n 2 sh -c 'sed -i "" "$2s/) /)/g" $1' sh
➜ cat errors.txt | grep "Mismatching spaces" | tr ":" " " | cut -d" " -f1,2 | sort -rn -k1 -k2 | xargs -n 2 sh -c 'sed -i "" "$2s/( /(/g" $1' sh
➜ cat errors.txt | grep "Mismatching spaces" | tr ":" " " | cut -d" " -f1,2 | sort -rn -k1 -k2 | xargs -n 2 sh -c 'sed -i "" "$2s/ )/)/g" $1' sh
```

---

:information_source: A simple way to confirm that the changes affect white spaces only:

![Screenshot 2020-08-13 at 9 24 35](https://user-images.githubusercontent.com/64011968/90105812-d0dfd280-dd46-11ea-96ab-b004bfb73f59.png)