### PR TITLE
MINIFICPP-1419 Stabilize docker tests in Github Actions

### DIFF
--- a/docker/test/integration/test_filter_zero_file.py
+++ b/docker/test/integration/test_filter_zero_file.py
@@ -34,4 +34,4 @@ def test_filter_zero_file():
     with DockerTestCluster(NoFileOutPutValidator()) as cluster:
         cluster.deploy_flow(recv_flow, name='nifi', engine='nifi')
         cluster.deploy_flow(send_flow)
-        assert cluster.check_output(60)
+        assert cluster.check_output(120)

--- a/docker/test/integration/test_s2s.py
+++ b/docker/test/integration/test_s2s.py
@@ -37,4 +37,4 @@ def test_minifi_to_nifi():
         cluster.deploy_flow(recv_flow, name='nifi', engine='nifi')
         cluster.deploy_flow(send_flow)
 
-        assert cluster.check_output(60)
+        assert cluster.check_output(120)

--- a/docker/test/integration/test_zero_file.py
+++ b/docker/test/integration/test_zero_file.py
@@ -34,4 +34,4 @@ def test_zero_file():
     with DockerTestCluster(EmptyFilesOutPutValidator()) as cluster:
         cluster.deploy_flow(recv_flow, name='nifi', engine='nifi')
         cluster.deploy_flow(send_flow)
-        assert cluster.check_output(60)
+        assert cluster.check_output(120)


### PR DESCRIPTION
There have been cases in the past where test_zero_file.py test was failing in Github Actions. The test timed out and failed, but the issue could not be reproduced locally. It is probably due to timing issues as locally the test would take 40-50 seconds to run and on the slower VMs running on Github the test would probably need more than 60 seconds sometimes which was the timeout period. As the test was running minifi and nifi agents as well the setup would probably take most of the time. 

I updated the timeouts to 120 seconds in tests running minifi and nifi together and ran the docker tests in the CI environment more than 50 times and no failures occured: https://github.com/lordgamez/nifi-minifi-cpp/actions

-------------------------------------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
