### PR TITLE
MINIFICPP-1496 "Enable all extensions" in bootstrap.sh should not enable ASAN_BUILD

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -290,6 +290,9 @@ add_dependency COAP_ENABLED "automake"
 add_dependency COAP_ENABLED "autoconf"
 add_dependency COAP_ENABLED "libtool"
 
+add_disabled_option JNI_ENABLED ${FALSE} "ENABLE_JNI"
+add_dependency JNI_ENABLED "jnibuild"
+
 add_disabled_option OPENCV_ENABLED ${FALSE} "ENABLE_OPENCV"
 
 add_disabled_option OPENCV_ENABLED ${FALSE} "ENABLE_OPENCV"
@@ -314,9 +317,6 @@ add_dependency TENSORFLOW_ENABLED "tensorflow"
 
 add_disabled_option OPC_ENABLED ${FALSE} "ENABLE_OPC"
 add_dependency OPC_ENABLED "mbedtls"
-
-JNI_ENABLED=${FALSE}
-add_dependency JNI_ENABLED "jnibuild"
 
 USE_SHARED_LIBS=${TRUE}
 TESTS_DISABLED=${FALSE}
@@ -445,12 +445,6 @@ build_cmake_command(){
       fi
     fi
   done
-
-  if [ "${JNI_ENABLED}" = "${TRUE}" ]; then
-    CMAKE_BUILD_COMMAND="${CMAKE_BUILD_COMMAND} -DENABLE_JNI=ON "
-  else
-    CMAKE_BUILD_COMMAND="${CMAKE_BUILD_COMMAND} -DENABLE_JNI=OFF"
-  fi
 
   if [ "${DEBUG_SYMBOLS}" = "${TRUE}" ]; then
     CMAKE_BUILD_COMMAND="${CMAKE_BUILD_COMMAND} -DCMAKE_BUILD_TYPE=RelWithDebInfo"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -290,9 +290,6 @@ add_dependency COAP_ENABLED "automake"
 add_dependency COAP_ENABLED "autoconf"
 add_dependency COAP_ENABLED "libtool"
 
-add_disabled_option JNI_ENABLED ${FALSE} "ENABLE_JNI"
-add_dependency JNI_ENABLED "jnibuild"
-
 add_disabled_option OPENCV_ENABLED ${FALSE} "ENABLE_OPENCV"
 
 add_disabled_option OPENCV_ENABLED ${FALSE} "ENABLE_OPENCV"
@@ -318,13 +315,15 @@ add_dependency TENSORFLOW_ENABLED "tensorflow"
 add_disabled_option OPC_ENABLED ${FALSE} "ENABLE_OPC"
 add_dependency OPC_ENABLED "mbedtls"
 
+JNI_ENABLED=${FALSE}
+add_dependency JNI_ENABLED "jnibuild"
+
 USE_SHARED_LIBS=${TRUE}
 TESTS_DISABLED=${FALSE}
+ASAN_ENABLED=${FALSE}
 
 ## name, default, values
 add_multi_option BUILD_PROFILE "RelWithDebInfo" "RelWithDebInfo" "Debug" "MinSizeRel" "Release"
-
-add_disabled_option ASAN_ENABLED ${FALSE} "ASAN_BUILD"
 
 if [ "$GUIDED_INSTALL" == "${TRUE}" ]; then
   EnableAllFeatures
@@ -446,6 +445,13 @@ build_cmake_command(){
       fi
     fi
   done
+
+  if [ "${JNI_ENABLED}" = "${TRUE}" ]; then
+    CMAKE_BUILD_COMMAND="${CMAKE_BUILD_COMMAND} -DENABLE_JNI=ON "
+  else
+    CMAKE_BUILD_COMMAND="${CMAKE_BUILD_COMMAND} -DENABLE_JNI=OFF"
+  fi
+
   if [ "${DEBUG_SYMBOLS}" = "${TRUE}" ]; then
     CMAKE_BUILD_COMMAND="${CMAKE_BUILD_COMMAND} -DCMAKE_BUILD_TYPE=RelWithDebInfo"
   fi
@@ -455,6 +461,12 @@ build_cmake_command(){
   else
     # user may have disabled tests previously, so let's force them to be re-enabled
     CMAKE_BUILD_COMMAND="${CMAKE_BUILD_COMMAND} -DSKIP_TESTS= "
+  fi
+
+  if [ "${ASAN_ENABLED}" = "${TRUE}" ]; then
+    CMAKE_BUILD_COMMAND="${CMAKE_BUILD_COMMAND} -DASAN_BUILD=ON "
+  else
+    CMAKE_BUILD_COMMAND="${CMAKE_BUILD_COMMAND} -DASAN_BUILD=OFF"
   fi
   
   if [ "${USE_SHARED_LIBS}" = "${TRUE}" ]; then

--- a/bstrp_functions.sh
+++ b/bstrp_functions.sh
@@ -169,6 +169,7 @@ save_state(){
   echo_state_variable TESTS_DISABLED
   echo_state_variable BUILD_PROFILE
   echo_state_variable USE_SHARED_LIBS
+  echo_state_variable ASAN_ENABLED
   for option in "${OPTIONS[@]}" ; do
     echo_state_variable $option
   done


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-1496

ASAN_BUILD should be handled like the the other Build Options (like USE_SHARED_LIBS and SKIP_TESTS) and not like extensions.  In particular, if you select option 2, "Enable all extensions", it should not be enabled.

(Ideally, the same should apply to ENABLE_JNI, but that would be a bigger change [see the Jira; thanks to @adebreceni for pointing this out], so I won't address that in this PR.)

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
