### PR TITLE
MINIFICPP-1461 Enable Curl dependent expression language tests on Windows (mini-PR)

### DIFF
--- a/extensions/expression-language/tests/ExpressionLanguageTests.cpp
+++ b/extensions/expression-language/tests/ExpressionLanguageTests.cpp
@@ -1176,7 +1176,6 @@ TEST_CASE("Encode Decode CSV", "[expressionEncodeDecodeCSV]") {  // NOLINT
   REQUIRE("Zero > One < \"two!\" & 'true'" == expr({ flow_file_a }).asString());
 }
 
-#ifndef WIN32
 #ifndef DISABLE_CURL
 TEST_CASE("Encode URL", "[expressionEncodeURL]") {  // NOLINT
   auto expr = expression::compile("${message:urlEncode()}");
@@ -1225,7 +1224,6 @@ TEST_CASE("Encode Decode URL", "[expressionEncodeDecodeURLExcept]") {  // NOLINT
   flow_file_a->addAttribute("message", "some value with spaces");
   REQUIRE_THROWS(expr({flow_file_a}).asString());
 }
-#endif
 #endif
 
 #ifdef EXPRESSION_LANGUAGE_USE_DATE


### PR DESCRIPTION
After merging the changes of MINIFICPP-1446 in #973, there should be no problems anymore from compiling and running EL tests using CURL library features on Windows.

-------------------------------------------------------------------

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
