### PR TITLE
fix StringUtils::trim

### DIFF
--- a/extensions/expression-language/Expression.cpp
+++ b/extensions/expression-language/Expression.cpp
@@ -840,10 +840,7 @@ Value expr_find(const std::vector<Value> &args) {
 #endif  // EXPRESSION_LANGUAGE_USE_REGEX
 
 Value expr_trim(const std::vector<Value> &args) {
-  std::string result = args[0].asString();
-  auto ws_front = std::find_if_not(result.begin(), result.end(), [](int c) {return std::isspace(c);});
-  auto ws_back = std::find_if_not(result.rbegin(), result.rend(), [](int c) {return std::isspace(c);}).base();
-  return (ws_back <= ws_front ? Value(std::string()) : Value(std::string(ws_front, ws_back)));
+  return Value{utils::StringUtils::trim(args[0].asString())};
 }
 
 Value expr_append(const std::vector<Value> &args) {

--- a/libminifi/include/utils/StringUtils.h
+++ b/libminifi/include/utils/StringUtils.h
@@ -99,7 +99,7 @@ class StringUtils {
    * @returns modified string
    */
   static inline std::string trimLeft(std::string s) {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](char c) -> bool { return !isspace(c); }));
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char c) -> bool { return !isspace(c); }));
     return s;
   }
 
@@ -110,7 +110,7 @@ class StringUtils {
    */
 
   static inline std::string trimRight(std::string s) {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](char c) -> bool { return !isspace(c); }).base(), s.end());
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char c) -> bool { return !isspace(c); }).base(), s.end());
     return s;
   }
 

--- a/libminifi/include/utils/ValueParser.h
+++ b/libminifi/include/utils/ValueParser.h
@@ -148,7 +148,7 @@ class ValueParser {
   }
 
   void skipWhitespace() {
-    while (offset < str.length() && std::isspace(str[offset])) {
+    while (offset < str.length() && std::isspace(static_cast<unsigned char>(str[offset]))) {
       ++offset;
     }
   }


### PR DESCRIPTION
[MINIFICPP-1477](https://issues.apache.org/jira/browse/MINIFICPP-1477)

from https://en.cppreference.com/w/cpp/string/byte/isspace:
> Like all other functions from `<cctype>`, the behavior of `std::isspace` is undefined if the argument's value is neither representable as `unsigned char` nor equal to `EOF`. To use these functions safely with plain `char`s (or `signed char`s), the argument should first be converted to `unsigned char`

It crashes on Windows in debug builds with assertion failure.
_____
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
