### PR TITLE
MINIFICPP-1203 - Correct linter reported inccorrect opening brace placement

### DIFF
--- a/extensions/bootstrap/bootstrap.cpp
+++ b/extensions/bootstrap/bootstrap.cpp
@@ -47,8 +47,7 @@ int main(int argc, char **argv) {
       std::cout << "Generated docs at " << result["outputc2docs"].as<std::string>() << std::endl;
     }
 
-  }catch (const std::exception &exc)
-  {
+  }catch (const std::exception &exc) {
       // catch anything thrown within try block that derives from std::exception
       std::cerr << exc.what() << std::endl;
   } catch (...) {

--- a/extensions/gps/GetGPS.h
+++ b/extensions/gps/GetGPS.h
@@ -30,12 +30,10 @@ namespace nifi {
 namespace minifi {
 namespace processors {
 
-class GetGPS : public core::Processor
-{
+class GetGPS : public core::Processor {
 public:
   GetGPS(std::string name, utils::Identifier uuid = utils::Identifier())
-  : core::Processor(name, uuid), logger_(logging::LoggerFactory<GetGPS>::getLogger())
-  {
+  : core::Processor(name, uuid), logger_(logging::LoggerFactory<GetGPS>::getLogger()) {
     gpsdHost_ = "localhost";
     gpsdPort_ = "2947";
     gpsdWaitTime_ = 50000000;

--- a/extensions/jni/jvm/JVMLoader.h
+++ b/extensions/jni/jvm/JVMLoader.h
@@ -329,8 +329,7 @@ class JVMLoader {
     LocalFree(messageBuffer);
   }
 
-  void *dlsym(void *handle, const char *name)
-  {
+  void *dlsym(void *handle, const char *name) {
     FARPROC symbol;
     HMODULE hModule;
 
@@ -339,8 +338,7 @@ class JVMLoader {
     if (symbol == nullptr) {
       store_error();
 
-      for (auto hndl : resource_mapping_)
-      {
+      for (auto hndl : resource_mapping_) {
         symbol = GetProcAddress((HMODULE)hndl.first, name);
         if (symbol != nullptr) {
           break;
@@ -354,8 +352,7 @@ class JVMLoader {
     return (void*)symbol;
   }
 
-  const char *dlerror(void)
-  {
+  const char *dlerror(void) {
     std::lock_guard<std::mutex> lock(internal_mutex_);
 
     error_str_ = current_error_;
@@ -370,8 +367,7 @@ class JVMLoader {
     HMODULE object;
     char * current_error = NULL;
     uint32_t uMode = SetErrorMode(SEM_FAILCRITICALERRORS);
-    if (nullptr == file)
-    {
+    if (nullptr == file) {
       HMODULE allModules[1024];
       HANDLE current_process_id = GetCurrentProcess();
       DWORD cbNeeded;
@@ -380,11 +376,9 @@ class JVMLoader {
       if (!object)
       store_error();
       if (EnumProcessModules(current_process_id, allModules,
-              sizeof(allModules), &cbNeeded) != 0)
-      {
+              sizeof(allModules), &cbNeeded) != 0) {
 
-        for (uint32_t i = 0; i < cbNeeded / sizeof(HMODULE); i++)
-        {
+        for (uint32_t i = 0; i < cbNeeded / sizeof(HMODULE); i++) {
           TCHAR szModName[MAX_PATH];
 
           // Get the full path to the module's file.
@@ -392,13 +386,11 @@ class JVMLoader {
         }
       }
     }
-    else
-    {
+    else {
       char lpFileName[MAX_PATH];
       int i;
 
-      for (i = 0; i < sizeof(lpFileName) - 1; i++)
-      {
+      for (i = 0; i < sizeof(lpFileName) - 1; i++) {
         if (!file[i])
         break;
         else if (file[i] == '/')
@@ -421,8 +413,7 @@ class JVMLoader {
 
   }
 
-  int dlclose(void *handle)
-  {
+  int dlclose(void *handle) {
     std::lock_guard<std::mutex> lock(internal_mutex_);
 
     HMODULE object = (HMODULE)handle;

--- a/extensions/libarchive/CompressContent.h
+++ b/extensions/libarchive/CompressContent.h
@@ -351,8 +351,7 @@ public:
       , compress_mode_(std::move(compress_mode))
       , compress_level_(compress_level)
       , flow_(std::move(flow))
-      , session_(std::move(session))
-    {
+      , session_(std::move(session)) {
     }
 
     std::shared_ptr<logging::Logger> logger_;

--- a/extensions/opc/include/opc.h
+++ b/extensions/opc/include/opc.h
@@ -99,8 +99,7 @@ struct NodeData {
   NodeData& operator= (const NodeData &) = delete;
   NodeData& operator= (NodeData &&) = delete;
 
-  NodeData(NodeData&& rhs) : data(rhs.data), attributes(rhs.attributes)
-  {
+  NodeData(NodeData&& rhs) : data(rhs.data), attributes(rhs.attributes) {
     dataTypeID = rhs.dataTypeID;
     this->var_ = rhs.var_;
     rhs.var_ = nullptr;

--- a/extensions/opc/src/fetchopc.cpp
+++ b/extensions/opc/src/fetchopc.cpp
@@ -188,8 +188,7 @@ namespace processors {
   bool FetchOPCProcessor::nodeFoundCallBack(opc::Client& client, const UA_ReferenceDescription *ref, const std::string& path,
       const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) {
     nodesFound_++;
-    if(ref->nodeClass == UA_NODECLASS_VARIABLE)
-    {
+    if(ref->nodeClass == UA_NODECLASS_VARIABLE) {
       try {
         opc::NodeData nodedata = connection_->getNodeData(ref, path);
         bool write = true;

--- a/extensions/opc/src/opc.cpp
+++ b/extensions/opc/src/opc.cpp
@@ -202,8 +202,7 @@ UA_StatusCode Client::connect(const std::string& url, const std::string& usernam
 }
 
 NodeData Client::getNodeData(const UA_ReferenceDescription *ref, const std::string& basePath) {
-  if(ref->nodeClass == UA_NODECLASS_VARIABLE)
-  {
+  if(ref->nodeClass == UA_NODECLASS_VARIABLE) {
     opc::NodeData nodedata;
     std::string browsename(reinterpret_cast<const char*>(ref->browseName.name.data), ref->browseName.name.length);
 
@@ -398,8 +397,7 @@ UA_StatusCode Client::translateBrowsePathsToNodeIdsRequest(const std::string& pa
 }
 
 template<typename T>
-UA_StatusCode Client::add_node(const UA_NodeId parentNodeId, const UA_NodeId targetNodeId, std::string browseName, T value, OPCNodeDataType dt, UA_NodeId *receivedNodeId)
-{
+UA_StatusCode Client::add_node(const UA_NodeId parentNodeId, const UA_NodeId targetNodeId, std::string browseName, T value, OPCNodeDataType dt, UA_NodeId *receivedNodeId) {
   UA_VariableAttributes attr = UA_VariableAttributes_default;
   add_value_to_variant(&attr.value, value);
   char local[6] = "en-US";
@@ -456,8 +454,7 @@ template UA_StatusCode Client::add_node<const char *>(const UA_NodeId parentNode
 template UA_StatusCode Client::add_node<std::string>(const UA_NodeId parentNodeId, const UA_NodeId targetNodeId, std::string browseName, std::string value, OPCNodeDataType dt, UA_NodeId *receivedNodeId);
 
 int32_t OPCNodeDataTypeToTypeID(OPCNodeDataType dt) {
-  switch(dt)
-  {
+  switch(dt) {
     case OPCNodeDataType::Boolean:
       return UA_NS0ID_BOOLEAN;
     case OPCNodeDataType::Int32:

--- a/extensions/sftp/processors/SFTPProcessorBase.cpp
+++ b/extensions/sftp/processors/SFTPProcessorBase.cpp
@@ -187,8 +187,7 @@ void SFTPProcessorBase::parseCommonPropertiesOnSchedule(const std::shared_ptr<co
 
 SFTPProcessorBase::CommonProperties::CommonProperties()
     : port(0U)
-    , proxy_port(0U)
-{
+    , proxy_port(0U) {
 }
 
 bool SFTPProcessorBase::parseCommonPropertiesOnTrigger(const std::shared_ptr<core::ProcessContext>& context, const std::shared_ptr<FlowFileRecord>& flow_file, CommonProperties& common_properties) {

--- a/extensions/sftp/tests/tools/SFTPTestServer.cpp
+++ b/extensions/sftp/tests/tools/SFTPTestServer.cpp
@@ -51,8 +51,7 @@ SFTPTestServer::SFTPTestServer(const std::string& working_directory,
   jar_path_ = utils::file::FileUtils::concat_path(executable_dir, jar_path);
 }
 
-SFTPTestServer::~SFTPTestServer()
-{
+SFTPTestServer::~SFTPTestServer() {
   try {
     this->stop();
   } catch (...) {

--- a/extensions/sql/data/SQLRowsetProcessor.h
+++ b/extensions/sql/data/SQLRowsetProcessor.h
@@ -30,8 +30,7 @@ namespace nifi {
 namespace minifi {
 namespace sql {
 
-class SQLRowsetProcessor
-{
+class SQLRowsetProcessor {
  public:
   SQLRowsetProcessor(const soci::rowset<soci::row>& rowset, const std::vector<SQLRowSubscriber*>& rowSubscribers);
 

--- a/extensions/sql/data/SQLWriter.h
+++ b/extensions/sql/data/SQLWriter.h
@@ -31,8 +31,7 @@ namespace nifi {
 namespace minifi {
 namespace sql {
 
-struct SQLWriter: public SQLRowSubscriber
-{
+struct SQLWriter: public SQLRowSubscriber {
   virtual std::string toString() = 0;
 };
 

--- a/extensions/sql/data/Utils.cpp
+++ b/extensions/sql/data/Utils.cpp
@@ -46,8 +46,7 @@ std::vector<std::string> inputStringToList(const std::string& str) {
   // Convert to lower and remove white characters.
   std::istringstream tokenStream(std::regex_replace(toLower(str), std::regex("\\s"), std::string("")));
 
-  while (std::getline(tokenStream, token, ','))
-  {
+  while (std::getline(tokenStream, token, ',')) {
     ret.push_back(token);
   }
 

--- a/extensions/windows-event-log/Bookmark.cpp
+++ b/extensions/windows-event-log/Bookmark.cpp
@@ -119,8 +119,7 @@ bool Bookmark::saveBookmarkXml(const std::wstring& bookmarkXml) {
   return state_manager_->set(state_map);
 }
 
-bool Bookmark::saveBookmark(EVT_HANDLE hEvent)
-{
+bool Bookmark::saveBookmark(EVT_HANDLE hEvent) {
   std::wstring bookmarkXml;
   if (!getNewBookmarkXml(hEvent, bookmarkXml)) {
     return false;

--- a/extensions/windows-event-log/Bookmark.h
+++ b/extensions/windows-event-log/Bookmark.h
@@ -36,8 +36,7 @@ namespace processors {
 
 #define LOG_LAST_ERROR(func) logger_->log_error("!"#func" error %x", GetLastError())
 
-class Bookmark
-{
+class Bookmark {
 public:
   Bookmark(const std::wstring& channel, const std::wstring& query, const std::string& bookmarkRootDir, const std::string& uuid, bool processOldEvents, std::shared_ptr<core::CoreComponentStateManager> state_manager, std::shared_ptr<logging::Logger> logger);
   ~Bookmark();

--- a/extensions/windows-event-log/CollectorInitiatedSubscription.cpp
+++ b/extensions/windows-event-log/CollectorInitiatedSubscription.cpp
@@ -360,8 +360,7 @@ bool CollectorInitiatedSubscription::checkSubscriptionRuntimeStatus() {
 
     std::wstring strRuntimeStatus;
 
-    switch (runtimeStatus)
-    {
+    switch (runtimeStatus) {
     case EcRuntimeStatusActiveStatusActive:
       strRuntimeStatus = L"Active";
       break;
@@ -462,8 +461,7 @@ bool CollectorInitiatedSubscription::createSubscription(const std::shared_ptr<co
   }
   const auto guard_hSubscription = gsl::finally([hSubscription]() { EcClose(hSubscription); });
 
-  struct SubscriptionProperty
-  {
+  struct SubscriptionProperty {
     SubscriptionProperty(EC_SUBSCRIPTION_PROPERTY_ID propId, const std::wstring& val) {
       propId_ = propId;
 
@@ -559,8 +557,7 @@ bool CollectorInitiatedSubscription::createSubscription(const std::shared_ptr<co
   return true;
 }
 
-bool CollectorInitiatedSubscription::subscribe(const std::shared_ptr<core::ProcessContext> &context)
-{
+bool CollectorInitiatedSubscription::subscribe(const std::shared_ptr<core::ProcessContext> &context) {
   logger_->log_debug("CollectorInitiatedSubscription: maxBufferSize_ %lld", maxBufferSize_.value());
 
   provenanceUri_ = "winlog://" + computerName_ + "/" + to_string(channel_.value().c_str()) + "?" + to_string(query_.value().c_str());

--- a/extensions/windows-event-log/CollectorInitiatedSubscription.h
+++ b/extensions/windows-event-log/CollectorInitiatedSubscription.h
@@ -37,8 +37,7 @@ namespace minifi {
 namespace processors {
 
 //! CollectorInitiatedSubscription Class
-class CollectorInitiatedSubscription : public core::Processor
-{
+class CollectorInitiatedSubscription : public core::Processor {
 public:
   //! Constructor
   /*!

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
@@ -643,8 +643,7 @@ void ConsumeWindowsEventLog::refreshTimeZoneData() {
   logger_->log_trace("Timezone name: %s, offset: %s", timezone_name_, timezone_offset_);
 }
 
-void ConsumeWindowsEventLog::putEventRenderFlowFileToSession(const EventRender& eventRender, core::ProcessSession& session)
-{
+void ConsumeWindowsEventLog::putEventRenderFlowFileToSession(const EventRender& eventRender, core::ProcessSession& session) {
   struct WriteCallback : public OutputStreamCallback {
     WriteCallback(const std::string& str)
       : str_(str) {
@@ -687,8 +686,7 @@ void ConsumeWindowsEventLog::putEventRenderFlowFileToSession(const EventRender& 
   }
 }
 
-void ConsumeWindowsEventLog::LogWindowsError(std::string error) const
-{
+void ConsumeWindowsEventLog::LogWindowsError(std::string error) const {
   auto error_id = GetLastError();
   LPVOID lpMsg;
 

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.h
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.h
@@ -51,8 +51,7 @@ struct EventRender {
 class Bookmark;
 
 //! ConsumeWindowsEventLog Class
-class ConsumeWindowsEventLog : public core::Processor
-{
+class ConsumeWindowsEventLog : public core::Processor {
 public:
   //! Constructor
   /*!

--- a/extensions/windows-event-log/TailEventLog.cpp
+++ b/extensions/windows-event-log/TailEventLog.cpp
@@ -89,14 +89,12 @@ void TailEventLog::onTrigger(const std::shared_ptr<core::ProcessContext> &contex
   
   logger_->log_trace("%d and %d", current_record_, num_records_);
 
-  if (ReadEventLog(log_handle_,EVENTLOG_FORWARDS_READ | EVENTLOG_SEEK_READ, current_record_, event_record,MAX_RECORD_BUFFER_SIZE, &bytes_to_read,&min_bytes))
-  {
+  if (ReadEventLog(log_handle_,EVENTLOG_FORWARDS_READ | EVENTLOG_SEEK_READ, current_record_, event_record,MAX_RECORD_BUFFER_SIZE, &bytes_to_read,&min_bytes)) {
     if (bytes_to_read == 0) {
       logger_->log_debug("Yielding");
       context->yield();
     }
-    while (bytes_to_read > 0)
-    {
+    while (bytes_to_read > 0) {
 
       std::shared_ptr<FlowFileRecord> flowFile = std::static_pointer_cast<FlowFileRecord>(session->create());
       if (flowFile == nullptr)

--- a/extensions/windows-event-log/TailEventLog.h
+++ b/extensions/windows-event-log/TailEventLog.h
@@ -35,8 +35,7 @@ namespace processors {
 const LPWSTR pEventTypeNames[] = { L"Error", L"Warning", L"Informational", L"Audit Success", L"Audit Failure" };
 char log_name[255] = "Application";
 
-class TailEventLog : public core::Processor
-{
+class TailEventLog : public core::Processor {
 public:
   TailEventLog(std::string name, utils::Identifier uuid = utils::Identifier())
   : core::Processor(name, uuid), logger_(logging::LoggerFactory<TailEventLog>::getLogger()),max_events_(1){
@@ -71,10 +70,8 @@ protected:
   }
 
 
-  inline std::string typeToString(WORD wEventType)
-  {
-    switch (wEventType)
-    {
+  inline std::string typeToString(WORD wEventType) {
+    switch (wEventType) {
     case EVENTLOG_ERROR_TYPE:
       return "Error";
     case EVENTLOG_WARNING_TYPE:
@@ -90,8 +87,7 @@ protected:
     }
   }
 
-  std::string getTimeStamp(const DWORD Time)
-  {
+  std::string getTimeStamp(const DWORD Time) {
     uint64_t ullTimeStamp = 0;
     uint64_t SecsTo1970 = 116444736000000000;
     SYSTEMTIME st;
@@ -111,8 +107,7 @@ protected:
     return str.str();
   }
 
-  void LogWindowsError(void)
-  {
+  void LogWindowsError(void) {
     auto error_id = GetLastError();
     LPVOID lpMsg;
 

--- a/extensions/windows-event-log/wel/WindowsEventLog.cpp
+++ b/extensions/windows-event-log/wel/WindowsEventLog.cpp
@@ -43,14 +43,11 @@ void WindowsEventLogMetadataImpl::renderMetadata() {
   const auto contextGuard = gsl::finally([&context](){
     EvtClose(context);
   });
-  if (!EvtRender(context, event_ptr_, EvtRenderEventValues, dwBufferSize, nullptr, &dwBufferUsed, &dwPropertyCount))
-  {
-    if (ERROR_INSUFFICIENT_BUFFER == (status = GetLastError()))
-    {
+  if (!EvtRender(context, event_ptr_, EvtRenderEventValues, dwBufferSize, nullptr, &dwBufferUsed, &dwPropertyCount)) {
+    if (ERROR_INSUFFICIENT_BUFFER == (status = GetLastError())) {
       dwBufferSize = dwBufferUsed;
       rendered_values = std::unique_ptr<EVT_VARIANT, utils::FreeDeleter>((PEVT_VARIANT)(malloc(dwBufferSize)));
-      if (rendered_values)
-      {
+      if (rendered_values) {
         EvtRender(context, event_ptr_, EvtRenderEventValues, dwBufferSize, rendered_values.get(), &dwBufferUsed, &dwPropertyCount);
       }
     }
@@ -58,8 +55,7 @@ void WindowsEventLogMetadataImpl::renderMetadata() {
       return;
     }
 
-    if (ERROR_SUCCESS != (status = GetLastError()))
-    {
+    if (ERROR_SUCCESS != (status = GetLastError())) {
       return;
     }
   }
@@ -88,8 +84,7 @@ void WindowsEventLogMetadataImpl::renderMetadata() {
   auto level = static_cast<PEVT_VARIANT>(rendered_values.get())[EvtSystemLevel];
   auto keyword = static_cast<PEVT_VARIANT>(rendered_values.get())[EvtSystemKeywords];
   if (level.Type == EvtVarTypeByte) {
-    switch (level.ByteVal)
-    {
+    switch (level.ByteVal) {
       case WINEVENT_LEVEL_CRITICAL:
       case WINEVENT_LEVEL_ERROR:
         event_type_ = "Error";
@@ -158,8 +153,7 @@ std::string WindowsEventLogMetadataImpl::getEventData(EVT_FORMAT_MESSAGE_FLAGS f
   return event_data;
 }
 
-std::string WindowsEventLogHandler::getEventMessage(EVT_HANDLE eventHandle) const
-{
+std::string WindowsEventLogHandler::getEventMessage(EVT_HANDLE eventHandle) const {
   std::string returnValue;
   std::unique_ptr<WCHAR, utils::FreeDeleter> pBuffer;
   DWORD dwBufferSize = 0;

--- a/extensions/windows-event-log/wel/WindowsEventLog.h
+++ b/extensions/windows-event-log/wel/WindowsEventLog.h
@@ -60,8 +60,7 @@ namespace wel {
 
 typedef std::vector<std::pair<METADATA, std::string>> METADATA_NAMES;
 
-class WindowsEventLogHandler
-{
+class WindowsEventLogHandler {
 public:
   WindowsEventLogHandler() : metadata_provider_(nullptr) {
   }

--- a/extensions/windows-event-log/wel/XMLString.h
+++ b/extensions/windows-event-log/wel/XMLString.h
@@ -40,13 +40,11 @@ namespace nifi {
 namespace minifi {
 namespace wel {
 
-  class XmlString : public pugi::xml_writer
-  {
+  class XmlString : public pugi::xml_writer {
   public:
     std::string xml_;
 
-    virtual void write(const void* data, size_t size)
-    {
+    virtual void write(const void* data, size_t size) {
       xml_.append(static_cast<const char*>(data), size);
     }
   };

--- a/main/MainHelper.cpp
+++ b/main/MainHelper.cpp
@@ -23,8 +23,7 @@
 #include "utils/file/FileUtils.h"
 
 #ifdef WIN32
-FILE* __cdecl _imp____iob_func()
-{
+FILE* __cdecl _imp____iob_func() {
   struct _iobuf_VS2012 { // ...\Microsoft Visual Studio 11.0\VC\include\stdio.h #56
     char *_ptr;
     int   _cnt;
@@ -50,8 +49,7 @@ FILE* __cdecl _imp____iob_func()
   return (FILE*)&bufs;
 }
 
-FILE* __cdecl __imp___iob_func()
-{
+FILE* __cdecl __imp___iob_func() {
   struct _iobuf_VS2012 { // ...\Microsoft Visual Studio 11.0\VC\include\stdio.h #56
     char *_ptr;
     int   _cnt;

--- a/main/MiNiFiMain.cpp
+++ b/main/MiNiFiMain.cpp
@@ -76,8 +76,7 @@ sem_t *running;
 
 #ifdef WIN32
 BOOL WINAPI consoleSignalHandler(DWORD signal) {
-  if (signal == CTRL_C_EVENT || signal == CTRL_BREAK_EVENT)
-  {
+  if (signal == CTRL_C_EVENT || signal == CTRL_BREAK_EVENT) {
     
     sem_post(running);
     if (sem_wait(running) == -1)

--- a/main/MiNiFiWindowsService.cpp
+++ b/main/MiNiFiWindowsService.cpp
@@ -84,12 +84,10 @@ void RunAsServiceIfNeeded() {
     return s_logger;
   };
 
-  SERVICE_TABLE_ENTRY serviceTable[] =
-  {
+  SERVICE_TABLE_ENTRY serviceTable[] = {
     {
       SERVICE_NAME,
-      [](DWORD argc, LPTSTR *argv)
-      {
+      [](DWORD argc, LPTSTR *argv) {
         setSyslogLogger();
 
         LOG_INFO("ServiceCtrlDispatcher");
@@ -366,8 +364,7 @@ bool CreateServiceTerminationThread(std::shared_ptr<logging::Logger> logger, HAN
       delete pThreadInfo;
 
       HANDLE arHandle[] = { terminationEventHandle, hService };
-      switch (auto res = WaitForMultipleObjects(_countof(arHandle), arHandle, FALSE, INFINITE))
-      {
+      switch (auto res = WaitForMultipleObjects(_countof(arHandle), arHandle, FALSE, INFINITE)) {
         case WAIT_FAILED:
           logger->log_error("!WaitForSingleObject lastError %x", GetLastError());
         break;

--- a/nanofi/include/core/log.h
+++ b/nanofi/include/core/log.h
@@ -26,8 +26,7 @@
 extern "C" {
 #endif
 
-typedef enum
-{
+typedef enum {
   off = 0,
   critical = 1,
   err = 2,

--- a/nanofi/src/core/cstream.c
+++ b/nanofi/src/core/cstream.c
@@ -172,8 +172,7 @@ cstream * create_socket(const char * host, uint16_t portnum) {
 
 #ifdef _WIN32
   WSADATA wsa;
-  if (WSAStartup(MAKEWORD(2,2),&wsa) != 0)
-  {
+  if (WSAStartup(MAKEWORD(2,2),&wsa) != 0) {
     logc(err, "%s", "WSAStartup failed");
     return NULL;
   }

--- a/nanofi/src/core/file_utils.c
+++ b/nanofi/src/core/file_utils.c
@@ -42,8 +42,7 @@ int is_directory(const char * path) {
     return S_ISDIR(dir_stat.st_mode);
 }
 
-const char * get_separator(int force_posix)
-{
+const char * get_separator(int force_posix) {
 #ifdef WIN32
     if (!force_posix) {
         return "\\";

--- a/nanofi/tests/CTestsBase.h
+++ b/nanofi/tests/CTestsBase.h
@@ -128,8 +128,7 @@ private:
 class TestControllerWithTemporaryWorkingDirectory {
 public:
   TestControllerWithTemporaryWorkingDirectory()
-    : old_cwd_(get_current_working_directory())
-  {
+    : old_cwd_(get_current_working_directory()) {
     char format[] = "/tmp/ctest_temp_dir.XXXXXX";
     std::string temp_dir = test_controller_.createTempDirectory(format);
     int result = change_current_working_directory(temp_dir.c_str());
@@ -138,8 +137,7 @@ public:
     }
   }
 
-  ~TestControllerWithTemporaryWorkingDirectory()
-  {
+  ~TestControllerWithTemporaryWorkingDirectory() {
     chdir(old_cwd_);
     free(old_cwd_);
   }


### PR DESCRIPTION
This PR branched off from the WIP #851, checked for linter errors and then corrected the currently most prevalent (opening brace not on new line).

Script used:
```bash
make linter |& egrep -v '^Done processing|^Ignoring' | grep "{ should almost always" | tr ":" " " | cut -d" " -f1,2 | sort -rn -k1 -k2 | xargs -n 2 sh -c 'sed -i "" "$2s/[[:blank:]]*{/{/" $1 && perl -pi -e "s/\\n/ / if $. == $2 - 1" $1' sh
```

This was run repeatedly until no more errors were present.