### PR TITLE
MINIFICPP-1441 Specify Lua version in Mac CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,16 @@ jobs:
       - id: checkout
         uses: actions/checkout@v2
       - id: install_dependencies
-        run: brew install ossp-uuid boost flex openssl python lua xz libssh2
+        run: brew install ossp-uuid boost flex openssl python lua@5.3 xz libssh2
       - id: setup_env
         run: |
           echo -e "127.0.0.1\t$HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
           sudo xcode-select -switch /Applications/Xcode_11.2.1.app
       - id: build
-        run: ./bootstrap.sh -e -t && cd build  && cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_LUA_SCRIPTING=1 -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES=OFF -DSTRICT_GSL_CHECKS=AUDIT .. && cmake --build . --parallel 4 && make test ARGS="--timeout 300 -j4 --output-on-failure" && make linter
+        run: |
+          export PATH="/usr/local/opt/lua@5.3/lib:/usr/local/opt/lua@5.3/include:/usr/local/opt/lua@5.3/bin:$PATH"
+          export PKG_CONFIG_PATH="/usr/local/opt/lua@5.3/lib/pkgconfig"
+          ./bootstrap.sh -e -t && cd build  && cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_LUA_SCRIPTING=1 -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES=OFF -DSTRICT_GSL_CHECKS=AUDIT .. && cmake --build . --parallel 4 && make test ARGS="--timeout 300 -j4 --output-on-failure" && make linter
   macos_xcode_12_0:
     name: "macos-xcode12.0"
     runs-on: macos-10.15
@@ -24,13 +27,16 @@ jobs:
       - id: checkout
         uses: actions/checkout@v2
       - id: install_dependencies
-        run: brew install ossp-uuid boost flex openssl python lua xz libssh2
+        run: brew install ossp-uuid boost flex openssl python lua@5.3 xz libssh2
       - id: setup_env
         run: |
           echo -e "127.0.0.1\t$HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
           sudo xcode-select -switch /Applications/Xcode_12.app
       - id: build
-        run: ./bootstrap.sh -e -t && cd build  && cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_LUA_SCRIPTING=1 -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES=OFF -DSTRICT_GSL_CHECKS=AUDIT .. && cmake --build . --parallel 4 && make test ARGS="--timeout 300 -j4 --output-on-failure" && make linter
+        run: |
+          export PATH="/usr/local/opt/lua@5.3/lib:/usr/local/opt/lua@5.3/include:/usr/local/opt/lua@5.3/bin:$PATH"
+          export PKG_CONFIG_PATH="/usr/local/opt/lua@5.3/lib/pkgconfig"
+          ./bootstrap.sh -e -t && cd build  && cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_LUA_SCRIPTING=1 -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES=OFF -DSTRICT_GSL_CHECKS=AUDIT .. && cmake --build . --parallel 4 && make test ARGS="--timeout 300 -j4 --output-on-failure" && make linter
   windows_VS2017:
     name: "windows-vs2017"
     runs-on: windows-2016

--- a/extensions/script/CMakeLists.txt
+++ b/extensions/script/CMakeLists.txt
@@ -34,7 +34,7 @@ if (ENABLE_LUA_SCRIPTING)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
-include(${CMAKE_SOURCE_DIR}/extensions/ExtensionHeader.txt) 
+include(${CMAKE_SOURCE_DIR}/extensions/ExtensionHeader.txt)
 
 set (OTHER_SOURCES "")
 if (NOT DISABLE_PYTHON_SCRIPTING)
@@ -69,7 +69,12 @@ if (NOT DISABLE_PYTHON_SCRIPTING)
 endif()
 
 if (ENABLE_LUA_SCRIPTING)
-    find_package(Lua REQUIRED)
+    SET(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
+    SET(CMAKE_FIND_PACKAGE_SORT_DIRECTION ASC)
+    find_package(Lua 5.1 REQUIRED)
+    if ("${LUA_VERSION_MAJOR}.${LUA_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.4")
+        message(FATAL_ERROR "No supported LUA version was found. Supported versions: 5.1, 5.2, 5.3")
+    endif()
 
     include_directories(${LUA_INCLUDE_DIR})
 


### PR DESCRIPTION
Current default Lua version 5.4 Github actions' Mac environments is unsupported by third party component sol2 2.20. 

CMake file is updated to only accept Lua versions supported by Sol2 v2.20 and Github worklfow is updated to use Lua version 5.3 in Mac environments.

--------------------------------------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
