### PR TITLE
MINIFICPP-1349 ConsumeWindowsEventLogs should honor batch commit size in a single session

### DIFF
--- a/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
@@ -397,11 +397,10 @@ void ConsumeWindowsEventLog::onTrigger(const std::shared_ptr<core::ProcessContex
 
   refreshTimeZoneData();
 
-  auto process_result = processEventLogs(context, session, event_query_results);
-  processed_event_count = std::get<0>(process_result);
-  std::wstring bookmark_xml = std::get<1>(process_result);
+  std::wstring bookmark_xml;
+  std::tie(processed_event_count, bookmark_xml) = processEventLogs(context, session, event_query_results);
 
- if (processed_event_count == 0 || !commitAndSaveBookmark(bookmark_xml, session)) {
+  if (processed_event_count == 0 || !commitAndSaveBookmark(bookmark_xml, session)) {
     context->yield();
     return;
   }

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
@@ -401,7 +401,7 @@ void ConsumeWindowsEventLog::onTrigger(const std::shared_ptr<core::ProcessContex
   processed_event_count = std::get<0>(process_result);
   std::wstring bookmark_xml = std::get<1>(process_result);
 
-  if (processed_event_count > 0 && !commitAndSaveBookmark(bookmark_xml, session)) {
+ if (processed_event_count == 0 || !commitAndSaveBookmark(bookmark_xml, session)) {
     context->yield();
     return;
   }

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
@@ -375,7 +375,7 @@ void ConsumeWindowsEventLog::onTrigger(const std::shared_ptr<core::ProcessContex
   size_t processed_event_count = 0;
   const TimeDiff time_diff;
   const auto timeGuard = gsl::finally([&]() {
-    logger_->log_debug("Processed %zu events in %"  PRId64 " ms", processed_event_count, time_diff());
+    logger_->log_debug("processed %zu Events in %"  PRId64 " ms", processed_event_count, time_diff());
   });
 
   const auto event_query_results = EvtQuery(0, wstrChannel_.c_str(), wstrQuery_.c_str(), EvtQueryChannelPath);

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
@@ -185,7 +185,7 @@ void ConsumeWindowsEventLog::notifyStop() {
       LOG_LAST_ERROR(LoadLibrary);
     }
   }
-  logger_->log_trace("finish notifyStop"); 
+  logger_->log_trace("finish notifyStop");
 }
 
 ConsumeWindowsEventLog::~ConsumeWindowsEventLog() {
@@ -197,7 +197,7 @@ ConsumeWindowsEventLog::~ConsumeWindowsEventLog() {
 void ConsumeWindowsEventLog::initialize() {
   //! Set the supported properties
   setSupportedProperties({
-     Channel, Query, MaxBufferSize, InactiveDurationToReconnect, IdentifierMatcher, IdentifierFunction, ResolveAsAttributes, 
+     Channel, Query, MaxBufferSize, InactiveDurationToReconnect, IdentifierMatcher, IdentifierFunction, ResolveAsAttributes,
      EventHeaderDelimiter, EventHeader, OutputFormat, BatchCommitSize, BookmarkRootDirectory, ProcessOldEvents
   });
 
@@ -360,7 +360,7 @@ void ConsumeWindowsEventLog::onTrigger(const std::shared_ptr<core::ProcessContex
 
   auto hBookmark = pBookmark_->getBookmarkHandleFromXML();
   if (!hBookmark) {
-    logger_->log_error("hBookmark is null, unrecoverable error!"); 
+    logger_->log_error("hBookmark is null, unrecoverable error!");
     pBookmark_.reset();
     context->yield();
     return;
@@ -381,8 +381,8 @@ void ConsumeWindowsEventLog::onTrigger(const std::shared_ptr<core::ProcessContex
     if (!EvtNext(hEventResults, 1, &hEvent, EVT_NEXT_TIMEOUT_MS, 0, &dwReturned)) {
       if (ERROR_NO_MORE_ITEMS != GetLastError()) {
         LogWindowsError("Failed to get next event");
-        continue; 
-        /* According to MS this iteration should only end when the return value is false AND 
+        continue;
+        /* According to MS this iteration should only end when the return value is false AND
          the error code is NO_MORE_ITEMS. See the following page for further details:
          https://docs.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtnext */
       }
@@ -430,12 +430,12 @@ wel::WindowsEventLogHandler ConsumeWindowsEventLog::getEventLogHandler(const std
   providers_[name] = wel::WindowsEventLogHandler(EvtOpenPublisherMetadata(NULL, widechar, NULL, 0, 0));
   logger_->log_trace("Not found the handler -> created handler for %s", name.c_str());
   return providers_[name];
-} 
+}
 
 // !!! Used a non-documented approach to resolve `%%` in XML via C:\Windows\System32\MsObjs.dll.
-// Links which mention this approach: 
+// Links which mention this approach:
 // https://social.technet.microsoft.com/Forums/Windows/en-US/340632d1-60f0-4cc5-ad6f-f8c841107d0d/translate-value-1833quot-on-impersonationlevel-and-similar-values?forum=winservergen
-// https://github.com/libyal/libevtx/blob/master/documentation/Windows%20XML%20Event%20Log%20(EVTX).asciidoc 
+// https://github.com/libyal/libevtx/blob/master/documentation/Windows%20XML%20Event%20Log%20(EVTX).asciidoc
 // https://stackoverflow.com/questions/33498244/marshaling-a-message-table-resource
 //
 // Traverse xml and check each node, if it starts with '%%' and contains only digits, use it as key to lookup value in C:\Windows\System32\MsObjs.dll.
@@ -556,7 +556,7 @@ bool ConsumeWindowsEventLog::createEventRender(EVT_HANDLE hEvent, EventRender& e
     return false;
   }
 
-  // this is a well known path. 
+  // this is a well known path.
   std::string providerName = doc.child("Event").child("System").child("Provider").attribute("Name").value();
   wel::WindowsEventLogMetadataImpl metadata{getEventLogHandler(providerName).getMetadata(), hEvent};
   wel::MetadataWalker walker{metadata, channel_, !resolve_as_attributes_, apply_identifier_function_, regex_};

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
@@ -205,7 +205,7 @@ void ConsumeWindowsEventLog::initialize() {
   setSupportedRelationships({Success});
 }
 
-bool ConsumeWindowsEventLog::insertHeaderName(wel::METADATA_NAMES &header, const std::string &key, const std::string & value) {
+bool ConsumeWindowsEventLog::insertHeaderName(wel::METADATA_NAMES &header, const std::string &key, const std::string & value) const {
 
   wel::METADATA name = wel::WindowsEventLogMetadata::getMetadataFromString(key);
 
@@ -635,7 +635,7 @@ void ConsumeWindowsEventLog::refreshTimeZoneData() {
   logger_->log_trace("Timezone name: %s, offset: %s", timezone_name_, timezone_offset_);
 }
 
-void ConsumeWindowsEventLog::putEventRenderFlowFileToSession(const EventRender& eventRender, core::ProcessSession& session) {
+void ConsumeWindowsEventLog::putEventRenderFlowFileToSession(const EventRender& eventRender, core::ProcessSession& session) const {
   struct WriteCallback : public OutputStreamCallback {
     WriteCallback(const std::string& str)
       : str_(str) {

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.h
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.h
@@ -98,7 +98,6 @@ public:
   virtual void initialize(void) override;
   void notifyStop() override;
 
-
 protected:
   void refreshTimeZoneData();
   void putEventRenderFlowFileToSession(const EventRender& eventRender, core::ProcessSession& session);
@@ -121,10 +120,8 @@ private:
   };
 
   bool commitAndSaveBookmark(const std::wstring &bookmarkXml, const std::shared_ptr<core::ProcessSession> &session);
-  void processEventLogs(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session,
+  std::wstring processEventLogs(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session,
     size_t& event_count, const EVT_HANDLE& event_query_results);
-  std::wstring populateSessionWithEventLogs(const std::shared_ptr<core::ProcessSession> &session,
-    size_t& processed_event_count, const EVT_HANDLE& event_query_results);
 
   // Logger
   std::shared_ptr<logging::Logger> logger_;

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.h
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.h
@@ -97,7 +97,7 @@ public:
   //! Initialize, overwrite by NiFi ConsumeWindowsEventLog
   virtual void initialize(void) override;
   void notifyStop() override;
-  
+
 
 protected:
   void refreshTimeZoneData();

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.h
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.h
@@ -123,8 +123,7 @@ private:
   bool commitAndSaveBookmark(const std::wstring &bookmarkXml, const std::shared_ptr<core::ProcessSession> &session);
   void processEventLogs(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session,
     size_t& event_count, const EVT_HANDLE& event_query_results);
-  void populateSessionWithEventLogs(size_t& processed_event_count, const EVT_HANDLE& event_query_results);
-  std::wstring ConsumeWindowsEventLog::populateSessionWithEventLogs(const std::shared_ptr<core::ProcessSession> &session,
+  std::wstring populateSessionWithEventLogs(const std::shared_ptr<core::ProcessSession> &session,
     size_t& processed_event_count, const EVT_HANDLE& event_query_results);
 
   // Logger

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.h
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.h
@@ -113,6 +113,17 @@ protected:
   static constexpr const char * const Plaintext = "Plaintext";
 
 private:
+  struct TimeDiff {
+    auto operator()() const {
+      return int64_t{ std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - time_).count() };
+    }
+    const decltype(std::chrono::steady_clock::now()) time_ = std::chrono::steady_clock::now();
+  };
+
+  bool commitAndSaveBookmark(const std::wstring &bookmarkXml, const std::shared_ptr<core::ProcessSession> &session);
+  void processEventLogs(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session,
+    size_t& event_count, const EVT_HANDLE& event_query_results);
+
   // Logger
   std::shared_ptr<logging::Logger> logger_;
   std::shared_ptr<core::CoreComponentStateManager> state_manager_;
@@ -134,8 +145,8 @@ private:
 
   bool writeXML_;
   bool writePlainText_;
-  std::unique_ptr<Bookmark> pBookmark_;
-  std::mutex onTriggerMutex_;
+  std::unique_ptr<Bookmark> bookmark_;
+  std::mutex on_trigger_mutex_;
   std::unordered_map<std::string, std::string> xmlPercentageItemsResolutions_;
   HMODULE hMsobjsDll_{};
 

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.h
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.h
@@ -123,6 +123,9 @@ private:
   bool commitAndSaveBookmark(const std::wstring &bookmarkXml, const std::shared_ptr<core::ProcessSession> &session);
   void processEventLogs(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session,
     size_t& event_count, const EVT_HANDLE& event_query_results);
+  void populateSessionWithEventLogs(size_t& processed_event_count, const EVT_HANDLE& event_query_results);
+  std::wstring ConsumeWindowsEventLog::populateSessionWithEventLogs(const std::shared_ptr<core::ProcessSession> &session,
+    size_t& processed_event_count, const EVT_HANDLE& event_query_results);
 
   // Logger
   std::shared_ptr<logging::Logger> logger_;

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.h
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.h
@@ -120,8 +120,8 @@ private:
   };
 
   bool commitAndSaveBookmark(const std::wstring &bookmarkXml, const std::shared_ptr<core::ProcessSession> &session);
-  std::wstring processEventLogs(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session,
-    size_t& event_count, const EVT_HANDLE& event_query_results);
+  std::tuple<size_t, std::wstring> processEventLogs(const std::shared_ptr<core::ProcessContext> &context,
+    const std::shared_ptr<core::ProcessSession> &session, const EVT_HANDLE& event_query_results);
 
   // Logger
   std::shared_ptr<logging::Logger> logger_;

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.h
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.h
@@ -100,9 +100,9 @@ public:
 
 protected:
   void refreshTimeZoneData();
-  void putEventRenderFlowFileToSession(const EventRender& eventRender, core::ProcessSession& session);
+  void putEventRenderFlowFileToSession(const EventRender& eventRender, core::ProcessSession& session) const;
   wel::WindowsEventLogHandler getEventLogHandler(const std::string & name);
-  bool insertHeaderName(wel::METADATA_NAMES &header, const std::string &key, const std::string &value);
+  bool insertHeaderName(wel::METADATA_NAMES &header, const std::string &key, const std::string &value) const;
   void LogWindowsError(std::string error = "Error") const;
   bool createEventRender(EVT_HANDLE eventHandle, EventRender& eventRender);
   void substituteXMLPercentageItems(pugi::xml_document& doc);

--- a/extensions/windows-event-log/tests/ConsumeWindowsEventLogTests.cpp
+++ b/extensions/windows-event-log/tests/ConsumeWindowsEventLogTests.cpp
@@ -335,11 +335,15 @@ TEST_CASE("ConsumeWindowsEventLog prints events in XML correctly", "[onTrigger]"
     test_controller.runSession(test_plan);
 
     REQUIRE(LogTestController::getInstance().contains(R"(<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event"><System><Provider Name="Application"/>)"));
-    REQUIRE(LogTestController::getInstance().contains(R"(<EventID Qualifiers="0">14985</EventID><Level>4</Level><Task>0</Task><Keywords>0x80000000000000</Keywords><TimeCreated SystemTime=")"));
+    REQUIRE(LogTestController::getInstance().contains(R"(<EventID Qualifiers="0">14985</EventID>)"));
+    REQUIRE(LogTestController::getInstance().contains(R"(<Level>4</Level>)"));
+    REQUIRE(LogTestController::getInstance().contains(R"(<Task>0</Task>)"));
+    REQUIRE(LogTestController::getInstance().contains(R"(<Keywords>0x80000000000000</Keywords><TimeCreated SystemTime=")"));
     // the timestamp (when the event was published) goes here
     REQUIRE(LogTestController::getInstance().contains(R"("/><EventRecordID>)"));
     // the ID of the event goes here (a number)
-    REQUIRE(LogTestController::getInstance().contains(R"(</EventRecordID><Channel>Application</Channel><Computer>)"));
+    REQUIRE(LogTestController::getInstance().contains(R"(</EventRecordID>)"));
+    REQUIRE(LogTestController::getInstance().contains(R"(<Channel>Application</Channel><Computer>)"));
     // the computer name goes here
     REQUIRE(LogTestController::getInstance().contains(R"(</Computer><Security/></System><EventData><Data>Event one</Data></EventData></Event>)"));
   }


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
