### PR TITLE
MINIFICPP-1398 Add strftime-based fallback to EL :format() when the date.h library is not available

### DIFF
--- a/extensions/expression-language/Expression.cpp
+++ b/extensions/expression-language/Expression.cpp
@@ -639,7 +639,8 @@ Value expr_format(const std::vector<Value>& args)
   const auto unix_time = std::chrono::system_clock::to_time_t(dt);
   const auto zoned_time = [&args, unix_time] {
     std::tm buf;
-    if (args.size() > 2 && args[2].asString() == "UTC") {
+    const auto requested_timezone = args.size() > 2 ? args[2].asString() : std::string{};
+    if (requested_timezone == "UTC" || requested_timezone == "GMT") {
 #ifdef WIN32
       const auto err = gmtime_s(&buf, &unix_time);
 #else
@@ -648,7 +649,7 @@ Value expr_format(const std::vector<Value>& args)
       const auto err = errno;
 #endif /* WIN32 */
       if (err) { throw std::system_error{err, std::generic_category()}; }
-    } else if (args.size() > 2) {
+    } else if (!requested_timezone.empty()) {
       throw std::domain_error{"format() with Non-UTC custom timezone is only supported when compiled with the date.h library"};
     } else {
 #ifdef WIN32

--- a/extensions/expression-language/Expression.cpp
+++ b/extensions/expression-language/Expression.cpp
@@ -56,7 +56,6 @@
 #include "date/tz.h"
 #else
 #include <ctime>
-#include <iomanip>
 #endif  // EXPRESSION_LANGUAGE_USE_DATE
 
 namespace org {
@@ -664,9 +663,9 @@ Value expr_format(const std::vector<Value>& args)
     }
     return buf;
   }();
-  std::stringstream result_s;
-  result_s << std::put_time(&zoned_time, args.at(1).asString().c_str());
-  return Value(result_s.str());
+  char result_buf[512] = {0};
+  std::strftime(result_buf, 512, args.at(1).asString().c_str(), &zoned_time);
+  return Value(std::string(result_buf));
 }
 
 Value expr_toDate(const std::vector<Value>&) {

--- a/extensions/expression-language/Expression.cpp
+++ b/extensions/expression-language/Expression.cpp
@@ -56,6 +56,7 @@
 #include "date/tz.h"
 #else
 #include <ctime>
+#include <iomanip>
 #endif  // EXPRESSION_LANGUAGE_USE_DATE
 
 namespace org {

--- a/extensions/expression-language/impl/expression/Expression.h
+++ b/extensions/expression-language/impl/expression/Expression.h
@@ -21,14 +21,14 @@
 #define EXPRESSION_LANGUAGE_USE_REGEX
 
 // Disable regex in EL for incompatible compilers
-#if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 9)
+#if !defined(WIN32) && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 9))
 #undef EXPRESSION_LANGUAGE_USE_REGEX
 #endif
 
 #define EXPRESSION_LANGUAGE_USE_DATE
 
 // Disable date in EL for incompatible compilers
-#if __GNUC__ < 5
+#if defined(WIN32) || __GNUC__ < 5
 #undef EXPRESSION_LANGUAGE_USE_DATE
 #endif
 

--- a/extensions/expression-language/tests/ExpressionLanguageTests.cpp
+++ b/extensions/expression-language/tests/ExpressionLanguageTests.cpp
@@ -1238,14 +1238,6 @@ TEST_CASE("Parse Date", "[expressionParseDate]") {  // NOLINT
   REQUIRE("1398841200000" == expr({ flow_file_a }).asString());
 }
 
-TEST_CASE("Format Date", "[expressionFormatDate]") {  // NOLINT
-  auto expr = expression::compile("${message:format('%m-%d-%Y', 'GMT')}");
-
-  auto flow_file_a = std::make_shared<core::FlowFile>();
-  flow_file_a->addAttribute("message", "1394755200000");
-  REQUIRE("03-14-2014" == expr({ flow_file_a }).asString());
-}
-
 TEST_CASE("Reformat Date", "[expressionReformatDate]") {  // NOLINT
   auto expr = expression::compile("${message:toDate('%Y/%m/%d', 'GMT'):format('%m-%d-%Y', 'America/New_York')}");
 
@@ -1253,6 +1245,8 @@ TEST_CASE("Reformat Date", "[expressionReformatDate]") {  // NOLINT
   flow_file_a->addAttribute("message", "2014/03/14");
   REQUIRE("03-13-2014" == expr({ flow_file_a }).asString());
 }
+
+#endif  // EXPRESSION_LANGUAGE_USE_DATE
 
 TEST_CASE("Now Date", "[expressionNowDate]") {  // NOLINT
   auto expr = expression::compile("${now():format('%Y')}");
@@ -1266,7 +1260,21 @@ TEST_CASE("Now Date", "[expressionNowDate]") {  // NOLINT
   REQUIRE((lt.tm_year + 1900) == expr({ flow_file_a }).asUnsignedLong());
 }
 
-#endif  // EXPRESSION_LANGUAGE_USE_DATE
+TEST_CASE("Format Date", "[expressionFormatDate]") {  // NOLINT
+  auto expr = expression::compile("${message:format('%m-%d-%Y', 'GMT')}");
+
+  auto flow_file_a = std::make_shared<core::FlowFile>();
+  flow_file_a->addAttribute("message", "1394755200000");
+  REQUIRE("03-14-2014" == expr({ flow_file_a }).asString());
+}
+
+TEST_CASE("Format Date", "[expressionFormatDate]") {  // NOLINT
+  auto expr = expression::compile("${message:format('%m-%d-%Y', 'UTC')}");
+
+  auto flow_file_a = std::make_shared<core::FlowFile>();
+  flow_file_a->addAttribute("message", "1394755200000");
+  REQUIRE("03-14-2014" == expr({ flow_file_a }).asString());
+}
 
 TEST_CASE("IP", "[expressionIP]") {  // NOLINT
   auto expr = expression::compile("${ip()}");

--- a/extensions/expression-language/tests/ExpressionLanguageTests.cpp
+++ b/extensions/expression-language/tests/ExpressionLanguageTests.cpp
@@ -1261,19 +1261,13 @@ TEST_CASE("Now Date", "[expressionNowDate]") {  // NOLINT
 }
 
 TEST_CASE("Format Date", "[expressionFormatDate]") {  // NOLINT
-  auto expr = expression::compile("${message:format('%m-%d-%Y', 'GMT')}");
+  auto expr_gmt = expression::compile("${message:format('%m-%d-%Y', 'GMT')}");
+  auto expr_utc = expression::compile("${message:format('%m-%d-%Y', 'UTC')}");
 
   auto flow_file_a = std::make_shared<core::FlowFile>();
   flow_file_a->addAttribute("message", "1394755200000");
-  REQUIRE("03-14-2014" == expr({ flow_file_a }).asString());
-}
-
-TEST_CASE("Format Date", "[expressionFormatDate]") {  // NOLINT
-  auto expr = expression::compile("${message:format('%m-%d-%Y', 'UTC')}");
-
-  auto flow_file_a = std::make_shared<core::FlowFile>();
-  flow_file_a->addAttribute("message", "1394755200000");
-  REQUIRE("03-14-2014" == expr({ flow_file_a }).asString());
+  REQUIRE("03-14-2014" == expr_gmt({ flow_file_a }).asString());
+  REQUIRE("03-14-2014" == expr_utc({ flow_file_a }).asString());
 }
 
 TEST_CASE("IP", "[expressionIP]") {  // NOLINT


### PR DESCRIPTION
- Implement fallback `expr_format` for the UTC/GMT and localtime cases based on `strftime`/`std::put_time`
- Make the current behavior of unsetting `EXPRESSION_LANGUAGE_USE_DATE` on windows explicit
- Move existing tests covering cases implemented in the fallback outside of the `#ifdef` guard
- Enable `:format()` and `:toDate()` regardless of `EXPRESSION_LANGUAGE_USE_DATE`
----
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
