### PR TITLE
MINIFICPP-1446 SQL extension doesn't compile on Debian

### DIFF
--- a/extensions/sql/services/ODBCConnector.h
+++ b/extensions/sql/services/ODBCConnector.h
@@ -91,12 +91,6 @@ class ODBCConnection : public sql::Connection {
  */
 class ODBCService : public DatabaseService {
  public:
-  explicit ODBCService(const std::string &name, const std::string &id)
-    : DatabaseService(name, id),
-      logger_(logging::LoggerFactory<ODBCService>::getLogger()) {
-    initialize();
-  }
-
   explicit ODBCService(const std::string &name, utils::Identifier uuid = utils::Identifier())
     : DatabaseService(name, uuid),
       logger_(logging::LoggerFactory<ODBCService>::getLogger()) {


### PR DESCRIPTION
Since I couldn't find any place where this constructor is used I assume it's safe to remove it (code compiled successfully). If it got this right, this class is only instantiated through ObjectFactory and I haven't seen a corresponding factory method.



Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
