### PR TITLE
MINIFICPP-1485 Improve 'exclusive property' error message (mini-PR)

### DIFF
--- a/extensions/standard-processors/tests/unit/YamlConfigurationTests.cpp
+++ b/extensions/standard-processors/tests/unit/YamlConfigurationTests.cpp
@@ -709,7 +709,7 @@ TEST_CASE("Test Exclusive Property 2", "[YamlConfigurationExclusiveProperty2]") 
   } catch (const std::exception &e) {
     config_failed = true;
     REQUIRE("Unable to parse configuration file for component named 'component A' because "
-        "property 'Prop B' is exclusive of property 'Prop A' values matching '^val.*$' "
+        "property 'Prop B' must not be set when the value of property 'Prop A' matches '^val.*$' "
         "[in 'section A' section of configuration file]" == std::string(e.what()));
   }
   REQUIRE(config_failed);

--- a/libminifi/src/core/yaml/YamlConfiguration.cpp
+++ b/libminifi/src/core/yaml/YamlConfiguration.cpp
@@ -895,13 +895,11 @@ void YamlConfiguration::validateComponentProperties(const std::shared_ptr<Config
   for (const auto &prop_pair : component_properties) {
     if (prop_pair.second.getRequired()) {
       if (prop_pair.second.getValue().to_string().empty()) {
-        std::stringstream reason;
-        reason << "required property '" << prop_pair.second.getName() << "' is not set";
-        raiseComponentError(component_name, yaml_section, reason.str());
+        std::string reason = utils::StringUtils::join_pack("required property '", prop_pair.second.getName(), "' is not set");
+        raiseComponentError(component_name, yaml_section, reason);
       } else if (!prop_pair.second.getValue().validate(prop_pair.first).valid()) {
-        std::stringstream reason;
-        reason << "Property '" << prop_pair.second.getName() << "' is not valid";
-        raiseComponentError(component_name, yaml_section, reason.str());
+        std::string reason = utils::StringUtils::join_pack("the value '", prop_pair.first, "' is not valid for property '", prop_pair.second.getName(), "'");
+        raiseComponentError(component_name, yaml_section, reason);
       }
     }
   }
@@ -916,11 +914,8 @@ void YamlConfiguration::validateComponentProperties(const std::shared_ptr<Config
 
     for (const auto &dep_prop_key : dep_props) {
       if (component_properties.at(dep_prop_key).getValue().to_string().empty()) {
-        std::string reason("property '");
-        reason.append(prop_pair.second.getName());
-        reason.append("' depends on property '");
-        reason.append(dep_prop_key);
-        reason.append("' which is not set");
+        std::string reason = utils::StringUtils::join_pack("property '", prop_pair.second.getName(),
+            "' depends on property '", dep_prop_key, "' which is not set");
         raiseComponentError(component_name, yaml_section, reason);
       }
     }
@@ -952,9 +947,8 @@ void YamlConfiguration::validateComponentProperties(const std::shared_ptr<Config
     if (!prop_regex_str.empty()) {
       std::regex prop_regex(prop_regex_str);
       if (!std::regex_match(prop_pair.second.getValue().to_string(), prop_regex)) {
-        std::stringstream reason;
-        reason << "property '" << prop_pair.second.getName() << "' does not match validation pattern '" << prop_regex_str << "'";
-        raiseComponentError(component_name, yaml_section, reason.str());
+        std::string reason = utils::StringUtils::join_pack("property '", prop_pair.second.getName(), "' does not match validation pattern '", prop_regex_str, "'");
+        raiseComponentError(component_name, yaml_section, reason);
       }
     }
   }

--- a/libminifi/src/core/yaml/YamlConfiguration.cpp
+++ b/libminifi/src/core/yaml/YamlConfiguration.cpp
@@ -938,13 +938,8 @@ void YamlConfiguration::validateComponentProperties(const std::shared_ptr<Config
     for (const auto &excl_pair : excl_props) {
       std::regex excl_expr(excl_pair.second);
       if (std::regex_match(component_properties.at(excl_pair.first).getValue().to_string(), excl_expr)) {
-        std::string reason("property '");
-        reason.append(prop_pair.second.getName());
-        reason.append("' is exclusive of property '");
-        reason.append(excl_pair.first);
-        reason.append("' values matching '");
-        reason.append(excl_pair.second);
-        reason.append("'");
+        std::string reason = utils::StringUtils::join_pack("property '", prop_pair.second.getName(),
+            "' must not be set when the value of property '", excl_pair.first, "' matches '", excl_pair.second, "'");
         raiseComponentError(component_name, yaml_section, reason);
       }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-1485

Old error message:
```
[error] Unable to parse configuration file for component named 'InvokeHTTP' because property
'SSL Context Service' is exclusive of property 'Remote URL' values matching '^http:.*$'
[in 'Processors' section of configuration file]
```
New error message:
```
[error] Unable to parse configuration file for component named 'InvokeHTTP' because property
'SSL Context Service' must not be set when the value of property 'Remote URL' matches '^http:.*$'
[in 'Processors' section of configuration file]
```

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
