### PR TITLE
MINIFICPP-1360 Configurable scheduling strategy in integration tests

### DIFF
--- a/docker/test/integration/minifi/__init__.py
+++ b/docker/test/integration/minifi/__init__.py
@@ -473,7 +473,8 @@ class InvokeHTTP(Processor):
                  proxy_port='',
                  proxy_username='',
                  proxy_password='',
-                 ssl_context_service=None):
+                 ssl_context_service=None,
+                 schedule={'scheduling strategy': 'EVENT_DRIVEN'}):
         properties = {'Remote URL': url,
                       'HTTP Method': method,
                       'Proxy Host': proxy_host,
@@ -494,11 +495,12 @@ class InvokeHTTP(Processor):
                                                          'response',
                                                          'retry',
                                                          'failure',
-                                                         'no retry'])
+                                                         'no retry'],
+                                         schedule=schedule)
 
 
 class ListenHTTP(Processor):
-    def __init__(self, port, cert=None):
+    def __init__(self, port, cert=None, schedule=None):
         properties = {'Listening Port': port}
 
         if cert is not None:
@@ -507,46 +509,39 @@ class ListenHTTP(Processor):
 
         super(ListenHTTP, self).__init__('ListenHTTP',
                                          properties=properties,
-                                         auto_terminate=['success'])
+                                         auto_terminate=['success'],
+                                         schedule=schedule)
 
 
 class LogAttribute(Processor):
-    def __init__(self, ):
+    def __init__(self, schedule={'scheduling strategy': 'EVENT_DRIVEN'}):
         super(LogAttribute, self).__init__('LogAttribute',
-                                           auto_terminate=['success'])
+                                           auto_terminate=['success'],
+                                           schedule=schedule)
 
 
-class DebugFlow(Processor):
-    def __init__(self, ):
-        super(DebugFlow, self).__init__('DebugFlow')
-
-class AttributesToJSON(Processor):
-    def __init__(self, destination, attributes):
-        super(AttributesToJSON, self).__init__('AttributesToJSON',
-                                      properties={'Destination': destination, 'Attributes List': attributes},
-                                      schedule={'scheduling period': '0 sec'},
-                                      auto_terminate=['failure'])
 class GetFile(Processor):
-    def __init__(self, input_dir):
+    def __init__(self, input_dir, schedule={'scheduling period': '2 sec'}):
         super(GetFile, self).__init__('GetFile',
                                       properties={'Input Directory': input_dir, 'Keep Source File': 'true'},
-                                      schedule={'scheduling period': '2 sec'},
+                                      schedule=schedule,
                                       auto_terminate=['success'])
+
 
 class GenerateFlowFile(Processor):
-    def __init__(self, file_size):
+    def __init__(self, file_size, schedule={'scheduling period': '0 sec'}):
         super(GenerateFlowFile, self).__init__('GenerateFlowFile',
                                       properties={'File Size': file_size},
-                                      schedule={'scheduling period': '0 sec'},
+                                      schedule=schedule,
                                       auto_terminate=['success'])
-
 
 
 class PutFile(Processor):
-    def __init__(self, output_dir):
+    def __init__(self, output_dir, schedule={'scheduling strategy': 'EVENT_DRIVEN'}):
         super(PutFile, self).__init__('PutFile',
                                       properties={'Directory': output_dir},
-                                      auto_terminate=['success', 'failure'])
+                                      auto_terminate=['success', 'failure'],
+                                      schedule=schedule)
 
     def nifi_property_key(self, key):
         if key == 'Output Directory':
@@ -556,16 +551,17 @@ class PutFile(Processor):
 
 
 class PublishKafka(Processor):
-    def __init__(self):
+    def __init__(self, schedule={'scheduling strategy': 'EVENT_DRIVEN'}):
         super(PublishKafka, self).__init__('PublishKafka',
                                            properties={'Client Name': 'nghiaxlee', 'Known Brokers': 'kafka-broker:9092', 'Topic Name': 'test',
                                                        'Batch Size': '10', 'Compress Codec': 'none', 'Delivery Guarantee': '1',
                                                        'Request Timeout': '10 sec', 'Message Timeout': '12 sec'},
-                                           auto_terminate=['success'])
+                                           auto_terminate=['success'],
+                                           schedule=schedule)
 
 
 class PublishKafkaSSL(Processor):
-    def __init__(self):
+    def __init__(self, schedule={'scheduling strategy': 'EVENT_DRIVEN'}):
         super(PublishKafkaSSL, self).__init__('PublishKafka',
                                               properties={'Client Name': 'LMN', 'Known Brokers': 'kafka-broker:9093',
                                                           'Topic Name': 'test', 'Batch Size': '10',
@@ -576,7 +572,8 @@ class PublishKafkaSSL(Processor):
                                                           'Security Pass Phrase': 'abcdefgh',
                                                           'Security Private Key': '/tmp/resources/certs/client_LMN_client.key',
                                                           'Security Protocol': 'ssl'},
-                                              auto_terminate=['success'])
+                                              auto_terminate=['success'],
+                                              schedule=schedule)
 
 
 class InputPort(Connectable):

--- a/docker/test/integration/test_zero_file.py
+++ b/docker/test/integration/test_zero_file.py
@@ -24,7 +24,7 @@ def test_zero_file():
     port = InputPort('from-minifi', RemoteProcessGroup('http://nifi:8080/nifi'))
 
     recv_flow = (port
-                 >> LogAttribute()
+                 >> LogAttribute(schedule={'scheduling strategy': 'TIMER_DRIVEN'})
                  >> PutFile('/tmp/output'))
 
     send_flow = (GenerateFlowFile('0B')


### PR DESCRIPTION
The scheduling strategy was hard coded to be TIMER_DRIVEN for all
processors, which is not desirable in all cases. The processors have been
investigated on a case by case basis and changed to the most appropriate
default value. The desired scheduling can now be passed as a parameter
for all processors.

---------------------------------------------------------------------------------------------------

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
