### PR TITLE
MINIFICPP-1288 - Refactor FlowController::start and FlowController reload

### DIFF
--- a/libminifi/test/unit/ProvenanceTestHelper.h
+++ b/libminifi/test/unit/ProvenanceTestHelper.h
@@ -246,7 +246,7 @@ class TestFlowController : public minifi::FlowController {
 
   ~TestFlowController() override = default;
 
-  void load(const std::shared_ptr<core::ProcessGroup> &root = nullptr, bool reload = false) override {
+  void load(const std::shared_ptr<core::ProcessGroup> &root = nullptr) override {
   }
 
   int16_t start() override {


### PR DESCRIPTION
Update from PR #890.

The FlowController methods: start, stop, load, unload (and maybe even waitUnload), were strongly coupled and were controlled through FlowController states that made it difficult to argue about what goes on in each of them.

load had two versions with only minor differences, one reload (with a few extra steps) and one non-reload. The version that did the reload was only called during applyConfiguration, so I moved the extra behaviour required there (and renamed the related functions accordingly to prove there were no other instances of calling reload).

load was also changing the state of initialized_ read by only itself and start, but it is easy to argue that load is never called twice and start is never called without a preceeding load, proving this variable clutter.

Contains the following commits squashed from [hunyadi-dev:MINIFICPP-1288_FlowController_refactor_start_method](https://github.com/hunyadi-dev/nifi-minifi-cpp/commits/MINIFICPP-1288_FlowController_refactor_start_method):
- MINIFICPP-1288 - Decouple loads from reloads in FlowController (mid-refactor)
- MINIFICPP-1288 - Extract reinitializeSchedulersWithNewThreadPool from FlowController and use it to redefine reload (to be removed)
- MINIFICPP-1288 - Replace references for FlowController::load_with_reload (to be removed) to reload requirements and load_without_reload
- MINIFICPP-1288 - Remove load_with_reload method from the FlowController
- MINIFICPP-1288 - Rename FlowControl::load_without_reload to load
- MINIFICPP-1288 - Call a separate start method on FlowController start invocations that assumes that the FlowController is initialized
- MINIFICPP-1288 - Restore FlowController::start with the version asserting that the start is initialized
- MINIFICPP-1288 - Assert FlowController::load is never called twice and run tests accordingly
- MINIFICPP-1288 - Remove FlowController::initialized_ member variable
- MINIFICPP-1288 - Remove no longer used check on the return value of FlowController::start
- MINIFICPP-1288 - Rename reinitializeSchedulersWithNewThreadPool -> reinitializeSchedulersWithClearedThreadPool