### PR TITLE
MINIFICPP-1459 Cleanup temporary test directories

### DIFF
--- a/extensions/coap/tests/CoapC2VerifyHeartbeat.cpp
+++ b/extensions/coap/tests/CoapC2VerifyHeartbeat.cpp
@@ -78,8 +78,9 @@ class VerifyCoAPServer : public CoapIntegrationBase {
     file.close();
   }
 
-  void cleanup() {
+  void cleanup() override {
     unlink(ss.str().c_str());
+    CoapIntegrationBase::cleanup();
   }
 
   void runAssertions() {

--- a/extensions/expression-language/tests/integration/UpdateAttributeIntegrationTest.cpp
+++ b/extensions/expression-language/tests/integration/UpdateAttributeIntegrationTest.cpp
@@ -44,8 +44,6 @@ class TestHarness : public IntegrationBase {
     LogTestController::getInstance().setInfo<processors::LogAttribute>();
   }
 
-  void cleanup() override {}
-
   void runAssertions() override {
     using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
     assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_),

--- a/extensions/http-curl/tests/C2NullConfiguration.cpp
+++ b/extensions/http-curl/tests/C2NullConfiguration.cpp
@@ -54,9 +54,6 @@ public:
     file.close();
   }
 
-  void cleanup() override {
-  }
-
   void runAssertions() override {
     using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
     assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_),

--- a/extensions/http-curl/tests/C2VerifyServeResults.cpp
+++ b/extensions/http-curl/tests/C2VerifyServeResults.cpp
@@ -48,6 +48,7 @@ public:
 
   void cleanup() override {
     std::remove(ss.str().c_str());
+    IntegrationBase::cleanup();
   }
 
   void runAssertions() override {

--- a/extensions/http-curl/tests/HTTPIntegrationBase.h
+++ b/extensions/http-curl/tests/HTTPIntegrationBase.h
@@ -136,6 +136,7 @@ class VerifyC2Base : public HTTPIntegrationBase {
 
   void cleanup() override {
     LogTestController::getInstance().reset();
+    HTTPIntegrationBase::cleanup();
   }
 };
 
@@ -154,7 +155,7 @@ class VerifyC2Describe : public VerifyC2Base {
 
   void runAssertions() override {
     // This class is never used for running assertions, but we are forced to wait for DescribeManifestHandler to verifyJsonHasAgentManifest
-    // if we were to log something on finished verification, we could poll on finding it 
+    // if we were to log something on finished verification, we could poll on finding it
     std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_));
   }
 };
@@ -181,6 +182,7 @@ public:
 
   void cleanup() override {
     LogTestController::getInstance().reset();
+    HTTPIntegrationBase::cleanup();
   }
 
   void runAssertions() override {
@@ -213,6 +215,7 @@ class VerifyFlowFetched : public HTTPIntegrationBase {
 
   void cleanup() override {
     LogTestController::getInstance().reset();
+    HTTPIntegrationBase::cleanup();
   }
 
   void runAssertions() override {

--- a/extensions/http-curl/tests/HTTPSiteToSiteTests.cpp
+++ b/extensions/http-curl/tests/HTTPSiteToSiteTests.cpp
@@ -63,10 +63,8 @@ public:
     configuration->set("nifi.remote.input.socket.port", "8099");
   }
 
-  void cleanup() override {}
-
   void runAssertions() override {
-    // There is nothing to verify here, but we are expected to wait for all paralell events to execute 
+    // There is nothing to verify here, but we are expected to wait for all paralell events to execute
     std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_));
   }
 

--- a/extensions/http-curl/tests/HttpPostIntegrationTest.cpp
+++ b/extensions/http-curl/tests/HttpPostIntegrationTest.cpp
@@ -64,6 +64,7 @@ public:
 
   void cleanup() override {
     std::remove(ss.str().c_str());
+    IntegrationBase::cleanup();
   }
 
   void runAssertions() override {

--- a/extensions/http-curl/tests/SiteToSiteRestTest.cpp
+++ b/extensions/http-curl/tests/SiteToSiteRestTest.cpp
@@ -85,6 +85,7 @@ public:
 
   void cleanup() override {
     std::remove(ss.str().c_str());
+    IntegrationBase::cleanup();
   }
 
   void runAssertions() override {

--- a/extensions/http-curl/tests/ThreadPoolAdjust.cpp
+++ b/extensions/http-curl/tests/ThreadPoolAdjust.cpp
@@ -63,6 +63,7 @@ class HttpTestHarness : public IntegrationBase {
 
   void cleanup() override {
     std::remove(ss.str().c_str());
+    IntegrationBase::cleanup();
   }
 
   void runAssertions() override {

--- a/extensions/http-curl/tests/TimeoutHTTPSiteToSiteTests.cpp
+++ b/extensions/http-curl/tests/TimeoutHTTPSiteToSiteTests.cpp
@@ -64,10 +64,8 @@ public:
     configuration->set("nifi.remote.input.socket.port", "8099");
   }
 
-  void cleanup() override {}
-
   void runAssertions() override {
-    // There is nothing to verify here, but we are expected to wait for all paralell events to execute 
+    // There is nothing to verify here, but we are expected to wait for all paralell events to execute
     std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_));
   }
 

--- a/extensions/http-curl/tests/VerifyInvokeHTTPTest.cpp
+++ b/extensions/http-curl/tests/VerifyInvokeHTTPTest.cpp
@@ -41,9 +41,6 @@ class VerifyInvokeHTTP : public HTTPIntegrationBase {
     LogTestController::getInstance().setTrace<minifi::processors::LogAttribute>();
   }
 
-  void cleanup() override {
-  }
-
   void setUrl(const std::string &url, ServerAwareHandler *handler) override {
     if (path_) {
       throw std::logic_error("Url is already set");

--- a/extensions/librdkafka/tests/PublishKafkaOnScheduleTests.cpp
+++ b/extensions/librdkafka/tests/PublishKafkaOnScheduleTests.cpp
@@ -61,8 +61,6 @@ class PublishKafkaOnScheduleTests : public IntegrationBase {
       LogTestController::getInstance().setDebug<core::ProcessSession>();
       LogTestController::getInstance().setDebug<minifi::processors::PublishKafka>();
     }
-
-    virtual void cleanup() {}
 };
 
 int main(int argc, char **argv) {

--- a/extensions/sftp/tests/ListSFTPTests.cpp
+++ b/extensions/sftp/tests/ListSFTPTests.cpp
@@ -87,21 +87,11 @@ class ListSFTPTestsFixture {
   virtual ~ListSFTPTestsFixture() {
     free(src_dir);
     LogTestController::getInstance().reset();
-    if (!state_dir_.empty()) {
-      minifi::utils::file::delete_dir(state_dir_);
-    }
-  }
-
-  std::string createNewStateDir() {
-    if (!state_dir_.empty()) {
-      minifi::utils::file::delete_dir(state_dir_);
-    }
-    state_dir_ = minifi::utils::createTempDir(&testController);
-    return state_dir_;
   }
 
   void createPlan(utils::Identifier* list_sftp_uuid = nullptr, const std::shared_ptr<minifi::Configure>& configuration = nullptr) {
-    const std::string state_dir = plan == nullptr ? createNewStateDir() : plan->getStateDir();
+    char format[] = "/var/tmp/gt.XXXXXX";
+    const std::string state_dir = plan == nullptr ? minifi::utils::createTempDir(&testController, format) : plan->getStateDir();
 
     log_attribute.reset();
     list_sftp.reset();
@@ -181,7 +171,6 @@ class ListSFTPTestsFixture {
   std::shared_ptr<TestPlan> plan;
   std::shared_ptr<core::Processor> list_sftp;
   std::shared_ptr<core::Processor> log_attribute;
-  std::string state_dir_;
 };
 
 class PersistentListSFTPTestsFixture : public ListSFTPTestsFixture {

--- a/extensions/standard-processors/tests/integration/SecureSocketGetTCPTest.cpp
+++ b/extensions/standard-processors/tests/integration/SecureSocketGetTCPTest.cpp
@@ -74,6 +74,7 @@ class SecureSocketTest : public IntegrationBase {
 
   void cleanup() override {
     LogTestController::getInstance().reset();
+    IntegrationBase::cleanup();
   }
 
   void runAssertions() override {

--- a/extensions/standard-processors/tests/integration/TailFileTest.cpp
+++ b/extensions/standard-processors/tests/integration/TailFileTest.cpp
@@ -56,6 +56,7 @@ class TailFileTestHarness : public IntegrationBase {
   void cleanup() override {
     std::remove(ss.str().c_str());
     std::remove(statefile.c_str());
+    IntegrationBase::cleanup();
   }
 
   void runAssertions() override {

--- a/extensions/standard-processors/tests/unit/TailFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/TailFileTests.cpp
@@ -86,7 +86,8 @@ TEST_CASE("TailFile reads the file until the first delimiter", "[simple]") {
   auto id = tailfile->getUUIDStr();
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto dir = minifi::utils::createTempDir(&testController, format);
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
 
@@ -127,7 +128,8 @@ TEST_CASE("TailFile picks up the second line if a delimiter is written between r
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto dir = minifi::utils::createTempDir(&testController, format);
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
 
@@ -171,7 +173,8 @@ TEST_CASE("TailFile re-reads the file if the state is deleted between runs", "[s
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto dir = minifi::utils::createTempDir(&testController, format);
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
 
@@ -212,7 +215,8 @@ TEST_CASE("TailFile picks up the state correctly if it is rewritten between runs
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto dir = minifi::utils::createTempDir(&testController, format);
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
 
@@ -280,7 +284,8 @@ TEST_CASE("TailFile converts the old-style state file to the new-style state", "
   auto logattribute = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
   plan->setProperty(logattribute, org::apache::nifi::minifi::processors::LogAttribute::FlowFilesToLog.getName(), "0");
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto dir = minifi::utils::createTempDir(&testController, format);
   std::stringstream state_file;
   state_file << dir << utils::file::FileUtils::get_separator() << STATE_FILE;
 
@@ -389,7 +394,8 @@ TEST_CASE("TailFile picks up the new File to Tail if it is changed between runs"
   std::shared_ptr<core::Processor> log_attribute = plan->addProcessor("LogAttribute", "log_attribute", core::Relationship("success", "description"), true);
   plan->setProperty(log_attribute, org::apache::nifi::minifi::processors::LogAttribute::FlowFilesToLog.getName(), "0");
 
-  std::string directory = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  std::string directory = minifi::utils::createTempDir(&testController, format);
   std::string first_test_file = createTempFile(directory, "first.log", "my first log line\n");
   plan->setProperty(tail_file, org::apache::nifi::minifi::processors::TailFile::FileName.getName(), first_test_file);
   testController.runSession(plan, true);
@@ -422,7 +428,8 @@ TEST_CASE("TailFile picks up the new File to Tail if it is changed between runs 
   LogTestController::getInstance().setDebug<minifi::processors::TailFile>();
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
-  std::string directory = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  std::string directory = minifi::utils::createTempDir(&testController, format);
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<core::Processor> tail_file = plan->addProcessor("TailFile", "tail_file");
@@ -478,7 +485,8 @@ TEST_CASE("TailFile finds the single input file in both Single and Multiple mode
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto dir = minifi::utils::createTempDir(&testController, format);
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
   std::ofstream tmpfile;
@@ -515,7 +523,8 @@ TEST_CASE("TailFile picks up new files created between runs", "[multiple_file]")
   LogTestController::getInstance().setDebug<core::ProcessSession>();
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto dir = minifi::utils::createTempDir(&testController, format);
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfile");
@@ -550,7 +559,8 @@ TEST_CASE("TailFile can handle input files getting removed", "[multiple_file]") 
   LogTestController::getInstance().setDebug<core::ProcessSession>();
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto dir = minifi::utils::createTempDir(&testController, format);
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfile");
@@ -605,7 +615,8 @@ TEST_CASE("TailFile processes a very long line correctly", "[simple]") {
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto dir = minifi::utils::createTempDir(&testController, format);
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
   std::ofstream tmpfile;
@@ -682,7 +693,8 @@ TEST_CASE("TailFile processes a long line followed by multiple newlines correctl
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
   auto id = tailfile->getUUIDStr();
-  auto dir = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto dir = minifi::utils::createTempDir(&testController, format);
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
   std::ofstream tmpfile;
@@ -775,7 +787,8 @@ TEST_CASE("TailFile onSchedule throws in Multiple mode if the Base Directory doe
   }
 
   SECTION("Base Directory is set and it exists") {
-    std::string directory = minifi::utils::createTempDir(&testController);
+    char format[] = "/var/tmp/gt.XXXXXX";
+    std::string directory = minifi::utils::createTempDir(&testController, format);
 
     plan->setProperty(tailfile, processors::TailFile::BaseDirectory.getName(), directory);
     plan->setProperty(tailfile, processors::TailFile::LookupFrequency.getName(), "0 sec");
@@ -794,7 +807,8 @@ TEST_CASE("TailFile finds and finishes the renamed file and continues with the n
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
   auto plan = testController.createPlan();
-  auto dir = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto dir = minifi::utils::createTempDir(&testController, format);
   std::string in_file = dir + utils::file::FileUtils::get_separator() + "testfifo.txt";
 
   std::ofstream in_file_stream(in_file, std::ios::out | std::ios::binary);
@@ -860,7 +874,8 @@ TEST_CASE("TailFile finds and finishes multiple rotated files and continues with
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
   auto plan = testController.createPlan();
-  auto dir = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto dir = minifi::utils::createTempDir(&testController, format);
   std::string test_file = dir + utils::file::FileUtils::get_separator() + "fruits.log";
 
   std::ofstream test_file_stream_0(test_file, std::ios::binary);
@@ -917,7 +932,8 @@ TEST_CASE("TailFile ignores old rotated files", "[rotation]") {
   LogTestController::getInstance().setDebug<core::ProcessSession>();
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
-  const std::string dir = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  const std::string dir = minifi::utils::createTempDir(&testController, format);
   std::string log_file_name = dir + utils::file::FileUtils::get_separator() + "test.log";
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
@@ -962,7 +978,8 @@ TEST_CASE("TailFile rotation works with multiple input files", "[rotation][multi
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
   auto plan = testController.createPlan();
-  auto dir = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto dir = minifi::utils::createTempDir(&testController, format);
 
   createTempFile(dir, "fruit.log", "apple\npear\nbanana\n");
   createTempFile(dir, "animal.log", "bear\ngiraffe\n");
@@ -1026,7 +1043,8 @@ TEST_CASE("TailFile handles the Rolling Filename Pattern property correctly", "[
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
   auto plan = testController.createPlan();
-  auto dir = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto dir = minifi::utils::createTempDir(&testController, format);
   std::string test_file = createTempFile(dir, "test.log", "some stuff\n");
 
   // Build MiNiFi processing graph
@@ -1088,13 +1106,16 @@ TEST_CASE("TailFile finds and finishes the renamed file and continues with the n
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  auto log_dir = minifi::utils::createTempDir(&testController);
+
+  char log_dir_format[] = "/var/tmp/gt.XXXXXX";
+  auto log_dir = minifi::utils::createTempDir(&testController, log_dir_format);
 
   std::string test_file_1 = createTempFile(log_dir, "test.1", "line one\nline two\nline three\n");  // old rotated file
   std::this_thread::sleep_for(std::chrono::seconds(1));
   std::string test_file = createTempFile(log_dir, "test.log", "line four\nline five\nline six\n");  // current log file
 
-  auto state_dir = minifi::utils::createTempDir(&testController);
+  char state_dir_format[] = "/var/tmp/gt.XXXXXX";
+  auto state_dir = minifi::utils::createTempDir(&testController, state_dir_format);
 
   utils::Identifier tail_file_uuid = utils::IdGenerator::getIdGenerator()->generate();
   const core::Relationship success_relationship{"success", "everything is fine"};
@@ -1144,7 +1165,8 @@ TEST_CASE("TailFile yields if no work is done", "[yield]") {
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  auto temp_directory = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto temp_directory = minifi::utils::createTempDir(&testController, format);
   auto plan = testController.createPlan();
   auto tail_file = plan->addProcessor("TailFile", "Tail");
   plan->setProperty(tail_file, processors::TailFile::Delimiter.getName(), "\n");
@@ -1217,7 +1239,8 @@ TEST_CASE("TailFile yields if no work is done on any files", "[yield][multiple_f
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  auto temp_directory = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto temp_directory = minifi::utils::createTempDir(&testController, format);
   auto plan = testController.createPlan();
   auto tail_file = plan->addProcessor("TailFile", "Tail");
   plan->setProperty(tail_file, processors::TailFile::Delimiter.getName(), "\n");
@@ -1274,7 +1297,8 @@ TEST_CASE("TailFile doesn't yield if work was done on rotated files only", "[yie
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  auto temp_directory = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto temp_directory = minifi::utils::createTempDir(&testController, format);
   std::string full_file_name = createTempFile(temp_directory, "test.log", "stuff\n");
 
   auto plan = testController.createPlan();
@@ -1333,7 +1357,8 @@ TEST_CASE("TailFile handles the Delimiter setting correctly", "[delimiter]") {
     LogTestController::getInstance().setTrace<processors::TailFile>();
     LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-    auto temp_directory = minifi::utils::createTempDir(&testController);
+    char format[] = "/var/tmp/gt.XXXXXX";
+    auto temp_directory = minifi::utils::createTempDir(&testController, format);
 
     std::string delimiter = test_case.second;
     std::string full_file_name = createTempFile(temp_directory, "test.log", "one" + delimiter + "two" + delimiter);
@@ -1367,7 +1392,8 @@ TEST_CASE("TailFile handles Unix/Windows line endings correctly", "[simple]") {
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  auto temp_directory = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  auto temp_directory = minifi::utils::createTempDir(&testController, format);
   std::string full_file_name = createTempFile(temp_directory, "test.log", "line1\nline two\n", std::ios::out);  // write in text mode
 
   auto plan = testController.createPlan();
@@ -1397,7 +1423,8 @@ TEST_CASE("TailFile can tail all files in a directory recursively", "[multiple]"
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  std::string base_directory = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  std::string base_directory = minifi::utils::createTempDir(&testController, format);
   std::string directory1 = base_directory + utils::file::FileUtils::get_separator() + "one";
   utils::file::FileUtils::create_dir(directory1);
   std::string directory11 = directory1 + utils::file::FileUtils::get_separator() + "one_child";
@@ -1448,7 +1475,8 @@ TEST_CASE("TailFile interprets the lookup frequency property correctly", "[multi
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  std::string directory = minifi::utils::createTempDir(&testController);
+  char format[] = "/var/tmp/gt.XXXXXX";
+  std::string directory = minifi::utils::createTempDir(&testController, format);
   createTempFile(directory, "test.red.log", "cherry\n");
 
   auto plan = testController.createPlan();

--- a/extensions/standard-processors/tests/unit/TailFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/TailFileTests.cpp
@@ -40,6 +40,7 @@
 #include "core/ProcessorNode.h"
 #include "TailFile.h"
 #include "LogAttribute.h"
+#include "utils/TestUtils.h"
 
 static std::string NEWLINE_FILE = ""  // NOLINT
         "one,two,three\n"
@@ -85,9 +86,7 @@ TEST_CASE("TailFile reads the file until the first delimiter", "[simple]") {
   auto id = tailfile->getUUIDStr();
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
-
+  auto dir = minifi::utils::createTempDir(&testController);
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
 
@@ -128,9 +127,7 @@ TEST_CASE("TailFile picks up the second line if a delimiter is written between r
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
-
+  auto dir = minifi::utils::createTempDir(&testController);
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
 
@@ -174,9 +171,7 @@ TEST_CASE("TailFile re-reads the file if the state is deleted between runs", "[s
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
-
+  auto dir = minifi::utils::createTempDir(&testController);
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
 
@@ -217,8 +212,7 @@ TEST_CASE("TailFile picks up the state correctly if it is rewritten between runs
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = minifi::utils::createTempDir(&testController);
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
 
@@ -286,9 +280,7 @@ TEST_CASE("TailFile converts the old-style state file to the new-style state", "
   auto logattribute = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
   plan->setProperty(logattribute, org::apache::nifi::minifi::processors::LogAttribute::FlowFilesToLog.getName(), "0");
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
-
+  auto dir = minifi::utils::createTempDir(&testController);
   std::stringstream state_file;
   state_file << dir << utils::file::FileUtils::get_separator() << STATE_FILE;
 
@@ -397,9 +389,7 @@ TEST_CASE("TailFile picks up the new File to Tail if it is changed between runs"
   std::shared_ptr<core::Processor> log_attribute = plan->addProcessor("LogAttribute", "log_attribute", core::Relationship("success", "description"), true);
   plan->setProperty(log_attribute, org::apache::nifi::minifi::processors::LogAttribute::FlowFilesToLog.getName(), "0");
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  std::string directory = testController.createTempDirectory(format);
-
+  std::string directory = minifi::utils::createTempDir(&testController);
   std::string first_test_file = createTempFile(directory, "first.log", "my first log line\n");
   plan->setProperty(tail_file, org::apache::nifi::minifi::processors::TailFile::FileName.getName(), first_test_file);
   testController.runSession(plan, true);
@@ -432,8 +422,7 @@ TEST_CASE("TailFile picks up the new File to Tail if it is changed between runs 
   LogTestController::getInstance().setDebug<minifi::processors::TailFile>();
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  std::string directory = testController.createTempDirectory(format);
+  std::string directory = minifi::utils::createTempDir(&testController);
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<core::Processor> tail_file = plan->addProcessor("TailFile", "tail_file");
@@ -489,9 +478,7 @@ TEST_CASE("TailFile finds the single input file in both Single and Multiple mode
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
-
+  auto dir = minifi::utils::createTempDir(&testController);
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
   std::ofstream tmpfile;
@@ -528,8 +515,7 @@ TEST_CASE("TailFile picks up new files created between runs", "[multiple_file]")
   LogTestController::getInstance().setDebug<core::ProcessSession>();
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = minifi::utils::createTempDir(&testController);
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfile");
@@ -564,8 +550,7 @@ TEST_CASE("TailFile can handle input files getting removed", "[multiple_file]") 
   LogTestController::getInstance().setDebug<core::ProcessSession>();
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = minifi::utils::createTempDir(&testController);
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfile");
@@ -620,9 +605,7 @@ TEST_CASE("TailFile processes a very long line correctly", "[simple]") {
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
-
+  auto dir = minifi::utils::createTempDir(&testController);
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
   std::ofstream tmpfile;
@@ -699,10 +682,7 @@ TEST_CASE("TailFile processes a long line followed by multiple newlines correctl
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
   auto id = tailfile->getUUIDStr();
-
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
-
+  auto dir = minifi::utils::createTempDir(&testController);
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
   std::ofstream tmpfile;
@@ -795,8 +775,7 @@ TEST_CASE("TailFile onSchedule throws in Multiple mode if the Base Directory doe
   }
 
   SECTION("Base Directory is set and it exists") {
-    char format[] = "/var/tmp/gt.XXXXXX";
-    std::string directory = testController.createTempDirectory(format);
+    std::string directory = minifi::utils::createTempDir(&testController);
 
     plan->setProperty(tailfile, processors::TailFile::BaseDirectory.getName(), directory);
     plan->setProperty(tailfile, processors::TailFile::LookupFrequency.getName(), "0 sec");
@@ -815,10 +794,7 @@ TEST_CASE("TailFile finds and finishes the renamed file and continues with the n
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
   auto plan = testController.createPlan();
-
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
-
+  auto dir = minifi::utils::createTempDir(&testController);
   std::string in_file = dir + utils::file::FileUtils::get_separator() + "testfifo.txt";
 
   std::ofstream in_file_stream(in_file, std::ios::out | std::ios::binary);
@@ -884,10 +860,7 @@ TEST_CASE("TailFile finds and finishes multiple rotated files and continues with
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
   auto plan = testController.createPlan();
-
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
-
+  auto dir = minifi::utils::createTempDir(&testController);
   std::string test_file = dir + utils::file::FileUtils::get_separator() + "fruits.log";
 
   std::ofstream test_file_stream_0(test_file, std::ios::binary);
@@ -944,9 +917,7 @@ TEST_CASE("TailFile ignores old rotated files", "[rotation]") {
   LogTestController::getInstance().setDebug<core::ProcessSession>();
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  const std::string dir = testController.createTempDirectory(format);
-
+  const std::string dir = minifi::utils::createTempDir(&testController);
   std::string log_file_name = dir + utils::file::FileUtils::get_separator() + "test.log";
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
@@ -991,9 +962,7 @@ TEST_CASE("TailFile rotation works with multiple input files", "[rotation][multi
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
   auto plan = testController.createPlan();
-
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = minifi::utils::createTempDir(&testController);
 
   createTempFile(dir, "fruit.log", "apple\npear\nbanana\n");
   createTempFile(dir, "animal.log", "bear\ngiraffe\n");
@@ -1055,11 +1024,9 @@ TEST_CASE("TailFile handles the Rolling Filename Pattern property correctly", "[
   LogTestController::getInstance().setTrace<TestPlan>();
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
+
   auto plan = testController.createPlan();
-
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
-
+  auto dir = minifi::utils::createTempDir(&testController);
   std::string test_file = createTempFile(dir, "test.log", "some stuff\n");
 
   // Build MiNiFi processing graph
@@ -1121,22 +1088,19 @@ TEST_CASE("TailFile finds and finishes the renamed file and continues with the n
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  char log_dir_format[] = "/var/tmp/gt.XXXXXX";
-  auto log_dir = testController.createTempDirectory(log_dir_format);
+  auto log_dir = minifi::utils::createTempDir(&testController);
 
   std::string test_file_1 = createTempFile(log_dir, "test.1", "line one\nline two\nline three\n");  // old rotated file
   std::this_thread::sleep_for(std::chrono::seconds(1));
   std::string test_file = createTempFile(log_dir, "test.log", "line four\nline five\nline six\n");  // current log file
 
-  char state_dir_format[] = "/var/tmp/gt.XXXXXX";
-  auto state_dir = testController.createTempDirectory(state_dir_format);
+  auto state_dir = minifi::utils::createTempDir(&testController);
 
   utils::Identifier tail_file_uuid = utils::IdGenerator::getIdGenerator()->generate();
   const core::Relationship success_relationship{"success", "everything is fine"};
 
   // use persistent state storage that defaults to rocksDB, not volatile
   const auto configuration = std::make_shared<minifi::Configure>();
-
   {
     auto test_plan = testController.createPlan(configuration, state_dir.c_str());
     auto tail_file = test_plan->addProcessor("TailFile", tail_file_uuid, "Tail", {success_relationship});
@@ -1180,11 +1144,8 @@ TEST_CASE("TailFile yields if no work is done", "[yield]") {
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto temp_directory = testController.createTempDirectory(format);
-
+  auto temp_directory = minifi::utils::createTempDir(&testController);
   auto plan = testController.createPlan();
-
   auto tail_file = plan->addProcessor("TailFile", "Tail");
   plan->setProperty(tail_file, processors::TailFile::Delimiter.getName(), "\n");
   plan->setProperty(tail_file, processors::TailFile::TailMode.getName(), "Multiple file");
@@ -1256,11 +1217,8 @@ TEST_CASE("TailFile yields if no work is done on any files", "[yield][multiple_f
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto temp_directory = testController.createTempDirectory(format);
-
+  auto temp_directory = minifi::utils::createTempDir(&testController);
   auto plan = testController.createPlan();
-
   auto tail_file = plan->addProcessor("TailFile", "Tail");
   plan->setProperty(tail_file, processors::TailFile::Delimiter.getName(), "\n");
   plan->setProperty(tail_file, processors::TailFile::TailMode.getName(), "Multiple file");
@@ -1316,8 +1274,7 @@ TEST_CASE("TailFile doesn't yield if work was done on rotated files only", "[yie
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto temp_directory = testController.createTempDirectory(format);
+  auto temp_directory = minifi::utils::createTempDir(&testController);
   std::string full_file_name = createTempFile(temp_directory, "test.log", "stuff\n");
 
   auto plan = testController.createPlan();
@@ -1376,8 +1333,7 @@ TEST_CASE("TailFile handles the Delimiter setting correctly", "[delimiter]") {
     LogTestController::getInstance().setTrace<processors::TailFile>();
     LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-    char format[] = "/var/tmp/gt.XXXXXX";
-    auto temp_directory = testController.createTempDirectory(format);
+    auto temp_directory = minifi::utils::createTempDir(&testController);
 
     std::string delimiter = test_case.second;
     std::string full_file_name = createTempFile(temp_directory, "test.log", "one" + delimiter + "two" + delimiter);
@@ -1411,8 +1367,7 @@ TEST_CASE("TailFile handles Unix/Windows line endings correctly", "[simple]") {
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  auto temp_directory = testController.createTempDirectory(format);
+  auto temp_directory = minifi::utils::createTempDir(&testController);
   std::string full_file_name = createTempFile(temp_directory, "test.log", "line1\nline two\n", std::ios::out);  // write in text mode
 
   auto plan = testController.createPlan();
@@ -1442,8 +1397,7 @@ TEST_CASE("TailFile can tail all files in a directory recursively", "[multiple]"
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  std::string base_directory = testController.createTempDirectory(format);
+  std::string base_directory = minifi::utils::createTempDir(&testController);
   std::string directory1 = base_directory + utils::file::FileUtils::get_separator() + "one";
   utils::file::FileUtils::create_dir(directory1);
   std::string directory11 = directory1 + utils::file::FileUtils::get_separator() + "one_child";
@@ -1494,9 +1448,7 @@ TEST_CASE("TailFile interprets the lookup frequency property correctly", "[multi
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  char format[] = "/var/tmp/gt.XXXXXX";
-  std::string directory = testController.createTempDirectory(format);
-
+  std::string directory = minifi::utils::createTempDir(&testController);
   createTempFile(directory, "test.red.log", "cherry\n");
 
   auto plan = testController.createPlan();

--- a/libminifi/include/utils/TestUtils.h
+++ b/libminifi/include/utils/TestUtils.h
@@ -31,9 +31,14 @@ namespace nifi {
 namespace minifi {
 namespace utils {
 
-std::string createTempDir(TestController* testController) {
-  char dirtemplate[] = "/tmp/gt.XXXXXX";
-  std::string temp_dir = testController->createTempDirectory(dirtemplate);
+std::string createTempDir(TestController* testController, char* format = nullptr) {
+  std::string temp_dir;
+  if (format == nullptr) {
+    char dirtemplate[] = "/tmp/gt.XXXXXX";
+    temp_dir = testController->createTempDirectory(dirtemplate);
+  } else {
+    temp_dir = testController->createTempDirectory(format);
+  }
   REQUIRE(!temp_dir.empty());
   REQUIRE(file::FileUtils::is_directory(temp_dir.c_str()));
   return temp_dir;

--- a/libminifi/include/utils/file/FileUtils.h
+++ b/libminifi/include/utils/file/FileUtils.h
@@ -151,6 +151,10 @@ inline std::string get_temp_directory() {
 }
 
 inline int64_t delete_dir(const std::string &path, bool delete_files_recursively = true) {
+  // Empty path is interpreted as the root of the current partition on Windows, which should not be allowed
+  if (path.empty()) {
+    return -1;
+  }
 #ifdef USE_BOOST
   try {
     if (boost::filesystem::exists(path)) {

--- a/libminifi/test/TestBase.cpp
+++ b/libminifi/test/TestBase.cpp
@@ -40,6 +40,7 @@ TestPlan::TestPlan(std::shared_ptr<core::ContentRepository> content_repo, std::s
       content_repo_(content_repo),
       flow_repo_(flow_repo),
       prov_repo_(prov_repo),
+      is_state_dir_owner_(state_dir == nullptr),
       finalized(false),
       location(-1),
       current_flowfile_(nullptr),
@@ -63,6 +64,9 @@ TestPlan::~TestPlan() {
     processor->setScheduledState(core::ScheduledState::STOPPED);
   }
   controller_services_provider_->clearControllerServices();
+  if (is_state_dir_owner_) {
+    utils::file::FileUtils::delete_dir(state_dir_, true);
+  }
 }
 
 std::shared_ptr<core::Processor> TestPlan::addProcessor(const std::shared_ptr<core::Processor> &processor, const std::string& /*name*/, const std::initializer_list<core::Relationship>& relationships,

--- a/libminifi/test/TestBase.h
+++ b/libminifi/test/TestBase.h
@@ -281,7 +281,7 @@ class TestPlan {
   }
 
   std::string getStateDir() const {
-    return state_dir_;
+    return state_dir_->getPath();
   }
 
   std::shared_ptr<core::CoreComponentStateManagerProvider> getStateManagerProvider() {
@@ -291,6 +291,35 @@ class TestPlan {
   void finalize();
 
  protected:
+  class StateDir {
+   public:
+    StateDir() {
+      char state_dir_name_template[] = "/var/tmp/teststate.XXXXXX";
+      path_ = utils::file::FileUtils::create_temp_directory(state_dir_name_template);
+      is_owner_ = true;
+    }
+
+    StateDir(std::string path) : path_(std::move(path)), is_owner_(false) {}
+
+    StateDir(const StateDir&) = delete;
+    StateDir& operator=(const StateDir&) = delete;
+
+    ~StateDir() {
+      if (is_owner_) {
+        utils::file::FileUtils::delete_dir(path_, true);
+      }
+    }
+
+    std::string getPath() const {
+      return path_;
+    }
+
+   private:
+    std::string path_;
+    bool is_owner_;
+  };
+
+  std::unique_ptr<StateDir> state_dir_;
 
   std::shared_ptr<minifi::Connection> buildFinalConnection(std::shared_ptr<core::Processor> processor, bool setDest = false);
 
@@ -307,9 +336,6 @@ class TestPlan {
   std::shared_ptr<core::controller::ControllerServiceProvider> controller_services_provider_;
 
   std::shared_ptr<core::CoreComponentStateManagerProvider> state_manager_provider_;
-
-  bool is_state_dir_owner_;
-  std::string state_dir_;
 
   std::recursive_mutex mutex;
 

--- a/libminifi/test/TestBase.h
+++ b/libminifi/test/TestBase.h
@@ -308,6 +308,7 @@ class TestPlan {
 
   std::shared_ptr<core::CoreComponentStateManagerProvider> state_manager_provider_;
 
+  bool is_state_dir_owner_;
   std::string state_dir_;
 
   std::recursive_mutex mutex;

--- a/libminifi/test/integration/IntegrationBase.h
+++ b/libminifi/test/integration/IntegrationBase.h
@@ -57,7 +57,9 @@ class IntegrationBase {
   }
 
   virtual void cleanup() {
-    utils::file::delete_dir(state_dir);
+    if (!state_dir.empty()) {
+      utils::file::delete_dir(state_dir);
+    }
   }
 
   virtual void runAssertions() = 0;

--- a/libminifi/test/integration/IntegrationBase.h
+++ b/libminifi/test/integration/IntegrationBase.h
@@ -56,7 +56,9 @@ class IntegrationBase {
     return configuration;
   }
 
-  virtual void cleanup() = 0;
+  virtual void cleanup() {
+    utils::file::delete_dir(state_dir);
+  }
 
   virtual void runAssertions() = 0;
 

--- a/libminifi/test/integration/OnScheduleErrorHandlingTests.cpp
+++ b/libminifi/test/integration/OnScheduleErrorHandlingTests.cpp
@@ -70,8 +70,6 @@ class KamikazeErrorHandlingTests : public IntegrationBase {
     LogTestController::getInstance().setDebug<core::ProcessSession>();
     LogTestController::getInstance().setDebug<minifi::processors::KamikazeProcessor>();
   }
-
-  void cleanup() override {}
 };
 
 /*Verify that event driven processors without incoming connections are not scheduled*/
@@ -103,8 +101,6 @@ class EventDriverScheduleErrorHandlingTests: public IntegrationBase {
   void testSetup() override {
     LogTestController::getInstance().setDebug<core::ProcessGroup>();
   }
-
-  void cleanup() override {}
 };
 
 int main(int argc, char **argv) {

--- a/libminifi/test/pcap-tests/PcapTest.cpp
+++ b/libminifi/test/pcap-tests/PcapTest.cpp
@@ -62,8 +62,9 @@ class PcapTestHarness : public IntegrationBase {
     LogTestController::getInstance().setDebug<minifi::ThreadedSchedulingAgent>();
   }
 
-  void cleanup() {
+  void cleanup() override {
     LogTestController::getInstance().reset();
+    IntegrationBase::cleanup();
   }
 
   void runAssertions() {

--- a/libminifi/test/sensors-tests/SensorTests.cpp
+++ b/libminifi/test/sensors-tests/SensorTests.cpp
@@ -60,8 +60,9 @@ class PcapTestHarness : public IntegrationBase {
     LogTestController::getInstance().setDebug<minifi::ThreadedSchedulingAgent>();
   }
 
-  void cleanup() {
+  void cleanup() override {
     LogTestController::getInstance().reset();
+    IntegrationBase::cleanup();
   }
 
   void runAssertions() {

--- a/libminifi/test/unit/FileUtilsTests.cpp
+++ b/libminifi/test/unit/FileUtilsTests.cpp
@@ -407,3 +407,9 @@ TEST_CASE("FileUtils::exists", "[TestExists]") {
   REQUIRE(FileUtils::exists(path));
   REQUIRE(!FileUtils::exists(invalid_path));
 }
+
+TEST_CASE("TestFileUtils::delete_dir should fail with empty path", "[TestEmptyDeleteDir]") {
+  TestController testController;
+  REQUIRE(FileUtils::delete_dir("") != 0);
+  REQUIRE(FileUtils::delete_dir("", false) != 0);
+}


### PR DESCRIPTION
Running MiNiFiCPP tests creates more than 200 temporal test directories with test resources, that are kept after test runs and need to be manually cleaned up. After multiple test runs these resources can mount up to a lot of storage and can be cumbersome to deal with. It would be a better solution to clean up test resources automatically after each run.


---------------------------------------------------

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
