### PR TITLE
MINIFICPP-1346 Add SNI info to the TLS handshake

### DIFF
--- a/cmake/BundledLibreSSL.cmake
+++ b/cmake/BundledLibreSSL.cmake
@@ -49,8 +49,8 @@ function(use_libre_ssl SOURCE_DIR BINARY_DIR)
     # Build project
     ExternalProject_Add(
         libressl-portable
-        URL https://cdn.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.8.3.tar.gz https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.8.3.tar.gz https://gentoo.osuosl.org/distfiles/libressl-2.8.3.tar.gz
-        URL_HASH "SHA256=9b640b13047182761a99ce3e4f000be9687566e0828b4a72709e9e6a3ef98477"
+        URL https://cdn.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.0.2.tar.gz https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.0.2.tar.gz https://gentoo.osuosl.org/distfiles/libressl-3.0.2.tar.gz
+        URL_HASH "SHA256=df7b172bf79b957dd27ef36dcaa1fb162562c0e8999e194aa8c1a3df2f15398e"
         SOURCE_DIR "${BINARY_DIR}/thirdparty/libressl-src"
         CMAKE_ARGS ${LIBRESSL_CMAKE_ARGS}
         BUILD_BYPRODUCTS ${LIBRESSL_LIBRARIES_LIST}

--- a/libminifi/src/io/tls/TLSSocket.cpp
+++ b/libminifi/src/io/tls/TLSSocket.cpp
@@ -224,6 +224,7 @@ int16_t TLSSocket::initialize(bool blocking) {
   if (!is_server) {
     ssl_ = SSL_new(context_->getContext());
     SSL_set_fd(ssl_, socket_file_descriptor_);
+    SSL_set_tlsext_host_name(ssl_, requested_hostname_.c_str());  // SNI extension
     connected_ = false;
     int rez = SSL_connect(ssl_);
     if (rez < 0) {

--- a/libminifi/test/unit/SocketTests.cpp
+++ b/libminifi/test/unit/SocketTests.cpp
@@ -171,7 +171,7 @@ TEST_CASE("TestSocketWriteTestAfterClose", "[TestSocket7]") {
   server.close();
 }
 
-#ifdef OPENSSL_ENABLED
+#ifdef OPENSSL_SUPPORT
 std::atomic<uint8_t> counter;
 std::mt19937_64 seed { std::random_device { }() };
 bool createSocket() {
@@ -239,4 +239,4 @@ TEST_CASE("TestTLSContextCreationNullptr", "[TestSocket10]") {
   minifi::io::TLSSocket *tls = dynamic_cast<minifi::io::TLSSocket*>(socket);
   REQUIRE(tls == nullptr);
 }
-#endif
+#endif  // OPENSSL_SUPPORT


### PR DESCRIPTION
Add Server Name Indication info (ie., which server we are trying to connect to, which can be useful if the physical server has multiple aliases) to the ClientHello message in the TLS handshake.

As part of this pull request, I have also upgraded our bundled LibreSSL version from 2.8.3 to 3.0.2.

I was not able to write unit tests for this change, but I have attached the results of my manual testing to the Jira ticket: https://issues.apache.org/jira/browse/MINIFICPP-1346

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
