### PR TITLE
MINIFICPP-1453: Verify Supported TLS Protocols

### DIFF
--- a/extensions/standard-processors/tests/CMakeLists.txt
+++ b/extensions/standard-processors/tests/CMakeLists.txt
@@ -22,6 +22,8 @@ file(GLOB PROCESSOR_UNIT_TESTS  "unit/*.cpp")
 file(GLOB PROCESSOR_INTEGRATION_TESTS "integration/*.cpp")
 if(OPENSSL_OFF)
 	list(REMOVE_ITEM PROCESSOR_INTEGRATION_TESTS "${CMAKE_CURRENT_SOURCE_DIR}/integration/SecureSocketGetTCPTest.cpp")
+	list(REMOVE_ITEM PROCESSOR_INTEGRATION_TESTS "${CMAKE_CURRENT_SOURCE_DIR}/integration/TLSServerSocketSupportedProtocolsTest.cpp")
+	list(REMOVE_ITEM PROCESSOR_INTEGRATION_TESTS "${CMAKE_CURRENT_SOURCE_DIR}/integration/TLSClientSocketSupportedProtocolsTest.cpp")
 endif()
 
 SET(PROCESSOR_INT_TEST_COUNT 0)
@@ -78,6 +80,9 @@ if(NOT OPENSSL_OFF)
 	add_test(NAME SecureSocketGetTCPTestEmptyPass COMMAND SecureSocketGetTCPTest "${TEST_RESOURCES}/TestGetTCPSecureEmptyPass.yml"  "${TEST_RESOURCES}/")
 	add_test(NAME SecureSocketGetTCPTestWithPassword COMMAND SecureSocketGetTCPTest "${TEST_RESOURCES}/TestGetTCPSecureWithPass.yml"  "${TEST_RESOURCES}/")
 	add_test(NAME SecureSocketGetTCPTestWithPasswordFile COMMAND SecureSocketGetTCPTest "${TEST_RESOURCES}/TestGetTCPSecureWithFilePass.yml"  "${TEST_RESOURCES}/")
+	
+	add_test(NAME TLSServerSocketSupportedProtocolsTest COMMAND TLSServerSocketSupportedProtocolsTest "${TEST_RESOURCES}/")
+	add_test(NAME TLSClientSocketSupportedProtocolsTest COMMAND TLSClientSocketSupportedProtocolsTest "${TEST_RESOURCES}/")
 endif()
 
 add_test(NAME TailFileTest COMMAND TailFileTest "${TEST_RESOURCES}/TestTailFile.yml"  "${TEST_RESOURCES}/")

--- a/extensions/standard-processors/tests/integration/TLSClientSocketSupportedProtocolsTest.cpp
+++ b/extensions/standard-processors/tests/integration/TLSClientSocketSupportedProtocolsTest.cpp
@@ -164,12 +164,12 @@ class TLSClientSocketSupportedProtocolsTest {
 
   template <class TLSTestSever>
   void verifyTLSProtocolIncompatibility() {
-    verifyTLSProtocolCompatibility<TLSTestSever> (false);
+    verifyTLSProtocolCompatibility<TLSTestSever>(false);
   }
 
   template <class TLSTestSever>
   void verifyTLSProtocolCompatibility() {
-    verifyTLSProtocolCompatibility<TLSTestSever> (true);
+    verifyTLSProtocolCompatibility<TLSTestSever>(true);
   }
 
   template <class TLSTestSever>

--- a/extensions/standard-processors/tests/integration/TLSClientSocketSupportedProtocolsTest.cpp
+++ b/extensions/standard-processors/tests/integration/TLSClientSocketSupportedProtocolsTest.cpp
@@ -182,7 +182,7 @@ class TLSClientSocketSupportedProtocolsTest {
     const bool client_initialized_successfully = (client_socket_->initialize() == 0);
     assert(client_initialized_successfully == should_be_compatible);
     server.shutdownServer();
-    assert(server.hasConnection() == should_be_compatible);
+    assert(server.hadConnection() == should_be_compatible);
   }
 
  protected:

--- a/extensions/standard-processors/tests/integration/TLSClientSocketSupportedProtocolsTest.cpp
+++ b/extensions/standard-processors/tests/integration/TLSClientSocketSupportedProtocolsTest.cpp
@@ -26,7 +26,6 @@
 #include <string>
 #include "properties/Configure.h"
 #include "io/tls/TLSSocket.h"
-#include "io/tls/TLSServerSocket.h"
 
 #ifdef WIN32
 using SocketDescriptor = SOCKET;
@@ -38,10 +37,11 @@ static constexpr SocketDescriptor INVALID_SOCKET = -1;
 
 class SimpleSSLTestServer  {
  public:
-  SimpleSSLTestServer(const SSL_METHOD* method, std::string port, std::string path)
-      : port_(port), hasConnection_(false) {
+  SimpleSSLTestServer(const SSL_METHOD* method, const std::string& port, const std::string& path)
+      : port_(port), has_connection_(false) {
     ctx_ = SSL_CTX_new(method);
-    configure_context(path);
+    configureContext(path);
+    socket_descriptor_ = createSocket(std::stoi(port_));
   }
 
   ~SimpleSSLTestServer() {
@@ -51,30 +51,29 @@ class SimpleSSLTestServer  {
   }
 
   void waitForConnection() {
-    sock_ = create_socket(std::stoi(port_));
     server_read_thread_ = std::thread([this]() -> void {
-        SocketDescriptor client = accept(sock_, nullptr, nullptr);
+        SocketDescriptor client = accept(socket_descriptor_, nullptr, nullptr);
         if (client != INVALID_SOCKET) {
             ssl_ = SSL_new(ctx_);
             SSL_set_fd(ssl_, client);
-            hasConnection_ = (SSL_accept(ssl_) == 1);
+            has_connection_ = (SSL_accept(ssl_) == 1);
         }
     });
   }
 
   void shutdownServer() {
 #ifdef WIN32
-    shutdown(sock_, SD_BOTH);
-    closesocket(sock_);
+    shutdown(socket_descriptor_, SD_BOTH);
+    closesocket(socket_descriptor_);
 #else
-    shutdown(sock_, SHUT_RDWR);
-    close(sock_);
+    shutdown(socket_descriptor_, SHUT_RDWR);
+    close(socket_descriptor_);
 #endif
     server_read_thread_.join();
   }
 
   bool hasConnection() const {
-    return hasConnection_;
+    return has_connection_;
   }
 
  private:
@@ -82,134 +81,133 @@ class SimpleSSLTestServer  {
   SSL* ssl_;
   std::string port_;
   uint16_t listeners_;
-  SocketDescriptor sock_;
-  bool hasConnection_;
+  SocketDescriptor socket_descriptor_;
+  bool has_connection_;
   std::thread server_read_thread_;
 
-  void configure_context(std::string path) {
+  void configureContext(const std::string& path) {
       SSL_CTX_set_ecdh_auto(ctx_, 1);
       /* Set the key and cert */
       assert(SSL_CTX_use_certificate_file(ctx_, (path + "cn.crt.pem").c_str(), SSL_FILETYPE_PEM) > 0);
       assert(SSL_CTX_use_PrivateKey_file(ctx_, (path + "cn.ckey.pem").c_str(), SSL_FILETYPE_PEM) > 0);
   }
 
-  SocketDescriptor create_socket(int port) const {
-    SocketDescriptor s;
+  static SocketDescriptor createSocket(int port) {
     struct sockaddr_in addr;
 
     addr.sin_family = AF_INET;
     addr.sin_port = htons(port);
     addr.sin_addr.s_addr = htonl(INADDR_ANY);
 
-    s = socket(AF_INET, SOCK_STREAM, 0);
-    assert(s >= 0);
-    assert(bind(s, (struct sockaddr*)&addr, sizeof(addr)) >= 0);
-    assert(listen(s, 1) >= 0);
+    SocketDescriptor socket_descriptor = socket(AF_INET, SOCK_STREAM, 0);
+    assert(socket_descriptor >= 0);
+    assert(bind(socket_descriptor, (struct sockaddr*)&addr, sizeof(addr)) >= 0);
+    assert(listen(socket_descriptor, 1) >= 0);
 
-    return s;
+    return socket_descriptor;
   }
 };
 
 class SimpleSSLTestServerTLSv1  : public SimpleSSLTestServer {
  public:
-  SimpleSSLTestServerTLSv1(std::string port, std::string path) : SimpleSSLTestServer(TLSv1_server_method(), port, path) {
+  SimpleSSLTestServerTLSv1(const std::string& port, const std::string& path)
+      : SimpleSSLTestServer(TLSv1_server_method(), port, path) {
   }
 };
 
 class SimpleSSLTestServerTLSv1_1  : public SimpleSSLTestServer {
  public:
-  SimpleSSLTestServerTLSv1_1(std::string port, std::string path) : SimpleSSLTestServer(TLSv1_1_server_method(), port, path) {
+  SimpleSSLTestServerTLSv1_1(const std::string& port, const std::string& path)
+      : SimpleSSLTestServer(TLSv1_1_server_method(), port, path) {
   }
 };
 
 class SimpleSSLTestServerTLSv1_2  : public SimpleSSLTestServer {
  public:
-  SimpleSSLTestServerTLSv1_2(std::string port, std::string path) : SimpleSSLTestServer(TLSv1_2_server_method(), port, path) {
+  SimpleSSLTestServerTLSv1_2(const std::string& port, const std::string& path)
+      : SimpleSSLTestServer(TLSv1_2_server_method(), port, path) {
   }
 };
 
 class TLSClientSocketSupportedProtocolsTest {
  public:
-  TLSClientSocketSupportedProtocolsTest()
-      : configuration_(std::make_shared<minifi::Configure>()) {
+  explicit TLSClientSocketSupportedProtocolsTest(const std::string& key_dir)
+      : key_dir_(key_dir), configuration_(std::make_shared<minifi::Configure>()) {
   }
 
   void run() {
     configureSecurity();
 
-    runAssertions();
+    verifyTLSClientSocketExclusiveCompatibilityWithTLSv1_2();
   }
 
-  void setKeyDir(const std::string key_dir) {
-    this->key_dir = key_dir;
-  }
 
  protected:
   void configureSecurity() {
     host_ = org::apache::nifi::minifi::io::Socket::getMyHostName();
-    port_ = "38776";
-    if (!key_dir.empty()) {
+    port_ = "38777";
+    if (!key_dir_.empty()) {
       configuration_->set(minifi::Configure::nifi_remote_input_secure, "true");
-      configuration_->set(minifi::Configure::nifi_security_client_certificate, key_dir + "cn.crt.pem");
-      configuration_->set(minifi::Configure::nifi_security_client_private_key, key_dir + "cn.ckey.pem");
-      configuration_->set(minifi::Configure::nifi_security_client_pass_phrase, key_dir + "cn.pass");
-      configuration_->set(minifi::Configure::nifi_security_client_ca_certificate, key_dir + "nifi-cert.pem");
-      configuration_->set(minifi::Configure::nifi_default_directory, key_dir);
+      configuration_->set(minifi::Configure::nifi_security_client_certificate, key_dir_ + "cn.crt.pem");
+      configuration_->set(minifi::Configure::nifi_security_client_private_key, key_dir_ + "cn.ckey.pem");
+      configuration_->set(minifi::Configure::nifi_security_client_pass_phrase, key_dir_ + "cn.pass");
+      configuration_->set(minifi::Configure::nifi_security_client_ca_certificate, key_dir_ + "nifi-cert.pem");
+      configuration_->set(minifi::Configure::nifi_default_directory, key_dir_);
     }
   }
 
-  void runAssertions() {
-    {
-      SimpleSSLTestServerTLSv1 server(port_, key_dir);
-      server.waitForConnection();
+  void verifyTLSClientSocketExclusiveCompatibilityWithTLSv1_2() {
+    verifyTLSProtocolIncompatibility<SimpleSSLTestServerTLSv1>();
+    verifyTLSProtocolIncompatibility<SimpleSSLTestServerTLSv1_1>();
+    verifyTLSProtocolCompatibility<SimpleSSLTestServerTLSv1_2>();
+  }
 
-      const auto socket_context = std::make_shared<org::apache::nifi::minifi::io::TLSContext>(configuration_);
-      client_socket_ = std::make_shared<org::apache::nifi::minifi::io::TLSSocket>(socket_context, host_, std::stoi(port_), 0);
-      assert(client_socket_->initialize() != 0);
-      assert(!server.hasConnection());
-      server.shutdownServer();
-    }
-    {
-      SimpleSSLTestServerTLSv1_1 server(port_, key_dir);
-      server.waitForConnection();
+  template <class TLSTestSever>
+  void verifyTLSProtocolIncompatibility() {
+    verifyTLSProtocolCompatibility<TLSTestSever> (false);
+  }
 
-      const auto socket_context = std::make_shared<org::apache::nifi::minifi::io::TLSContext>(configuration_);
-      client_socket_ = std::make_shared<org::apache::nifi::minifi::io::TLSSocket>(socket_context, host_, std::stoi(port_), 0);
-      assert(client_socket_->initialize() != 0);
-      assert(!server.hasConnection());
-      server.shutdownServer();
-    }
-    {
-      SimpleSSLTestServerTLSv1_2 server(port_, key_dir);
-      server.waitForConnection();
+  template <class TLSTestSever>
+  void verifyTLSProtocolCompatibility() {
+    verifyTLSProtocolCompatibility<TLSTestSever> (true);
+  }
 
-      const auto socket_context = std::make_shared<org::apache::nifi::minifi::io::TLSContext>(configuration_);
-      client_socket_ = std::make_shared<org::apache::nifi::minifi::io::TLSSocket>(socket_context, host_, std::stoi(port_), 0);
-      assert(client_socket_->initialize() == 0);
-      assert(server.hasConnection());
-      server.shutdownServer();
-    }
+  template <class TLSTestSever>
+  void verifyTLSProtocolCompatibility(bool should_be_compatible) {
+    TLSTestSever server(port_, key_dir_);
+    server.waitForConnection();
+
+    const auto socket_context = std::make_shared<org::apache::nifi::minifi::io::TLSContext>(configuration_);
+    client_socket_ = std::make_shared<org::apache::nifi::minifi::io::TLSSocket>(socket_context, host_, std::stoi(port_), 0);
+    const bool client_initialized_successfully = (client_socket_->initialize() == 0);
+    assert(client_initialized_successfully == should_be_compatible);
+    assert(server.hasConnection() == should_be_compatible);
+    server.shutdownServer();
   }
 
  protected:
     std::shared_ptr<org::apache::nifi::minifi::io::TLSSocket> client_socket_;
     std::string host_;
     std::string port_;
-    std::string key_dir;
+    std::string key_dir_;
     std::shared_ptr<minifi::Configure> configuration_;
 };
 
+static void sigpipe_handle(int) {
+}
+
 int main(int argc, char **argv) {
-  std::string key_dir, test_file_location;
+  std::string key_dir;
   if (argc > 1) {
     key_dir = argv[1];
   }
+#ifndef WIN32
+  signal(SIGPIPE, sigpipe_handle);
+#endif
 
-  TLSClientSocketSupportedProtocolsTest clientSocketSupportedProtocolsTest;
+  TLSClientSocketSupportedProtocolsTest client_socket_supported_protocols_verifier(key_dir);
 
-  clientSocketSupportedProtocolsTest.setKeyDir(key_dir);
-
-  clientSocketSupportedProtocolsTest.run();
+  client_socket_supported_protocols_verifier.run();
 
   return 0;
 }

--- a/extensions/standard-processors/tests/integration/TLSClientSocketSupportedProtocolsTest.cpp
+++ b/extensions/standard-processors/tests/integration/TLSClientSocketSupportedProtocolsTest.cpp
@@ -38,7 +38,7 @@ static constexpr SocketDescriptor INVALID_SOCKET = -1;
 class SimpleSSLTestServer  {
  public:
   SimpleSSLTestServer(const SSL_METHOD* method, const std::string& port, const std::string& path)
-      : port_(port), has_connection_(false) {
+      : port_(port), had_connection_(false) {
     ctx_ = SSL_CTX_new(method);
     configureContext(path);
     socket_descriptor_ = createSocket(std::stoi(port_));
@@ -56,7 +56,7 @@ class SimpleSSLTestServer  {
         if (client != INVALID_SOCKET) {
             ssl_ = SSL_new(ctx_);
             SSL_set_fd(ssl_, client);
-            has_connection_ = (SSL_accept(ssl_) == 1);
+            had_connection_ = (SSL_accept(ssl_) == 1);
         }
     });
   }
@@ -72,8 +72,8 @@ class SimpleSSLTestServer  {
     server_read_thread_.join();
   }
 
-  bool hasConnection() const {
-    return has_connection_;
+  bool hadConnection() const {
+    return had_connection_;
   }
 
  private:
@@ -82,7 +82,7 @@ class SimpleSSLTestServer  {
   std::string port_;
   uint16_t listeners_;
   SocketDescriptor socket_descriptor_;
-  bool has_connection_;
+  bool had_connection_;
   std::thread server_read_thread_;
 
   void configureContext(const std::string& path) {
@@ -173,7 +173,7 @@ class TLSClientSocketSupportedProtocolsTest {
   }
 
   template <class TLSTestSever>
-  void verifyTLSProtocolCompatibility(bool should_be_compatible) {
+  void verifyTLSProtocolCompatibility(const bool should_be_compatible) {
     TLSTestSever server(port_, key_dir_);
     server.waitForConnection();
 
@@ -181,8 +181,8 @@ class TLSClientSocketSupportedProtocolsTest {
     client_socket_ = std::make_shared<org::apache::nifi::minifi::io::TLSSocket>(socket_context, host_, std::stoi(port_), 0);
     const bool client_initialized_successfully = (client_socket_->initialize() == 0);
     assert(client_initialized_successfully == should_be_compatible);
-    assert(server.hasConnection() == should_be_compatible);
     server.shutdownServer();
+    assert(server.hasConnection() == should_be_compatible);
   }
 
  protected:

--- a/extensions/standard-processors/tests/integration/TLSClientSocketSupportedProtocolsTest.cpp
+++ b/extensions/standard-processors/tests/integration/TLSClientSocketSupportedProtocolsTest.cpp
@@ -156,19 +156,9 @@ class TLSClientSocketSupportedProtocolsTest {
   }
 
   void verifyTLSClientSocketExclusiveCompatibilityWithTLSv1_2() {
-    verifyTLSProtocolIncompatibility<SimpleSSLTestServerTLSv1>();
-    verifyTLSProtocolIncompatibility<SimpleSSLTestServerTLSv1_1>();
-    verifyTLSProtocolCompatibility<SimpleSSLTestServerTLSv1_2>();
-  }
-
-  template <class TLSTestSever>
-  void verifyTLSProtocolIncompatibility() {
-    verifyTLSProtocolCompatibility<TLSTestSever>(false);
-  }
-
-  template <class TLSTestSever>
-  void verifyTLSProtocolCompatibility() {
-    verifyTLSProtocolCompatibility<TLSTestSever>(true);
+    verifyTLSProtocolCompatibility<SimpleSSLTestServerTLSv1>(false);
+    verifyTLSProtocolCompatibility<SimpleSSLTestServerTLSv1_1>(false);
+    verifyTLSProtocolCompatibility<SimpleSSLTestServerTLSv1_2>(true);
   }
 
   template <class TLSTestSever>
@@ -177,7 +167,7 @@ class TLSClientSocketSupportedProtocolsTest {
     server.waitForConnection();
 
     const auto socket_context = std::make_shared<org::apache::nifi::minifi::io::TLSContext>(configuration_);
-    client_socket_ = std::make_shared<org::apache::nifi::minifi::io::TLSSocket>(socket_context, host_, std::stoi(port_), 0);
+    client_socket_ = utils::make_unique<org::apache::nifi::minifi::io::TLSSocket>(socket_context, host_, std::stoi(port_), 0);
     const bool client_initialized_successfully = (client_socket_->initialize() == 0);
     assert(client_initialized_successfully == should_be_compatible);
     server.shutdownServer();
@@ -185,7 +175,7 @@ class TLSClientSocketSupportedProtocolsTest {
   }
 
  protected:
-    std::shared_ptr<org::apache::nifi::minifi::io::TLSSocket> client_socket_;
+    std::unique_ptr<org::apache::nifi::minifi::io::TLSSocket> client_socket_;
     std::string host_;
     std::string port_;
     std::string key_dir_;

--- a/extensions/standard-processors/tests/integration/TLSClientSocketSupportedProtocolsTest.cpp
+++ b/extensions/standard-processors/tests/integration/TLSClientSocketSupportedProtocolsTest.cpp
@@ -77,10 +77,9 @@ class SimpleSSLTestServer  {
   }
 
  private:
-  SSL_CTX *ctx_;
-  SSL* ssl_;
+  SSL_CTX *ctx_ = nullptr;
+  SSL* ssl_ = nullptr;
   std::string port_;
-  uint16_t listeners_;
   SocketDescriptor socket_descriptor_;
   bool had_connection_;
   std::thread server_read_thread_;
@@ -88,8 +87,8 @@ class SimpleSSLTestServer  {
   void configureContext(const std::string& path) {
     SSL_CTX_set_ecdh_auto(ctx_, 1);
     /* Set the key and cert */
-    assert(SSL_CTX_use_certificate_file(ctx_, (path + "cn.crt.pem").c_str(), SSL_FILETYPE_PEM) > 0);
-    assert(SSL_CTX_use_PrivateKey_file(ctx_, (path + "cn.ckey.pem").c_str(), SSL_FILETYPE_PEM) > 0);
+    assert(SSL_CTX_use_certificate_file(ctx_, (path + "cn.crt.pem").c_str(), SSL_FILETYPE_PEM) == 1);
+    assert(SSL_CTX_use_PrivateKey_file(ctx_, (path + "cn.ckey.pem").c_str(), SSL_FILETYPE_PEM) == 1);
   }
 
   static SocketDescriptor createSocket(int port) {

--- a/extensions/standard-processors/tests/integration/TLSClientSocketSupportedProtocolsTest.cpp
+++ b/extensions/standard-processors/tests/integration/TLSClientSocketSupportedProtocolsTest.cpp
@@ -86,10 +86,10 @@ class SimpleSSLTestServer  {
   std::thread server_read_thread_;
 
   void configureContext(const std::string& path) {
-      SSL_CTX_set_ecdh_auto(ctx_, 1);
-      /* Set the key and cert */
-      assert(SSL_CTX_use_certificate_file(ctx_, (path + "cn.crt.pem").c_str(), SSL_FILETYPE_PEM) > 0);
-      assert(SSL_CTX_use_PrivateKey_file(ctx_, (path + "cn.ckey.pem").c_str(), SSL_FILETYPE_PEM) > 0);
+    SSL_CTX_set_ecdh_auto(ctx_, 1);
+    /* Set the key and cert */
+    assert(SSL_CTX_use_certificate_file(ctx_, (path + "cn.crt.pem").c_str(), SSL_FILETYPE_PEM) > 0);
+    assert(SSL_CTX_use_PrivateKey_file(ctx_, (path + "cn.ckey.pem").c_str(), SSL_FILETYPE_PEM) > 0);
   }
 
   static SocketDescriptor createSocket(int port) {

--- a/extensions/standard-processors/tests/integration/TLSClientSocketSupportedProtocolsTest.cpp
+++ b/extensions/standard-processors/tests/integration/TLSClientSocketSupportedProtocolsTest.cpp
@@ -1,0 +1,221 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <signal.h>
+#include <sys/stat.h>
+#include <chrono>
+#include <thread>
+#undef NDEBUG
+#include <cassert>
+#include <utility>
+#include <memory>
+#include <string>
+#include "properties/Configure.h"
+#include "io/tls/TLSSocket.h"
+#include "io/tls/TLSServerSocket.h"
+
+class SimpleSSLTestServer  {
+ public:
+  SimpleSSLTestServer(const SSL_METHOD* method, std::string port, std::string path)
+      : port_(port) {
+    ctx_ = SSL_CTX_new(method);
+    configure_context(path);
+  }
+
+  ~SimpleSSLTestServer() {
+      SSL_shutdown(ssl_);
+      SSL_free(ssl_);
+      SSL_CTX_free(ctx_);
+  }
+
+  void waitForConnection() {
+    isRunning_ = true;
+    sock_ = create_socket(std::stoi(port_));
+    server_read_thread_ = std::thread([this]() -> void {
+      while (isRunning_) {
+        struct sockaddr_in addr;
+        uint len = sizeof(addr);
+
+        int client = accept(sock_, (struct sockaddr*)&addr, &len);
+        ssl_ = SSL_new(ctx_);
+        SSL_set_fd(ssl_, client);
+        successful = (SSL_accept(ssl_) == 1);
+      }
+    });
+  }
+
+  bool isRunning_;
+  std::thread server_read_thread_;
+  int sock_;
+  bool successful;
+
+ private:
+  SSL_CTX *ctx_;
+  SSL* ssl_;
+  std::string port_;
+  uint16_t listeners_;
+
+  void configure_context(std::string path) {
+      SSL_CTX_set_ecdh_auto(ctx_, 1);
+      /* Set the key and cert */
+      assert(SSL_CTX_use_certificate_file(ctx_, (path + "cn.crt.pem").c_str(), SSL_FILETYPE_PEM) > 0);
+      assert(SSL_CTX_use_PrivateKey_file(ctx_, (path + "cn.ckey.pem").c_str(), SSL_FILETYPE_PEM) > 0);
+  }
+
+  int create_socket(int port) {
+    int s;
+    struct sockaddr_in addr;
+
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    s = socket(AF_INET, SOCK_STREAM, 0);
+    if (s < 0) {
+      perror("Unable to create socket");
+      exit(EXIT_FAILURE);
+    }
+
+    if (bind(s, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+      perror("Unable to bind");
+      exit(EXIT_FAILURE);
+    }
+
+    if (listen(s, 1) < 0) {
+      perror("Unable to listen");
+      exit(EXIT_FAILURE);
+    }
+
+    return s;
+  }
+};
+
+class SimpleSSLTestServerTLSv1  : public SimpleSSLTestServer {
+ public:
+  SimpleSSLTestServerTLSv1(std::string port, std::string path) : SimpleSSLTestServer(TLSv1_server_method(), port, path) {
+  }
+};
+
+class SimpleSSLTestServerTLSv1_1  : public SimpleSSLTestServer {
+ public:
+  SimpleSSLTestServerTLSv1_1(std::string port, std::string path) : SimpleSSLTestServer(TLSv1_1_server_method(), port, path) {
+  }
+};
+
+class SimpleSSLTestServerTLSv1_2  : public SimpleSSLTestServer {
+ public:
+  SimpleSSLTestServerTLSv1_2(std::string port, std::string path) : SimpleSSLTestServer(TLSv1_2_server_method(), port, path) {
+  }
+};
+
+class TLSClientSocketSupportedProtocolsTest {
+ public:
+  TLSClientSocketSupportedProtocolsTest()
+      : configuration_(std::make_shared<minifi::Configure>()) {
+  }
+
+  void run() {
+    configureSecurity();
+
+    runAssertions();
+  }
+
+  void setKeyDir(const std::string key_dir) {
+    this->key_dir = key_dir;
+  }
+
+ protected:
+  void configureSecurity() {
+    host_ = org::apache::nifi::minifi::io::Socket::getMyHostName();
+    port_ = "3684";
+    if (!key_dir.empty()) {
+      configuration_->set(minifi::Configure::nifi_remote_input_secure, "true");
+      configuration_->set(minifi::Configure::nifi_security_client_certificate, key_dir + "cn.crt.pem");
+      configuration_->set(minifi::Configure::nifi_security_client_private_key, key_dir + "cn.ckey.pem");
+      configuration_->set(minifi::Configure::nifi_security_client_pass_phrase, key_dir + "cn.pass");
+      configuration_->set(minifi::Configure::nifi_security_client_ca_certificate, key_dir + "nifi-cert.pem");
+      configuration_->set(minifi::Configure::nifi_default_directory, key_dir);
+    }
+  }
+
+  void runAssertions() {
+    {
+      SimpleSSLTestServerTLSv1 server(port_, key_dir);
+      server.waitForConnection();
+
+      std::shared_ptr<org::apache::nifi::minifi::io::TLSContext> socket_context = std::make_shared<org::apache::nifi::minifi::io::TLSContext>(configuration_);
+      client_socket_ = std::make_shared<org::apache::nifi::minifi::io::TLSSocket>(socket_context, host_, std::stoi(port_), 0);
+      assert(client_socket_->initialize() != 0);
+      shutdown(server.sock_, SHUT_RD);
+      close(server.sock_);
+      server.isRunning_ = false;
+      server.server_read_thread_.join();
+    }
+    {
+      SimpleSSLTestServerTLSv1_1 server(port_, key_dir);
+      server.waitForConnection();
+
+      std::shared_ptr<org::apache::nifi::minifi::io::TLSContext> socket_context = std::make_shared<org::apache::nifi::minifi::io::TLSContext>(configuration_);
+      client_socket_ = std::make_shared<org::apache::nifi::minifi::io::TLSSocket>(socket_context, host_, std::stoi(port_), 0);
+      assert(client_socket_->initialize() != 0);
+      shutdown(server.sock_, SHUT_RD);
+      close(server.sock_);
+      server.isRunning_ = false;
+      server.server_read_thread_.join();
+    }
+    {
+      SimpleSSLTestServerTLSv1_2 server(port_, key_dir);
+      server.waitForConnection();
+
+      std::shared_ptr<org::apache::nifi::minifi::io::TLSContext> socket_context = std::make_shared<org::apache::nifi::minifi::io::TLSContext>(configuration_);
+      client_socket_ = std::make_shared<org::apache::nifi::minifi::io::TLSSocket>(socket_context, host_, std::stoi(port_), 0);
+      assert(client_socket_->initialize() == 0);
+      shutdown(server.sock_, SHUT_RD);
+      close(server.sock_);
+      server.isRunning_ = false;
+      server.server_read_thread_.join();
+    }
+  }
+
+ protected:
+    std::shared_ptr<org::apache::nifi::minifi::io::TLSSocket> client_socket_;
+    std::string host_;
+    std::string port_;
+    std::string key_dir;
+    std::shared_ptr<minifi::Configure> configuration_;
+};
+
+static void sigpipe_handle(int /*x*/) {
+}
+
+int main(int argc, char **argv) {
+  std::string key_dir, test_file_location;
+  if (argc > 1) {
+    key_dir = argv[1];
+  }
+
+#ifndef WIN32
+  signal(SIGPIPE, sigpipe_handle);
+#endif
+  TLSClientSocketSupportedProtocolsTest clientSocketSupportedProtocolsTest;
+
+  clientSocketSupportedProtocolsTest.setKeyDir(key_dir);
+
+  clientSocketSupportedProtocolsTest.run();
+
+  return 0;
+}

--- a/extensions/standard-processors/tests/integration/TLSServerSocketSupportedProtocolsTest.cpp
+++ b/extensions/standard-processors/tests/integration/TLSServerSocketSupportedProtocolsTest.cpp
@@ -151,8 +151,6 @@ class SimpleSSLTestClient  {
   gsl::not_null<std::shared_ptr<logging::Logger>> logger_{gsl::make_not_null(logging::LoggerFactory<SimpleSSLTestClient>::getLogger())};
 
   static SocketDescriptor openConnection(const char *host_name, const char *port, logging::Logger& logger) {
-    struct hostent *host;
-    assert((host = gethostbyname(host_name)) != nullptr);
     struct addrinfo hints = {0}, *addrs;
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;

--- a/extensions/standard-processors/tests/integration/TLSServerSocketSupportedProtocolsTest.cpp
+++ b/extensions/standard-processors/tests/integration/TLSServerSocketSupportedProtocolsTest.cpp
@@ -213,6 +213,7 @@ class TLSServerSocketSupportedProtocolsTest {
 
     ~TLSServerSocketSupportedProtocolsTest() {
       shutdownServerSocket();
+      server_socket_.reset();
     }
 
     void run() {

--- a/extensions/standard-processors/tests/integration/TLSServerSocketSupportedProtocolsTest.cpp
+++ b/extensions/standard-processors/tests/integration/TLSServerSocketSupportedProtocolsTest.cpp
@@ -1,0 +1,217 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <signal.h>
+#include <sys/stat.h>
+#include <chrono>
+#include <thread>
+#undef NDEBUG
+#include <cassert>
+#include <utility>
+#include <memory>
+#include <string>
+#include "properties/Configure.h"
+#include "io/tls/TLSSocket.h"
+#include "io/tls/TLSServerSocket.h"
+
+class SimpleSSLTestClient  {
+ public:
+  SimpleSSLTestClient(const SSL_METHOD* method, std::string host, std::string port) :
+    host_(host),
+    port_(port) {
+      ctx_ = SSL_CTX_new(method);
+      sfd_ = openConnection(host_.c_str(), port_.c_str());
+      if (ctx_ != nullptr)
+        ssl_ = SSL_new(ctx_);
+      if (ssl_ != nullptr)
+        SSL_set_fd(ssl_, sfd_);
+  }
+
+  ~SimpleSSLTestClient() {
+    SSL_free(ssl_);
+    close(sfd_);
+    SSL_CTX_free(ctx_);
+  }
+
+  bool canConnect() {
+    const int status = SSL_connect(ssl_);
+    bool successfulConnection = (status == 1);
+    return successfulConnection;
+  }
+
+ private:
+  SSL_CTX *ctx_;
+  SSL* ssl_;
+  int sfd_;
+  std::string host_;
+  std::string port_;
+
+  int openConnection(const char *hostname, const char *port) {
+    constexpr int ERROR_STATUS = -1;
+    struct hostent *host;
+    if ((host = gethostbyname(hostname)) == nullptr) {
+        perror(hostname);
+        exit(EXIT_FAILURE);
+    }
+    struct addrinfo hints = {0}, *addrs;
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+    const int status = getaddrinfo(hostname, port, &hints, &addrs);
+    if (status != 0) {
+        fprintf(stderr, "%s: %s\n", hostname, gai_strerror(status));
+        exit(EXIT_FAILURE);
+    }
+    int sfd, err;
+    for (struct addrinfo *addr = addrs; addr != nullptr; addr = addr->ai_next) {
+        sfd = socket(addrs->ai_family, addrs->ai_socktype, addrs->ai_protocol);
+        if (sfd == ERROR_STATUS) {
+            err = errno;
+            continue;
+        }
+        if (connect(sfd, addr->ai_addr, addr->ai_addrlen) == 0) {
+            break;
+        }
+        err = errno;
+        sfd = ERROR_STATUS;
+        close(sfd);
+    }
+    freeaddrinfo(addrs);
+    if (sfd == ERROR_STATUS) {
+        fprintf(stderr, "%s: %s\n", hostname, strerror(err));
+        exit(EXIT_FAILURE);
+    }
+    return sfd;
+  }
+};
+
+class SimpleSSLTestClientTLSv1  : public SimpleSSLTestClient {
+ public:
+  SimpleSSLTestClientTLSv1(std::string host, std::string port) : SimpleSSLTestClient(TLSv1_client_method(), host, port) {
+  }
+};
+
+class SimpleSSLTestClientTLSv1_1  : public SimpleSSLTestClient {
+ public:
+  SimpleSSLTestClientTLSv1_1(std::string host, std::string port) : SimpleSSLTestClient(TLSv1_1_client_method(), host, port) {
+  }
+};
+
+class SimpleSSLTestClientTLSv1_2  : public SimpleSSLTestClient {
+ public:
+  SimpleSSLTestClientTLSv1_2(std::string host, std::string port) : SimpleSSLTestClient(TLSv1_2_client_method(), host, port) {
+  }
+};
+
+class TLSServerSocketSupportedProtocolsTest {
+ public:
+    TLSServerSocketSupportedProtocolsTest()
+        : isRunning_{ false }, configuration_(std::make_shared<minifi::Configure>()) {
+    }
+
+    void run() {
+      configureSecurity();
+
+      createServerSocket();
+
+      runAssertions();
+    }
+
+    void setKeyDir(const std::string key_dir) {
+      this->key_dir = key_dir;
+    }
+
+ protected:
+    void configureSecurity() {
+      host_ = org::apache::nifi::minifi::io::Socket::getMyHostName();
+      port_ = "3684";
+      if (!key_dir.empty()) {
+        configuration_->set(minifi::Configure::nifi_remote_input_secure, "true");
+        configuration_->set(minifi::Configure::nifi_security_client_certificate, key_dir + "cn.crt.pem");
+        configuration_->set(minifi::Configure::nifi_security_client_private_key, key_dir + "cn.ckey.pem");
+        configuration_->set(minifi::Configure::nifi_security_client_pass_phrase, key_dir + "cn.pass");
+        configuration_->set(minifi::Configure::nifi_security_client_ca_certificate, key_dir + "nifi-cert.pem");
+        configuration_->set(minifi::Configure::nifi_default_directory, key_dir);
+      }
+    }
+
+    void createServerSocket() {
+      std::shared_ptr<org::apache::nifi::minifi::io::TLSContext> socket_context = std::make_shared<org::apache::nifi::minifi::io::TLSContext>(configuration_);
+      server_socket_ = std::make_shared<org::apache::nifi::minifi::io::TLSServerSocket>(socket_context, host_, std::stoi(port_), 3);
+      assert(0 == server_socket_->initialize());
+
+      isRunning_ = true;
+      check = [this]() -> bool {
+        return isRunning_;
+      };
+      handler = [this](std::vector<uint8_t> *b, int *size) {
+        std::cout << "oh write!" << std::endl;
+        b->reserve(20);
+        memset(b->data(), 0x00, 20);
+        memcpy(b->data(), "hello world", 11);
+        *size = 20;
+        return *size;
+      };
+      server_socket_->registerCallback(check, handler, std::chrono::milliseconds(50));
+    }
+
+    void runAssertions() {
+      {
+        SimpleSSLTestClientTLSv1 client(host_, port_);
+        assert(!client.canConnect());
+      }
+      {
+        SimpleSSLTestClientTLSv1_1 client(host_, port_);
+        assert(!client.canConnect());
+      }
+      {
+        SimpleSSLTestClientTLSv1_2 client(host_, port_);
+        assert(client.canConnect());
+      }
+      isRunning_ = false;
+    }
+
+    std::function<bool()> check;
+    std::function<int(std::vector<uint8_t>*b, int *size)> handler;
+    std::atomic<bool> isRunning_;
+    std::shared_ptr<org::apache::nifi::minifi::io::TLSServerSocket> server_socket_;
+    std::string host_;
+    std::string port_;
+    std::string key_dir;
+    std::shared_ptr<minifi::Configure> configuration_;
+};
+
+static void sigpipe_handle(int /*x*/) {
+}
+
+int main(int argc, char **argv) {
+  std::string key_dir, test_file_location;
+  if (argc > 1) {
+    key_dir = argv[1];
+  }
+
+#ifndef WIN32
+  signal(SIGPIPE, sigpipe_handle);
+#endif
+  TLSServerSocketSupportedProtocolsTest serverSocketSupportedProtocolsTest;
+
+  serverSocketSupportedProtocolsTest.setKeyDir(key_dir);
+
+  serverSocketSupportedProtocolsTest.run();
+
+  return 0;
+}

--- a/extensions/standard-processors/tests/integration/TLSServerSocketSupportedProtocolsTest.cpp
+++ b/extensions/standard-processors/tests/integration/TLSServerSocketSupportedProtocolsTest.cpp
@@ -21,6 +21,7 @@
 #include <thread>
 #include <cerrno>
 #include <cinttypes>
+#include <arpa/inet.h>
 #undef NDEBUG
 #include <cassert>
 #include <utility>

--- a/extensions/standard-processors/tests/integration/TLSServerSocketSupportedProtocolsTest.cpp
+++ b/extensions/standard-processors/tests/integration/TLSServerSocketSupportedProtocolsTest.cpp
@@ -15,13 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <arpa/inet.h>
 #include <signal.h>
 #include <sys/stat.h>
 #include <chrono>
 #include <thread>
 #include <cerrno>
 #include <cinttypes>
-#include <arpa/inet.h>
 #undef NDEBUG
 #include <cassert>
 #include <utility>
@@ -44,7 +44,7 @@ static constexpr SocketDescriptor INVALID_SOCKET = -1;
 
 namespace {
 const char* str_family(int family) {
-  switch(family) {
+  switch (family) {
     case AF_INET: return "AF_INET";
     case AF_INET6: return "AF_INET6";
     default: return "(n/a)";
@@ -52,7 +52,7 @@ const char* str_family(int family) {
 }
 
 const char* str_socktype(int socktype) {
-  switch(socktype) {
+  switch (socktype) {
     case SOCK_STREAM: return "SOCK_STREAM";
     case SOCK_DGRAM: return "SOCK_DGRAM";
     default: return "(n/a)";
@@ -60,7 +60,7 @@ const char* str_socktype(int socktype) {
 }
 
 const char* str_proto(int protocol) {
-  switch(protocol) {
+  switch (protocol) {
     case IPPROTO_TCP: return "IPPROTO_TCP";
     case IPPROTO_UDP: return "IPPROTO_UDP";
     case IPPROTO_IP: return "IPPROTO_IP";

--- a/extensions/standard-processors/tests/integration/TLSServerSocketSupportedProtocolsTest.cpp
+++ b/extensions/standard-processors/tests/integration/TLSServerSocketSupportedProtocolsTest.cpp
@@ -86,18 +86,18 @@ class SimpleSSLTestClient  {
     assert(status == 0);
     SocketDescriptor sfd = INVALID_SOCKET;
     for (struct addrinfo *addr = addrs; addr != nullptr; addr = addr->ai_next) {
-        sfd = socket(addrs->ai_family, addrs->ai_socktype, addrs->ai_protocol);
-        if (sfd == INVALID_SOCKET) {
-            continue;
-        }
-        if (connect(sfd, addr->ai_addr, addr->ai_addrlen) == 0) {
-            break;
-        }
-        sfd = INVALID_SOCKET;
+      sfd = socket(addrs->ai_family, addrs->ai_socktype, addrs->ai_protocol);
+      if (sfd == INVALID_SOCKET) {
+          continue;
+      }
+      if (connect(sfd, addr->ai_addr, addr->ai_addrlen) == 0) {
+          break;
+      }
+      sfd = INVALID_SOCKET;
 #ifdef WIN32
-        closesocket(sfd);
+      closesocket(sfd);
 #else
-        close(sfd);
+      close(sfd);
 #endif
     }
     freeaddrinfo(addrs);

--- a/extensions/standard-processors/tests/integration/TLSServerSocketSupportedProtocolsTest.cpp
+++ b/extensions/standard-processors/tests/integration/TLSServerSocketSupportedProtocolsTest.cpp
@@ -15,7 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef WIN32
 #include <arpa/inet.h>
+#endif
 #include <signal.h>
 #include <sys/stat.h>
 #include <chrono>
@@ -75,7 +77,11 @@ std::string str_addr(const sockaddr* const sa) {
     case AF_INET: {
       sockaddr_in sin{};
       memcpy(&sin, sa, sizeof(sockaddr_in));
+#ifdef WIN32
+      const auto addr_str = InetNtop(AF_INET, &sin.sin_addr, buf, sizeof(buf));
+#else
       const auto addr_str = inet_ntop(AF_INET, &sin.sin_addr, buf, sizeof(buf));
+#endif
       if (!addr_str) {
         throw std::runtime_error{minifi::io::get_last_socket_error_message()};
       }
@@ -84,7 +90,11 @@ std::string str_addr(const sockaddr* const sa) {
     case AF_INET6: {
       sockaddr_in6 sin6{};
       memcpy(&sin6, sa, sizeof(sockaddr_in6));
-      const auto addr_str = inet_ntop(AF_INET6, &sin6.sin6_addr, buf, sizeof(buf));
+#ifdef WIN32
+      const auto addr_str = InetNtop(AF_INET, &sin6.sin6_addr, buf, sizeof(buf));
+#else
+      const auto addr_str = inet_ntop(AF_INET, &sin6.sin6_addr, buf, sizeof(buf));
+#endif
       if (!addr_str) {
         throw std::runtime_error{minifi::io::get_last_socket_error_message()};
       }


### PR DESCRIPTION
Currently org::apache::nifi:minifi::io::TLSSocket
(which, among other things, handles communications with C2)
only accept TLSv1.2 protocol (hardcoded behaviour)

Added integration tests to verify this behaviour
  TLSClientSocketSupportedProtocolsTest
    creates simple TLS enabled test servers with various protocols
    org::apache::nifi::minifi::io::TLSSocket only connects
    to the TLSv1.2 enabled server

  TLSServerSocketSupportedProtocolsTest
    creates an org::apache::nifi::minifi::io::TLSServerSocket
    various test clients try to connect to it,
    but only the TLSv1.2 enabled client succeeds

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
