### PR TITLE
MINIFICPP-1421 - Correct C2JstackTest synchronization

### DIFF
--- a/extensions/http-curl/tests/C2JstackTest.cpp
+++ b/extensions/http-curl/tests/C2JstackTest.cpp
@@ -26,8 +26,10 @@
 class VerifyC2DescribeJstack : public VerifyC2Describe {
  public:
   void runAssertions() override {
-    using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
-    assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_), "SchedulingAgent"));
+    // This check was previously only confirming the presence of log sinks.
+    // See: https://issues.apache.org/jira/browse/MINIFICPP-1421
+    // using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
+    // assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_), "SchedulingAgent"));
   }
 };
 

--- a/extensions/http-curl/tests/C2JstackTest.cpp
+++ b/extensions/http-curl/tests/C2JstackTest.cpp
@@ -18,6 +18,7 @@
 
 #undef NDEBUG
 #include <string>
+#include <atomic>
 #include "TestBase.h"
 #include "HTTPIntegrationBase.h"
 #include "HTTPHandlers.h"
@@ -25,30 +26,38 @@
 
 class VerifyC2DescribeJstack : public VerifyC2Describe {
  public:
+  explicit VerifyC2DescribeJstack(const std::atomic_bool& acknowledgement_checked) : VerifyC2Describe(), acknowledgement_checked_(acknowledgement_checked) {}
   void runAssertions() override {
     // This check was previously only confirming the presence of log sinks.
     // See: https://issues.apache.org/jira/browse/MINIFICPP-1421
-    // using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
-    // assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_), "SchedulingAgent"));
+    using org::apache::nifi::minifi::utils::verifyEventHappenedInPollTime;
+    assert(verifyEventHappenedInPollTime(std::chrono::milliseconds(wait_time_), [&] { return acknowledgement_checked_.load(); }));
   }
+ protected:
+  const std::atomic_bool& acknowledgement_checked_;
 };
 
 class DescribeJstackHandler : public HeartbeatHandler {
  public:
+  explicit DescribeJstackHandler(std::atomic_bool& acknowledgement_checked) : HeartbeatHandler(), acknowledgement_checked_(acknowledgement_checked) {}
   void handleHeartbeat(const rapidjson::Document&, struct mg_connection * conn) override {
     sendHeartbeatResponse("DESCRIBE", "jstack", "889398", conn);
   }
 
   void handleAcknowledge(const rapidjson::Document& root) override {
     assert(root.HasMember("Flowcontroller threadpool #0"));
+    acknowledgement_checked_.store(true);
   }
+ protected:
+  std::atomic_bool& acknowledgement_checked_;
 };
 
 int main(int argc, char **argv) {
   const cmd_args args = parse_cmdline_args(argc, argv, "heartbeat");
-  VerifyC2DescribeJstack harness;
+  std::atomic_bool acknowledgement_checked{ false };
+  VerifyC2DescribeJstack harness{ acknowledgement_checked };
   harness.setKeyDir(args.key_dir);
-  DescribeJstackHandler responder;
+  DescribeJstackHandler responder{ acknowledgement_checked };
   harness.setUrl(args.url, &responder);
   harness.run(args.test_file);
   return 0;

--- a/extensions/http-curl/tests/C2JstackTest.cpp
+++ b/extensions/http-curl/tests/C2JstackTest.cpp
@@ -26,38 +26,36 @@
 
 class VerifyC2DescribeJstack : public VerifyC2Describe {
  public:
-  explicit VerifyC2DescribeJstack(const std::atomic_bool& acknowledgement_checked) : VerifyC2Describe(), acknowledgement_checked_(acknowledgement_checked) {}
+  explicit VerifyC2DescribeJstack(const std::atomic_bool& acknowledgement_received) : VerifyC2Describe(), acknowledgement_received_(acknowledgement_received) {}
   void runAssertions() override {
-    // This check was previously only confirming the presence of log sinks.
-    // See: https://issues.apache.org/jira/browse/MINIFICPP-1421
     using org::apache::nifi::minifi::utils::verifyEventHappenedInPollTime;
-    assert(verifyEventHappenedInPollTime(std::chrono::milliseconds(wait_time_), [&] { return acknowledgement_checked_.load(); }));
+    assert(verifyEventHappenedInPollTime(std::chrono::milliseconds(wait_time_), [&] { return acknowledgement_received_.load(); }));
   }
  protected:
-  const std::atomic_bool& acknowledgement_checked_;
+  const std::atomic_bool& acknowledgement_received_;
 };
 
 class DescribeJstackHandler : public HeartbeatHandler {
  public:
-  explicit DescribeJstackHandler(std::atomic_bool& acknowledgement_checked) : HeartbeatHandler(), acknowledgement_checked_(acknowledgement_checked) {}
+  explicit DescribeJstackHandler(std::atomic_bool& acknowledgement_received) : HeartbeatHandler(), acknowledgement_received_(acknowledgement_received) {}
   void handleHeartbeat(const rapidjson::Document&, struct mg_connection * conn) override {
     sendHeartbeatResponse("DESCRIBE", "jstack", "889398", conn);
   }
 
   void handleAcknowledge(const rapidjson::Document& root) override {
     assert(root.HasMember("Flowcontroller threadpool #0"));
-    acknowledgement_checked_.store(true);
+    acknowledgement_received_.store(true);
   }
  protected:
-  std::atomic_bool& acknowledgement_checked_;
+  std::atomic_bool& acknowledgement_received_;
 };
 
 int main(int argc, char **argv) {
   const cmd_args args = parse_cmdline_args(argc, argv, "heartbeat");
-  std::atomic_bool acknowledgement_checked{ false };
-  VerifyC2DescribeJstack harness{ acknowledgement_checked };
+  std::atomic_bool acknowledgement_received{ false };
+  VerifyC2DescribeJstack harness{ acknowledgement_received };
   harness.setKeyDir(args.key_dir);
-  DescribeJstackHandler responder{ acknowledgement_checked };
+  DescribeJstackHandler responder{ acknowledgement_received };
   harness.setUrl(args.url, &responder);
   harness.run(args.test_file);
   return 0;


### PR DESCRIPTION
C2JstackTest is currently looks for a log line that contains the word "SchedulingAgent". This line however is only present due to the LogTestController logs that log lines from the SchedulingAgents will not be shown.
```bash
➜  ./extensions/http-curl/tests/C2JstackTest ../src/libminifi/test/resources/TestHTTPGet.yml ../src/libminifi/test/resources/ |& grep "SchedulingAgent"                                                                               
[2020-12-08 10:48:51.955] [org::apache::nifi::minifi::core::logging::LoggerConfiguration] [debug] org::apache::nifi::minifi::SchedulingAgent logger got sinks from namespace root and level error from namespace root                       
[2020-12-08 10:48:51.955] [org::apache::nifi::minifi::core::logging::LoggerConfiguration] [debug] org::apache::nifi::minifi::ThreadedSchedulingAgent logger got sinks from namespace root and level error from namespace root               
[2020-12-08 10:48:51.955] [org::apache::nifi::minifi::core::logging::LoggerConfiguration] [debug] org::apache::nifi::minifi::TimerDrivenSchedulingAgent logger got sinks from namespace root and level error from namespace root 
```
Enabling all sinks still did not produce any relevant log line that would be worth matching against:
```c++
#include "../../extensions/standard-processors/controllers/UnorderedMapKeyValueStoreService.h"
#include "../../extensions/standard-processors/controllers/UnorderedMapPersistableKeyValueStoreService.h"
#include "../../extensions/http-curl/processors/InvokeHTTP.h"
#include "../../extensions/http-curl/processors/InvokeHTTP.h"
#include "../../extensions/standard-processors/processors/LogAttribute.h"
#include "../../extensions/standard-processors/processors/LogAttribute.h"
#include "../../libminifi/include/c2/ControllerSocketProtocol.h"
#include "../../libminifi/include/c2/ControllerSocketProtocol.h"
#include "../../extensions/standard-processors/processors/AppendHostInfo.h"
#include "../../extensions/standard-processors/processors/AppendHostInfo.h"
#include "../../extensions/standard-processors/processors/ExecuteProcess.h"
#include "../../extensions/standard-processors/processors/ExecuteProcess.h"
#include "../../extensions/standard-processors/processors/ExtractText.h"
#include "../../extensions/standard-processors/processors/ExtractText.h"
#include "../../extensions/standard-processors/processors/GenerateFlowFile.h"
#include "../../extensions/standard-processors/processors/GenerateFlowFile.h"
#include "../../extensions/standard-processors/processors/GetFile.h"
#include "../../extensions/standard-processors/processors/GetFile.h"
#include "../../extensions/standard-processors/processors/GetTCP.h"
#include "../../extensions/standard-processors/processors/GetTCP.h"
#include "../../extensions/standard-processors/processors/HashContent.h"
#include "../../extensions/standard-processors/processors/HashContent.h"
#include "../../extensions/standard-processors/processors/ListenSyslog.h"
#include "../../extensions/standard-processors/processors/ListenSyslog.h"
#include "../../extensions/standard-processors/processors/PutFile.h"
#include "../../extensions/standard-processors/processors/PutFile.h"
#include "../../extensions/standard-processors/processors/RetryFlowFile.h"
#include "../../extensions/standard-processors/processors/RetryFlowFile.h"
#include "../../extensions/standard-processors/processors/RouteOnAttribute.h"
#include "../../extensions/standard-processors/processors/RouteOnAttribute.h"
#include "../../extensions/standard-processors/processors/TailFile.h"
#include "../../extensions/standard-processors/processors/TailFile.h"
#include "../../extensions/standard-processors/processors/UpdateAttribute.h"
#include "../../extensions/standard-processors/processors/UpdateAttribute.h"
#include "../../extensions/http-curl/protocols/AgentPrinter.h"
#include "../../extensions/http-curl/protocols/AgentPrinter.h"
#include "../../extensions/http-curl/protocols/RESTReceiver.h"
#include "../../extensions/http-curl/protocols/RESTReceiver.h"
#include "../../extensions/civetweb/processors/ListenHTTP.h"
#include "../../extensions/civetweb/processors/ListenHTTP.h"

(...)

LogTestController::getInstance().setTrace<org::apache::nifi::minifi::utils::IdGenerator>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::core::FlowFile>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::provenance::ProvenanceEventRecord>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::FlowFileRecord>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::Properties>();
LogTestController::getInstance().setTrace<LogTestController>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::c2::C2Agent>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::c2::RESTSender>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::FlowController>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::utils::HTTPClient>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::core::Connectable>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::core::Repository>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::core::repository::VolatileContentRepository>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::utils::file::FileSystem>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::core::FlowConfiguration>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::core::ConfigurableComponent>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::core::controller::StandardControllerServiceProvider>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::core::YamlConfiguration>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::controllers::AbstractAutoPersistingKeyValueStoreService>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::controllers::UnorderedMapKeyValueStoreService>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::controllers::UnorderedMapPersistableKeyValueStoreService>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::core::controller::StandardControllerServiceNode>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::core::ProcessGroup>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::core::Processor>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::processors::InvokeHTTP>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::processors::LogAttribute>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::Connection>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::c2::C2Client>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::FlowControlProtocol>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::SchedulingAgent>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::ThreadedSchedulingAgent>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::TimerDrivenSchedulingAgent>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::core::repository::FileSystemRepository>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::core::ProcessContext>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::core::ProcessSession>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::provenance::ProvenanceReporter>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::utils::ByteOutputCallback>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::c2::ControllerSocketProtocol>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::processors::AppendHostInfo>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::processors::ExecuteProcess>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::processors::ExtractText>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::processors::GenerateFlowFile>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::processors::GetFile>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::processors::GetTCP>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::processors::HashContent>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::processors::ListenSyslog>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::processors::PutFile>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::processors::RetryFlowFile>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::processors::RouteOnAttribute>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::processors::TailFile>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::processors::UpdateAttribute>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::c2::AgentPrinter>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::c2::RESTReceiver>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::processors::ListenHTTP>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::controllers::SSLContextService>();
LogTestController::getInstance().setTrace<org::apache::nifi::minifi::controllers::UpdatePolicyControllerService>();
```
```bash
➜  build ./extensions/http-curl/tests/C2JstackTest ../src/libminifi/test/resources/TestHTTPGet.yml ../src/libminifi/test/resources/ |& egrep -v "got sinks|log level" | grep "SchedulingAgent"
[2020-12-08 13:23:08.954] [org::apache::nifi::minifi::ThreadedSchedulingAgent] [debug] Shutting down threads for processor invoke/2438e3c8-015a-1000-79ca-83af40ec1991
[2020-12-08 13:23:08.954] [org::apache::nifi::minifi::ThreadedSchedulingAgent] [debug] Shutting down threads for processor invoke/2438e3c8-015a-1000-79ca-83af40ec1991
[2020-12-08 13:23:08.954] [org::apache::nifi::minifi::ThreadedSchedulingAgent] [warning] Cannot unschedule threads for processor invoke because it is not running
[2020-12-08 13:23:08.954] [org::apache::nifi::minifi::ThreadedSchedulingAgent] [debug] Shutting down threads for processor LogAttribute/2438e3c8-015a-1000-79ca-83af40ec1992
```

As the test breaks if once we disable the inclusion of "logger got sinks" by default on test, we should turn off this test and at some point investigate what exactly the test was meant to check. One could probably check out the version of the MiNiFi this was introduced in and see if something important was captured by checking against this log line.