### PR TITLE
MINIFICPP-1391 Upgrade XCode version and replace usages of set-env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           sudo xcode-select -switch /Applications/Xcode_11.2.1.app
       - id: build
         run: ./bootstrap.sh -e -t && cd build  && cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_LUA_SCRIPTING=1 -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES=OFF -DSTRICT_GSL_CHECKS=AUDIT .. && cmake --build . --parallel 4 && make test ARGS="--timeout 300 -j4 --output-on-failure" && make linter
-  macos_xcode_11_7:
+  macos_xcode_12_0:
     name: "macos-xcode12.0"
     runs-on: macos-10.15
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
   docker_integration_tests:
     name: "Docker integration tests"
     runs-on: ubuntu-20.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - id: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,6 @@
 name: "MiNiFi-CPP CI"
 on: [push, pull_request, workflow_dispatch]
 jobs:
-  macos_xcode_10_3:
-    name: "macos-xcode10.3"
-    runs-on: macos-10.15
-    timeout-minutes: 60
-    steps:
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: install_dependencies
-        run: brew install ossp-uuid boost flex openssl python lua libpcap xz libssh2
-      - id: setup_env
-        run: |
-          echo -e "127.0.0.1\t$HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
-          echo "::set-env name=CMAKE_BUILD_OPTIONS::-DENABLE_PCAP=TRUE -DENABLE_LUA_SCRIPTING=1"
-          sudo xcode-select -switch /Applications/Xcode_10.3.app
-      - id: build
-        run: ./bootstrap.sh -e -t && cd build  && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES=OFF -DSTRICT_GSL_CHECKS=AUDIT .. && cmake --build . --parallel 4 && make test ARGS="--timeout 300 -j4 --output-on-failure" && make linter
   macos_xcode_11_2_1:
     name: "macos-xcode11.2.1"
     runs-on: macos-10.15
@@ -31,6 +15,22 @@ jobs:
           echo -e "127.0.0.1\t$HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
           echo "::set-env name=CMAKE_BUILD_OPTIONS::-DENABLE_PCAP=TRUE -DENABLE_LUA_SCRIPTING=1"
           sudo xcode-select -switch /Applications/Xcode_11.2.1.app
+      - id: build
+        run: ./bootstrap.sh -e -t && cd build  && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES=OFF -DSTRICT_GSL_CHECKS=AUDIT .. && cmake --build . --parallel 4 && make test ARGS="--timeout 300 -j4 --output-on-failure" && make linter
+  macos_xcode_11_7:
+    name: "macos-xcode12.0"
+    runs-on: macos-10.15
+    timeout-minutes: 60
+    steps:
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: install_dependencies
+        run: brew install ossp-uuid boost flex openssl python lua libpcap xz libssh2
+      - id: setup_env
+        run: |
+          echo -e "127.0.0.1\t$HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
+          echo "::set-env name=CMAKE_BUILD_OPTIONS::-DENABLE_PCAP=TRUE -DENABLE_LUA_SCRIPTING=1"
+          sudo xcode-select -switch /Applications/Xcode_12.app
       - id: build
         run: ./bootstrap.sh -e -t && cd build  && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES=OFF -DSTRICT_GSL_CHECKS=AUDIT .. && cmake --build . --parallel 4 && make test ARGS="--timeout 300 -j4 --output-on-failure" && make linter
   windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - id: setup_env
         run: |
           echo -e "127.0.0.1\t$HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
-          echo "::set-env name=CMAKE_BUILD_OPTIONS::-DENABLE_PCAP=TRUE -DENABLE_LUA_SCRIPTING=1"
+          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE -DENABLE_LUA_SCRIPTING=1\"" >> $GITHUB_ENV
           sudo xcode-select -switch /Applications/Xcode_11.2.1.app
       - id: build
         run: ./bootstrap.sh -e -t && cd build  && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES=OFF -DSTRICT_GSL_CHECKS=AUDIT .. && cmake --build . --parallel 4 && make test ARGS="--timeout 300 -j4 --output-on-failure" && make linter
@@ -29,7 +29,7 @@ jobs:
       - id: setup_env
         run: |
           echo -e "127.0.0.1\t$HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
-          echo "::set-env name=CMAKE_BUILD_OPTIONS::-DENABLE_PCAP=TRUE -DENABLE_LUA_SCRIPTING=1"
+          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE -DENABLE_LUA_SCRIPTING=1\"" >> $GITHUB_ENV
           sudo xcode-select -switch /Applications/Xcode_12.app
       - id: build
         run: ./bootstrap.sh -e -t && cd build  && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES=OFF -DSTRICT_GSL_CHECKS=AUDIT .. && cmake --build . --parallel 4 && make test ARGS="--timeout 300 -j4 --output-on-failure" && make linter
@@ -77,9 +77,9 @@ jobs:
             ubuntu-16.04-ccache-refs/heads/main-
       - id: install_deps
         run: |
-          echo "::set-env name=CMAKE_BUILD_OPTIONS::-DENABLE_PCAP=TRUE"
+          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt install -y ccache
-          echo "::set-env name=PATH::/usr/lib/ccache:$PATH"
+          echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
         run: ./bootstrap.sh -e -t && cd build  && cmake -DUSE_SHARED_LIBS= -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES=OFF -DSTRICT_GSL_CHECKS=AUDIT .. && cmake --build . --parallel 4   && make test ARGS="--timeout 300 -j2 --output-on-failure"
   ubuntu_16_04_gcc_4_8:
@@ -99,11 +99,11 @@ jobs:
             ubuntu-16.04-gcc-4.8-ccache-refs/heads/main-
       - id: install_deps
         run: |
-          echo "::set-env name=CMAKE_BUILD_OPTIONS::-DENABLE_PCAP=TRUE"
+          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
           sudo apt update
           sudo apt install -y gcc-4.8 g++-4.8 bison flex libboost-all-dev uuid-dev openssl libcurl4-openssl-dev ccache libpython3-dev liblua5.1-0-dev libpcap-dev libssh2-1-dev
-          echo "::set-env name=PATH::/usr/lib/ccache:$PATH"
+          echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
           sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-4.8 /usr/bin/gcc
           sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-4.8 /usr/bin/g++
       - id: build
@@ -125,9 +125,9 @@ jobs:
             ubuntu-20.04-ccache-refs/heads/main-
       - id: install_deps
         run: |
-          echo "::set-env name=CMAKE_BUILD_OPTIONS::-DENABLE_PCAP=TRUE"
+          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt install -y ccache libfl-dev
-          echo "::set-env name=PATH::/usr/lib/ccache:$PATH"
+          echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
         run: ./bootstrap.sh -e -t && cd build  && cmake -DUSE_SHARED_LIBS= -DSTRICT_GSL_CHECKS=AUDIT .. && make -j4 VERBOSE=1  && make test ARGS="--timeout 300 -j2 --output-on-failure"
   ubuntu_16_04_all:
@@ -147,11 +147,11 @@ jobs:
             ubuntu-16.04-all-ccache-refs/heads/main-
       - id: install_deps
         run: |
-          echo "::set-env name=CMAKE_BUILD_OPTIONS::-DENABLE_PCAP=TRUE"
+          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
           sudo apt update
           sudo apt install -y ccache openjdk-8-jdk maven
-          echo "::set-env name=PATH::/usr/lib/ccache:$PATH"
+          echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
         run: sudo mount tmpfs -t tmpfs /tmp && ./bootstrap.sh -e -t && cd build  && cmake -DUSE_SHARED_LIBS= -DENABLE_LIBRDKAFKA=ON -DENABLE_OPC=ON -DENABLE_SFTP=ON -DENABLE_MQTT=ON -DENABLE_COAP=ON -DENABLE_PYTHON=ON -DSTRICT_GSL_CHECKS=AUDIT .. &&  cmake --build . --parallel 4  && make test ARGS="--timeout 300 -j8 --output-on-failure"
   debian:
@@ -171,9 +171,9 @@ jobs:
             debian-ccache-refs/heads/main-
       - id: install_deps
         run: |
-          echo "::set-env name=CMAKE_BUILD_OPTIONS::-DENABLE_PCAP=TRUE"
+          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt install -y ccache
-          echo "::set-env name=PATH::/usr/lib/ccache:$PATH"
+          echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
         run: mkdir -p build && cd build && cmake -DSTRICT_GSL_CHECKS=AUDIT .. && make debian
   centos:
@@ -193,9 +193,9 @@ jobs:
             centos-ccache-refs/heads/main-
       - id: install_deps
         run: |
-          echo "::set-env name=CMAKE_BUILD_OPTIONS::-DENABLE_PCAP=TRUE"
+          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt install -y ccache
-          echo "::set-env name=PATH::/usr/lib/ccache:$PATH"
+          echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
         run: mkdir -p build && cd build && cmake -DSTRICT_GSL_CHECKS=AUDIT .. && make centos
   fedora:
@@ -215,9 +215,9 @@ jobs:
             fedora-ccache-refs/heads/main-
       - id: install_deps
         run: |
-          echo "::set-env name=CMAKE_BUILD_OPTIONS::-DENABLE_PCAP=TRUE"
+          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt install -y ccache
-          echo "::set-env name=PATH::/usr/lib/ccache:$PATH"
+          echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
         run: mkdir -p build && cd build && cmake -DSTRICT_GSL_CHECKS=AUDIT .. && make fedora
   ubuntu_18_04:
@@ -237,9 +237,9 @@ jobs:
             ubuntu-18.04-ccache-refs/heads/main
       - id: install_deps
         run: |
-          echo "::set-env name=CMAKE_BUILD_OPTIONS::-DENABLE_PCAP=TRUE"
+          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt install -y ccache
-          echo "::set-env name=PATH::/usr/lib/ccache:$PATH"
+          echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
         run: mkdir -p build && cd build && cmake -DSTRICT_GSL_CHECKS=AUDIT .. && make u18
   ubuntu_16_04_shared:
@@ -259,9 +259,9 @@ jobs:
             ubuntu-16.04-shared-ccache-refs/heads/main-
       - id: install_deps
         run: |
-          echo "::set-env name=CMAKE_BUILD_OPTIONS::-DENABLE_PCAP=TRUE"
+          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt install -y ccache
-          echo "::set-env name=PATH::/usr/lib/ccache:$PATH"
+          echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
         run: ./bootstrap.sh -e -t && cd build  && cmake -DUSE_SHARED_LIBS=ON -DSTRICT_GSL_CHECKS=AUDIT .. &&  cmake --build . --parallel 4  && make test ARGS="--timeout 300 -j4 --output-on-failure"
   docker_integration_tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,9 @@ jobs:
       - id: setup_env
         run: |
           echo -e "127.0.0.1\t$HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
-          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE -DENABLE_LUA_SCRIPTING=1\"" >> $GITHUB_ENV
           sudo xcode-select -switch /Applications/Xcode_11.2.1.app
       - id: build
-        run: ./bootstrap.sh -e -t && cd build  && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES=OFF -DSTRICT_GSL_CHECKS=AUDIT .. && cmake --build . --parallel 4 && make test ARGS="--timeout 300 -j4 --output-on-failure" && make linter
+        run: ./bootstrap.sh -e -t && cd build  && cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_LUA_SCRIPTING=1 -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES=OFF -DSTRICT_GSL_CHECKS=AUDIT .. && cmake --build . --parallel 4 && make test ARGS="--timeout 300 -j4 --output-on-failure" && make linter
   macos_xcode_11_7:
     name: "macos-xcode12.0"
     runs-on: macos-10.15
@@ -29,10 +28,9 @@ jobs:
       - id: setup_env
         run: |
           echo -e "127.0.0.1\t$HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
-          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE -DENABLE_LUA_SCRIPTING=1\"" >> $GITHUB_ENV
           sudo xcode-select -switch /Applications/Xcode_12.app
       - id: build
-        run: ./bootstrap.sh -e -t && cd build  && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES=OFF -DSTRICT_GSL_CHECKS=AUDIT .. && cmake --build . --parallel 4 && make test ARGS="--timeout 300 -j4 --output-on-failure" && make linter
+        run: ./bootstrap.sh -e -t && cd build  && cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_LUA_SCRIPTING=1 -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES=OFF -DSTRICT_GSL_CHECKS=AUDIT .. && cmake --build . --parallel 4 && make test ARGS="--timeout 300 -j4 --output-on-failure" && make linter
   windows:
     name: "windows"
     runs-on: windows-2016
@@ -77,7 +75,6 @@ jobs:
             ubuntu-16.04-ccache-refs/heads/main-
       - id: install_deps
         run: |
-          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt install -y ccache
           echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
@@ -99,7 +96,6 @@ jobs:
             ubuntu-16.04-gcc-4.8-ccache-refs/heads/main-
       - id: install_deps
         run: |
-          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
           sudo apt update
           sudo apt install -y gcc-4.8 g++-4.8 bison flex libboost-all-dev uuid-dev openssl libcurl4-openssl-dev ccache libpython3-dev liblua5.1-0-dev libpcap-dev libssh2-1-dev
@@ -125,7 +121,6 @@ jobs:
             ubuntu-20.04-ccache-refs/heads/main-
       - id: install_deps
         run: |
-          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt install -y ccache libfl-dev
           echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
@@ -147,7 +142,6 @@ jobs:
             ubuntu-16.04-all-ccache-refs/heads/main-
       - id: install_deps
         run: |
-          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
           sudo apt update
           sudo apt install -y ccache openjdk-8-jdk maven
@@ -171,7 +165,6 @@ jobs:
             debian-ccache-refs/heads/main-
       - id: install_deps
         run: |
-          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt install -y ccache
           echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
@@ -193,7 +186,6 @@ jobs:
             centos-ccache-refs/heads/main-
       - id: install_deps
         run: |
-          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt install -y ccache
           echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
@@ -215,7 +207,6 @@ jobs:
             fedora-ccache-refs/heads/main-
       - id: install_deps
         run: |
-          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt install -y ccache
           echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
@@ -237,7 +228,6 @@ jobs:
             ubuntu-18.04-ccache-refs/heads/main
       - id: install_deps
         run: |
-          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt install -y ccache
           echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
@@ -259,7 +249,6 @@ jobs:
             ubuntu-16.04-shared-ccache-refs/heads/main-
       - id: install_deps
         run: |
-          echo "CMAKE_BUILD_OPTIONS=\"-DENABLE_PCAP=TRUE\"" >> $GITHUB_ENV
           sudo apt install -y ccache
           echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build


### PR DESCRIPTION
GitHub actions fixes:

- Remove the XCode 10.3 job, and add a new job with XCode 12.0
- Replace deprecated usages of `set-env` (see https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)
- Remove the CMAKE_BUILD_OPTIONS env setting, as it doesn't work -- our CI jobs look like they set ENABLE_PCAP=TRUE, but they do not
- Increase the timeout on the Docker test, as it sometimes takes more than 60 minutes.

https://issues.apache.org/jira/browse/MINIFICPP-1391

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
