### PR TITLE
MINIFICPP-1341 Fix libc++ compilation errors

### DIFF
--- a/extensions/expression-language/Expression.cpp
+++ b/extensions/expression-language/Expression.cpp
@@ -632,7 +632,9 @@ Value expr_toDate(const std::vector<Value> &args) {
 #endif  // EXPRESSION_LANGUAGE_USE_DATE
 
 Value expr_now(const std::vector<Value> &args) {
-  return Value(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+  using namespace std::chrono;
+  int64_t unix_time_ms = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+  return Value(unix_time_ms);
 }
 
 Value expr_unescapeCsv(const std::vector<Value> &args) {

--- a/extensions/expression-language/Expression.cpp
+++ b/extensions/expression-language/Expression.cpp
@@ -633,7 +633,7 @@ Value expr_toDate(const std::vector<Value> &args) {
 
 Value expr_now(const std::vector<Value> &args) {
   using namespace std::chrono;
-  int64_t unix_time_ms = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+  int64_t unix_time_ms{duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count()};
   return Value(unix_time_ms);
 }
 

--- a/extensions/standard-processors/processors/TailFile.cpp
+++ b/extensions/standard-processors/processors/TailFile.cpp
@@ -364,7 +364,10 @@ void TailFile::onSchedule(const std::shared_ptr<core::ProcessContext> &context, 
 
     context->getProperty(RecursiveLookup.getName(), recursive_lookup_);
 
-    context->getProperty(LookupFrequency.getName(), lookup_frequency_);
+    int64_t lookup_frequency;
+    if (context->getProperty(LookupFrequency.getName(), lookup_frequency)) {
+      lookup_frequency_ = std::chrono::milliseconds{lookup_frequency};
+    }
 
     recoverState(context);
 

--- a/extensions/standard-processors/processors/TailFile.cpp
+++ b/extensions/standard-processors/processors/TailFile.cpp
@@ -364,6 +364,10 @@ void TailFile::onSchedule(const std::shared_ptr<core::ProcessContext> &context, 
 
     context->getProperty(RecursiveLookup.getName(), recursive_lookup_);
 
+    // NOTE:
+    //   context->getProperty(LookupFrequency.getName(), lookup_frequency_);
+    // is incorrect, as std::chrono::milliseconds::rep is unspecified, and may not be supported by getProperty()
+    // (e.g. in clang/libc++, this underlying type is long long)
     int64_t lookup_frequency;
     if (context->getProperty(LookupFrequency.getName(), lookup_frequency)) {
       lookup_frequency_ = std::chrono::milliseconds{lookup_frequency};


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-1341

In libc++ milliseconds::rep is long long, unlike in libstdc++ where it is long.
Although these are both signed 64-bit numbers, they are different types,
and some code in minifi is not able to handle long long.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
