### PR TITLE
MINIFICPP-1203 - Make cpplint ignore bison generated expression language code

### DIFF
--- a/extensions/expression-language/CPPLINT.cfg
+++ b/extensions/expression-language/CPPLINT.cfg
@@ -1,4 +1,3 @@
-set noparent
 exclude_files=Scanner.cpp
 exclude_files=Parser.cpp
 exclude_files=Parser.hpp

--- a/extensions/expression-language/CPPLINT.cfg
+++ b/extensions/expression-language/CPPLINT.cfg
@@ -1,0 +1,7 @@
+set noparent
+exclude_files=Scanner.cpp
+exclude_files=Parser.cpp
+exclude_files=Parser.hpp
+exclude_files=location.hh
+exclude_files=position.hh
+exclude_files=stack.hh


### PR DESCRIPTION
This is done to later enable cpplint for the whole project.