### PR TITLE
MINIFICPP-1325 - Allow const reference UUID setters [mini-PR]

### DIFF
--- a/libminifi/include/core/Core.h
+++ b/libminifi/include/core/Core.h
@@ -187,7 +187,7 @@ class CoreComponent {
    * Set UUID in this instance
    * @param uuid uuid to apply to the internal representation.
    */
-  void setUUID(utils::Identifier &uuid);
+  void setUUID(const utils::Identifier& uuid);
 
   void setUUIDStr(const std::string &uuidStr);
 

--- a/libminifi/include/core/FlowConfiguration.h
+++ b/libminifi/include/core/FlowConfiguration.h
@@ -93,7 +93,7 @@ class FlowConfiguration : public CoreComponent {
   std::unique_ptr<core::ProcessGroup> createRootProcessGroup(std::string name, utils::Identifier & uuid, int version);
 
   std::shared_ptr<core::controller::ControllerServiceNode> createControllerService(const std::string &class_name, const std::string &full_class_name, const std::string &name,
-                                                                                   utils::Identifier & uuid);
+      const utils::Identifier& uuid);
 
   // Create Remote Processor Group
   std::unique_ptr<core::ProcessGroup> createRemoteProcessGroup(std::string name, utils::Identifier & uuid);

--- a/libminifi/include/core/ProcessGroup.h
+++ b/libminifi/include/core/ProcessGroup.h
@@ -158,7 +158,7 @@ class ProcessGroup {
   }
 
   // Set UUID
-  void setUUID(utils::Identifier &uuid) {
+  void setUUID(const utils::Identifier& uuid) {
     uuid_ = uuid;
   }
   // Get UUID

--- a/libminifi/include/core/ProcessorNode.h
+++ b/libminifi/include/core/ProcessorNode.h
@@ -210,7 +210,7 @@ class ProcessorNode : public ConfigurableComponent, public Connectable {
    * Set UUID in this instance
    * @param uuid uuid to apply to the internal representation.
    */
-  void setUUID(utils::Identifier &uuid) {
+  void setUUID(const utils::Identifier& uuid) {
     Connectable::setUUID(uuid);
     processor_->setUUID(uuid);
   }

--- a/libminifi/include/core/controller/ControllerServiceNode.h
+++ b/libminifi/include/core/controller/ControllerServiceNode.h
@@ -74,7 +74,7 @@ class ControllerServiceNode : public CoreComponent, public ConfigurableComponent
     controller_service_->setName(name);
   }
 
-  void setUUID(utils::Identifier &uuid) {
+  void setUUID(const utils::Identifier& uuid) {
     CoreComponent::setUUID(uuid);
     controller_service_->setUUID(uuid);
   }

--- a/libminifi/src/core/Core.cpp
+++ b/libminifi/src/core/Core.cpp
@@ -27,7 +27,7 @@ namespace minifi {
 namespace core {
 
 // Set UUID
-void CoreComponent::setUUID(utils::Identifier &uuid) {
+void CoreComponent::setUUID(const utils::Identifier& uuid) {
   uuid_ = uuid;
   uuidStr_ = uuid_.to_string();
 }

--- a/libminifi/src/core/FlowConfiguration.cpp
+++ b/libminifi/src/core/FlowConfiguration.cpp
@@ -117,7 +117,7 @@ std::shared_ptr<minifi::Connection> FlowConfiguration::createConnection(std::str
 }
 
 std::shared_ptr<core::controller::ControllerServiceNode> FlowConfiguration::createControllerService(const std::string &class_name, const std::string &full_class_name, const std::string &name,
-                                                                                                    utils::Identifier & uuid) {
+    const utils::Identifier& uuid) {
   std::shared_ptr<core::controller::ControllerServiceNode> controllerServicesNode = service_provider_->createControllerService(class_name, full_class_name, name, true);
   if (nullptr != controllerServicesNode)
     controllerServicesNode->setUUID(uuid);


### PR DESCRIPTION
Simple change extracted as separate commit, so that further changes will be easier to review.