### PR TITLE
MINIFICPP-1432 Remove the timing-sensitivity of NetworkPrioritizerServiceTests, version 1

### DIFF
--- a/libminifi/include/controllers/NetworkPrioritizerService.h
+++ b/libminifi/include/controllers/NetworkPrioritizerService.h
@@ -18,11 +18,13 @@
 #ifndef LIBMINIFI_INCLUDE_CONTROLLERS_NETWORKPRIORITIZERSERVICE_H_
 #define LIBMINIFI_INCLUDE_CONTROLLERS_NETWORKPRIORITIZERSERVICE_H_
 
-#include <string>
-#include <vector>
 #include <iostream>
-#include <memory>
 #include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "core/Resource.h"
 #include "utils/StringUtils.h"
 #include "io/validation.h"
@@ -43,7 +45,9 @@ namespace controllers {
  */
 class NetworkPrioritizerService : public core::controller::ControllerService, public minifi::io::NetworkPrioritizer, public std::enable_shared_from_this<NetworkPrioritizerService> {
  public:
-  explicit NetworkPrioritizerService(const std::string &name, const utils::Identifier& uuid = {})
+  explicit NetworkPrioritizerService(const std::string& name,
+                                     const utils::Identifier& uuid = {},
+                                     std::shared_ptr<utils::timeutils::Clock> clock = std::make_shared<utils::timeutils::SteadyClock>())
       : ControllerService(name, uuid),
         enabled_(false),
         max_throughput_(std::numeric_limits<uint64_t>::max()),
@@ -53,6 +57,7 @@ class NetworkPrioritizerService : public core::controller::ControllerService, pu
         timestamp_(0),
         bytes_per_token_(0),
         verify_interfaces_(true),
+        clock_(std::move(clock)),
         logger_(logging::LoggerFactory<NetworkPrioritizerService>::getLogger()) {
   }
 
@@ -121,6 +126,7 @@ class NetworkPrioritizerService : public core::controller::ControllerService, pu
   bool verify_interfaces_;
 
  private:
+  std::shared_ptr<utils::timeutils::Clock> clock_;
   std::shared_ptr<logging::Logger> logger_;
 };
 

--- a/libminifi/include/utils/TestUtils.h
+++ b/libminifi/include/utils/TestUtils.h
@@ -23,6 +23,7 @@
 #include "../../test/TestBase.h"
 #include "utils/file/FileUtils.h"
 #include "utils/Environment.h"
+#include "utils/TimeUtil.h"
 
 namespace org {
 namespace apache {
@@ -59,6 +60,15 @@ std::string getFileContent(const std::string& file_name) {
   const std::string file_content{ (std::istreambuf_iterator<char>(file_handle)), (std::istreambuf_iterator<char>()) };
   return file_content;
 }
+
+class ManualClock : public timeutils::Clock {
+ public:
+  std::chrono::milliseconds timeSinceEpoch() const override { return time_; }
+  void advance(std::chrono::milliseconds elapsed_time) { time_ += elapsed_time; }
+
+ private:
+  std::chrono::milliseconds time_{0};
+};
 
 }  // namespace utils
 }  // namespace minifi

--- a/libminifi/include/utils/TimeUtil.h
+++ b/libminifi/include/utils/TimeUtil.h
@@ -54,6 +54,29 @@ inline uint64_t getTimeNano() {
 }
 
 /**
+ * Mockable clock classes
+ */
+class Clock {
+ public:
+  virtual ~Clock() = default;
+  virtual std::chrono::milliseconds timeSinceEpoch() const = 0;
+};
+
+class SystemClock : public Clock {
+ public:
+  std::chrono::milliseconds timeSinceEpoch() const override {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
+  }
+};
+
+class SteadyClock : public Clock {
+ public:
+  std::chrono::milliseconds timeSinceEpoch() const override {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch());
+  }
+};
+
+/**
  * Returns a string based on TIME_FORMAT, converting
  * the parameter to a string
  * @param msec milliseconds since epoch


### PR DESCRIPTION
NOTE: alternative PR to #960, only one of the two should be merged!

https://issues.apache.org/jira/browse/MINIFICPP-1432

* Add a mockable Clock field to `NetworkPrioritizerService`
* Fix and clean up the tests
* Fix some bugs in `NetworkPrioritizerService`:
   - `max_payload_` was not set in `onEnable()`
   - only payloads strictly smaller than `max_payload_` were allowed
   - use `steady_clock` instead of `system_clock`

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
