### PR TITLE
MINIFICPP-1352 - Comment out unused parameters (for enabling -Wall)

### DIFF
--- a/extensions/civetweb/processors/ListenHTTP.cpp
+++ b/extensions/civetweb/processors/ListenHTTP.cpp
@@ -99,7 +99,7 @@ void ListenHTTP::initialize() {
   setSupportedRelationships(relationships);
 }
 
-void ListenHTTP::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory) {
+void ListenHTTP::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory* /*sessionFactory*/) {
   std::string basePath;
 
   if (!context->getProperty(BasePath.getName(), basePath)) {
@@ -230,7 +230,7 @@ void ListenHTTP::onSchedule(core::ProcessContext *context, core::ProcessSessionF
 
 ListenHTTP::~ListenHTTP() = default;
 
-void ListenHTTP::onTrigger(core::ProcessContext *context, core::ProcessSession *session) {
+void ListenHTTP::onTrigger(core::ProcessContext* /*context*/, core::ProcessSession *session) {
   logger_->log_debug("OnTrigger ListenHTTP");
   processIncomingFlowFile(session);
   processRequestBuffer(session);
@@ -343,7 +343,7 @@ void ListenHTTP::Handler::enqueueRequest(mg_connection *conn, const mg_request_i
   writeBody(conn, req_info);
 }
 
-bool ListenHTTP::Handler::handlePost(CivetServer *server, struct mg_connection *conn) {
+bool ListenHTTP::Handler::handlePost(CivetServer* /*server*/, struct mg_connection *conn) {
   auto req_info = mg_get_request_info(conn);
   if (!req_info) {
       logger_->log_error("ListenHTTP handling POST resulted in a null request");
@@ -377,7 +377,7 @@ bool ListenHTTP::Handler::authRequest(mg_connection *conn, const mg_request_info
   return authorized;
 }
 
-bool ListenHTTP::Handler::handleGet(CivetServer *server, struct mg_connection *conn) {
+bool ListenHTTP::Handler::handleGet(CivetServer* /*server*/, struct mg_connection *conn) {
   auto req_info = mg_get_request_info(conn);
   if (!req_info) {
       logger_->log_error("ListenHTTP handling GET resulted in a null request");
@@ -393,7 +393,7 @@ bool ListenHTTP::Handler::handleGet(CivetServer *server, struct mg_connection *c
   return true;
 }
 
-bool ListenHTTP::Handler::handleHead(CivetServer *server, struct mg_connection *conn) {
+bool ListenHTTP::Handler::handleHead(CivetServer* /*server*/, struct mg_connection *conn) {
   auto req_info = mg_get_request_info(conn);
   if (!req_info) {
     logger_->log_error("ListenHTTP handling HEAD resulted in a null request");

--- a/extensions/coap/protocols/CoapC2Protocol.cpp
+++ b/extensions/coap/protocols/CoapC2Protocol.cpp
@@ -51,7 +51,7 @@ void CoapProtocol::initialize(core::controller::ControllerServiceProvider* contr
   }
 }
 
-minifi::c2::C2Payload CoapProtocol::consumePayload(const std::string &url, const minifi::c2::C2Payload &payload, minifi::c2::Direction direction, bool async) {
+minifi::c2::C2Payload CoapProtocol::consumePayload(const std::string &url, const minifi::c2::C2Payload &payload, minifi::c2::Direction direction, bool /*async*/) {
   return RESTSender::consumePayload(url, payload, direction, false);
 }
 

--- a/extensions/coap/protocols/CoapC2Protocol.h
+++ b/extensions/coap/protocols/CoapC2Protocol.h
@@ -76,11 +76,11 @@ class CoapProtocol : public minifi::c2::RESTSender {
    */
   minifi::c2::C2Payload consumePayload(const std::string &url, const minifi::c2::C2Payload &payload, minifi::c2::Direction direction, bool async) override;
 
-  minifi::c2::C2Payload consumePayload(const minifi::c2::C2Payload &payload, minifi::c2::Direction direction, bool async) override {
+  minifi::c2::C2Payload consumePayload(const minifi::c2::C2Payload &payload, minifi::c2::Direction /*direction*/, bool /*async*/) override {
       return serialize(payload);
   }
 
-  void update(const std::shared_ptr<Configure> &configure) override {
+  void update(const std::shared_ptr<Configure>& /*configure*/) override {
     // no op.
   }
 

--- a/extensions/coap/server/CoapServer.h
+++ b/extensions/coap/server/CoapServer.h
@@ -208,7 +208,7 @@ class CoapServer : public core::Connectable {
 
  protected:
 
-  static void handle_response_with_passthrough(coap_context_t *ctx, struct coap_resource_t *resource, coap_session_t *session, coap_pdu_t *request, coap_binary_t *token, coap_string_t *query,
+  static void handle_response_with_passthrough(coap_context_t* /*ctx*/, struct coap_resource_t *resource, coap_session_t *session, coap_pdu_t *request, coap_binary_t* /*token*/, coap_string_t* /*query*/,
                                                coap_pdu_t *response) {
 
     auto fx = functions_.find(resource);

--- a/extensions/coap/tests/CoapIntegrationBase.h
+++ b/extensions/coap/tests/CoapIntegrationBase.h
@@ -22,7 +22,7 @@
 #include "CivetServer.h"
 #include "integration/IntegrationBase.h"
 
-int log_message(const struct mg_connection *conn, const char *message) {
+int log_message(const struct mg_connection* /*conn*/, const char *message) {
   puts(message);
   return 1;
 }

--- a/extensions/expression-language/Expression.cpp
+++ b/extensions/expression-language/Expression.cpp
@@ -82,7 +82,7 @@ Expression make_dynamic(const std::function<Value(const Parameters &params, cons
 }
 
 Expression make_dynamic_attr(const std::string &attribute_id) {
-  return make_dynamic([attribute_id](const Parameters &params, const std::vector<Expression> &sub_exprs) -> Value {
+  return make_dynamic([attribute_id](const Parameters &params, const std::vector<Expression>& /*sub_exprs*/) -> Value {
 
     std::string result;
     const auto cur_flow_file = params.flow_file.lock();
@@ -145,7 +145,7 @@ Value expr_hostname(const std::vector<Value> &args) {
   return Value(std::string(hostname));
 }
 
-Value expr_ip(const std::vector<Value> &args) {
+Value expr_ip(const std::vector<Value>& /*args*/) {
   char hostname[1024];
   hostname[1023] = '\0';
   gethostname(hostname, 1023);
@@ -178,7 +178,7 @@ Value expr_ip(const std::vector<Value> &args) {
   return Value();
 }
 
-Value expr_uuid(const std::vector<Value> &args) {
+Value expr_uuid(const std::vector<Value>& /*args*/) {
   return Value(utils::IdGenerator::getIdGenerator()->generate().to_string());
 }
 
@@ -678,7 +678,7 @@ Value expr_toDate(const std::vector<Value>&) {
 
 #endif  // EXPRESSION_LANGUAGE_USE_DATE
 
-Value expr_now(const std::vector<Value> &args) {
+Value expr_now(const std::vector<Value>& /*args*/) {
   using namespace std::chrono;
   int64_t unix_time_ms{duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count()};
   return Value(unix_time_ms);
@@ -934,7 +934,7 @@ Value expr_fromRadix(const std::vector<Value> &args) {
   return Value(std::to_string(std::stoll(args[0].asString(), nullptr, radix)));
 }
 
-Value expr_random(const std::vector<Value> &args) {
+Value expr_random(const std::vector<Value>& /*args*/) {
   std::random_device random_device;
   std::mt19937 generator(random_device());
   std::uniform_int_distribution<int64_t> distribution(0, LLONG_MAX);
@@ -962,7 +962,7 @@ Expression make_dynamic_function_incomplete(const std::string &function_name, co
     },
                                  multi_args);
   } else {
-    return make_dynamic([=](const Parameters &params, const std::vector<Expression> &sub_exprs) -> Value {
+    return make_dynamic([=](const Parameters &params, const std::vector<Expression>& /*sub_exprs*/) -> Value {
       std::vector<Value> evaluated_args;
 
       for (const auto &arg : args) {
@@ -1087,12 +1087,12 @@ Expression make_allAttributes(const std::string &function_name, const std::vecto
     return Value(all_true);
   });
 
-  result.make_multi([=](const Parameters &params) -> std::vector<Expression> {
+  result.make_multi([=](const Parameters& /*params*/) -> std::vector<Expression> {
     std::vector<Expression> out_exprs;
 
     for (const auto &arg : args) {
       out_exprs.emplace_back(make_dynamic([=](const Parameters &params,
-                  const std::vector<Expression> &sub_exprs) -> Value {
+                  const std::vector<Expression>& /*sub_exprs*/) -> Value {
                 std::string attr_id;
                 attr_id = arg(params).asString();
                 std::string attr_val;
@@ -1132,12 +1132,12 @@ Expression make_anyAttribute(const std::string &function_name, const std::vector
     return Value(any_true);
   });
 
-  result.make_multi([=](const Parameters &params) -> std::vector<Expression> {
+  result.make_multi([=](const Parameters& /*params*/) -> std::vector<Expression> {
     std::vector<Expression> out_exprs;
 
     for (const auto &arg : args) {
       out_exprs.emplace_back(make_dynamic([=](const Parameters &params,
-                  const std::vector<Expression> &sub_exprs) -> Value {
+                  const std::vector<Expression>& /*sub_exprs*/) -> Value {
                 std::string attr_id;
                 attr_id = arg(params).asString();
                 std::string attr_val;
@@ -1193,8 +1193,8 @@ Expression make_allMatchingAttributes(const std::string &function_name, const st
 
       for (const auto &attr : attrs) {
         if (std::regex_match(attr.first.begin(), attr.first.end(), attr_regex)) {
-          out_exprs.emplace_back(make_dynamic([=](const Parameters &params,
-                      const std::vector<Expression> &sub_exprs) -> Value {
+          out_exprs.emplace_back(make_dynamic([=](const Parameters& /*params*/,
+                      const std::vector<Expression>& /*sub_exprs*/) -> Value {
                     std::string attr_val;
 
                     if (cur_flow_file && cur_flow_file->getAttribute(attr.first, attr_val)) {
@@ -1246,8 +1246,8 @@ Expression make_anyMatchingAttribute(const std::string &function_name, const std
 
       for (const auto &attr : attrs) {
         if (std::regex_match(attr.first.begin(), attr.first.end(), attr_regex)) {
-          out_exprs.emplace_back(make_dynamic([=](const Parameters &params,
-                      const std::vector<Expression> &sub_exprs) -> Value {
+          out_exprs.emplace_back(make_dynamic([=](const Parameters& /*params*/,
+                      const std::vector<Expression>& /*sub_exprs*/) -> Value {
                     std::string attr_val;
 
                     if (cur_flow_file && cur_flow_file->getAttribute(attr.first, attr_val)) {
@@ -1583,7 +1583,7 @@ Expression Expression::operator+(const Expression &other_expr) const {
     other_val_fn,
     sub_expr_generator,
     other_sub_expr_generator](const Parameters &params,
-        const std::vector<Expression> &sub_exprs) -> Value {
+        const std::vector<Expression>& /*sub_exprs*/) -> Value {
       Value result = val_fn(params, sub_expr_generator(params));
       return Value(result.asString().append(other_val_fn(params, other_sub_expr_generator(params)).asString()));
     });
@@ -1594,7 +1594,7 @@ Expression Expression::operator+(const Expression &other_expr) const {
     return make_dynamic([val_fn,
     other_val,
     sub_expr_generator](const Parameters &params,
-        const std::vector<Expression> &sub_exprs) -> Value {
+        const std::vector<Expression>& /*sub_exprs*/) -> Value {
       Value result = val_fn(params, sub_expr_generator(params));
       return Value(result.asString().append(other_val.asString()));
     });
@@ -1605,7 +1605,7 @@ Expression Expression::operator+(const Expression &other_expr) const {
     return make_dynamic([val,
     other_val_fn,
     other_sub_expr_generator](const Parameters &params,
-        const std::vector<Expression> &sub_exprs) -> Value {
+        const std::vector<Expression>& /*sub_exprs*/) -> Value {
       Value result(val);
       return Value(result.asString().append(other_val_fn(params, other_sub_expr_generator(params)).asString()));
     });
@@ -1635,7 +1635,7 @@ Expression Expression::compose_multi(const std::function<Value(const std::vector
     std::vector<Expression> out_exprs {};
     for (const auto &sub_expr : sub_exprs) {
       out_exprs.emplace_back(make_dynamic([=](const Parameters &params,
-                  const std::vector<Expression> &sub_exprs) {
+                  const std::vector<Expression>& /*sub_exprs*/) {
                 std::vector<Value> evaluated_args;
 
                 evaluated_args.emplace_back(sub_expr(params));
@@ -1659,7 +1659,7 @@ Expression Expression::make_aggregate(std::function<Value(const Parameters &para
   auto sub_expr_generator = sub_expr_generator_;
   return make_dynamic([sub_expr_generator,
   val_fn](const Parameters &params,
-      const std::vector<Expression> &sub_exprs) -> Value {
+      const std::vector<Expression>& /*sub_exprs*/) -> Value {
     return val_fn(params, sub_expr_generator(params));
   });
 }

--- a/extensions/expression-language/impl/expression/Expression.h
+++ b/extensions/expression-language/impl/expression/Expression.h
@@ -79,7 +79,7 @@ class Expression {
         fn_args_(),
         is_multi_(false) {
     val_ = val;
-    sub_expr_generator_ = [](const Parameters &params) -> std::vector<Expression> {return {};};
+    sub_expr_generator_ = [](const Parameters& /*params*/) -> std::vector<Expression> {return {};};
   }
 
   /**

--- a/extensions/expression-language/tests/integration/UpdateAttributeIntegrationTest.cpp
+++ b/extensions/expression-language/tests/integration/UpdateAttributeIntegrationTest.cpp
@@ -54,7 +54,7 @@ class TestHarness : public IntegrationBase {
     assert(false == verifyLogLinePresenceInPollTime(std::chrono::milliseconds(200), "ProcessSession rollback"));  // No rollback happened
   }
 
-  void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> pg) override {
+  void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> /*pg*/) override {
     // inject the variable into the context.
     configuration->set("nifi.variable.test", "replacement_value");
   }

--- a/extensions/http-curl/client/HTTPClient.cpp
+++ b/extensions/http-curl/client/HTTPClient.cpp
@@ -347,7 +347,7 @@ void HTTPClient::set_request_method(const std::string method) {
   }
 }
 
-int HTTPClient::onProgress(void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow){
+int HTTPClient::onProgress(void *clientp, curl_off_t /*dltotal*/, curl_off_t dlnow, curl_off_t /*ultotal*/, curl_off_t ulnow){
   HTTPClient& client = *(HTTPClient*)(clientp);
   auto now = std::chrono::steady_clock::now();
   auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - client.progress_.last_transferred_);

--- a/extensions/http-curl/client/HTTPClient.h
+++ b/extensions/http-curl/client/HTTPClient.h
@@ -206,7 +206,7 @@ class HTTPClient : public BaseHTTPClient, public core::Connectable {
    * Block until work is available on any input connection, or the given duration elapses
    * @param timeoutMs timeout in milliseconds
    */
-  void waitForWork(uint64_t timeoutMs) {
+  void waitForWork(uint64_t /*timeoutMs*/) {
   }
 
   void yield() override {
@@ -252,7 +252,7 @@ class HTTPClient : public BaseHTTPClient, public core::Connectable {
  protected:
   inline bool matches(const std::string &value, const std::string &sregex) override;
 
-  static CURLcode configure_ssl_context(CURL *curl, void *ctx, void *param) {
+  static CURLcode configure_ssl_context(CURL* /*curl*/, void *ctx, void *param) {
 #ifdef OPENSSL_SUPPORT
     minifi::controllers::SSLContextService *ssl_context_service = static_cast<minifi::controllers::SSLContextService*>(param);
     if (!ssl_context_service->configure_ssl_context(static_cast<SSL_CTX*>(ctx))) {

--- a/extensions/http-curl/client/HTTPStream.cpp
+++ b/extensions/http-curl/client/HTTPStream.cpp
@@ -49,7 +49,7 @@ void HttpStream::close() {
   http_read_callback_.close();
 }
 
-void HttpStream::seek(uint64_t offset) {
+void HttpStream::seek(uint64_t /*offset*/) {
   // seek is an unnecessary part of this implementatino
   throw std::logic_error{"HttpStream::seek is unimplemented"};
 }

--- a/extensions/http-curl/processors/InvokeHTTP.cpp
+++ b/extensions/http-curl/processors/InvokeHTTP.cpp
@@ -166,7 +166,7 @@ bool getTimeMSFromString(const std::string& propertyName, uint64_t& valInt) {
       && core::Property::ConvertTimeUnitToMS(valInt, unit, valInt);
 }
 
-void InvokeHTTP::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) {
+void InvokeHTTP::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory>& /*sessionFactory*/) {
   if (!context->getProperty(Method.getName(), method_)) {
     logger_->log_debug("%s attribute is missing, so default value of %s will be used", Method.getName(), Method.getValue());
     return;

--- a/extensions/http-curl/protocols/RESTReceiver.cpp
+++ b/extensions/http-curl/protocols/RESTReceiver.cpp
@@ -30,12 +30,12 @@ namespace nifi {
 namespace minifi {
 namespace c2 {
 
-int log_message(const struct mg_connection *conn, const char *message) {
+int log_message(const struct mg_connection* /*conn*/, const char *message) {
   puts(message);
   return 1;
 }
 
-int ssl_protocol_en(void *ssl_context, void *user_data) {
+int ssl_protocol_en(void* /*ssl_context*/, void* /*user_data*/) {
   return 0;
 }
 

--- a/extensions/http-curl/protocols/RESTReceiver.h
+++ b/extensions/http-curl/protocols/RESTReceiver.h
@@ -59,7 +59,7 @@ class RESTReceiver : public RESTProtocol, public HeartBeatReporter {
    public:
     ListeningProtocol() = default;
 
-    bool handleGet(CivetServer *server, struct mg_connection *conn) {
+    bool handleGet(CivetServer* /*server*/, struct mg_connection *conn) {
       std::string currentvalue;
       {
         std::lock_guard<std::mutex> lock(reponse_mutex_);

--- a/extensions/http-curl/protocols/RESTSender.cpp
+++ b/extensions/http-curl/protocols/RESTSender.cpp
@@ -60,7 +60,7 @@ void RESTSender::initialize(core::controller::ControllerServiceProvider* control
   logger_->log_debug("Submitting to %s", rest_uri_);
 }
 
-C2Payload RESTSender::consumePayload(const std::string &url, const C2Payload &payload, Direction direction, bool async) {
+C2Payload RESTSender::consumePayload(const std::string &url, const C2Payload &payload, Direction direction, bool /*async*/) {
   std::string outputConfig;
 
   if (direction == Direction::TRANSMIT) {

--- a/extensions/http-curl/sitetosite/HTTPProtocol.cpp
+++ b/extensions/http-curl/sitetosite/HTTPProtocol.cpp
@@ -217,8 +217,8 @@ std::shared_ptr<minifi::utils::HTTPClient> HttpSiteToSiteClient::openConnectionF
 }
 
 //! Transfer string for the process session
-bool HttpSiteToSiteClient::transmitPayload(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session, const std::string &payload,
-                                           std::map<std::string, std::string> attributes) {
+bool HttpSiteToSiteClient::transmitPayload(const std::shared_ptr<core::ProcessContext>& /*context*/, const std::shared_ptr<core::ProcessSession>& /*session*/, const std::string& /*payload*/,
+                                           std::map<std::string, std::string> /*attributes*/) {
   return false;
 }
 

--- a/extensions/http-curl/sitetosite/HTTPProtocol.h
+++ b/extensions/http-curl/sitetosite/HTTPProtocol.h
@@ -64,7 +64,7 @@ class HttpSiteToSiteClient : public sitetosite::SiteToSiteClient {
   /*!
    * Create a new http protocol
    */
-  HttpSiteToSiteClient(std::string name, utils::Identifier uuid = utils::Identifier())
+  HttpSiteToSiteClient(std::string /*name*/, utils::Identifier /*uuid*/ = utils::Identifier())
       : SiteToSiteClient(),
         current_code(UNRECOGNIZED_RESPONSE_CODE),
         logger_(logging::LoggerFactory<HttpSiteToSiteClient>::getLogger()) {

--- a/extensions/http-curl/tests/HTTPHandlers.h
+++ b/extensions/http-curl/tests/HTTPHandlers.h
@@ -52,7 +52,7 @@ class SiteToSiteLocationResponder : public ServerAwareHandler {
   explicit SiteToSiteLocationResponder(bool isSecure)
       : isSecure(isSecure) {
   }
-  bool handleGet(CivetServer *server, struct mg_connection *conn) override {
+  bool handleGet(CivetServer* /*server*/, struct mg_connection *conn) override {
     std::string site2site_rest_resp = "{"
         "\"revision\": {"
         "\"clientId\": \"483d53eb-53ec-4e93-b4d4-1fc3d23dae6f\""
@@ -82,7 +82,7 @@ class PeerResponder : public ServerAwareHandler {
     assert(parse_http_components(base_url, port, scheme, path));
   }
 
-  bool handleGet(CivetServer *server, struct mg_connection *conn) override {
+  bool handleGet(CivetServer* /*server*/, struct mg_connection *conn) override {
   
 #ifdef WIN32
     std::string hostname = org::apache::nifi::minifi::io::Socket::getMyHostName();
@@ -110,7 +110,7 @@ class SiteToSiteBaseResponder : public ServerAwareHandler {
       : base_url(std::move(base_url)) {
   }
 
-  bool handleGet(CivetServer *server, struct mg_connection *conn) override {
+  bool handleGet(CivetServer* /*server*/, struct mg_connection *conn) override {
     std::string site2site_rest_resp =
         "{\"controller\":{\"id\":\"96dab149-0162-1000-7924-ed3122d6ea2b\",\"name\":\"NiFi Flow\",\"comments\":\"\",\"runningCount\":3,\"stoppedCount\":6,\"invalidCount\":1,\"disabledCount\":0,\"inputPortCount\":1,\"outputPortCount\":1,\"remoteSiteListeningPort\":10443,\"siteToSiteSecure\":false,\"instanceId\":\"13881505-0167-1000-be72-aa29341a3e9a\",\"inputPorts\":[{\"id\":\"471deef6-2a6e-4a7d-912a-81cc17e3a204\",\"name\":\"RPGIN\",\"comments\":\"\",\"state\":\"RUNNING\"}],\"outputPorts\":[{\"id\":\"9cf15a63-0166-1000-1b29-027406d96013\",\"name\":\"ddsga\",\"comments\":\"\",\"state\":\"STOPPED\"}]}}";
     std::stringstream headers;
@@ -146,7 +146,7 @@ class TransactionResponder : public ServerAwareHandler {
     }
   }
 
-  bool handlePost(CivetServer *server, struct mg_connection *conn) override {
+  bool handlePost(CivetServer* /*server*/, struct mg_connection *conn) override {
     std::string site2site_rest_resp;
     std::stringstream headers;
     headers << "HTTP/1.1 201 OK\r\nContent-Type: application/json\r\nContent-Length: " << site2site_rest_resp.length() << "\r\nX-Location-Uri-Intent: ";
@@ -204,7 +204,7 @@ class FlowFileResponder : public ServerAwareHandler {
     flow_files_feed_ = feed;
   }
 
-  bool handlePost(CivetServer *server, struct mg_connection *conn) override {
+  bool handlePost(CivetServer* /*server*/, struct mg_connection *conn) override {
     std::string site2site_rest_resp;
     std::stringstream headers;
 
@@ -260,7 +260,7 @@ class FlowFileResponder : public ServerAwareHandler {
     return true;
   }
 
-  bool handleGet(CivetServer *server, struct mg_connection *conn) override {
+  bool handleGet(CivetServer* /*server*/, struct mg_connection *conn) override {
 
     if (flow_files_feed_->size_approx() > 0) {
       std::shared_ptr<FlowObj> flowobj;
@@ -332,7 +332,7 @@ class DeleteTransactionResponder : public ServerAwareHandler {
         response_code(std::move(response_code)) {
   }
 
-  bool handleDelete(CivetServer *server, struct mg_connection *conn) override {
+  bool handleDelete(CivetServer* /*server*/, struct mg_connection *conn) override {
     std::string site2site_rest_resp;
     std::stringstream headers;
     std::string resp;
@@ -453,7 +453,7 @@ class C2UpdateHandler : public ServerAwareHandler {
     : test_file_location_(test_file_location) {
   }
 
-  bool handlePost(CivetServer *server, struct mg_connection *conn) override {
+  bool handlePost(CivetServer* /*server*/, struct mg_connection *conn) override {
     calls_++;
     if (!response_.empty()) {
       mg_printf(conn, "HTTP/1.1 200 OK\r\nContent-Type: "
@@ -468,7 +468,7 @@ class C2UpdateHandler : public ServerAwareHandler {
     return true;
   }
 
-  bool handleGet(CivetServer *server, struct mg_connection *conn) override {
+  bool handleGet(CivetServer* /*server*/, struct mg_connection *conn) override {
     std::ifstream myfile(test_file_location_.c_str(), std::ios::in | std::ios::binary);
     if (myfile.good()) {
       std::string str((std::istreambuf_iterator<char>(myfile)), (std::istreambuf_iterator<char>()));

--- a/extensions/http-curl/tests/HTTPIntegrationBase.h
+++ b/extensions/http-curl/tests/HTTPIntegrationBase.h
@@ -27,7 +27,7 @@
 #include "utils/IntegrationTestUtils.h"
 #include "TestServer.h"
 
-int log_message(const struct mg_connection *conn, const char *message) {
+int log_message(const struct mg_connection* /*conn*/, const char *message) {
   puts(message);
   return 1;
 }

--- a/extensions/http-curl/tests/HttpGetIntegrationTest.cpp
+++ b/extensions/http-curl/tests/HttpGetIntegrationTest.cpp
@@ -39,7 +39,7 @@
 #include "integration/IntegrationBase.h"
 #include "utils/IntegrationTestUtils.h"
 
-int log_message(const struct mg_connection *conn, const char *message) {
+int log_message(const struct mg_connection* /*conn*/, const char *message) {
   puts(message);
   return 1;
 }
@@ -52,7 +52,7 @@ int ssl_enable(void* /*ssl_context*/, void* /*user_data*/) {
 class HttpResponder : public CivetHandler {
  private:
  public:
-  bool handleGet(CivetServer *server, struct mg_connection *conn) override {
+  bool handleGet(CivetServer* /*server*/, struct mg_connection *conn) override {
     puts("handle get");
     static const std::string site2site_rest_resp = "hi this is a get test";
     mg_printf(conn, "HTTP/1.1 200 OK\r\nContent-Type: "

--- a/extensions/http-curl/tests/SiteToSiteRestTest.cpp
+++ b/extensions/http-curl/tests/SiteToSiteRestTest.cpp
@@ -38,7 +38,7 @@ class Responder : public ServerAwareHandler {
   explicit Responder(bool isSecure)
       : isSecure(isSecure) {
   }
-  bool handleGet(CivetServer *server, struct mg_connection *conn) override {
+  bool handleGet(CivetServer* /*server*/, struct mg_connection *conn) override {
     std::string site2site_rest_resp = "{"
         "\"revision\": {"
         "\"clientId\": \"483d53eb-53ec-4e93-b4d4-1fc3d23dae6f\""

--- a/extensions/http-curl/tests/TestServer.h
+++ b/extensions/http-curl/tests/TestServer.h
@@ -50,7 +50,7 @@ class TestServer{
     }
   };
  public:
-  TestServer(std::string &port, std::string &rooturi, CivetHandler *handler, CivetCallbacks *callbacks, std::string &cert, std::string &ca_cert) {
+  TestServer(std::string &port, std::string &rooturi, CivetHandler *handler, CivetCallbacks *callbacks, std::string& /*cert*/, std::string &ca_cert) {
 
     if (!mg_check_feature(2)) {
       throw std::runtime_error("Error: Embedded example built with SSL support, "

--- a/extensions/http-curl/tests/unit/HTTPClientTests.cpp
+++ b/extensions/http-curl/tests/unit/HTTPClientTests.cpp
@@ -47,12 +47,12 @@ TEST_CASE("HTTPClientTestChunkedResponse", "[basic]") {
       mg_send_chunk(conn, nullptr, 0U);
     }
 
-    bool handleGet(CivetServer *server, struct mg_connection *conn) {
+    bool handleGet(CivetServer* /*server*/, struct mg_connection *conn) {
       send_response(conn);
       return true;
     }
 
-    bool handlePost(CivetServer *server, struct mg_connection *conn) {
+    bool handlePost(CivetServer* /*server*/, struct mg_connection *conn) {
       mg_printf(conn, "HTTP/1.1 100 Continue\r\n\r\n");
 
       std::array<uint8_t, 16384U> buf;

--- a/extensions/libarchive/BinFiles.cpp
+++ b/extensions/libarchive/BinFiles.cpp
@@ -96,7 +96,7 @@ void BinFiles::initialize() {
   setSupportedRelationships(relationships);
 }
 
-void BinFiles::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory) {
+void BinFiles::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory* /*sessionFactory*/) {
   uint32_t val32;
   uint64_t val64;
   if (context->getProperty(MinSize.getName(), val64)) {
@@ -131,7 +131,7 @@ void BinFiles::onSchedule(core::ProcessContext *context, core::ProcessSessionFac
   }
 }
 
-void BinFiles::preprocessFlowFile(core::ProcessContext *context, core::ProcessSession *session, std::shared_ptr<core::FlowFile> flow) {
+void BinFiles::preprocessFlowFile(core::ProcessContext* /*context*/, core::ProcessSession* /*session*/, std::shared_ptr<core::FlowFile> flow) {
   // handle backward compatibility with old segment attributes
   std::string value;
   if (!flow->getAttribute(BinFiles::FRAGMENT_COUNT_ATTRIBUTE, value) && flow->getAttribute(BinFiles::SEGMENT_COUNT_ATTRIBUTE, value)) {
@@ -330,7 +330,7 @@ void BinFiles::onTrigger(const std::shared_ptr<core::ProcessContext> &context, c
   }
 }
 
-void BinFiles::transferFlowsToFail(core::ProcessContext *context, core::ProcessSession *session, std::unique_ptr<Bin> &bin) {
+void BinFiles::transferFlowsToFail(core::ProcessContext* /*context*/, core::ProcessSession *session, std::unique_ptr<Bin> &bin) {
   std::deque<std::shared_ptr<core::FlowFile>> &flows = bin->getFlowFile();
   for (auto flow : flows) {
     session->transfer(flow, Failure);
@@ -338,7 +338,7 @@ void BinFiles::transferFlowsToFail(core::ProcessContext *context, core::ProcessS
   flows.clear();
 }
 
-void BinFiles::addFlowsToSession(core::ProcessContext *context, core::ProcessSession *session, std::unique_ptr<Bin> &bin) {
+void BinFiles::addFlowsToSession(core::ProcessContext* /*context*/, core::ProcessSession *session, std::unique_ptr<Bin> &bin) {
   std::deque<std::shared_ptr<core::FlowFile>> &flows = bin->getFlowFile();
   for (auto flow : flows) {
     session->add(flow);

--- a/extensions/libarchive/BinFiles.h
+++ b/extensions/libarchive/BinFiles.h
@@ -244,7 +244,7 @@ class BinFiles : public core::Processor {
    */
   void onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory) override;
   // OnTrigger method, implemented by NiFi BinFiles
-  void onTrigger(core::ProcessContext *context, core::ProcessSession *session) override {
+  void onTrigger(core::ProcessContext* /*context*/, core::ProcessSession* /*session*/) override {
   }
   // OnTrigger method, implemented by NiFi BinFiles
   void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
@@ -259,11 +259,11 @@ class BinFiles : public core::Processor {
   // Allows general pre-processing of a flow file before it is offered to a bin. This is called before getGroupId().
   virtual void preprocessFlowFile(core::ProcessContext *context, core::ProcessSession *session, std::shared_ptr<core::FlowFile> flow);
   // Returns a group ID representing a bin. This allows flow files to be binned into like groups
-  virtual std::string getGroupId(core::ProcessContext *context, std::shared_ptr<core::FlowFile> flow) {
+  virtual std::string getGroupId(core::ProcessContext* /*context*/, std::shared_ptr<core::FlowFile> /*flow*/) {
     return "";
   }
   // Processes a single bin.
-  virtual bool processBin(core::ProcessContext *context, core::ProcessSession *session, std::unique_ptr<Bin> &bin) {
+  virtual bool processBin(core::ProcessContext* /*context*/, core::ProcessSession* /*session*/, std::unique_ptr<Bin>& /*bin*/) {
     return false;
   }
   // transfer flows to failure in bin

--- a/extensions/libarchive/CompressContent.cpp
+++ b/extensions/libarchive/CompressContent.cpp
@@ -97,7 +97,7 @@ void CompressContent::initialize() {
   setSupportedRelationships(relationships);
 }
 
-void CompressContent::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory) {
+void CompressContent::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory* /*sessionFactory*/) {
   context->getProperty(CompressLevel.getName(), compressLevel_);
   context->getProperty(CompressMode.getName(), compressMode_);
   context->getProperty(CompressFormat.getName(), compressFormat_);

--- a/extensions/libarchive/CompressContent.h
+++ b/extensions/libarchive/CompressContent.h
@@ -181,7 +181,7 @@ public:
     CompressContent::ReadCallbackDecompress readDecompressCb_;
     int status_;
 
-    static la_ssize_t archive_write(struct archive *arch, void *context, const void *buff, size_t size) {
+    static la_ssize_t archive_write(struct archive* /*arch*/, void *context, const void *buff, size_t size) {
       WriteCallback *callback = (WriteCallback *) context;
       la_ssize_t ret = callback->stream_->write(reinterpret_cast<uint8_t*>(const_cast<void*>(buff)), size);
       if (ret > 0)
@@ -201,7 +201,7 @@ public:
       }
     }
 
-    static la_int64_t archive_skip(struct archive *a, void *client_data, la_int64_t request) {
+    static la_int64_t archive_skip(struct archive* /*a*/, void* /*client_data*/, la_int64_t /*request*/) {
       return 0;
     }
 
@@ -426,7 +426,7 @@ public:
    */
   void onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory);
   // OnTrigger method, implemented by NiFi CompressContent
-  virtual void onTrigger(core::ProcessContext *context, core::ProcessSession *session) {
+  virtual void onTrigger(core::ProcessContext* /*context*/, core::ProcessSession* /*session*/) {
   }
   // OnTrigger method, implemented by NiFi CompressContent
   virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session);

--- a/extensions/libarchive/FocusArchiveEntry.h
+++ b/extensions/libarchive/FocusArchiveEntry.h
@@ -79,7 +79,7 @@ class FocusArchiveEntry : public core::Processor {
     core::Processor * const proc_;
     std::shared_ptr<logging::Logger> logger_;
     ArchiveMetadata *_archiveMetadata;
-    static int ok_cb(struct archive *, void *d) { return ARCHIVE_OK; }
+    static int ok_cb(struct archive *, void* /*d*/) { return ARCHIVE_OK; }
     static la_ssize_t read_cb(struct archive * a, void *d, const void **buf);
   };
 

--- a/extensions/libarchive/ManipulateArchive.cpp
+++ b/extensions/libarchive/ManipulateArchive.cpp
@@ -71,7 +71,7 @@ void ManipulateArchive::initialize() {
     setSupportedRelationships(relationships);
 }
 
-void ManipulateArchive::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory) {
+void ManipulateArchive::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory* /*sessionFactory*/) {
     context->getProperty(Operation.getName(), operation_);
     bool invalid = false;
     std::transform(operation_.begin(), operation_.end(), operation_.begin(), ::tolower);
@@ -114,7 +114,7 @@ void ManipulateArchive::onSchedule(core::ProcessContext *context, core::ProcessS
     }
 }
 
-void ManipulateArchive::onTrigger(core::ProcessContext *context, core::ProcessSession *session) {
+void ManipulateArchive::onTrigger(core::ProcessContext* /*context*/, core::ProcessSession *session) {
     std::shared_ptr<core::FlowFile> flowFile = session->get();
 
     if (!flowFile) {

--- a/extensions/libarchive/MergeContent.cpp
+++ b/extensions/libarchive/MergeContent.cpp
@@ -350,7 +350,7 @@ BinaryConcatenationMerge::BinaryConcatenationMerge(const std::string &header, co
     footer_(footer),
     demarcator_(demarcator) {}
 
-void BinaryConcatenationMerge::merge(core::ProcessContext *context, core::ProcessSession *session,
+void BinaryConcatenationMerge::merge(core::ProcessContext* /*context*/, core::ProcessSession *session,
     std::deque<std::shared_ptr<core::FlowFile>> &flows, FlowFileSerializer& serializer, const std::shared_ptr<core::FlowFile>& merge_flow) {
   BinaryConcatenationMerge::WriteCallback callback(header_, footer_, demarcator_, flows, serializer);
   session->write(merge_flow, &callback);
@@ -364,7 +364,7 @@ void BinaryConcatenationMerge::merge(core::ProcessContext *context, core::Proces
     session->putAttribute(merge_flow, core::SpecialFlowAttribute::FILENAME, fileName);
 }
 
-void TarMerge::merge(core::ProcessContext *context, core::ProcessSession *session,
+void TarMerge::merge(core::ProcessContext* /*context*/, core::ProcessSession *session,
     std::deque<std::shared_ptr<core::FlowFile>> &flows, FlowFileSerializer& serializer, const std::shared_ptr<core::FlowFile>& merge_flow) {
   ArchiveMerge::WriteCallback callback(std::string(merge_content_options::MERGE_FORMAT_TAR_VALUE), flows, serializer);
   session->write(merge_flow, &callback);
@@ -381,7 +381,7 @@ void TarMerge::merge(core::ProcessContext *context, core::ProcessSession *sessio
   }
 }
 
-void ZipMerge::merge(core::ProcessContext *context, core::ProcessSession *session,
+void ZipMerge::merge(core::ProcessContext* /*context*/, core::ProcessSession *session,
     std::deque<std::shared_ptr<core::FlowFile>> &flows, FlowFileSerializer& serializer, const std::shared_ptr<core::FlowFile>& merge_flow) {
   ArchiveMerge::WriteCallback callback(std::string(merge_content_options::MERGE_FORMAT_ZIP_VALUE), flows, serializer);
   session->write(merge_flow, &callback);

--- a/extensions/libarchive/MergeContent.h
+++ b/extensions/libarchive/MergeContent.h
@@ -167,7 +167,7 @@ class ArchiveMerge {
     std::shared_ptr<logging::Logger> logger_;
     FlowFileSerializer& serializer_;
 
-    static la_ssize_t archive_write(struct archive *arch, void *context, const void *buff, size_t size) {
+    static la_ssize_t archive_write(struct archive* /*arch*/, void *context, const void *buff, size_t size) {
       WriteCallback *callback = (WriteCallback *) context;
       uint8_t* data = reinterpret_cast<uint8_t*>(const_cast<void*>(buff));
       la_ssize_t totalWrote = 0;

--- a/extensions/libarchive/UnfocusArchiveEntry.h
+++ b/extensions/libarchive/UnfocusArchiveEntry.h
@@ -75,7 +75,7 @@ class UnfocusArchiveEntry : public core::Processor {
     //! Logger
     std::shared_ptr<Logger> logger_;
     ArchiveMetadata *_archiveMetadata;
-    static int ok_cb(struct archive *, void *d) { return ARCHIVE_OK; }
+    static int ok_cb(struct archive *, void* /*d*/) { return ARCHIVE_OK; }
     static la_ssize_t write_cb(struct archive *, void *d, const void *buffer, size_t length);
   };
 

--- a/extensions/librdkafka/PublishKafka.cpp
+++ b/extensions/librdkafka/PublishKafka.cpp
@@ -497,7 +497,7 @@ void PublishKafka::initialize() {
   setSupportedRelationships(relationships);
 }
 
-void PublishKafka::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) {
+void PublishKafka::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory>& /*sessionFactory*/) {
   interrupted_ = false;
 
   // Try to get a KafkaConnection

--- a/extensions/mqtt/controllerservice/MQTTControllerService.h
+++ b/extensions/mqtt/controllerservice/MQTTControllerService.h
@@ -258,7 +258,7 @@ class MQTTControllerService : public core::controller::ControllerService {
     MQTTClient_free(topicName);
     return 1;
   }
-  static void reconnectCallback(void *context, char *cause) {
+  static void reconnectCallback(void *context, char* /*cause*/) {
     MQTTControllerService *service = (MQTTControllerService *) context;
     service->reconnect();
   }

--- a/extensions/mqtt/processors/AbstractMQTTProcessor.cpp
+++ b/extensions/mqtt/processors/AbstractMQTTProcessor.cpp
@@ -53,7 +53,7 @@ const std::set<core::Property> AbstractMQTTProcessor::getSupportedProperties() {
   return {BrokerURL, CleanSession, ClientID, UserName, PassWord, KeepLiveInterval, ConnectionTimeOut, QOS, Topic};
 }
 
-void AbstractMQTTProcessor::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &factory) {
+void AbstractMQTTProcessor::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory>& /*factory*/) {
   sslEnabled_ = false;
   sslopts_ = MQTTClient_SSLOptions_initializer;
 

--- a/extensions/mqtt/processors/AbstractMQTTProcessor.h
+++ b/extensions/mqtt/processors/AbstractMQTTProcessor.h
@@ -101,7 +101,7 @@ class AbstractMQTTProcessor : public core::Processor {
     AbstractMQTTProcessor *processor = (AbstractMQTTProcessor *) context;
     processor->delivered_token_ = dt;
   }
-  static int msgReceived(void *context, char *topicName, int topicLen, MQTTClient_message *message) {
+  static int msgReceived(void *context, char *topicName, int /*topicLen*/, MQTTClient_message *message) {
     AbstractMQTTProcessor *processor = (AbstractMQTTProcessor *) context;
     if (processor->isSubscriber_) {
       if (!processor->enqueueReceiveMQTTMsg(message))
@@ -112,13 +112,13 @@ class AbstractMQTTProcessor : public core::Processor {
     MQTTClient_free(topicName);
     return 1;
   }
-  static void connectionLost(void *context, char *cause) {
+  static void connectionLost(void *context, char* /*cause*/) {
     AbstractMQTTProcessor *processor = (AbstractMQTTProcessor *) context;
     processor->reconnect();
   }
   bool reconnect();
   // enqueue receive MQTT message
-  virtual bool enqueueReceiveMQTTMsg(MQTTClient_message *message) {
+  virtual bool enqueueReceiveMQTTMsg(MQTTClient_message* /*message*/) {
     return false;
   }
 

--- a/extensions/mqtt/processors/ConsumeMQTT.cpp
+++ b/extensions/mqtt/processors/ConsumeMQTT.cpp
@@ -82,7 +82,7 @@ void ConsumeMQTT::onSchedule(const std::shared_ptr<core::ProcessContext> &contex
   }
 }
 
-void ConsumeMQTT::onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) {
+void ConsumeMQTT::onTrigger(const std::shared_ptr<core::ProcessContext>& /*context*/, const std::shared_ptr<core::ProcessSession> &session) {
   // reconnect if necessary
   if(!reconnect()) {
     yield();

--- a/extensions/mqtt/processors/ConvertBase.cpp
+++ b/extensions/mqtt/processors/ConvertBase.cpp
@@ -50,7 +50,7 @@ void ConvertBase::initialize() {
   setSupportedRelationships(relationships);
 }
 
-void ConvertBase::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) {
+void ConvertBase::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory>& /*sessionFactory*/) {
   std::string controller_service_name = "";
   if (context->getProperty(MQTTControllerService.getName(), controller_service_name) && !controller_service_name.empty()) {
     auto service = context->getControllerService(controller_service_name);

--- a/extensions/mqtt/processors/ConvertUpdate.cpp
+++ b/extensions/mqtt/processors/ConvertUpdate.cpp
@@ -28,7 +28,7 @@ namespace processors {
 
 core::Property ConvertUpdate::SSLContext("SSL Context Service", "The SSL Context Service used to provide client certificate information for TLS/SSL (https) connections.", "");
 
-void ConvertUpdate::onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) {
+void ConvertUpdate::onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession>& /*session*/) {
   if (nullptr == mqtt_service_) {
     context->yield();
     return;

--- a/extensions/mqtt/processors/PublishMQTT.cpp
+++ b/extensions/mqtt/processors/PublishMQTT.cpp
@@ -69,7 +69,7 @@ void PublishMQTT::onSchedule(const std::shared_ptr<core::ProcessContext> &contex
   }
 }
 
-void PublishMQTT::onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) {
+void PublishMQTT::onTrigger(const std::shared_ptr<core::ProcessContext>& /*context*/, const std::shared_ptr<core::ProcessSession> &session) {
   if (!reconnect()) {
     logger_->log_error("MQTT connect to %s failed", uri_);
     yield();

--- a/extensions/mqtt/protocol/MQTTC2Protocol.cpp
+++ b/extensions/mqtt/protocol/MQTTC2Protocol.cpp
@@ -61,7 +61,7 @@ void MQTTC2Protocol::initialize(core::controller::ControllerServiceProvider* con
   }
 }
 
-C2Payload MQTTC2Protocol::consumePayload(const std::string &url, const C2Payload &payload, Direction direction, bool async) {
+C2Payload MQTTC2Protocol::consumePayload(const std::string &url, const C2Payload &payload, Direction /*direction*/, bool /*async*/) {
   // we are getting an update.
   std::lock_guard<std::mutex> lock(input_mutex_);
   io::BufferStream stream;

--- a/extensions/mqtt/protocol/MQTTC2Protocol.h
+++ b/extensions/mqtt/protocol/MQTTC2Protocol.h
@@ -56,11 +56,11 @@ class MQTTC2Protocol : public C2Protocol {
    */
   virtual C2Payload consumePayload(const std::string &url, const C2Payload &payload, Direction direction, bool async) override;
 
-  virtual C2Payload consumePayload(const C2Payload &payload, Direction direction, bool async) override {
+  virtual C2Payload consumePayload(const C2Payload &payload, Direction /*direction*/, bool /*async*/) override {
     return serialize(payload);
   }
 
-  virtual void update(const std::shared_ptr<Configure> &configure) override {
+  virtual void update(const std::shared_ptr<Configure>& /*configure*/) override {
     // no op.
   }
 

--- a/extensions/rocksdb-repos/DatabaseContentRepository.cpp
+++ b/extensions/rocksdb-repos/DatabaseContentRepository.cpp
@@ -158,7 +158,7 @@ bool DatabaseContentRepository::remove(const minifi::ResourceClaim &claim) {
   }
 }
 
-std::shared_ptr<io::BaseStream> DatabaseContentRepository::write(const minifi::ResourceClaim& claim, bool append, rocksdb::WriteBatch* batch) {
+std::shared_ptr<io::BaseStream> DatabaseContentRepository::write(const minifi::ResourceClaim& claim, bool /*append*/, rocksdb::WriteBatch* batch) {
   // the traditional approach with these has been to return -1 from the stream; however, since we have the ability here
   // we can simply return a nullptr, which is also valid from the API when this stream is not valid.
   if (!is_valid_ || !db_)

--- a/extensions/rocksdb-repos/DatabaseContentRepository.h
+++ b/extensions/rocksdb-repos/DatabaseContentRepository.h
@@ -40,7 +40,7 @@ class StringAppender : public rocksdb::AssociativeMergeOperator {
   // Constructor: specify delimiter
   explicit StringAppender() = default;
 
-  virtual bool Merge(const rocksdb::Slice& key, const rocksdb::Slice* existing_value, const rocksdb::Slice& value, std::string* new_value, rocksdb::Logger* logger) const {
+  virtual bool Merge(const rocksdb::Slice& /*key*/, const rocksdb::Slice* existing_value, const rocksdb::Slice& value, std::string* new_value, rocksdb::Logger* /*logger*/) const {
     // Clear the *new_value for writing.
     if (nullptr == new_value) {
       return false;

--- a/extensions/rocksdb-repos/FlowFileRepository.h
+++ b/extensions/rocksdb-repos/FlowFileRepository.h
@@ -57,7 +57,7 @@ class FlowFileRepository : public core::Repository, public std::enable_shared_fr
  public:
   // Constructor
 
-  FlowFileRepository(std::string name, utils::Identifier uuid)
+  FlowFileRepository(std::string name, utils::Identifier /*uuid*/)
       : FlowFileRepository(name) {
   }
 

--- a/extensions/rocksdb-repos/ProvenanceRepository.h
+++ b/extensions/rocksdb-repos/ProvenanceRepository.h
@@ -37,7 +37,7 @@ namespace provenance {
 
 class ProvenanceRepository : public core::Repository, public std::enable_shared_from_this<ProvenanceRepository> {
  public:
-  ProvenanceRepository(std::string name, utils::Identifier uuid)
+  ProvenanceRepository(std::string name, utils::Identifier /*uuid*/)
       : ProvenanceRepository(name){
 
   }
@@ -137,7 +137,7 @@ class ProvenanceRepository : public core::Repository, public std::enable_shared_
   }
 
   // Delete
-  virtual bool Delete(std::string key) {
+  virtual bool Delete(std::string /*key*/) {
     // The repo is cleaned up by itself, there is no need to delete items.
     return true;
   }

--- a/extensions/rocksdb-repos/RocksDbStream.cpp
+++ b/extensions/rocksdb-repos/RocksDbStream.cpp
@@ -47,7 +47,7 @@ RocksDbStream::RocksDbStream(std::string path, gsl::not_null<minifi::internal::R
 void RocksDbStream::close() {
 }
 
-void RocksDbStream::seek(uint64_t offset) {
+void RocksDbStream::seek(uint64_t /*offset*/) {
   // noop
 }
 

--- a/extensions/rocksdb-repos/controllers/RocksDbPersistableKeyValueStoreService.cpp
+++ b/extensions/rocksdb-repos/controllers/RocksDbPersistableKeyValueStoreService.cpp
@@ -182,7 +182,7 @@ bool RocksDbPersistableKeyValueStoreService::clear() {
   return true;
 }
 
-bool RocksDbPersistableKeyValueStoreService::update(const std::string& key, const std::function<bool(bool /*exists*/, std::string& /*value*/)>& update_func) {
+bool RocksDbPersistableKeyValueStoreService::update(const std::string& /*key*/, const std::function<bool(bool /*exists*/, std::string& /*value*/)>& /*update_func*/) {
   if (!db_) {
     return false;
   }

--- a/extensions/script/ExecuteScript.cpp
+++ b/extensions/script/ExecuteScript.cpp
@@ -69,7 +69,7 @@ void ExecuteScript::initialize() {
 #endif  // PYTHON_SUPPORT
 }
 
-void ExecuteScript::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory) {
+void ExecuteScript::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory* /*sessionFactory*/) {
   if (!context->getProperty(ScriptEngine.getName(), script_engine_)) {
     logger_->log_error("Script Engine attribute is missing or invalid");
   }

--- a/extensions/script/ExecuteScript.h
+++ b/extensions/script/ExecuteScript.h
@@ -52,7 +52,7 @@ class ExecuteScript : public core::Processor {
 
   void initialize() override;
   void onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory) override;
-  void onTrigger(core::ProcessContext *context, core::ProcessSession *session) override {
+  void onTrigger(core::ProcessContext* /*context*/, core::ProcessSession* /*session*/) override {
     logger_->log_error("onTrigger invocation with raw pointers is not implemented");
   }
   void onTrigger(const std::shared_ptr<core::ProcessContext> &context,

--- a/extensions/script/python/ExecutePythonProcessor.cpp
+++ b/extensions/script/python/ExecutePythonProcessor.cpp
@@ -98,7 +98,7 @@ void ExecutePythonProcessor::initialize() {
   }
 }
 
-void ExecutePythonProcessor::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) {
+void ExecutePythonProcessor::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory>& /*sessionFactory*/) {
   if (!valid_init_) {
     throw std::runtime_error("Could not correctly initialize " + getName());
   }

--- a/extensions/standard-processors/processors/GenerateFlowFile.cpp
+++ b/extensions/standard-processors/processors/GenerateFlowFile.cpp
@@ -93,7 +93,7 @@ void generateData(std::vector<char>& data, bool textData = false) {
   }
 }
 
-void GenerateFlowFile::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) {
+void GenerateFlowFile::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory>& /*sessionFactory*/) {
   if (context->getProperty(FileSize.getName(), fileSize_)) {
     logger_->log_trace("File size is configured to be %d", fileSize_);
   }
@@ -116,7 +116,7 @@ void GenerateFlowFile::onSchedule(const std::shared_ptr<core::ProcessContext> &c
   }
 }
 
-void GenerateFlowFile::onTrigger(core::ProcessContext *context, core::ProcessSession *session) {
+void GenerateFlowFile::onTrigger(core::ProcessContext* /*context*/, core::ProcessSession *session) {
   for (uint64_t i = 0; i < batchSize_; i++) {
     // For each batch
     std::shared_ptr<core::FlowFile> flowFile = session->create();

--- a/extensions/standard-processors/processors/GetFile.cpp
+++ b/extensions/standard-processors/processors/GetFile.cpp
@@ -115,7 +115,7 @@ void GetFile::initialize() {
   setSupportedRelationships(relationships);
 }
 
-void GetFile::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory) {
+void GetFile::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory* /*sessionFactory*/) {
   std::string value;
   if (context->getProperty(BatchSize.getName(), value)) {
     core::Property::StringToInt(value, request_.batchSize);
@@ -156,7 +156,7 @@ void GetFile::onSchedule(core::ProcessContext *context, core::ProcessSessionFact
   request_.inputDirectory = value;
 }
 
-void GetFile::onTrigger(core::ProcessContext *context, core::ProcessSession *session) {
+void GetFile::onTrigger(core::ProcessContext* /*context*/, core::ProcessSession *session) {
   // Perform directory list
 
   metrics_->iterations_++;

--- a/extensions/standard-processors/processors/GetTCP.cpp
+++ b/extensions/standard-processors/processors/GetTCP.cpp
@@ -234,7 +234,7 @@ void GetTCP::notifyStop() {
     socket_ring_buffer_.try_dequeue(socket_ptr);
   }
 }
-void GetTCP::onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) {
+void GetTCP::onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession>& /*session*/) {
   // Perform directory list
   metrics_->iterations_++;
   std::lock_guard<std::mutex> lock(mutex_);

--- a/extensions/standard-processors/processors/GetTCP.h
+++ b/extensions/standard-processors/processors/GetTCP.h
@@ -65,7 +65,7 @@ class SocketAfterExecute : public utils::AfterExecute<int> {
       return false;
     }
   }
-  bool isCancelled(const int &result) override {
+  bool isCancelled(const int& /*result*/) override {
     if (!running_)
       return true;
     else
@@ -209,7 +209,7 @@ class GetTCP : public core::Processor, public state::response::MetricsNodeSource
    */
   void onSchedule(const std::shared_ptr<core::ProcessContext> &processContext, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
 
-  void onSchedule(core::ProcessContext *processContext, core::ProcessSessionFactory *sessionFactory) override {
+  void onSchedule(core::ProcessContext* /*processContext*/, core::ProcessSessionFactory* /*sessionFactory*/) override {
     throw std::logic_error{"GetTCP::onSchedule(ProcessContext*, ProcessSessionFactory*) is unimplemented"};
   }
   /**
@@ -219,7 +219,7 @@ class GetTCP : public core::Processor, public state::response::MetricsNodeSource
    */
   void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
 
-  void onTrigger(core::ProcessContext *context, core::ProcessSession *session) override {
+  void onTrigger(core::ProcessContext* /*context*/, core::ProcessSession* /*session*/) override {
     throw std::logic_error{"GetTCP::onTrigger(ProcessContext*, ProcessSession*) is unimplemented"};
   }
 

--- a/extensions/standard-processors/processors/HashContent.cpp
+++ b/extensions/standard-processors/processors/HashContent.cpp
@@ -56,7 +56,7 @@ void HashContent::initialize() {
   setSupportedRelationships(relationships);
 }
 
-void HashContent::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory) {
+void HashContent::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory* /*sessionFactory*/) {
   std::string value;
 
   attrKey_ = (context->getProperty(HashAttribute.getName(), value)) ? value : "Checksum";

--- a/extensions/standard-processors/processors/LogAttribute.cpp
+++ b/extensions/standard-processors/processors/LogAttribute.cpp
@@ -87,7 +87,7 @@ void LogAttribute::initialize() {
   setSupportedRelationships(relationships);
 }
 
-void LogAttribute::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &factory) {
+void LogAttribute::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory>& /*factory*/) {
   context->getProperty(FlowFilesToLog.getName(), flowfiles_to_log_);
   logger_->log_debug("FlowFiles To Log: %llu", flowfiles_to_log_);
 

--- a/extensions/standard-processors/processors/PutFile.cpp
+++ b/extensions/standard-processors/processors/PutFile.cpp
@@ -89,7 +89,7 @@ void PutFile::initialize() {
   setSupportedRelationships(relationships);
 }
 
-void PutFile::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory) {
+void PutFile::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory* /*sessionFactory*/) {
   if (!context->getProperty(ConflictResolution.getName(), conflict_resolution_)) {
     logger_->log_error("Conflict Resolution Strategy attribute is missing or invalid");
   }

--- a/extensions/standard-processors/processors/RouteOnAttribute.cpp
+++ b/extensions/standard-processors/processors/RouteOnAttribute.cpp
@@ -42,7 +42,7 @@ void RouteOnAttribute::initialize() {
   setSupportedRelationships(relationships);
 }
 
-void RouteOnAttribute::onDynamicPropertyModified(const core::Property &orig_property, const core::Property &new_property) {
+void RouteOnAttribute::onDynamicPropertyModified(const core::Property& /*orig_property*/, const core::Property &new_property) {
   // Update the routing table when routes are added via dynamic properties.
   route_properties_[new_property.getName()] = new_property;
 

--- a/extensions/standard-processors/processors/TailFile.cpp
+++ b/extensions/standard-processors/processors/TailFile.cpp
@@ -330,7 +330,7 @@ void TailFile::initialize() {
   setSupportedRelationships(relationships);
 }
 
-void TailFile::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) {
+void TailFile::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory>& /*sessionFactory*/) {
   std::lock_guard<std::mutex> tail_lock(tail_file_mutex_);
 
   tail_states_.clear();

--- a/extensions/standard-processors/processors/UpdateAttribute.cpp
+++ b/extensions/standard-processors/processors/UpdateAttribute.cpp
@@ -43,7 +43,7 @@ void UpdateAttribute::initialize() {
   setSupportedRelationships(relationships);
 }
 
-void UpdateAttribute::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory) {
+void UpdateAttribute::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory* /*sessionFactory*/) {
   attributes_.clear();
   const auto &dynamic_prop_keys = context->getDynamicPropertyKeys();
   logger_->log_info("UpdateAttribute registering %d keys", dynamic_prop_keys.size());

--- a/extensions/standard-processors/tests/integration/SecureSocketGetTCPTest.cpp
+++ b/extensions/standard-processors/tests/integration/SecureSocketGetTCPTest.cpp
@@ -140,7 +140,7 @@ class SecureSocketTest : public IntegrationBase {
   std::shared_ptr<org::apache::nifi::minifi::io::TLSServerSocket> server_socket_;
 };
 
-static void sigpipe_handle(int x) {
+static void sigpipe_handle(int /*x*/) {
 }
 
 int main(int argc, char **argv) {

--- a/extensions/standard-processors/tests/integration/TestExecuteProcess.cpp
+++ b/extensions/standard-processors/tests/integration/TestExecuteProcess.cpp
@@ -43,7 +43,7 @@
 #include "core/ProcessorNode.h"
 #include "TestBase.h"
 
-int main(int argc, char **argv) {
+int main(int /*argc*/, char ** /*argv*/) {
 #ifndef WIN32
   TestController testController;
   std::shared_ptr<core::Processor> processor = std::make_shared<org::apache::nifi::minifi::processors::ExecuteProcess>("executeProcess");

--- a/extensions/standard-processors/tests/unit/ProcessorTests.cpp
+++ b/extensions/standard-processors/tests/unit/ProcessorTests.cpp
@@ -514,14 +514,14 @@ class TestProcessorNoContent : public minifi::core::Processor {
    * @param sessionFactory process session factory that is used when creating
    * ProcessSession objects.
    */
-  void onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory) {
+  void onSchedule(core::ProcessContext* /*context*/, core::ProcessSessionFactory* /*sessionFactory*/) {
   }
   /**
    * Execution trigger for the GetFile Processor
    * @param context processor context
    * @param session processor session reference.
    */
-  virtual void onTrigger(core::ProcessContext *context, core::ProcessSession *session) {
+  virtual void onTrigger(core::ProcessContext* /*context*/, core::ProcessSession *session) {
     auto ff = session->create();
     ff->addAttribute("Attribute", "AttributeValue");
     session->transfer(ff, Success);

--- a/extensions/standard-processors/tests/unit/RetryFlowFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/RetryFlowFileTests.cpp
@@ -73,8 +73,8 @@ class RetryFlowFileTest {
   }
 
   void retryRoutingTest(
-      optional<std::string> exp_retry_prop_name,
-      optional<int> exp_retry_prop_val,
+      optional<std::string> /*exp_retry_prop_name*/,
+      optional<int> /*exp_retry_prop_val*/,
       core::Relationship exp_outbound_relationship,
       bool exp_penalty_on_flowfile,
       optional<std::string> retry_attr_name_on_flowfile,

--- a/libminifi/include/FlowController.h
+++ b/libminifi/include/FlowController.h
@@ -123,7 +123,7 @@ class FlowController : public core::controller::ControllerServiceProvider,  publ
 
   int16_t clearConnection(const std::string &connection) override;
 
-  int16_t applyUpdate(const std::string &source, const std::shared_ptr<state::Update>&) override { return -1; }
+  int16_t applyUpdate(const std::string& /*source*/, const std::shared_ptr<state::Update>&) override { return -1; }
   // Asynchronous function trigger unloading and wait for a period of time
   virtual void waitUnload(uint64_t timeToWaitMs);
   // Unload the current flow xml, clean the root process group and all its children

--- a/libminifi/include/controllers/ThreadManagementService.h
+++ b/libminifi/include/controllers/ThreadManagementService.h
@@ -44,7 +44,7 @@ class ThreadManagementService : public core::controller::ControllerService {
         logger_(logging::LoggerFactory<ThreadManagementService>::getLogger()) {
   }
 
-  explicit ThreadManagementService(const std::string &name, const std::shared_ptr<Configure> &configuration)
+  explicit ThreadManagementService(const std::string &name, const std::shared_ptr<Configure>& /*configuration*/)
       : ControllerService(name),
         logger_(logging::LoggerFactory<ThreadManagementService>::getLogger()) {
   }

--- a/libminifi/include/core/ClassLoader.h
+++ b/libminifi/include/core/ClassLoader.h
@@ -96,28 +96,28 @@ class ObjectFactory {
   /**
    * Create a shared pointer to a new processor.
    */
-  virtual std::shared_ptr<CoreComponent> create(const std::string &name) {
+  virtual std::shared_ptr<CoreComponent> create(const std::string& /*name*/) {
     return nullptr;
   }
 
   /**
    * Create a shared pointer to a new processor.
    */
-  virtual CoreComponent *createRaw(const std::string &name) {
+  virtual CoreComponent *createRaw(const std::string& /*name*/) {
     return nullptr;
   }
 
   /**
    * Create a shared pointer to a new processor.
    */
-  virtual std::shared_ptr<CoreComponent> create(const std::string &name, const utils::Identifier & uuid) {
+  virtual std::shared_ptr<CoreComponent> create(const std::string& /*name*/, const utils::Identifier& /*uuid*/) {
     return nullptr;
   }
 
   /**
    * Create a shared pointer to a new processor.
    */
-  virtual CoreComponent* createRaw(const std::string &name, const utils::Identifier & uuid) {
+  virtual CoreComponent* createRaw(const std::string& /*name*/, const utils::Identifier& /*uuid*/) {
     return nullptr;
   }
 
@@ -224,7 +224,7 @@ class DefautObjectFactory : public ObjectFactory {
     return container;
   }
 
-  virtual std::unique_ptr<ObjectFactory> assign(const std::string &class_name) {
+  virtual std::unique_ptr<ObjectFactory> assign(const std::string& /*class_name*/) {
     return nullptr;
   }
 

--- a/libminifi/include/core/ConfigurableComponent.h
+++ b/libminifi/include/core/ConfigurableComponent.h
@@ -154,13 +154,13 @@ class ConfigurableComponent {
   /**
    * Invoked anytime a static property is modified
    */
-  virtual void onPropertyModified(const Property &old_property, const Property &new_property) {
+  virtual void onPropertyModified(const Property& /*old_property*/, const Property& /*new_property*/) {
   }
 
   /**
    * Invoked anytime a dynamic property is modified.
    */
-  virtual void onDynamicPropertyModified(const Property &old_property, const Property &new_property) {
+  virtual void onDynamicPropertyModified(const Property& /*old_property*/, const Property& /*new_property*/) {
   }
 
   /**

--- a/libminifi/include/core/Connectable.h
+++ b/libminifi/include/core/Connectable.h
@@ -81,7 +81,7 @@ class Connectable : public CoreComponent {
    */
   virtual std::set<std::shared_ptr<Connectable>> getOutGoingConnections(const std::string &relationship) const;
 
-  virtual void put(const std::shared_ptr<FlowFile>& flow) {
+  virtual void put(const std::shared_ptr<FlowFile>& /*flow*/) {
   }
 
   virtual void restore(const std::shared_ptr<FlowFile>& file) {

--- a/libminifi/include/core/Core.h
+++ b/libminifi/include/core/Core.h
@@ -195,7 +195,7 @@ class CoreComponent {
     return uuid_.to_string();
   }
 
-  virtual void configure(const std::shared_ptr<Configure> &configuration) {
+  virtual void configure(const std::shared_ptr<Configure>& /*configuration*/) {
   }
 
   void loadComponent() {

--- a/libminifi/include/core/FlowConfiguration.h
+++ b/libminifi/include/core/FlowConfiguration.h
@@ -66,7 +66,7 @@ class FlowConfiguration : public CoreComponent {
    * Constructor that will be used for configuring
    * the flow controller.
    */
-  explicit FlowConfiguration(std::shared_ptr<core::Repository> repo, std::shared_ptr<core::Repository> flow_file_repo,
+  explicit FlowConfiguration(std::shared_ptr<core::Repository> /*repo*/, std::shared_ptr<core::Repository> flow_file_repo,
                              std::shared_ptr<core::ContentRepository> content_repo, std::shared_ptr<io::StreamFactory> stream_factory,
                              std::shared_ptr<Configure> configuration, const utils::optional<std::string>& path,
                              std::shared_ptr<utils::file::FileSystem> filesystem = std::make_shared<utils::file::FileSystem>())
@@ -141,7 +141,7 @@ class FlowConfiguration : public CoreComponent {
 
   std::unique_ptr<core::ProcessGroup> updateFromPayload(const std::string& url, const std::string& yamlConfigPayload);
 
-  virtual std::unique_ptr<core::ProcessGroup> getRootFromPayload(const std::string &yamlConfigPayload) {
+  virtual std::unique_ptr<core::ProcessGroup> getRootFromPayload(const std::string& /*yamlConfigPayload*/) {
     return nullptr;
   }
 

--- a/libminifi/include/core/ProcessContext.h
+++ b/libminifi/include/core/ProcessContext.h
@@ -102,13 +102,13 @@ class ProcessContext : public controller::ControllerServiceLookup, public core::
     return getPropertyImp<typename std::common_type<T>::type>(name, value);
   }
 
-  virtual bool getProperty(const Property &property, std::string &value, const std::shared_ptr<FlowFile> &flow_file) {
+  virtual bool getProperty(const Property &property, std::string &value, const std::shared_ptr<FlowFile>& /*flow_file*/) {
     return getProperty(property.getName(), value);
   }
   bool getDynamicProperty(const std::string &name, std::string &value) const {
     return processor_node_->getDynamicProperty(name, value);
   }
-  virtual bool getDynamicProperty(const Property &property, std::string &value, const std::shared_ptr<FlowFile> &flow_file) {
+  virtual bool getDynamicProperty(const Property &property, std::string &value, const std::shared_ptr<FlowFile>& /*flow_file*/) {
     return getDynamicProperty(property.getName(), value);
   }
   std::vector<std::string> getDynamicPropertyKeys() const {

--- a/libminifi/include/core/Processor.h
+++ b/libminifi/include/core/Processor.h
@@ -236,7 +236,7 @@ class Processor : public Connectable, public ConfigurableComponent, public std::
   virtual void onTrigger(const std::shared_ptr<ProcessContext> &context, const std::shared_ptr<ProcessSession> &session) {
     onTrigger(context.get(), session.get());
   }
-  virtual void onTrigger(ProcessContext *context, ProcessSession *session) {
+  virtual void onTrigger(ProcessContext* /*context*/, ProcessSession* /*session*/) {
   }
   // Initialize, overridden by NiFi Process Designer
   void initialize() override {
@@ -245,7 +245,7 @@ class Processor : public Connectable, public ConfigurableComponent, public std::
   virtual void onSchedule(const std::shared_ptr<ProcessContext> &context, const std::shared_ptr<ProcessSessionFactory> &sessionFactory) {
     onSchedule(context.get(), sessionFactory.get());
   }
-  virtual void onSchedule(ProcessContext *context, ProcessSessionFactory *sessionFactory) {
+  virtual void onSchedule(ProcessContext* /*context*/, ProcessSessionFactory* /*sessionFactory*/) {
   }
 
   // Hook executed when onSchedule fails (throws). Configuration should be reset in this

--- a/libminifi/include/core/Repository.h
+++ b/libminifi/include/core/Repository.h
@@ -91,20 +91,20 @@ class Repository : public virtual core::SerializableComponent, public core::Trac
   virtual void flush();
 
   // initialize
-  virtual bool initialize(const std::shared_ptr<Configure> &configure) {
+  virtual bool initialize(const std::shared_ptr<Configure>& /*configure*/) {
     return true;
   }
   // Put
-  virtual bool Put(std::string key, const uint8_t *buf, size_t bufLen) {
+  virtual bool Put(std::string /*key*/, const uint8_t* /*buf*/, size_t /*bufLen*/) {
     return true;
   }
 
-  virtual bool MultiPut(const std::vector<std::pair<std::string, std::unique_ptr<io::BufferStream>>>& data) {
+  virtual bool MultiPut(const std::vector<std::pair<std::string, std::unique_ptr<io::BufferStream>>>& /*data*/) {
     return true;
   }
 
   // Delete
-  virtual bool Delete(std::string key) {
+  virtual bool Delete(std::string /*key*/) {
     return true;
   }
 
@@ -124,7 +124,7 @@ class Repository : public virtual core::SerializableComponent, public core::Trac
     this->containers = containers;
   }
 
-  virtual bool Get(const std::string &key, std::string &value) {
+  virtual bool Get(const std::string& /*key*/, std::string& /*value*/) {
     return false;
   }
 
@@ -163,7 +163,7 @@ class Repository : public virtual core::SerializableComponent, public core::Trac
    *
    * Base implementation returns true;
    */
-  virtual bool Serialize(std::vector<std::shared_ptr<core::SerializableComponent>> &store, size_t max_size) {
+  virtual bool Serialize(std::vector<std::shared_ptr<core::SerializableComponent>>& /*store*/, size_t /*max_size*/) {
     return true;
   }
 
@@ -176,7 +176,7 @@ class Repository : public virtual core::SerializableComponent, public core::Trac
    *
    * Base implementation returns true;
    */
-  virtual bool DeSerialize(std::vector<std::shared_ptr<core::SerializableComponent>> &store, size_t &max_size) {
+  virtual bool DeSerialize(std::vector<std::shared_ptr<core::SerializableComponent>>& /*store*/, size_t& /*max_size*/) {
     return true;
   }
 
@@ -191,28 +191,28 @@ class Repository : public virtual core::SerializableComponent, public core::Trac
    *
    * Base implementation returns true;
    */
-  virtual bool DeSerialize(std::vector<std::shared_ptr<core::SerializableComponent>> &store, size_t &max_size, std::function<std::shared_ptr<core::SerializableComponent>()> lambdaConstructor) {
+  virtual bool DeSerialize(std::vector<std::shared_ptr<core::SerializableComponent>>& /*store*/, size_t& /*max_size*/, std::function<std::shared_ptr<core::SerializableComponent>()> /*lambdaConstructor*/) { // NOLINT
     return true;
   }
 
   /**
    * Base implementation returns true;
    */
-  virtual bool Serialize(const std::shared_ptr<core::SerializableComponent> &store) {
+  virtual bool Serialize(const std::shared_ptr<core::SerializableComponent>& /*store*/) {
     return true;
   }
 
   /**
    * Base implementation returns true;
    */
-  virtual bool DeSerialize(const std::shared_ptr<core::SerializableComponent> &store) {
+  virtual bool DeSerialize(const std::shared_ptr<core::SerializableComponent>& /*store*/) {
     return true;
   }
 
   /**
    * Base implementation returns true;
    */
-  virtual bool DeSerialize(const uint8_t *buffer, const size_t bufferSize) {
+  virtual bool DeSerialize(const uint8_t* /*buffer*/, const size_t /*bufferSize*/) {
     return true;
   }
 
@@ -220,11 +220,11 @@ class Repository : public virtual core::SerializableComponent, public core::Trac
     return Put(key, buffer, bufferSize);
   }
 
-  uint64_t incrementSize(const char *fpath, const struct stat *sb, int typeflag) {
+  uint64_t incrementSize(const char* /*fpath*/, const struct stat *sb, int /*typeflag*/) {
     return (repo_size_ += sb->st_size);
   }
 
-  virtual void loadComponent(const std::shared_ptr<core::ContentRepository> &content_repo) {
+  virtual void loadComponent(const std::shared_ptr<core::ContentRepository>& /*content_repo*/) {
   }
 
   virtual uint64_t getRepoSize();

--- a/libminifi/include/core/SerializableComponent.h
+++ b/libminifi/include/core/SerializableComponent.h
@@ -74,7 +74,7 @@ class SerializableComponent : public core::Connectable {
    * @param bufferSize length of buffer
    * @return status of serialization
    */
-  virtual bool Serialize(const std::string &key, const uint8_t *buffer, const size_t bufferSize) {
+  virtual bool Serialize(const std::string& /*key*/, const uint8_t* /*buffer*/, const size_t /*bufferSize*/) {
     return false;
   }
 

--- a/libminifi/include/core/controller/ControllerServiceProvider.h
+++ b/libminifi/include/core/controller/ControllerServiceProvider.h
@@ -144,7 +144,7 @@ class ControllerServiceProvider : public CoreComponent, public ConfigurableCompo
    * Disables referencing components for <code>serviceNode</code> can be disabled.
    * @param serviceNode shared pointer to a controller service node.
    */
-  virtual std::vector<std::shared_ptr<core::controller::ControllerServiceNode>> disableReferencingServices(std::shared_ptr<core::controller::ControllerServiceNode> &serviceNode) {
+  virtual std::vector<std::shared_ptr<core::controller::ControllerServiceNode>> disableReferencingServices(std::shared_ptr<core::controller::ControllerServiceNode>& /*serviceNode*/) {
     return std::vector<std::shared_ptr<core::controller::ControllerServiceNode>>();
   }
 
@@ -175,7 +175,7 @@ class ControllerServiceProvider : public CoreComponent, public ConfigurableCompo
    * Returns a controller service for the service identifier and componentID
    * @param service Identifier service identifier.
    */
-  virtual std::shared_ptr<ControllerService> getControllerServiceForComponent(const std::string &serviceIdentifier, const utils::Identifier &componentId) {
+  virtual std::shared_ptr<ControllerService> getControllerServiceForComponent(const std::string &serviceIdentifier, const utils::Identifier& /*componentId*/) {
     std::shared_ptr<ControllerService> node = getControllerService(serviceIdentifier);
     return node;
   }

--- a/libminifi/include/core/controller/StandardControllerServiceProvider.h
+++ b/libminifi/include/core/controller/StandardControllerServiceProvider.h
@@ -79,7 +79,7 @@ class StandardControllerServiceProvider : public ControllerServiceProvider, publ
     agent_ = agent;
   }
 
-  std::shared_ptr<ControllerServiceNode> createControllerService(const std::string &type, const std::string &fullType, const std::string &id, bool firstTimeAdded) {
+  std::shared_ptr<ControllerServiceNode> createControllerService(const std::string &type, const std::string &fullType, const std::string &id, bool /*firstTimeAdded*/) {
     std::shared_ptr<ControllerService> new_controller_service = extension_loader_.instantiate<ControllerService>(type, id);
 
     if (nullptr == new_controller_service) {
@@ -149,7 +149,7 @@ class StandardControllerServiceProvider : public ControllerServiceProvider, publ
     controller_map_->clear();
   }
 
-  void verifyCanStopReferencingComponents(std::shared_ptr<core::controller::ControllerServiceNode> &serviceNode) {
+  void verifyCanStopReferencingComponents(std::shared_ptr<core::controller::ControllerServiceNode>& /*serviceNode*/) {
   }
 
   std::vector<std::shared_ptr<core::controller::ControllerServiceNode>> unscheduleReferencingComponents(std::shared_ptr<core::controller::ControllerServiceNode> &serviceNode) {

--- a/libminifi/include/core/repository/VolatileFlowFileRepository.h
+++ b/libminifi/include/core/repository/VolatileFlowFileRepository.h
@@ -39,7 +39,7 @@ class VolatileFlowFileRepository : public VolatileRepository<std::string>, publi
   using utils::EnableSharedFromThis<VolatileFlowFileRepository>::sharedFromThis;
 
  public:
-  explicit VolatileFlowFileRepository(std::string repo_name = "", std::string dir = REPOSITORY_DIRECTORY, int64_t maxPartitionMillis = MAX_REPOSITORY_ENTRY_LIFE_TIME, int64_t maxPartitionBytes =
+  explicit VolatileFlowFileRepository(std::string repo_name = "", std::string /*dir*/ = REPOSITORY_DIRECTORY, int64_t maxPartitionMillis = MAX_REPOSITORY_ENTRY_LIFE_TIME, int64_t maxPartitionBytes =
   MAX_REPOSITORY_STORAGE_SIZE,
                                       uint64_t purgePeriod = REPOSITORY_PURGE_PERIOD)
       : core::SerializableComponent(repo_name),

--- a/libminifi/include/core/repository/VolatileProvenanceRepository.h
+++ b/libminifi/include/core/repository/VolatileProvenanceRepository.h
@@ -34,7 +34,7 @@ namespace repository {
  */
 class VolatileProvenanceRepository : public VolatileRepository<std::string> {
  public:
-  explicit VolatileProvenanceRepository(std::string repo_name = "", std::string dir = REPOSITORY_DIRECTORY, int64_t maxPartitionMillis = MAX_REPOSITORY_ENTRY_LIFE_TIME, int64_t maxPartitionBytes =
+  explicit VolatileProvenanceRepository(std::string repo_name = "", std::string /*dir*/ = REPOSITORY_DIRECTORY, int64_t maxPartitionMillis = MAX_REPOSITORY_ENTRY_LIFE_TIME, int64_t maxPartitionBytes =
   MAX_REPOSITORY_STORAGE_SIZE,
                                         uint64_t purgePeriod = REPOSITORY_PURGE_PERIOD)
       : core::SerializableComponent(repo_name), VolatileRepository(repo_name.length() > 0 ? repo_name : core::getClassName<VolatileRepository>(), "", maxPartitionMillis, maxPartitionBytes, purgePeriod) { // NOLINT

--- a/libminifi/include/core/repository/VolatileRepository.h
+++ b/libminifi/include/core/repository/VolatileRepository.h
@@ -59,7 +59,7 @@ class VolatileRepository : public core::Repository, public utils::EnableSharedFr
   static const char *volatile_repo_max_bytes;
   // Constructor
 
-  explicit VolatileRepository(std::string repo_name = "", std::string dir = REPOSITORY_DIRECTORY, int64_t maxPartitionMillis = MAX_REPOSITORY_ENTRY_LIFE_TIME, int64_t maxPartitionBytes =
+  explicit VolatileRepository(std::string repo_name = "", std::string /*dir*/ = REPOSITORY_DIRECTORY, int64_t maxPartitionMillis = MAX_REPOSITORY_ENTRY_LIFE_TIME, int64_t maxPartitionBytes =
   MAX_REPOSITORY_STORAGE_SIZE,
                               uint64_t purgePeriod = REPOSITORY_PURGE_PERIOD)
       : core::SerializableComponent(repo_name),
@@ -192,7 +192,7 @@ template<typename T>
 const char *VolatileRepository<T>::volatile_repo_max_bytes = "max.bytes";
 
 template<typename T>
-void VolatileRepository<T>::loadComponent(const std::shared_ptr<core::ContentRepository> &content_repo) {
+void VolatileRepository<T>::loadComponent(const std::shared_ptr<core::ContentRepository>& /*content_repo*/) {
 }
 
 // Destructor

--- a/libminifi/include/core/state/UpdateController.h
+++ b/libminifi/include/core/state/UpdateController.h
@@ -134,7 +134,7 @@ class UpdateRunner : public utils::AfterExecute<Update> {
       return true;
     }
   }
-  virtual bool isCancelled(const Update &result) {
+  virtual bool isCancelled(const Update& /*result*/) {
     return !*running_;
   }
 

--- a/libminifi/include/core/state/Value.h
+++ b/libminifi/include/core/state/Value.h
@@ -188,7 +188,7 @@ class UInt32Value : public Value {
     return true;
   }
 
-  virtual bool getValue(bool &ref) {
+  virtual bool getValue(bool& /*ref*/) {
     return false;
   }
 
@@ -233,7 +233,7 @@ class IntValue : public Value {
     return true;
   }
 
-  virtual bool getValue(bool &ref) {
+  virtual bool getValue(bool& /*ref*/) {
     return false;
   }
 
@@ -311,11 +311,11 @@ class UInt64Value : public Value {
   }
 
  protected:
-  virtual bool getValue(int &ref) {
+  virtual bool getValue(int& /*ref*/) {
     return false;
   }
 
-  virtual bool getValue(uint32_t &ref) {
+  virtual bool getValue(uint32_t& /*ref*/) {
     return false;
   }
 
@@ -332,7 +332,7 @@ class UInt64Value : public Value {
     return true;
   }
 
-  virtual bool getValue(bool &ref) {
+  virtual bool getValue(bool& /*ref*/) {
     return false;
   }
 
@@ -357,11 +357,11 @@ class Int64Value : public Value {
   }
 
  protected:
-  virtual bool getValue(int &ref) {
+  virtual bool getValue(int& /*ref*/) {
     return false;
   }
 
-  virtual bool getValue(uint32_t &ref) {
+  virtual bool getValue(uint32_t& /*ref*/) {
     return false;
   }
 
@@ -376,7 +376,7 @@ class Int64Value : public Value {
     return true;
   }
 
-  virtual bool getValue(bool &ref) {
+  virtual bool getValue(bool& /*ref*/) {
     return false;
   }
 

--- a/libminifi/include/io/ClientSocket.h
+++ b/libminifi/include/io/ClientSocket.h
@@ -78,7 +78,7 @@ bool valid_socket(SocketDescriptor) noexcept;
  */
 class SocketContext {
  public:
-  SocketContext(const std::shared_ptr<Configure> &configure) { // NOLINT
+  SocketContext(const std::shared_ptr<Configure>& /*configure*/) { // NOLINT
   }
 };
 /**

--- a/libminifi/include/io/Stream.h
+++ b/libminifi/include/io/Stream.h
@@ -31,7 +31,7 @@ class Stream {
  public:
   virtual void close() {}
 
-  virtual void seek(uint64_t offset) {
+  virtual void seek(uint64_t /*offset*/) {
     throw std::runtime_error("Seek is not supported");
   }
 

--- a/libminifi/include/utils/FileOutputCallback.h
+++ b/libminifi/include/utils/FileOutputCallback.h
@@ -42,7 +42,7 @@ class FileOutputCallback : public ByteOutputCallback {
  public:
   FileOutputCallback() = delete;
 
-  explicit FileOutputCallback(std::string file, bool wait_on_read = false)
+  explicit FileOutputCallback(std::string file, bool /*wait_on_read*/ = false)
       : ByteOutputCallback(INT_MAX), file_(file), file_stream_(file),
         logger_(logging::LoggerFactory<FileOutputCallback>::getLogger()) {
   }

--- a/libminifi/include/utils/Monitors.h
+++ b/libminifi/include/utils/Monitors.h
@@ -68,7 +68,7 @@ class TimerAwareMonitor : public utils::AfterExecute<std::chrono::milliseconds> 
     }
     return true;
   }
-  bool isCancelled(const std::chrono::milliseconds &result) override {
+  bool isCancelled(const std::chrono::milliseconds& /*result*/) override {
     if (*run_monitor_) {
       return false;
     }
@@ -96,7 +96,7 @@ class SingleRunMonitor : public utils::AfterExecute<bool>{
   bool isFinished(const bool &result) override {
     return result;
   }
-  bool isCancelled(const bool &result) override {
+  bool isCancelled(const bool& /*result*/) override {
     return false;
   }
   std::chrono::milliseconds wait_time() override {
@@ -146,7 +146,7 @@ class ComplexMonitor : public utils::AfterExecute<TaskRescheduleInfo> {
     current_wait_.store(result.wait_time_);
     return false;
   }
-  bool isCancelled(const TaskRescheduleInfo &result) override {
+  bool isCancelled(const TaskRescheduleInfo& /*result*/) override {
     return false;
   }
   /**

--- a/libminifi/include/utils/file/DiffUtils.h
+++ b/libminifi/include/utils/file/DiffUtils.h
@@ -39,7 +39,7 @@ extern "C" {
 
 }
 #else
-int apply_bsdiff_patch(const char *oldfile, const char *newfile, const char *patch) {
+int apply_bsdiff_patch(const char* /*oldfile*/, const char* /*newfile*/, const char* /*patch*/) {
   return -1;
 }
 
@@ -64,7 +64,7 @@ class DiffUtils {
     return apply_bsdiff_patch(file_original, file_new, result_file);
   }
 
-  static int binary_diff(const char *file_original, const char *file_other, const char *patchfile) {
+  static int binary_diff(const char* /*file_original*/, const char* /*file_other*/, const char* /*patchfile*/) {
     return -1;
   }
 };

--- a/libminifi/include/utils/file/FileUtils.h
+++ b/libminifi/include/utils/file/FileUtils.h
@@ -115,14 +115,18 @@ static inline int platform_create_dir(const std::string& path) {
  * @param force_posix returns the posix path separator ('/'), even when not on posix. Useful when dealing with remote posix paths.
  * @return the path separator character
  */
-inline char get_separator(bool /*force_posix*/ = false) {
 #ifdef WIN32
+inline char get_separator(bool force_posix = false) {
   if (!force_posix) {
     return '\\';
   }
-#endif
   return '/';
 }
+#else
+inline char get_separator(bool /*force_posix*/ = false) {
+  return '/';
+}
+#endif
 
 inline std::string normalize_path_separators(std::string path, bool force_posix = false) {
   const auto normalize_separators = [force_posix](const char c) {

--- a/libminifi/include/utils/file/FileUtils.h
+++ b/libminifi/include/utils/file/FileUtils.h
@@ -115,7 +115,7 @@ static inline int platform_create_dir(const std::string& path) {
  * @param force_posix returns the posix path separator ('/'), even when not on posix. Useful when dealing with remote posix paths.
  * @return the path separator character
  */
-inline char get_separator(bool force_posix = false) {
+inline char get_separator(bool /*force_posix*/ = false) {
 #ifdef WIN32
   if (!force_posix) {
     return '\\';

--- a/libminifi/src/FlowControlProtocol.cpp
+++ b/libminifi/src/FlowControlProtocol.cpp
@@ -37,11 +37,11 @@ namespace apache {
 namespace nifi {
 namespace minifi {
 
-int FlowControlProtocol::connectServer(const char *host, uint16_t port) {
+int FlowControlProtocol::connectServer(const char* /*host*/, uint16_t /*port*/) {
   return 0;
 }
 
-int FlowControlProtocol::sendData(uint8_t *buf, int buflen) {
+int FlowControlProtocol::sendData(uint8_t* /*buf*/, int /*buflen*/) {
   return 0;
 }
 

--- a/libminifi/src/FlowController.cpp
+++ b/libminifi/src/FlowController.cpp
@@ -59,7 +59,7 @@ namespace minifi {
 
 FlowController::FlowController(std::shared_ptr<core::Repository> provenance_repo, std::shared_ptr<core::Repository> flow_file_repo,
                                std::shared_ptr<Configure> configure, std::unique_ptr<core::FlowConfiguration> flow_configuration,
-                               std::shared_ptr<core::ContentRepository> content_repo, const std::string name, bool headless_mode,
+                               std::shared_ptr<core::ContentRepository> content_repo, const std::string /*name*/, bool headless_mode,
                                std::shared_ptr<utils::file::FileSystem> filesystem)
     : core::controller::ControllerServiceProvider(core::getClassName<FlowController>()),
       c2::C2Client(std::move(configure), std::move(provenance_repo), std::move(flow_file_repo),
@@ -399,7 +399,7 @@ std::future<utils::TaskRescheduleInfo> FlowController::enableControllerService(s
  * Enables controller services
  * @param serviceNoden vector of service nodes which will be enabled, along with linked services.
  */
-void FlowController::enableControllerServices(std::vector<std::shared_ptr<core::controller::ControllerServiceNode>> serviceNodes) {
+void FlowController::enableControllerServices(std::vector<std::shared_ptr<core::controller::ControllerServiceNode>> /*serviceNodes*/) {
 }
 
 /**
@@ -441,7 +441,7 @@ std::shared_ptr<core::controller::ControllerServiceNode> FlowController::getCont
   return controller_service_provider_->getControllerServiceNode(id);
 }
 
-void FlowController::verifyCanStopReferencingComponents(std::shared_ptr<core::controller::ControllerServiceNode> &serviceNode) {
+void FlowController::verifyCanStopReferencingComponents(std::shared_ptr<core::controller::ControllerServiceNode>& /*serviceNode*/) {
 }
 
 /**

--- a/libminifi/src/RemoteProcessorGroupPort.cpp
+++ b/libminifi/src/RemoteProcessorGroupPort.cpp
@@ -135,7 +135,7 @@ void RemoteProcessorGroupPort::initialize() {
   logger_->log_trace("Finished initialization");
 }
 
-void RemoteProcessorGroupPort::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) {
+void RemoteProcessorGroupPort::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory>& /*sessionFactory*/) {
   std::string value;
   if (context->getProperty(portUUID.getName(), value) && !value.empty()) {
     protocol_uuid_ = value;

--- a/libminifi/src/controllers/LinuxPowerManagementService.cpp
+++ b/libminifi/src/controllers/LinuxPowerManagementService.cpp
@@ -56,7 +56,7 @@ core::Property LinuxPowerManagerService::LowBatteryThreshold(
     core::PropertyBuilder::createProperty("Low Battery Threshold")->withDescription("Battery threshold before which we will aggressively reduce. Should be a number from 1-100")->isRequired(true)
         ->withDefaultValue<int>(50)->build());
 
-bool LinuxPowerManagerService::isAboveMax(int new_tasks) {
+bool LinuxPowerManagerService::isAboveMax(int /*new_tasks*/) {
   return false;
 }
 

--- a/libminifi/src/controllers/SSLContextService.cpp
+++ b/libminifi/src/controllers/SSLContextService.cpp
@@ -244,8 +244,8 @@ bool SSLContextService::addPemCertificateToSSLContext(SSL_CTX* ctx) const {
   return true;
 }
 
-bool SSLContextService::addClientCertificateFromSystemStoreToSSLContext(SSL_CTX* /*ctx*/) const {
 #ifdef WIN32
+bool SSLContextService::addClientCertificateFromSystemStoreToSSLContext(SSL_CTX* ctx) const {
   utils::tls::WindowsCertStoreLocation store_location{cert_store_location_};
   HCERTSTORE hCertStore = CertOpenStore(CERT_STORE_PROV_SYSTEM_A, 0, NULL,
                                         CERT_STORE_OPEN_EXISTING_FLAG | CERT_STORE_READONLY_FLAG | store_location.getBitfieldValue(),
@@ -269,11 +269,13 @@ bool SSLContextService::addClientCertificateFromSystemStoreToSSLContext(SSL_CTX*
 
   logger_->log_error("Could not find any suitable client certificate in sytem store %s/%s", cert_store_location_, client_cert_store_);
   return false;
+}
 #else
+bool SSLContextService::addClientCertificateFromSystemStoreToSSLContext(SSL_CTX* /*ctx*/) const {
   logger_->log_error("Getting client certificate from the system store is only supported on Windows");
   return false;
-#endif  // WIN32
 }
+#endif  // WIN32
 
 #ifdef WIN32
 bool SSLContextService::useClientCertificate(SSL_CTX* ctx, PCCERT_CONTEXT certificate) const {

--- a/libminifi/src/controllers/SSLContextService.cpp
+++ b/libminifi/src/controllers/SSLContextService.cpp
@@ -244,7 +244,7 @@ bool SSLContextService::addPemCertificateToSSLContext(SSL_CTX* ctx) const {
   return true;
 }
 
-bool SSLContextService::addClientCertificateFromSystemStoreToSSLContext(SSL_CTX* ctx) const {
+bool SSLContextService::addClientCertificateFromSystemStoreToSSLContext(SSL_CTX* /*ctx*/) const {
 #ifdef WIN32
   utils::tls::WindowsCertStoreLocation store_location{cert_store_location_};
   HCERTSTORE hCertStore = CertOpenStore(CERT_STORE_PROV_SYSTEM_A, 0, NULL,

--- a/libminifi/src/core/Connectable.cpp
+++ b/libminifi/src/core/Connectable.cpp
@@ -166,7 +166,7 @@ std::shared_ptr<Connectable> Connectable::getNextIncomingConnection() {
   return getNextIncomingConnectionImpl(lock);
 }
 
-std::shared_ptr<Connectable> Connectable::getNextIncomingConnectionImpl(const std::lock_guard<std::mutex>& relatioship_mutex_lock) {
+std::shared_ptr<Connectable> Connectable::getNextIncomingConnectionImpl(const std::lock_guard<std::mutex>& /*relatioship_mutex_lock*/) {
   if (_incomingConnections.size() == 0)
     return nullptr;
 

--- a/libminifi/src/core/ProcessSession.cpp
+++ b/libminifi/src/core/ProcessSession.cpp
@@ -567,7 +567,7 @@ void ProcessSession::import(std::string source, std::vector<std::shared_ptr<Flow
   }
 }
 
-bool ProcessSession::exportContent(const std::string &destination, const std::string &tmpFile, const std::shared_ptr<core::FlowFile> &flow, bool keepContent) {
+bool ProcessSession::exportContent(const std::string &destination, const std::string &tmpFile, const std::shared_ptr<core::FlowFile> &flow, bool /*keepContent*/) {
   logger_->log_debug("Exporting content of %s to %s", flow->getUUIDStr(), destination);
 
   ProcessSessionReadCallback cb(tmpFile, destination, logger_);

--- a/libminifi/src/core/logging/Logger.cpp
+++ b/libminifi/src/core/logging/Logger.cpp
@@ -46,7 +46,7 @@ void LoggerControl::setEnabled(bool status) {
 
 BaseLogger::~BaseLogger() = default;
 
-bool BaseLogger::should_log(const LOG_LEVEL &level) {
+bool BaseLogger::should_log(const LOG_LEVEL& /*level*/) {
   return true;
 }
 

--- a/libminifi/src/core/reporting/SiteToSiteProvenanceReportingTask.cpp
+++ b/libminifi/src/core/reporting/SiteToSiteProvenanceReportingTask.cpp
@@ -94,7 +94,7 @@ void appendJsonStr(const utils::SmallString<N>& value, rapidjson::Value& parent,
   parent.PushBack(valueVal, alloc);
 }
 
-void SiteToSiteProvenanceReportingTask::getJsonReport(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session,
+void SiteToSiteProvenanceReportingTask::getJsonReport(const std::shared_ptr<core::ProcessContext>& /*context*/, const std::shared_ptr<core::ProcessSession>& /*session*/,
                                                       std::vector<std::shared_ptr<core::SerializableComponent>> &records, std::string &report) {
   rapidjson::Document array(rapidjson::kArrayType);
   rapidjson::Document::AllocatorType &alloc = array.GetAllocator();
@@ -157,7 +157,7 @@ void SiteToSiteProvenanceReportingTask::getJsonReport(const std::shared_ptr<core
   report = buffer.GetString();
 }
 
-void SiteToSiteProvenanceReportingTask::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) {
+void SiteToSiteProvenanceReportingTask::onSchedule(const std::shared_ptr<core::ProcessContext>& /*context*/, const std::shared_ptr<core::ProcessSessionFactory>& /*sessionFactory*/) {
 }
 
 void SiteToSiteProvenanceReportingTask::onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) {

--- a/libminifi/src/core/repository/VolatileContentRepository.cpp
+++ b/libminifi/src/core/repository/VolatileContentRepository.cpp
@@ -78,7 +78,7 @@ void VolatileContentRepository::start() {
   logger_->log_info("%s Repository Monitor Thread Start", getName());
 }
 
-std::shared_ptr<io::BaseStream> VolatileContentRepository::write(const minifi::ResourceClaim &claim, bool append) {
+std::shared_ptr<io::BaseStream> VolatileContentRepository::write(const minifi::ResourceClaim &claim, bool /*append*/) {
   logger_->log_info("enter write for %s", claim.getContentFullPath());
   {
     std::lock_guard<std::mutex> lock(map_mutex_);

--- a/libminifi/src/io/ServerSocket.cpp
+++ b/libminifi/src/io/ServerSocket.cpp
@@ -57,7 +57,7 @@ ServerSocket::~ServerSocket() {
  * @return result of the creation operation.
  */
 void ServerSocket::registerCallback(std::function<bool()> accept_function, std::function<void(io::BaseStream *)> handler) {
-  auto fx = [this](std::function<bool()> accept_function, std::function<void(io::BaseStream *stream)> handler) {
+  auto fx = [this](std::function<bool()> /*accept_function*/, std::function<void(io::BaseStream *stream)> handler) {
     while (running_) {
       int fd = select_descriptor(1000);
       if (fd >= 0) {

--- a/libminifi/src/io/tls/TLSServerSocket.cpp
+++ b/libminifi/src/io/tls/TLSServerSocket.cpp
@@ -68,7 +68,7 @@ TLSServerSocket::~TLSServerSocket() {
  * @return result of the creation operation.
  */
 void TLSServerSocket::registerCallback(std::function<bool()> accept_function, std::function<void(io::BaseStream *)> handler) {
-  auto fx = [this](std::function<bool()> accept_function, std::function<void(io::BaseStream *)> handler) {
+  auto fx = [this](std::function<bool()> /*accept_function*/, std::function<void(io::BaseStream *)> handler) {
     while (running_) {
       int fd = select_descriptor(1000);
       if (fd >= 0) {

--- a/libminifi/src/io/tls/TLSSocket.cpp
+++ b/libminifi/src/io/tls/TLSSocket.cpp
@@ -351,7 +351,7 @@ int16_t TLSSocket::select_descriptor(const uint16_t msec) {
   return -1;
 }
 
-int TLSSocket::read(uint8_t *buf, int buflen, bool retrieve_all_bytes) {
+int TLSSocket::read(uint8_t *buf, int buflen, bool /*retrieve_all_bytes*/) {
   gsl_Expects(buflen >= 0);
   int total_read = 0;
   int status = 0;

--- a/libminifi/src/sitetosite/SiteToSiteClient.cpp
+++ b/libminifi/src/sitetosite/SiteToSiteClient.cpp
@@ -25,7 +25,7 @@ namespace nifi {
 namespace minifi {
 namespace sitetosite {
 
-int SiteToSiteClient::readResponse(const std::shared_ptr<Transaction> &transaction, RespondCode &code, std::string &message) {
+int SiteToSiteClient::readResponse(const std::shared_ptr<Transaction>& /*transaction*/, RespondCode &code, std::string &message) {
   uint8_t firstByte;
 
   int ret = peer_->read(firstByte);
@@ -78,7 +78,7 @@ void SiteToSiteClient::deleteTransaction(const utils::Identifier& transactionID)
   known_transactions_.erase(transactionID);
 }
 
-int SiteToSiteClient::writeResponse(const std::shared_ptr<Transaction> &transaction, RespondCode code, std::string message) {
+int SiteToSiteClient::writeResponse(const std::shared_ptr<Transaction>& /*transaction*/, RespondCode code, std::string message) {
   RespondCodeContext *resCode = this->getRespondCodeContext(code);
 
   if (resCode == NULL) {

--- a/libminifi/src/utils/BackTrace.cpp
+++ b/libminifi/src/utils/BackTrace.cpp
@@ -148,7 +148,7 @@ BackTrace TraceResolver::getBackTrace(std::string thread_name, std::thread::nati
   return std::move(trace_);
 }
 #ifdef HAS_EXECINFO
-void handler(int signr, siginfo_t *info, void *secret) {
+void handler(int /*signr*/, siginfo_t* /*info*/, void* /*secret*/) {
   std::unique_lock<std::mutex> lock(TraceResolver::getResolver().lock());
   pull_trace();
   TraceResolver::getResolver().notifyPullTracesDone(lock);

--- a/libminifi/src/utils/tls/TLSUtils.cpp
+++ b/libminifi/src/utils/tls/TLSUtils.cpp
@@ -29,7 +29,7 @@ namespace minifi {
 namespace utils {
 namespace tls {
 
-int pemPassWordCb(char *buf, int size, int rwflag, void *userdata) {
+int pemPassWordCb(char *buf, int size, int /*rwflag*/, void *userdata) {
   const std::string * const origPass = reinterpret_cast<std::string*>(userdata);
   // make copy the password, trimming it
   const auto pass = utils::StringUtils::trimRight(*origPass);

--- a/libminifi/test/KamikazeProcessor.cpp
+++ b/libminifi/test/KamikazeProcessor.cpp
@@ -51,7 +51,7 @@ void KamikazeProcessor::initialize() {
   setSupportedProperties({ThrowInOnSchedule, ThrowInOnTrigger});
 }
 
-void KamikazeProcessor::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory) {
+void KamikazeProcessor::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory* /*sessionFactory*/) {
   std::string value;
   bool bool_value;
 

--- a/libminifi/test/TestBase.cpp
+++ b/libminifi/test/TestBase.cpp
@@ -65,7 +65,7 @@ TestPlan::~TestPlan() {
   controller_services_provider_->clearControllerServices();
 }
 
-std::shared_ptr<core::Processor> TestPlan::addProcessor(const std::shared_ptr<core::Processor> &processor, const std::string &name, const std::initializer_list<core::Relationship>& relationships,
+std::shared_ptr<core::Processor> TestPlan::addProcessor(const std::shared_ptr<core::Processor> &processor, const std::string& /*name*/, const std::initializer_list<core::Relationship>& relationships,
                                                         bool linkToPrevious) {
   if (finalized) {
     return nullptr;

--- a/libminifi/test/flow-tests/CustomProcessors.h
+++ b/libminifi/test/flow-tests/CustomProcessors.h
@@ -54,7 +54,7 @@ class TestProcessor : public core::Processor, public ProcessorWithStatistics {
     setSupportedProperties({AppleProbability, BananaProbability});
     setSupportedRelationships({Apple, Banana});
   }
-  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override {
+  void onTrigger(const std::shared_ptr<core::ProcessContext>& /*context*/, const std::shared_ptr<core::ProcessSession> &session) override {
     ++trigger_count;
     if (onTriggerCb_) {
       onTriggerCb_();
@@ -75,7 +75,7 @@ class TestProcessor : public core::Processor, public ProcessorWithStatistics {
     }
     throw std::runtime_error("Couldn't route file");
   }
-  void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override {
+  void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory>& /*sessionFactory*/) override {
     int apple;
     bool appleSuccess = context->getProperty(AppleProbability.getName(), apple);
     assert(appleSuccess);

--- a/libminifi/test/integration/IntegrationBase.h
+++ b/libminifi/test/integration/IntegrationBase.h
@@ -65,7 +65,7 @@ class IntegrationBase {
   virtual void configureC2() {
   }
 
-  virtual void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> pg) {
+  virtual void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> /*pg*/) {
 
   }
 
@@ -73,7 +73,7 @@ class IntegrationBase {
 
   }
 
-  virtual void updateProperties(std::shared_ptr<minifi::FlowController> fc) {
+  virtual void updateProperties(std::shared_ptr<minifi::FlowController> /*fc*/) {
 
   }
 

--- a/libminifi/test/persistence-tests/PersistenceTests.cpp
+++ b/libminifi/test/persistence-tests/PersistenceTests.cpp
@@ -230,7 +230,7 @@ TEST_CASE("Processors Can Store FlowFiles", "[TestP1]") {
 class ContentUpdaterProcessor : public core::Processor{
  public:
   ContentUpdaterProcessor(const std::string& name, utils::Identifier& id) : Processor(name, id) {}
-  void onTrigger(core::ProcessContext *context, core::ProcessSession *session) override {
+  void onTrigger(core::ProcessContext* /*context*/, core::ProcessSession *session) override {
     auto ff = session->get();
     std::string data = "<override>";
     minifi::io::BufferStream stream(reinterpret_cast<const uint8_t*>(data.c_str()), data.length());

--- a/libminifi/test/unit/BackTraceTests.cpp
+++ b/libminifi/test/unit/BackTraceTests.cpp
@@ -47,7 +47,7 @@ class WorkerNumberExecutions : public utils::AfterExecute<int> {
       return true;
     }
   }
-  bool isCancelled(const int &result) override {
+  bool isCancelled(const int& /*result*/) override {
     return false;
   }
 

--- a/libminifi/test/unit/ControllerTests.cpp
+++ b/libminifi/test/unit/ControllerTests.cpp
@@ -77,7 +77,7 @@ class TestUpdateSink : public minifi::state::StateMonitor {
         controller(controller),
         update_calls(0) {
   }
-  std::vector<std::shared_ptr<StateController>> getComponents(const std::string &name) override {
+  std::vector<std::shared_ptr<StateController>> getComponents(const std::string& /*name*/) override {
     std::vector<std::shared_ptr<StateController>> vec;
     vec.push_back(controller);
     return vec;
@@ -138,7 +138,7 @@ class TestUpdateSink : public minifi::state::StateMonitor {
   /**
    * Clear connection for the agent.
    */
-  int16_t clearConnection(const std::string &connection) override {
+  int16_t clearConnection(const std::string& /*connection*/) override {
     clear_calls++;
     return 0;
   }
@@ -149,7 +149,7 @@ class TestUpdateSink : public minifi::state::StateMonitor {
    * < 0 is an error code
    * 0 is success
    */
-  int16_t applyUpdate(const std::string &source, const std::string &configuration, bool persist = false) override {
+  int16_t applyUpdate(const std::string& /*source*/, const std::string& /*configuration*/, bool /*persist*/ = false) override {
     update_calls++;
     return 0;
   }
@@ -158,7 +158,7 @@ class TestUpdateSink : public minifi::state::StateMonitor {
    * Apply an update that the agent must decode. This is useful for certain operations
    * that can't be encapsulated within these definitions.
    */
-  int16_t applyUpdate(const std::string &source, const std::shared_ptr<minifi::state::Update> &updateController) override {
+  int16_t applyUpdate(const std::string& /*source*/, const std::shared_ptr<minifi::state::Update>& /*updateController*/) override {
     return 0;
   }
 

--- a/libminifi/test/unit/MockClasses.h
+++ b/libminifi/test/unit/MockClasses.h
@@ -93,7 +93,7 @@ class MockProcessor : public core::Processor {
   }
 
   // OnTrigger method, implemented by NiFi Processor Designer
-  virtual void onTrigger(core::ProcessContext *context, core::ProcessSession *session) {
+  virtual void onTrigger(core::ProcessContext *context, core::ProcessSession* /*session*/) {
 
     std::string linked_service = "";
     getProperty("linkedService", linked_service);

--- a/libminifi/test/unit/ProvenanceTestHelper.h
+++ b/libminifi/test/unit/ProvenanceTestHelper.h
@@ -110,7 +110,7 @@ class TestRepository : public core::Repository {
     }
   }
 
-  bool Serialize(std::vector<std::shared_ptr<core::SerializableComponent>> &store, size_t max_size) override {
+  bool Serialize(std::vector<std::shared_ptr<core::SerializableComponent>>& /*store*/, size_t /*max_size*/) override {
     return false;
   }
 
@@ -129,7 +129,7 @@ class TestRepository : public core::Repository {
     return true;
   }
 
-  bool Serialize(const std::shared_ptr<core::SerializableComponent> &store) override {
+  bool Serialize(const std::shared_ptr<core::SerializableComponent>& /*store*/) override {
     return false;
   }
 
@@ -140,7 +140,7 @@ class TestRepository : public core::Repository {
     return true;
   }
 
-  bool DeSerialize(const uint8_t *buffer, const size_t bufferSize) override {
+  bool DeSerialize(const uint8_t* /*buffer*/, const size_t /*bufferSize*/) override {
     return false;
   }
 
@@ -225,7 +225,7 @@ class TestFlowRepository : public core::Repository {
     }
   }
 
-  void loadComponent(const std::shared_ptr<core::ContentRepository> &content_repo) override {
+  void loadComponent(const std::shared_ptr<core::ContentRepository>& /*content_repo*/) override {
   }
 
   void run() override {
@@ -240,13 +240,13 @@ class TestFlowRepository : public core::Repository {
 class TestFlowController : public minifi::FlowController {
 
  public:
-  TestFlowController(std::shared_ptr<core::Repository> repo, std::shared_ptr<core::Repository> flow_file_repo, std::shared_ptr<core::ContentRepository> content_repo)
+  TestFlowController(std::shared_ptr<core::Repository> repo, std::shared_ptr<core::Repository> flow_file_repo, std::shared_ptr<core::ContentRepository> /*content_repo*/)
       : minifi::FlowController(repo, flow_file_repo, std::make_shared<minifi::Configure>(), nullptr, std::make_shared<core::repository::VolatileContentRepository>(), "", true) {
   }
 
   ~TestFlowController() override = default;
 
-  void load(const std::shared_ptr<core::ProcessGroup> &root = nullptr, bool reload = false) override {
+  void load(const std::shared_ptr<core::ProcessGroup>& /*root*/ = nullptr, bool /*reload*/ = false) override {
   }
 
   int16_t start() override {
@@ -258,7 +258,7 @@ class TestFlowController : public minifi::FlowController {
     running_.store(false);
     return 0;
   }
-  void waitUnload(const uint64_t timeToWaitMs) override {
+  void waitUnload(const uint64_t /*timeToWaitMs*/) override {
     stop();
   }
 
@@ -274,19 +274,19 @@ class TestFlowController : public minifi::FlowController {
     return true;
   }
 
-  std::shared_ptr<core::Processor> createProcessor(std::string name, utils::Identifier &  uuid) {
+  std::shared_ptr<core::Processor> createProcessor(std::string /*name*/, utils::Identifier& /*uuid*/) {
     return 0;
   }
 
-  core::ProcessGroup *createRootProcessGroup(std::string name, utils::Identifier &  uuid) {
+  core::ProcessGroup *createRootProcessGroup(std::string /*name*/, utils::Identifier& /*uuid*/) {
     return 0;
   }
 
-  core::ProcessGroup *createRemoteProcessGroup(std::string name, utils::Identifier &  uuid) {
+  core::ProcessGroup *createRemoteProcessGroup(std::string /*name*/, utils::Identifier& /*uuid*/) {
     return 0;
   }
 
-  std::shared_ptr<minifi::Connection> createConnection(std::string name, utils::Identifier &  uuid) {
+  std::shared_ptr<minifi::Connection> createConnection(std::string /*name*/, utils::Identifier& /*uuid*/) {
     return 0;
   }
 };

--- a/libminifi/test/unit/ThreadPoolTests.cpp
+++ b/libminifi/test/unit/ThreadPoolTests.cpp
@@ -47,7 +47,7 @@ class WorkerNumberExecutions : public utils::AfterExecute<int> {
       return true;
     }
   }
-  bool isCancelled(const int &result) override {
+  bool isCancelled(const int& /*result*/) override {
     return false;
   }
 

--- a/nanofi/include/cxx/Instance.h
+++ b/nanofi/include/cxx/Instance.h
@@ -100,7 +100,7 @@ class Instance {
     return rpgInitialized_;
   }
 
-  void enableAsyncC2(C2_Server *server, c2_stop_callback *c1, c2_start_callback *c2, c2_update_callback *c3) {
+  void enableAsyncC2(C2_Server *server, c2_stop_callback *c1, c2_start_callback* /*c2*/, c2_update_callback* /*c3*/) {
     running_ = true;
     if (server->type != C2_Server_Type::MQTT) {
       configure_->set("c2.rest.url", server->url);
@@ -148,7 +148,7 @@ class Instance {
 
  protected:
 
-  bool registerUpdateListener(const std::shared_ptr<state::UpdateController> &updateController, const int64_t &delay) {
+  bool registerUpdateListener(const std::shared_ptr<state::UpdateController> &updateController, const int64_t& /*delay*/) {
     auto functions = updateController->getFunctions();
     // run all functions independently
 

--- a/nanofi/include/cxx/ReflexiveSession.h
+++ b/nanofi/include/cxx/ReflexiveSession.h
@@ -57,7 +57,7 @@ class ReflexiveSession : public ProcessSession{
    virtual void add(const std::shared_ptr<core::FlowFile> &flow){
      ff = flow;
    }
-   virtual void transfer(const std::shared_ptr<core::FlowFile> &flow, Relationship relationship){
+   virtual void transfer(const std::shared_ptr<core::FlowFile>& /*flow*/, Relationship /*relationship*/){
      // no op
    }
  protected:

--- a/nanofi/include/sitetosite/CPeer.h
+++ b/nanofi/include/sitetosite/CPeer.h
@@ -98,7 +98,7 @@ static void setPort(struct SiteToSiteCPeer * peer, uint16_t port) {
   }
 }
 
-static void initPeer(struct SiteToSiteCPeer * peer, const char * host, uint16_t port, const char * ifc) {
+static void initPeer(struct SiteToSiteCPeer * peer, const char * host, uint16_t port) {
   peer->_stream = NULL;
   peer->_host = NULL;
   peer->_url = NULL;

--- a/nanofi/include/sitetosite/CRawSocketProtocol.h
+++ b/nanofi/include/sitetosite/CRawSocketProtocol.h
@@ -76,11 +76,11 @@ int16_t sendPacket(struct CRawSiteToSiteClient * client, const char * transactio
 
 CTransaction* createTransaction(struct CRawSiteToSiteClient * client, TransferDirection direction);
 
-static const char * getResourceName(const struct CRawSiteToSiteClient * c) {
+static const char * getResourceName() {
   return "SocketFlowFileProtocol";
 }
 
-static const char * getCodecResourceName(const struct CRawSiteToSiteClient * c) {
+static const char * getCodecResourceName() {
   return "StandardFlowFileCodec";
 }
 
@@ -193,7 +193,7 @@ static void initRawClient(struct CRawSiteToSiteClient *client, struct SiteToSite
 
 static struct CRawSiteToSiteClient* createClient(const char * host, uint16_t port, const char * nifi_port) {
   struct SiteToSiteCPeer * peer = (struct SiteToSiteCPeer *)malloc(sizeof(struct SiteToSiteCPeer));
-  initPeer(peer, host, port, "");
+  initPeer(peer, host, port);
   struct CRawSiteToSiteClient* client = (struct CRawSiteToSiteClient*)malloc(sizeof(struct CRawSiteToSiteClient));
   initRawClient(client, peer);
   client->_owns_resource = True;

--- a/nanofi/src/cxx/CallbackProcessor.cpp
+++ b/nanofi/src/cxx/CallbackProcessor.cpp
@@ -33,7 +33,7 @@ void CallbackProcessor::initialize() {
   setSupportedRelationships(relationships);
 }
 
-void CallbackProcessor::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory){
+void CallbackProcessor::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory* /*sessionFactory*/){
   if(onschedule_callback_ != nullptr) {
     onschedule_callback_(context);
   }

--- a/nanofi/src/cxx/Plan.cpp
+++ b/nanofi/src/cxx/Plan.cpp
@@ -47,7 +47,7 @@ std::shared_ptr<core::Processor> ExecutionPlan::addSimpleCallback(void *obj, std
     return nullptr;
   }
 
-  auto simple_func_wrapper = [fp](core::ProcessSession *session, core::ProcessContext *context)->void { fp(session); };
+  auto simple_func_wrapper = [fp](core::ProcessSession *session, core::ProcessContext* /*context*/)->void { fp(session); };
 
   return addCallback(obj, simple_func_wrapper);
 }
@@ -84,7 +84,7 @@ bool ExecutionPlan::setProperty(const std::shared_ptr<core::Processor>& proc, co
   return processor_contexts_.at(i)->setProperty(prop, value);
 }
 
-std::shared_ptr<core::Processor> ExecutionPlan::addProcessor(const std::shared_ptr<core::Processor> &processor, const std::string &name, core::Relationship relationship, bool linkToPrevious) {
+std::shared_ptr<core::Processor> ExecutionPlan::addProcessor(const std::shared_ptr<core::Processor> &processor, const std::string& /*name*/, core::Relationship relationship, bool linkToPrevious) {
   if (finalized) {
     return nullptr;
   }

--- a/nanofi/src/sitetosite/CRawSocketProtocol.c
+++ b/nanofi/src/sitetosite/CRawSocketProtocol.c
@@ -879,7 +879,7 @@ int initiateResourceNegotiation(struct CRawSiteToSiteClient* client) {
     return -1;
   }
 
-  int ret = writeUTF(getResourceName(client), strlen(getResourceName(client)), False, client->_peer->_stream);
+  int ret = writeUTF(getResourceName(), strlen(getResourceName()), False, client->_peer->_stream);
 
   if (ret <= 0) {
     return -1;
@@ -937,7 +937,7 @@ int initiateCodecResourceNegotiation(struct CRawSiteToSiteClient* client) {
     return -1;
   }
 
-  const char * coderresource = getCodecResourceName(client);
+  const char * coderresource = getCodecResourceName();
 
   int ret = writeUTF(coderresource, strlen(coderresource), False, client->_peer->_stream);
 

--- a/nanofi/tests/CAPITests.cpp
+++ b/nanofi/tests/CAPITests.cpp
@@ -47,7 +47,7 @@ void big_failure_counter(flow_file_record * fr) {
   free_flowfile(fr);
 }
 
-void custom_onschedule_logic(processor_context* ctx) {
+void custom_onschedule_logic(processor_context* /*ctx*/) {
   custom_onschedule_count++;
 }
 

--- a/nanofi/tests/CSite2SiteTests.cpp
+++ b/nanofi/tests/CSite2SiteTests.cpp
@@ -69,7 +69,7 @@ void wait_until(std::atomic<bool>& b) {
 
 TEST_CASE("TestSetPortId", "[S2S1]") {
   SiteToSiteCPeer peer;
-  initPeer(&peer, "fake_host", 65433, "");
+  initPeer(&peer, "fake_host", 65433);
   CRawSiteToSiteClient * protocol = (CRawSiteToSiteClient*)malloc(sizeof(CRawSiteToSiteClient));
 
   initRawClient(protocol, &peer);
@@ -185,7 +185,7 @@ TEST_CASE("TestSiteToBootStrap", "[S2S3]") {
 
     auto c_client_thread = [&transfer_state, &c_handshake_ok, &c_transfer_ok, port]() {
       SiteToSiteCPeer cpeer;
-      initPeer(&cpeer, "localhost", port, "");
+      initPeer(&cpeer, "localhost", port);
 
       CRawSiteToSiteClient cprotocol;
 


### PR DESCRIPTION
Script used:
```bash
cat build_logs.log | grep -v "thirdparty" | sort | uniq | egrep "\[-Wunused-parameter*\]" | tr ":" " " | cut -d" " -f1,2,9 |
tr "'" " " | tr -s " " | xargs -n3 python -c 'import os,sys; print("%s %s %s" % (os.path.abspath(sys.argv[1]), sys.argv[2], sys.argv[3]))' | 
sort | uniq | xargs -n 3 sh -c 'perl -pi -e "$. == $2 && s;( *([*&])? *)$3( *= *?[\w:]*(\(\))?)* *(?=[\),]);\2 /*$3*/\3;" $1' sh
```

Manual edits in:
> nanofi/include/sitetosite/CPeer.h (due to C compatibility enforcing naming arguments)
> nanofi/include/sitetosite/CRawSocketProtocol.h (due to C compatibility enforcing naming arguments)
> nanofi/src/sitetosite/CRawSocketProtocol.c (due to C compatibility enforcing naming arguments)
> libminifi/include/core/Repository.h (due to line becoming too long for linter checks)
> libminifi/include/utils/file/FileUtils.h (due to platform specific parameter usage)
