### PR TITLE
MINIFICPP-1353 Fix a heap-use-after-free error

### DIFF
--- a/extensions/http-curl/processors/InvokeHTTP.cpp
+++ b/extensions/http-curl/processors/InvokeHTTP.cpp
@@ -283,6 +283,7 @@ void InvokeHTTP::onTrigger(const std::shared_ptr<core::ProcessContext> &context,
   // create a transaction id
   std::string tx_id = generateId();
 
+  // Note: callback must be declared before callbackObj so that they are destructed in the correct order
   std::unique_ptr<utils::ByteInputCallBack> callback = nullptr;
   std::unique_ptr<utils::HTTPUploadCallback> callbackObj = nullptr;
 

--- a/extensions/http-curl/processors/InvokeHTTP.cpp
+++ b/extensions/http-curl/processors/InvokeHTTP.cpp
@@ -283,6 +283,10 @@ void InvokeHTTP::onTrigger(const std::shared_ptr<core::ProcessContext> &context,
   // create a transaction id
   std::string tx_id = generateId();
 
+  std::unique_ptr<utils::ByteInputCallBack> callback = nullptr;
+  std::unique_ptr<utils::HTTPUploadCallback> callbackObj = nullptr;
+
+  // Client declared after the callbacks to make sure the callbacks are still available when the client is destructed
   utils::HTTPClient client(url_, ssl_context_service_);
 
   client.initialize(method_);
@@ -302,8 +306,6 @@ void InvokeHTTP::onTrigger(const std::shared_ptr<core::ProcessContext> &context,
     client.setDisablePeerVerification();
   }
 
-  std::unique_ptr<utils::ByteInputCallBack> callback = nullptr;
-  std::unique_ptr<utils::HTTPUploadCallback> callbackObj = nullptr;
   if (emitFlowFile(method_)) {
     logger_->log_trace("InvokeHTTP -- reading flowfile");
     std::shared_ptr<ResourceClaim> claim = flowFile->getResourceClaim();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-1353

Declare the variables in the right order in `InvokeHTTP::onTrigger()` to make sure that the destructors run in the right order.

In the long term, the client should probably own the callbacks (and callbacks should own their sub-callbacks), but that would be a bigger change, and is less important.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
