### PR TITLE
MINIFICPP-1432 Remove the timing-sensitivity of NetworkPrioritizerServiceTests, version 2

### DIFF
--- a/libminifi/include/controllers/NetworkPrioritizerService.h
+++ b/libminifi/include/controllers/NetworkPrioritizerService.h
@@ -18,11 +18,14 @@
 #ifndef LIBMINIFI_INCLUDE_CONTROLLERS_NETWORKPRIORITIZERSERVICE_H_
 #define LIBMINIFI_INCLUDE_CONTROLLERS_NETWORKPRIORITIZERSERVICE_H_
 
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <memory>
 #include <string>
 #include <vector>
-#include <iostream>
-#include <memory>
-#include <limits>
+
 #include "core/Resource.h"
 #include "utils/StringUtils.h"
 #include "io/validation.h"
@@ -53,6 +56,7 @@ class NetworkPrioritizerService : public core::controller::ControllerService, pu
         timestamp_(0),
         bytes_per_token_(0),
         verify_interfaces_(true),
+        milliseconds_since_epoch_{[]{ return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()); }},
         logger_(logging::LoggerFactory<NetworkPrioritizerService>::getLogger()) {
   }
 
@@ -121,6 +125,9 @@ class NetworkPrioritizerService : public core::controller::ControllerService, pu
   bool verify_interfaces_;
 
  private:
+  friend class NetworkPrioritizerServiceTestAccessor;
+
+  std::function<std::chrono::milliseconds()> milliseconds_since_epoch_;
   std::shared_ptr<logging::Logger> logger_;
 };
 

--- a/libminifi/src/controllers/NetworkPrioritizerService.cpp
+++ b/libminifi/src/controllers/NetworkPrioritizerService.cpp
@@ -84,7 +84,7 @@ io::NetworkInterface NetworkPrioritizerService::getInterface(uint32_t size = 0) 
   std::vector<std::string> controllers;
   std::string ifc = "";
   if (!network_controllers_.empty()) {
-    if (sufficient_tokens(size) && size < max_payload_) {
+    if (sufficient_tokens(size) && size <= max_payload_) {
       controllers.insert(std::end(controllers), std::begin(network_controllers_), std::end(network_controllers_));
     }
   }
@@ -147,7 +147,7 @@ bool NetworkPrioritizerService::interface_online(const std::string &ifc) {
 std::vector<std::string> NetworkPrioritizerService::getInterfaces(uint32_t size = 0) {
   std::vector<std::string> interfaces;
   if (!network_controllers_.empty()) {
-    if (sufficient_tokens(size) && size < max_payload_) {
+    if (sufficient_tokens(size) && size <= max_payload_) {
       return network_controllers_;
     }
   }
@@ -156,7 +156,7 @@ std::vector<std::string> NetworkPrioritizerService::getInterfaces(uint32_t size 
 
 bool NetworkPrioritizerService::sufficient_tokens(uint32_t size) {
   std::lock_guard<std::mutex> lock(token_mutex_);
-  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  auto ms = milliseconds_since_epoch_().count();
   auto diff = ms - timestamp_;
   timestamp_ = ms;
   if (diff > 0) {
@@ -189,8 +189,7 @@ bool NetworkPrioritizerService::isWorkAvailable() {
 }
 
 void NetworkPrioritizerService::onEnable() {
-  std::string controllers, max_throughput, max_payload_, df_prioritizer, intersect, verify_interfaces, roundrobin_interfaces;
-// if we have defined controller services or we have linked services
+  std::string controllers;
   if (getProperty(NetworkControllers.getName(), controllers) || !linked_services_.empty()) {
     // if this controller service is defined, it will be an intersection of this config with linked services.
     if (getProperty(MaxThroughput.getName(), max_throughput_)) {
@@ -220,7 +219,7 @@ void NetworkPrioritizerService::onEnable() {
       }
     }
     getProperty(VerifyInterfaces.getName(), verify_interfaces_);
-    timestamp_ = std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1);
+    timestamp_ = milliseconds_since_epoch_().count();
     enabled_ = true;
     logger_->log_trace("Enabled");
   } else {

--- a/libminifi/test/unit/NetworkPrioritizerServiceTests.cpp
+++ b/libminifi/test/unit/NetworkPrioritizerServiceTests.cpp
@@ -48,7 +48,7 @@ namespace {
 std::shared_ptr<minifi::controllers::NetworkPrioritizerService> createNetworkPrioritizerService(
     const std::string& name,
     std::function<std::chrono::milliseconds()> mock_clock = []{ return std::chrono::milliseconds{0}; }) {
-  auto controller = std::make_shared<minifi::controllers::NetworkPrioritizerService>("TestService");
+  auto controller = std::make_shared<minifi::controllers::NetworkPrioritizerService>(name);
   minifi::controllers::NetworkPrioritizerServiceTestAccessor::setMockClock(*controller, mock_clock);
   return controller;
 }

--- a/libminifi/test/unit/NetworkPrioritizerServiceTests.cpp
+++ b/libminifi/test/unit/NetworkPrioritizerServiceTests.cpp
@@ -21,16 +21,42 @@
 #include <string>
 #include "../TestBase.h"
 #include "io/ClientSocket.h"
-#include "core/Processor.h"
-#include "../../controller/Controller.h"
 #include "core/controller/ControllerService.h"
-#include "c2/ControllerSocketProtocol.h"
 #include "controllers/NetworkPrioritizerService.h"
-#include "state/UpdateController.h"
+
+namespace org {
+namespace apache {
+namespace nifi {
+namespace minifi {
+namespace controllers {
+
+class NetworkPrioritizerServiceTestAccessor {
+ public:
+  static void setMockClock(minifi::controllers::NetworkPrioritizerService& service, std::function<std::chrono::milliseconds()> mock_clock) {
+    service.milliseconds_since_epoch_ = std::move(mock_clock);
+  }
+};
+
+}  // namespace controllers
+}  // namespace minifi
+}  // namespace nifi
+}  // namespace apache
+}  // namespace org
+
+namespace {
+
+std::shared_ptr<minifi::controllers::NetworkPrioritizerService> createNetworkPrioritizerService(
+    const std::string& name,
+    std::function<std::chrono::milliseconds()> mock_clock = []{ return std::chrono::milliseconds{0}; }) {
+  auto controller = std::make_shared<minifi::controllers::NetworkPrioritizerService>("TestService");
+  minifi::controllers::NetworkPrioritizerServiceTestAccessor::setMockClock(*controller, mock_clock);
+  return controller;
+}
+
+};  // namespace
 
 TEST_CASE("TestPrioritizerOneInterface", "[test1]") {
-  auto controller = std::make_shared<minifi::controllers::NetworkPrioritizerService>("TestService");
-  std::shared_ptr<minifi::Configure> configuration = std::make_shared<minifi::Configure>();
+  auto controller = createNetworkPrioritizerService("TestService");
   controller->initialize();
   controller->setProperty(minifi::controllers::NetworkPrioritizerService::NetworkControllers, "eth0,eth1");
   controller->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
@@ -41,129 +67,108 @@ TEST_CASE("TestPrioritizerOneInterface", "[test1]") {
 }
 
 TEST_CASE("TestPrioritizerOneInterfaceMaxPayload", "[test2]") {
-  auto controller = std::make_shared<minifi::controllers::NetworkPrioritizerService>("TestService");
-  std::shared_ptr<minifi::Configure> configuration = std::make_shared<minifi::Configure>();
+  auto controller = createNetworkPrioritizerService("TestService");
   controller->initialize();
   controller->setProperty(minifi::controllers::NetworkPrioritizerService::NetworkControllers, "eth0,eth1");
   controller->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
-  controller->setProperty(minifi::controllers::NetworkPrioritizerService::MaxThroughput, "1 B");
-  controller->setProperty(minifi::controllers::NetworkPrioritizerService::MaxPayload, "1 B");
+  controller->setProperty(minifi::controllers::NetworkPrioritizerService::MaxThroughput, "1 kB");
+  controller->setProperty(minifi::controllers::NetworkPrioritizerService::MaxPayload, "10 B");
   controller->onEnable();
-  // can't because we've triggered the max payload
-  REQUIRE("" == controller->getInterface(5).getInterface());
+
+  REQUIRE("eth0" == controller->getInterface(5).getInterface());
+  REQUIRE("" == controller->getInterface(20).getInterface());  // larger than max payload
+  REQUIRE("eth0" == controller->getInterface(5).getInterface());
 }
 
 TEST_CASE("TestPrioritizerOneInterfaceMaxThroughput", "[test3]") {
-  auto controller = std::make_shared<minifi::controllers::NetworkPrioritizerService>("TestService");
-  std::shared_ptr<minifi::Configure> configuration = std::make_shared<minifi::Configure>();
+  std::chrono::milliseconds mock_time_since_epoch{0};
+  const auto mock_clock = [&mock_time_since_epoch]{ return mock_time_since_epoch; };
+
+  auto controller = createNetworkPrioritizerService("TestService", mock_clock);
   controller->initialize();
   controller->setProperty(minifi::controllers::NetworkPrioritizerService::NetworkControllers, "eth0,eth1");
   controller->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
   controller->setProperty(minifi::controllers::NetworkPrioritizerService::MaxThroughput, "10 B");
   controller->onEnable();
-  // can't because we've triggered the max payload
   REQUIRE("eth0" == controller->getInterface(5).getInterface());
   REQUIRE("eth0" == controller->getInterface(5).getInterface());
-  REQUIRE("" == controller->getInterface(5).getInterface());
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  REQUIRE("eth0" == controller->getInterface(5).getInterface());
+  REQUIRE("" == controller->getInterface(5).getInterface());  // max throughput reached
+  mock_time_since_epoch += std::chrono::milliseconds{10};   // wait for more tokens to be generated
+  REQUIRE("eth0" == controller->getInterface(5).getInterface());  // now we can send again
 }
 
 TEST_CASE("TestPriorotizerMultipleInterfaces", "[test4]") {
-  LogTestController::getInstance().setTrace<minifi::controllers::NetworkPrioritizerService>();
+  std::chrono::milliseconds mock_time_since_epoch{0};
+  const auto mock_clock = [&mock_time_since_epoch]{ return mock_time_since_epoch; };
 
-  auto controller = std::make_shared<minifi::controllers::NetworkPrioritizerService>("TestService");
-  auto controller2 = std::make_shared<minifi::controllers::NetworkPrioritizerService>("TestService2");
-  auto controller3 = std::make_shared<minifi::controllers::NetworkPrioritizerService>("TestService3");
-  std::shared_ptr<minifi::Configure> configuration = std::make_shared<minifi::Configure>();
-  controller->initialize();
-  controller->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
+  auto parent_controller = createNetworkPrioritizerService("TestService", mock_clock);
+  parent_controller->initialize();
+  parent_controller->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
 
-  controller3->initialize();
-  controller3->setProperty(minifi::controllers::NetworkPrioritizerService::NetworkControllers, "eth0");
-  controller3->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
-  controller3->setProperty(minifi::controllers::NetworkPrioritizerService::MaxThroughput, "10 B");
-  controller3->onEnable();
+  auto controller0 = createNetworkPrioritizerService("TestService_eth0", mock_clock);
+  controller0->initialize();
+  controller0->setProperty(minifi::controllers::NetworkPrioritizerService::NetworkControllers, "eth0");
+  controller0->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
+  controller0->setProperty(minifi::controllers::NetworkPrioritizerService::MaxThroughput, "10 B");
+  controller0->onEnable();
 
-  controller2->initialize();
-  controller2->setProperty(minifi::controllers::NetworkPrioritizerService::NetworkControllers, "eth1");
-  controller2->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
-  controller2->setProperty(minifi::controllers::NetworkPrioritizerService::MaxThroughput, "10 B");
-  controller2->onEnable();
+  auto controller1 = createNetworkPrioritizerService("TestService_eth1", mock_clock);
+  controller1->initialize();
+  controller1->setProperty(minifi::controllers::NetworkPrioritizerService::NetworkControllers, "eth1");
+  controller1->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
+  controller1->setProperty(minifi::controllers::NetworkPrioritizerService::MaxThroughput, "10 B");
+  controller1->onEnable();
+
   std::vector<std::shared_ptr<core::controller::ControllerService> > services;
-  services.push_back(controller2);
-  services.push_back(controller3);
-  controller->setLinkedControllerServices(services);
-  controller->onEnable();
-  // can't because we've triggered the max payload
-  REQUIRE("eth1" == controller->getInterface(5).getInterface());
-  REQUIRE("eth1" == controller->getInterface(5).getInterface());
-  REQUIRE("eth0" == controller->getInterface(5).getInterface());
-  REQUIRE("eth0" == controller->getInterface(5).getInterface());
-}
+  services.push_back(controller0);
+  services.push_back(controller1);
+  parent_controller->setLinkedControllerServices(services);
+  parent_controller->onEnable();
 
-TEST_CASE("TestPriorotizerMultipleInterfacesNeverSwitch", "[test5]") {
-  auto controller = std::make_shared<minifi::controllers::NetworkPrioritizerService>("TestService");
-  auto controller2 = std::make_shared<minifi::controllers::NetworkPrioritizerService>("TestService2");
-  auto controller3 = std::make_shared<minifi::controllers::NetworkPrioritizerService>("TestService3");
-  std::shared_ptr<minifi::Configure> configuration = std::make_shared<minifi::Configure>();
-  controller->initialize();
-  controller->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
+  SECTION("Switch to second interface when the first is saturated") {
+    REQUIRE("eth0" == parent_controller->getInterface(5).getInterface());
+    REQUIRE("eth0" == parent_controller->getInterface(5).getInterface());
+    // triggered the max throughput on eth0, switching to eth1
+    REQUIRE("eth1" == parent_controller->getInterface(5).getInterface());
+    REQUIRE("eth1" == parent_controller->getInterface(5).getInterface());
+  }
 
-  controller3->initialize();
-  controller3->setProperty(minifi::controllers::NetworkPrioritizerService::NetworkControllers, "eth0");
-  controller3->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
-  controller3->setProperty(minifi::controllers::NetworkPrioritizerService::MaxThroughput, "1 kB");
-  controller3->onEnable();
-
-  controller2->initialize();
-  controller2->setProperty(minifi::controllers::NetworkPrioritizerService::NetworkControllers, "eth1");
-  controller2->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
-  controller2->setProperty(minifi::controllers::NetworkPrioritizerService::MaxThroughput, "10 B");
-  controller2->onEnable();
-  std::vector<std::shared_ptr<core::controller::ControllerService> > services;
-  services.push_back(controller3);
-  services.push_back(controller2);
-  controller->setLinkedControllerServices(services);
-  controller->onEnable();
-  // can't because we've triggered the max payload
-  for (int i = 0; i < 50; i++) {
-    REQUIRE("eth0" == controller->getInterface(5).getInterface());
-    REQUIRE("eth0" == controller->getInterface(5).getInterface());
-    REQUIRE("eth0" == controller->getInterface(5).getInterface());
-    REQUIRE("eth0" == controller->getInterface(5).getInterface());
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  SECTION("Can keep sending on eth0 if we wait between packets") {
+    for (int i = 0; i < 100; i++) {
+      REQUIRE("eth0" == parent_controller->getInterface(10).getInterface());
+      mock_time_since_epoch += std::chrono::milliseconds{5};
+    }
   }
 }
 
+TEST_CASE("TestPriorotizerMultipleInterfacesMaxPayload", "[test5]") {
+  auto parent_controller = createNetworkPrioritizerService("TestService");
+  parent_controller->initialize();
+  parent_controller->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
 
-TEST_CASE("TestPriorotizerMultipleInterfacesMaxPayload", "[test4]") {
-  auto controller = std::make_shared<minifi::controllers::NetworkPrioritizerService>("TestService");
-  auto controller2 = std::make_shared<minifi::controllers::NetworkPrioritizerService>("TestService2");
-  auto controller3 = std::make_shared<minifi::controllers::NetworkPrioritizerService>("TestService3");
-  std::shared_ptr<minifi::Configure> configuration = std::make_shared<minifi::Configure>();
-  controller->initialize();
-  controller->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
+  auto controller0 = createNetworkPrioritizerService("TestService_eth0");
+  controller0->initialize();
+  controller0->setProperty(minifi::controllers::NetworkPrioritizerService::NetworkControllers, "eth0");
+  controller0->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
+  controller0->setProperty(minifi::controllers::NetworkPrioritizerService::MaxThroughput, "1 kB");
+  controller0->setProperty(minifi::controllers::NetworkPrioritizerService::MaxPayload, "10 B");
+  controller0->onEnable();
 
-  controller3->initialize();
-  controller3->setProperty(minifi::controllers::NetworkPrioritizerService::NetworkControllers, "eth0");
-  controller3->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
-  controller3->setProperty(minifi::controllers::NetworkPrioritizerService::MaxThroughput, "1 kB");
+  auto controller1 = createNetworkPrioritizerService("TestService_eth1");
+  controller1->initialize();
+  controller1->setProperty(minifi::controllers::NetworkPrioritizerService::NetworkControllers, "eth1");
+  controller1->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
+  controller1->setProperty(minifi::controllers::NetworkPrioritizerService::MaxThroughput, "1 kB");
+  controller1->onEnable();
 
-  controller3->onEnable();
-
-  controller2->initialize();
-  controller2->setProperty(minifi::controllers::NetworkPrioritizerService::NetworkControllers, "eth1");
-  controller2->setProperty(minifi::controllers::NetworkPrioritizerService::VerifyInterfaces, "false");
-  controller2->setProperty(minifi::controllers::NetworkPrioritizerService::MaxThroughput, "10 B");
-  controller3->setProperty(minifi::controllers::NetworkPrioritizerService::MaxPayload, "10 B");
-  controller2->onEnable();
   std::vector<std::shared_ptr<core::controller::ControllerService> > services;
-  services.push_back(controller2);
-  services.push_back(controller3);
-  controller->setLinkedControllerServices(services);
-  controller->onEnable();
-  // can't because we've triggered the max payload
-  REQUIRE("eth0" == controller->getInterface(50).getInterface());
-  REQUIRE("eth0" == controller->getInterface(50).getInterface());
+  services.push_back(controller0);
+  services.push_back(controller1);
+  parent_controller->setLinkedControllerServices(services);
+  parent_controller->onEnable();
+
+  REQUIRE("eth0" == parent_controller->getInterface(10).getInterface());
+  REQUIRE("eth0" == parent_controller->getInterface(10).getInterface());
+  REQUIRE("eth1" == parent_controller->getInterface(50).getInterface());  // larger than max payload
+  REQUIRE("eth0" == parent_controller->getInterface(10).getInterface());
 }


### PR DESCRIPTION
NOTE: alternative PR to #958, only one of the two should be merged!

https://issues.apache.org/jira/browse/MINIFICPP-1432

* Add a mockable milliseconds_since_epoch_ field to NetworkPrioritizerService
* Fix and clean up the tests
* Fix some bugs in `NetworkPrioritizerService`:
   - `max_payload_` was not set in `onEnable()`
   - only payloads strictly smaller than `max_payload_` were allowed
   - use `steady_clock` instead of `system_clock`

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
