### PR TITLE
MINIFICPP-1343 Create a minimal docker image target

### DIFF
--- a/cmake/DockerConfig.cmake
+++ b/cmake/DockerConfig.cmake
@@ -18,37 +18,39 @@
 # Create a custom build target called "docker" that will invoke DockerBuild.sh and create the NiFi-MiNiFi-CPP Docker image
 add_custom_target(
     docker
-    COMMAND ${CMAKE_SOURCE_DIR}/docker/DockerBuild.sh 1000 1000 ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH} minificppsource ${CMAKE_SOURCE_DIR}
+    COMMAND ${CMAKE_SOURCE_DIR}/docker/DockerBuild.sh 1000 1000 ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH} minificppsource ${CMAKE_SOURCE_DIR} release
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docker/)
-    
+
+# Create minimal docker image
+add_custom_target(
+    docker-minimal
+    COMMAND ${CMAKE_SOURCE_DIR}/docker/DockerBuild.sh 1000 1000 ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH} minificppsource ${CMAKE_SOURCE_DIR} minimal
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docker/)
 
 add_custom_target(
     centos
     COMMAND ${CMAKE_SOURCE_DIR}/docker/ContainerBuild.sh 1000 1000 ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH} minificppsource ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} centos ${ENABLE_JNI}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docker/centos/)
-    
+
 add_custom_target(
     debian
     COMMAND ${CMAKE_SOURCE_DIR}/docker/ContainerBuild.sh 1000 1000 ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH} minificppsource ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} debian ${ENABLE_JNI}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docker/debian/)
-    
+
 add_custom_target(
     fedora
     COMMAND ${CMAKE_SOURCE_DIR}/docker/ContainerBuild.sh 1000 1000 ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH} minificppsource ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} fedora ${ENABLE_JNI}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docker/fedora/)          
-
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docker/fedora/)
 
 add_custom_target(
     u18
     COMMAND ${CMAKE_SOURCE_DIR}/docker/ContainerBuild.sh 1000 1000 ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH} minificppsource ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} bionic ${ENABLE_JNI}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docker/bionic/)         
-    
-    
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docker/bionic/)
+
 add_custom_target(
     u16
     COMMAND ${CMAKE_SOURCE_DIR}/docker/ContainerBuild.sh 1000 1000 ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH} minificppsource ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} xenial ${ENABLE_JNI}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docker/xenial/)     
-    
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docker/xenial/)
 
 add_custom_target(
     docker-verify

--- a/docker/DockerBuild.sh
+++ b/docker/DockerBuild.sh
@@ -24,6 +24,13 @@ GID_ARG=$2
 MINIFI_VERSION=$3
 MINIFI_SOURCE_CODE=$4
 CMAKE_SOURCE_DIR=$5
+IMAGE_TYPE=${6:-release}
+
+if [ "${IMAGE_TYPE}" == "release" ]; then
+  TAG=
+else
+  TAG="-${IMAGE_TYPE}"
+fi
 
 echo "NiFi-MiNiFi-CPP Version: $MINIFI_VERSION"
 echo "Current Working Directory: $(pwd)"
@@ -54,9 +61,10 @@ DOCKER_COMMAND="docker build --build-arg UID=$UID_ARG \
                              --build-arg GID=$GID_ARG \
                              --build-arg MINIFI_VERSION=$MINIFI_VERSION \
                              --build-arg MINIFI_SOURCE_CODE=$MINIFI_SOURCE_CODE \
+                             --target $IMAGE_TYPE \
                              -t \
-                             apacheminificpp:$MINIFI_VERSION ."
+                             apacheminificpp:${MINIFI_VERSION}${TAG} ."
 echo "Docker Command: '$DOCKER_COMMAND'"
-${DOCKER_COMMAND}
+DOCKER_BUILDKIT=1 ${DOCKER_COMMAND}
 
 rm -rf $CMAKE_SOURCE_DIR/docker/minificppsource

--- a/docker/DockerBuild.sh
+++ b/docker/DockerBuild.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements. See the NOTICE file
 # distributed with this work for additional information
@@ -16,8 +17,6 @@
 # under the License.
 #
 
-#!/bin/bash
-
 # Set env vars.
 UID_ARG=$1
 GID_ARG=$2
@@ -29,17 +28,17 @@ IMAGE_TYPE=${6:-release}
 if [ "${IMAGE_TYPE}" == "release" ]; then
   TAG=
 else
-  TAG="-${IMAGE_TYPE}"
+  TAG="${IMAGE_TYPE}-"
 fi
 
-echo "NiFi-MiNiFi-CPP Version: $MINIFI_VERSION"
+echo "NiFi-MiNiFi-CPP Version: ${MINIFI_VERSION}"
 echo "Current Working Directory: $(pwd)"
-echo "CMake Source Directory: $CMAKE_SOURCE_DIR"
-echo "MiNiFi Package: $MINIFI_SOURCE_CODE"
+echo "CMake Source Directory: ${CMAKE_SOURCE_DIR}"
+echo "MiNiFi Package: ${MINIFI_SOURCE_CODE}"
 
 # Copy the MiNiFi source tree to the Docker working directory before building
-rm -rf $CMAKE_SOURCE_DIR/docker/minificppsource
-mkdir -p $CMAKE_SOURCE_DIR/docker/minificppsource
+rm -rf "${CMAKE_SOURCE_DIR}/docker/minificppsource"
+mkdir -p "${CMAKE_SOURCE_DIR}/docker/minificppsource"
 rsync -avr \
       --exclude '/*build*' \
       --exclude '/*_repository*' \
@@ -54,17 +53,17 @@ rsync -avr \
       --exclude '/extensions/expression-language/position.hh' \
       --exclude '/extensions/expression-language/stack.hh' \
       --delete \
-      $CMAKE_SOURCE_DIR/ \
-      $CMAKE_SOURCE_DIR/docker/minificppsource/
+      "${CMAKE_SOURCE_DIR}/" \
+      "${CMAKE_SOURCE_DIR}/docker/minificppsource/"
 
-DOCKER_COMMAND="docker build --build-arg UID=$UID_ARG \
-                             --build-arg GID=$GID_ARG \
-                             --build-arg MINIFI_VERSION=$MINIFI_VERSION \
-                             --build-arg MINIFI_SOURCE_CODE=$MINIFI_SOURCE_CODE \
-                             --target $IMAGE_TYPE \
+DOCKER_COMMAND="docker build --build-arg UID=${UID_ARG} \
+                             --build-arg GID=${GID_ARG} \
+                             --build-arg MINIFI_VERSION=${MINIFI_VERSION} \
+                             --build-arg MINIFI_SOURCE_CODE=${MINIFI_SOURCE_CODE} \
+                             --target ${IMAGE_TYPE} \
                              -t \
-                             apacheminificpp:${MINIFI_VERSION}${TAG} ."
-echo "Docker Command: '$DOCKER_COMMAND'"
+                             apacheminificpp:${TAG}${MINIFI_VERSION} ."
+echo "Docker Command: '${DOCKER_COMMAND}'"
 DOCKER_BUILDKIT=1 ${DOCKER_COMMAND}
 
-rm -rf $CMAKE_SOURCE_DIR/docker/minificppsource
+rm -rf "${CMAKE_SOURCE_DIR}/docker/minificppsource"

--- a/docker/DockerBuild.sh
+++ b/docker/DockerBuild.sh
@@ -25,9 +25,8 @@ MINIFI_SOURCE_CODE=$4
 CMAKE_SOURCE_DIR=$5
 IMAGE_TYPE=${6:-release}
 
-if [ "${IMAGE_TYPE}" == "release" ]; then
-  TAG=
-else
+unset TAG
+if [ "${IMAGE_TYPE}" != "release" ]; then
   TAG="${IMAGE_TYPE}-"
 fi
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,15 +16,14 @@
 # under the License.
 #
 
-# First stage: the build environment
-# Edge required for rocksdb
-FROM alpine:3.8 AS builder
-MAINTAINER Apache NiFi <dev@nifi.apache.org>
+# First stage: the common build environment dependencies
+FROM alpine:3.12 AS build_deps
+LABEL maintainer="Apache NiFi <dev@nifi.apache.org>"
 
-ARG UID
-ARG GID
 ARG MINIFI_VERSION
 ARG MINIFI_SOURCE_CODE
+ARG UID=1000
+ARG GID=1000
 
 # Install the system dependencies needed for a build
 RUN apk --update --no-cache upgrade && apk --update --no-cache add gcc \
@@ -54,7 +53,9 @@ RUN apk --update --no-cache upgrade && apk --update --no-cache add gcc \
 	libressl-dev \
 	zlib-dev \
 	bzip2-dev \
-	python3-dev
+	python3-dev \
+	patch \
+	doxygen
 
 ENV USER minificpp
 ENV MINIFI_BASE_DIR /opt/minifi
@@ -72,7 +73,19 @@ USER ${USER}
 
 ENV MINIFI_HOME $MINIFI_BASE_DIR/nifi-minifi-cpp-${MINIFI_VERSION}
 
-# Perform the build
+
+# Build stage of the minimal image
+FROM build_deps AS build_minimal
+RUN cd ${MINIFI_BASE_DIR} \
+	&& mkdir build \
+	&& cd build \
+	&& cmake -DDISABLE_LIBARCHIVE=ON -DDISABLE_SCRIPTING=ON -DENABLE_LIBRDKAFKA=ON -DSKIP_TESTS=true -DCMAKE_BUILD_TYPE=MinSizeRel .. \
+	&& make -j8 package \
+	&& tar -xzvf ${MINIFI_BASE_DIR}/build/nifi-minifi-cpp-${MINIFI_VERSION}-bin.tar.gz -C ${MINIFI_BASE_DIR}
+
+
+# Build stage of normal image
+FROM build_deps AS build_release
 RUN cd ${MINIFI_BASE_DIR} \
 	&& mkdir build \
 	&& cd build \
@@ -80,18 +93,53 @@ RUN cd ${MINIFI_BASE_DIR} \
 	&& make -j8 package \
 	&& tar -xzvf ${MINIFI_BASE_DIR}/build/nifi-minifi-cpp-${MINIFI_VERSION}-bin.tar.gz -C ${MINIFI_BASE_DIR}
 
-# Second stage: the runtime image
-# Edge required for rocksdb
-FROM alpine:3.8
 
-ARG UID
-ARG GID
+# Common runtime image dependencies
+# Edge required for rocksdb
+FROM alpine:3.12 AS common_runtime_deps
+
+ARG UID=1000
+ARG GID=1000
 ARG MINIFI_VERSION
 ARG MINIFI_SOURCE_CODE
 
 # Add testing repo for rocksdb
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
 
+ENV USER minificpp
+ENV MINIFI_BASE_DIR /opt/minifi
+ENV MINIFI_HOME ${MINIFI_BASE_DIR}/minifi-current
+ENV MINIFI_VERSIONED_HOME ${MINIFI_BASE_DIR}/nifi-minifi-cpp-${MINIFI_VERSION}
+ENV JAVA_HOME /usr/lib/jvm/default-jvm
+ENV PATH ${PATH}:/usr/lib/jvm/default-jvm/bin
+
+RUN addgroup -g ${GID} ${USER} && adduser -u ${UID} -D -G ${USER} -g "" ${USER}
+RUN install -d -o  ${USER} -g  ${USER} ${MINIFI_BASE_DIR} \
+    && ln -s ${MINIFI_VERSIONED_HOME} ${MINIFI_HOME}
+
+
+# Final stage of the minimal image
+FROM common_runtime_deps AS minimal
+
+RUN apk --update --no-cache upgrade && apk add --update --no-cache \
+	libstdc++
+RUN install -d -o ${USER} -g ${USER} ${MINIFI_VERSIONED_HOME}/bin \
+    && install -d -o ${USER} -g ${USER} ${MINIFI_VERSIONED_HOME}/conf && chown ${USER}:${USER} ${MINIFI_HOME}
+
+# Copy built minifi distribution from builder
+COPY --from=build_minimal --chown=${USER}:${USER} ${MINIFI_VERSIONED_HOME}/bin/minifi ${MINIFI_HOME}/bin/minifi
+COPY --from=build_minimal --chown=${USER}:${USER} ${MINIFI_VERSIONED_HOME}/bin/minifi.sh ${MINIFI_HOME}/bin/minifi.sh
+COPY --from=build_minimal --chown=${USER}:${USER} ${MINIFI_VERSIONED_HOME}/conf ${MINIFI_HOME}/conf
+
+USER ${USER}
+WORKDIR ${MINIFI_HOME}
+
+# Start MiNiFi CPP in the foreground
+CMD ./bin/minifi.sh run
+
+
+# Final stage of release image
+FROM common_runtime_deps AS release
 RUN apk --update --no-cache upgrade && apk add --update --no-cache \
 	util-linux \
 	curl \
@@ -105,24 +153,10 @@ RUN apk --update --no-cache upgrade && apk add --update --no-cache \
 	python3 \
 	zlib
 
-ENV USER minificpp
-ENV MINIFI_BASE_DIR /opt/minifi
-ENV MINIFI_HOME ${MINIFI_BASE_DIR}/minifi-current
-ENV MINIFI_VERSIONED_HOME ${MINIFI_BASE_DIR}/nifi-minifi-cpp-${MINIFI_VERSION}
-
-ENV JAVA_HOME /usr/lib/jvm/default-jvm
-ENV PATH ${PATH}:/usr/lib/jvm/default-jvm/bin
-
-RUN addgroup -g ${GID} ${USER} && adduser -u ${UID} -D -G ${USER} -g "" ${USER}
-RUN mkdir -p ${MINIFI_BASE_DIR} \
-    && ln -s ${MINIFI_VERSIONED_HOME} ${MINIFI_HOME}
-
 # Copy built minifi distribution from builder
-COPY --from=builder ${MINIFI_VERSIONED_HOME} ${MINIFI_HOME}
-RUN chown -R ${USER}:${USER} /opt/minifi
+COPY --from=build_release --chown=${USER}:${USER} ${MINIFI_VERSIONED_HOME} ${MINIFI_HOME}
 
 USER ${USER}
-
 WORKDIR ${MINIFI_HOME}
 
 # Start MiNiFi CPP in the foreground

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,35 +27,35 @@ ARG GID=1000
 
 # Install the system dependencies needed for a build
 RUN apk --update --no-cache upgrade && apk --update --no-cache add gcc \
-	g++ \
-	make \
-	bison \
-	flex \
-	flex-dev \
-	maven \
-	openjdk8-jre-base \
-	openjdk8 \
-	autoconf \
-	libtool \
-	wget \
-	gdb \
-	musl-dev \
-	boost-dev \
-	vim \
-	util-linux-dev \
-	curl-dev \
-	cmake \
-	git \
-	nss \
-	nss-dev \
-	unzip \
-	gpsd-dev \
-	libressl-dev \
-	zlib-dev \
-	bzip2-dev \
-	python3-dev \
-	patch \
-	doxygen
+  g++ \
+  make \
+  bison \
+  flex \
+  flex-dev \
+  maven \
+  openjdk8-jre-base \
+  openjdk8 \
+  autoconf \
+  libtool \
+  wget \
+  gdb \
+  musl-dev \
+  boost-dev \
+  vim \
+  util-linux-dev \
+  curl-dev \
+  cmake \
+  git \
+  nss \
+  nss-dev \
+  unzip \
+  gpsd-dev \
+  libressl-dev \
+  zlib-dev \
+  bzip2-dev \
+  python3-dev \
+  patch \
+  doxygen
 
 ENV USER minificpp
 ENV MINIFI_BASE_DIR /opt/minifi
@@ -75,21 +75,21 @@ USER ${USER}
 # Build stage of the minimal image
 FROM build_deps AS build_minimal
 RUN cd ${MINIFI_BASE_DIR} \
-	&& mkdir build \
-	&& cd build \
-	&& cmake -DDISABLE_LIBARCHIVE=ON -DDISABLE_SCRIPTING=ON -DENABLE_LIBRDKAFKA=ON -DSKIP_TESTS=true -DCMAKE_BUILD_TYPE=MinSizeRel .. \
-	&& make -j$(nproc) package \
-	&& tar -xzvf ${MINIFI_BASE_DIR}/build/nifi-minifi-cpp-${MINIFI_VERSION}-bin.tar.gz -C ${MINIFI_BASE_DIR}
+  && mkdir build \
+  && cd build \
+  && cmake -DDISABLE_LIBARCHIVE=ON -DDISABLE_SCRIPTING=ON -DENABLE_LIBRDKAFKA=ON -DSKIP_TESTS=true -DCMAKE_BUILD_TYPE=MinSizeRel .. \
+  && make -j$(nproc) package \
+  && tar -xzvf ${MINIFI_BASE_DIR}/build/nifi-minifi-cpp-${MINIFI_VERSION}-bin.tar.gz -C ${MINIFI_BASE_DIR}
 
 
 # Build stage of normal image
 FROM build_deps AS build_release
 RUN cd ${MINIFI_BASE_DIR} \
-	&& mkdir build \
-	&& cd build \
-	&& cmake -DDISABLE_JEMALLOC=ON -DSTATIC_BUILD= -DSKIP_TESTS=true -DENABLE_JNI=ON -DENABLE_LIBRDKAFKA=ON .. \
-	&& make -j$(nproc) package \
-	&& tar -xzvf ${MINIFI_BASE_DIR}/build/nifi-minifi-cpp-${MINIFI_VERSION}-bin.tar.gz -C ${MINIFI_BASE_DIR}
+  && mkdir build \
+  && cd build \
+  && cmake -DDISABLE_JEMALLOC=ON -DSTATIC_BUILD= -DSKIP_TESTS=true -DENABLE_JNI=ON -DENABLE_LIBRDKAFKA=ON .. \
+  && make -j$(nproc) package \
+  && tar -xzvf ${MINIFI_BASE_DIR}/build/nifi-minifi-cpp-${MINIFI_VERSION}-bin.tar.gz -C ${MINIFI_BASE_DIR}
 
 
 # Common runtime image dependencies
@@ -113,7 +113,7 @@ ENV PATH ${PATH}:/usr/lib/jvm/default-jvm/bin
 
 RUN addgroup -g ${GID} ${USER} && adduser -u ${UID} -D -G ${USER} -g "" ${USER}
 RUN install -d -o ${USER} -g ${USER} ${MINIFI_BASE_DIR} \
-    && ln -s ${MINIFI_VERSIONED_HOME} ${MINIFI_HOME}
+  && ln -s ${MINIFI_VERSIONED_HOME} ${MINIFI_HOME}
 
 
 # Final stage of the minimal image
@@ -121,7 +121,7 @@ FROM common_runtime_deps AS minimal
 
 RUN apk --update --no-cache upgrade && apk add --update --no-cache libstdc++
 RUN install -d -o ${USER} -g ${USER} ${MINIFI_VERSIONED_HOME}/bin \
-    && install -d -o ${USER} -g ${USER} ${MINIFI_VERSIONED_HOME}/conf && chown ${USER}:${USER} ${MINIFI_HOME}
+  && install -d -o ${USER} -g ${USER} ${MINIFI_VERSIONED_HOME}/conf && chown ${USER}:${USER} ${MINIFI_HOME}
 
 # Copy built minifi distribution from builder
 COPY --from=build_minimal --chown=${USER}:${USER} ${MINIFI_VERSIONED_HOME}/bin/minifi ${MINIFI_HOME}/bin/minifi
@@ -138,17 +138,17 @@ CMD ./bin/minifi.sh run
 # Final stage of release image
 FROM common_runtime_deps AS release
 RUN apk --update --no-cache upgrade && apk add --update --no-cache \
-	util-linux \
-	curl \
-	unzip \
-	gpsd \
-	openjdk8-jre-base \
-	openjdk8 \
-	nss \
-	nss-dev \
-	libressl \
-	python3 \
-	zlib
+  util-linux \
+  curl \
+  unzip \
+  gpsd \
+  openjdk8-jre-base \
+  openjdk8 \
+  nss \
+  nss-dev \
+  libressl \
+  python3 \
+  zlib
 
 # Copy built minifi distribution from builder
 COPY --from=build_release --chown=${USER}:${USER} ${MINIFI_VERSIONED_HOME} ${MINIFI_HOME}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,19 +59,17 @@ RUN apk --update --no-cache upgrade && apk --update --no-cache add gcc \
 
 ENV USER minificpp
 ENV MINIFI_BASE_DIR /opt/minifi
+ENV JAVA_HOME /usr/lib/jvm/default-jvm
+ENV PATH ${PATH}:/usr/lib/jvm/default-jvm/bin
+ENV MINIFI_HOME $MINIFI_BASE_DIR/nifi-minifi-cpp-${MINIFI_VERSION}
 
 # Setup minificpp user
 RUN addgroup -g ${GID} ${USER} && adduser -u ${UID} -D -G ${USER} -g "" ${USER}
-RUN mkdir -p ${MINIFI_BASE_DIR}
-ENV JAVA_HOME /usr/lib/jvm/default-jvm
-ENV PATH ${PATH}:/usr/lib/jvm/default-jvm/bin
 
-ADD ${MINIFI_SOURCE_CODE} ${MINIFI_BASE_DIR}
-RUN chown -R ${USER}:${USER} ${MINIFI_BASE_DIR}
+RUN install -d -o ${USER} -g ${USER} ${MINIFI_BASE_DIR}
+COPY --chown=${USER}:${USER} ${MINIFI_SOURCE_CODE} ${MINIFI_BASE_DIR}
 
 USER ${USER}
-
-ENV MINIFI_HOME $MINIFI_BASE_DIR/nifi-minifi-cpp-${MINIFI_VERSION}
 
 
 # Build stage of the minimal image
@@ -114,15 +112,14 @@ ENV JAVA_HOME /usr/lib/jvm/default-jvm
 ENV PATH ${PATH}:/usr/lib/jvm/default-jvm/bin
 
 RUN addgroup -g ${GID} ${USER} && adduser -u ${UID} -D -G ${USER} -g "" ${USER}
-RUN install -d -o  ${USER} -g  ${USER} ${MINIFI_BASE_DIR} \
+RUN install -d -o ${USER} -g ${USER} ${MINIFI_BASE_DIR} \
     && ln -s ${MINIFI_VERSIONED_HOME} ${MINIFI_HOME}
 
 
 # Final stage of the minimal image
 FROM common_runtime_deps AS minimal
 
-RUN apk --update --no-cache upgrade && apk add --update --no-cache \
-	libstdc++
+RUN apk --update --no-cache upgrade && apk add --update --no-cache libstdc++
 RUN install -d -o ${USER} -g ${USER} ${MINIFI_VERSIONED_HOME}/bin \
     && install -d -o ${USER} -g ${USER} ${MINIFI_VERSIONED_HOME}/conf && chown ${USER}:${USER} ${MINIFI_HOME}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,7 +78,7 @@ RUN cd ${MINIFI_BASE_DIR} \
 	&& mkdir build \
 	&& cd build \
 	&& cmake -DDISABLE_LIBARCHIVE=ON -DDISABLE_SCRIPTING=ON -DENABLE_LIBRDKAFKA=ON -DSKIP_TESTS=true -DCMAKE_BUILD_TYPE=MinSizeRel .. \
-	&& make -j8 package \
+	&& make -j$(nproc) package \
 	&& tar -xzvf ${MINIFI_BASE_DIR}/build/nifi-minifi-cpp-${MINIFI_VERSION}-bin.tar.gz -C ${MINIFI_BASE_DIR}
 
 
@@ -88,7 +88,7 @@ RUN cd ${MINIFI_BASE_DIR} \
 	&& mkdir build \
 	&& cd build \
 	&& cmake -DDISABLE_JEMALLOC=ON -DSTATIC_BUILD= -DSKIP_TESTS=true -DENABLE_JNI=ON -DENABLE_LIBRDKAFKA=ON .. \
-	&& make -j8 package \
+	&& make -j$(nproc) package \
 	&& tar -xzvf ${MINIFI_BASE_DIR}/build/nifi-minifi-cpp-${MINIFI_VERSION}-bin.tar.gz -C ${MINIFI_BASE_DIR}
 
 


### PR DESCRIPTION
Minimalistic docker image can now be created with the docker-minimal
build target creating an apacheminificpp image with minimal-VERSION
tag.

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
