### PR TITLE
MINIFICPP-1203 - Remove linter reported redundant virtuals

### DIFF
--- a/extensions/expression-language/ExpressionContextBuilder.h
+++ b/extensions/expression-language/ExpressionContextBuilder.h
@@ -43,7 +43,7 @@ class ExpressionContextBuilder : public core::ProcessContextBuilder {
 
   virtual ~ExpressionContextBuilder();
 
-  virtual std::shared_ptr<core::ProcessContext> build(const std::shared_ptr<ProcessorNode> &processor) override;
+  std::shared_ptr<core::ProcessContext> build(const std::shared_ptr<ProcessorNode> &processor) override;
 };
 
 } /* namespace expressions */

--- a/extensions/expression-language/ExpressionLoader.h
+++ b/extensions/expression-language/ExpressionLoader.h
@@ -35,24 +35,24 @@ class ExpressionObjectFactory : public core::ObjectFactory {
    * Gets the name of the object.
    * @return class name of processor
    */
-  virtual std::string getName() override {
+  std::string getName() override {
     return "ExpressionObjectFactory";
   }
 
-  virtual std::string getClassName() override {
+  std::string getClassName() override {
     return "ExpressionObjectFactory";
   }
   /**
    * Gets the class name for the object
    * @return class name for the processor.
    */
-  virtual std::vector<std::string> getClassNames() override {
+  std::vector<std::string> getClassNames() override {
     std::vector<std::string> class_names;
     class_names.push_back("ProcessContextBuilder");
     return class_names;
   }
 
-  virtual std::unique_ptr<ObjectFactory> assign(const std::string &class_name) override {
+  std::unique_ptr<ObjectFactory> assign(const std::string &class_name) override {
     if (utils::StringUtils::equalsIgnoreCase(class_name, "ProcessContextBuilder")) {
       return std::unique_ptr<ObjectFactory>(new core::DefautObjectFactory<core::expressions::ExpressionContextBuilder>());
     } else {

--- a/extensions/expression-language/ProcessContextExpr.h
+++ b/extensions/expression-language/ProcessContextExpr.h
@@ -58,9 +58,9 @@ class ProcessContextExpr : public core::ProcessContext {
    * @param value that will be filled
    * @param flow_file flow file.
    */
-  virtual bool getProperty(const Property &property, std::string &value, const std::shared_ptr<FlowFile> &flow_file) override;
+  bool getProperty(const Property &property, std::string &value, const std::shared_ptr<FlowFile> &flow_file) override;
 
-  virtual bool getDynamicProperty(const Property &property, std::string &value, const std::shared_ptr<FlowFile> &flow_file) override;
+  bool getDynamicProperty(const Property &property, std::string &value, const std::shared_ptr<FlowFile> &flow_file) override;
  protected:
 
   std::map<std::string, org::apache::nifi::minifi::expression::Expression> expressions_;

--- a/extensions/gps/GetGPS.h
+++ b/extensions/gps/GetGPS.h
@@ -57,9 +57,9 @@ public:
    */
   void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
   //! OnTrigger method, implemented by NiFi GetGPS
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
   //! Initialize, over write by NiFi GetGPS
-  virtual void initialize(void) override;
+  void initialize(void) override;
 
 protected:
 

--- a/extensions/http-curl/HTTPCurlLoader.h
+++ b/extensions/http-curl/HTTPCurlLoader.h
@@ -54,18 +54,18 @@ class HttpCurlObjectFactory : public core::ObjectFactory {
    * Gets the name of the object.
    * @return class name of processor
    */
-  virtual std::string getName() override{
+  std::string getName() override{
     return "HttpCurlObjectFactory";
   }
 
-  virtual std::string getClassName() override{
+  std::string getClassName() override{
     return "HttpCurlObjectFactory";
   }
   /**
    * Gets the class name for the object
    * @return class name for the processor.
    */
-  virtual std::vector<std::string> getClassNames() override{
+  std::vector<std::string> getClassNames() override{
     std::vector<std::string> class_names;
     class_names.push_back("HttpProtocol");
     class_names.push_back("RESTSender");
@@ -75,7 +75,7 @@ class HttpCurlObjectFactory : public core::ObjectFactory {
     return class_names;
   }
 
-  virtual std::unique_ptr<ObjectFactory> assign(const std::string &class_name) override{
+  std::unique_ptr<ObjectFactory> assign(const std::string &class_name) override{
     if (utils::StringUtils::equalsIgnoreCase(class_name, "RESTSender")) {
       return std::unique_ptr<ObjectFactory>(new core::DefautObjectFactory<minifi::c2::RESTSender>());
     } else if (utils::StringUtils::equalsIgnoreCase(class_name, "InvokeHTTP")) {
@@ -89,7 +89,7 @@ class HttpCurlObjectFactory : public core::ObjectFactory {
     }
   }
 
-  virtual std::unique_ptr<core::ObjectFactoryInitializer> getInitializer() override{
+  std::unique_ptr<core::ObjectFactoryInitializer> getInitializer() override{
     return std::unique_ptr<core::ObjectFactoryInitializer>(new HttpCurlObjectFactoryInitializer());
   }
 

--- a/extensions/http-curl/client/HTTPStream.h
+++ b/extensions/http-curl/client/HTTPStream.h
@@ -46,7 +46,7 @@ class HttpStream : public io::BaseStream {
     forceClose();
   }
 
-  virtual void close() override;
+  void close() override;
 
   const std::shared_ptr<utils::HTTPClient> &getClientRef() {
     return http_client_;

--- a/extensions/http-curl/processors/InvokeHTTP.h
+++ b/extensions/http-curl/processors/InvokeHTTP.h
@@ -95,9 +95,9 @@ class InvokeHTTP : public core::Processor {
   static core::Relationship RelNoRetry;
   static core::Relationship RelFailure;
 
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
-  virtual void initialize() override;
-  virtual void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void initialize() override;
+  void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
   /**
    * Provides a reference to the URL.
    */

--- a/extensions/http-curl/protocols/AgentPrinter.h
+++ b/extensions/http-curl/protocols/AgentPrinter.h
@@ -45,23 +45,23 @@ class AgentPrinter : public RESTProtocol, public HeartBeatReporter {
   /**
    * Initialize agent printer.
    */
-  virtual void initialize(core::controller::ControllerServiceProvider* controller, const std::shared_ptr<state::StateMonitor> &updateSink,
+  void initialize(core::controller::ControllerServiceProvider* controller, const std::shared_ptr<state::StateMonitor> &updateSink,
                           const std::shared_ptr<Configure> &configure) override;
 
   /**
    * Accepts the heartbeat, only extracting AgentInformation.
    */
-  virtual int16_t heartbeat(const C2Payload &heartbeat) override;
+  int16_t heartbeat(const C2Payload &heartbeat) override;
 
   /**
    * Overrides extracting the agent information from the root.
    */
-  virtual std::string serializeJsonRootPayload(const C2Payload& payload) override;
+  std::string serializeJsonRootPayload(const C2Payload& payload) override;
 
   /**
    * Overrides extracting the agent information from the payload.
    */
-  virtual rapidjson::Value serializeJsonPayload(const C2Payload &payload, rapidjson::Document::AllocatorType &alloc) override;
+  rapidjson::Value serializeJsonPayload(const C2Payload &payload, rapidjson::Document::AllocatorType &alloc) override;
 
  protected:
 

--- a/extensions/http-curl/protocols/RESTReceiver.h
+++ b/extensions/http-curl/protocols/RESTReceiver.h
@@ -48,9 +48,9 @@ class RESTReceiver : public RESTProtocol, public HeartBeatReporter {
  public:
   RESTReceiver(std::string name, utils::Identifier uuid = utils::Identifier());
 
-  virtual void initialize(core::controller::ControllerServiceProvider* controller, const std::shared_ptr<state::StateMonitor> &updateSink,
+  void initialize(core::controller::ControllerServiceProvider* controller, const std::shared_ptr<state::StateMonitor> &updateSink,
                           const std::shared_ptr<Configure> &configure) override;
-  virtual int16_t heartbeat(const C2Payload &heartbeat) override;
+  int16_t heartbeat(const C2Payload &heartbeat) override;
 
  protected:
 

--- a/extensions/http-curl/protocols/RESTSender.h
+++ b/extensions/http-curl/protocols/RESTSender.h
@@ -50,13 +50,13 @@ class RESTSender : public RESTProtocol, public C2Protocol {
 
   explicit RESTSender(const std::string &name, const utils::Identifier &uuid = utils::Identifier());
 
-  virtual C2Payload consumePayload(const std::string &url, const C2Payload &payload, Direction direction, bool async) override;
+  C2Payload consumePayload(const std::string &url, const C2Payload &payload, Direction direction, bool async) override;
 
-  virtual C2Payload consumePayload(const C2Payload &payload, Direction direction, bool async) override;
+  C2Payload consumePayload(const C2Payload &payload, Direction direction, bool async) override;
 
-  virtual void update(const std::shared_ptr<Configure> &configure) override;
+  void update(const std::shared_ptr<Configure> &configure) override;
 
-  virtual void initialize(core::controller::ControllerServiceProvider* controller, const std::shared_ptr<Configure> &configure) override;
+  void initialize(core::controller::ControllerServiceProvider* controller, const std::shared_ptr<Configure> &configure) override;
 
  protected:
 

--- a/extensions/http-curl/sitetosite/HTTPProtocol.h
+++ b/extensions/http-curl/sitetosite/HTTPProtocol.h
@@ -94,19 +94,19 @@ class HttpSiteToSiteClient : public sitetosite::SiteToSiteClient {
    * Establish the protocol connection. Not needed for the HTTP connection, so we simply
    * return true.
    */
-  virtual bool establish() override {
+  bool establish() override {
     return true;
   }
 
-  virtual std::shared_ptr<Transaction> createTransaction(TransferDirection direction) override;
+  std::shared_ptr<Transaction> createTransaction(TransferDirection direction) override;
 
   // Transfer flow files for the process session
   // virtual bool transferFlowFiles(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session);
   //! Transfer string for the process session
-  virtual bool transmitPayload(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session, const std::string &payload,
+  bool transmitPayload(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session, const std::string &payload,
                                std::map<std::string, std::string> attributes) override;
   // deleteTransaction
-  virtual void deleteTransaction(const utils::Identifier& transactionID) override;
+  void deleteTransaction(const utils::Identifier& transactionID) override;
 
  protected:
 
@@ -116,14 +116,14 @@ class HttpSiteToSiteClient : public sitetosite::SiteToSiteClient {
    */
   void closeTransaction(const utils::Identifier &transactionID);
 
-  virtual int readResponse(const std::shared_ptr<Transaction> &transaction, RespondCode &code, std::string &message) override;
+  int readResponse(const std::shared_ptr<Transaction> &transaction, RespondCode &code, std::string &message) override;
   // write respond
-  virtual int writeResponse(const std::shared_ptr<Transaction> &transaction, RespondCode code, std::string message) override;
+  int writeResponse(const std::shared_ptr<Transaction> &transaction, RespondCode code, std::string message) override;
 
   /**
    * Bootstrapping is not really required for the HTTP Site To Site so we will set the peer state and return true.
    */
-  virtual bool bootstrap() override {
+  bool bootstrap() override {
     peer_state_ = READY;
     return true;
   }
@@ -153,7 +153,7 @@ class HttpSiteToSiteClient : public sitetosite::SiteToSiteClient {
     return uri;
   }
 
-  virtual void tearDown() override;
+  void tearDown() override;
 
   utils::optional<utils::Identifier> parseTransactionId(const std::string &uri);
 

--- a/extensions/jni/ExecuteJavaControllerService.h
+++ b/extensions/jni/ExecuteJavaControllerService.h
@@ -73,24 +73,24 @@ class ExecuteJavaControllerService : public ConfigurationContext, public std::en
   static core::Property NiFiControllerService;
   // Supported Relationships
 
-  virtual void onEnable() override;
-  virtual void initialize() override;
-  virtual bool supportsDynamicProperties() override {
+  void onEnable() override;
+  void initialize() override;
+  bool supportsDynamicProperties() override {
     return true;
   }
 
-  virtual void yield() override {
+  void yield() override {
   }
 
-  virtual bool isRunning() override {
+  bool isRunning() override {
     return getState() == core::controller::ControllerServiceState::ENABLED;
   }
 
-  virtual bool isWorkAvailable() override {
+  bool isWorkAvailable() override {
     return false;
   }
 
-  virtual void notifyStop() override {
+  void notifyStop() override {
     auto env = java_servicer_->attach();
     auto onEnabledName = java_servicer_->getAnnotation(class_name_, "OnDisabled");
     current_cs_class = java_servicer_->getObjectClass(class_name_, clazzInstance);
@@ -109,7 +109,7 @@ class ExecuteJavaControllerService : public ConfigurationContext, public std::en
       env->DeleteGlobalRef(contextInstance);
   }
 
-  virtual jobject getClassInstance() override {
+  jobject getClassInstance() override {
     return clazzInstance;
   }
 

--- a/extensions/jni/ExecuteJavaProcessor.h
+++ b/extensions/jni/ExecuteJavaProcessor.h
@@ -73,11 +73,11 @@ class ExecuteJavaProcessor : public core::Processor {
   // Supported Relationships
   static core::Relationship Success;
 
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
-  virtual void initialize() override;
-  virtual void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
-  virtual bool supportsDynamicProperties() override {
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void initialize() override;
+  void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
+  bool supportsDynamicProperties() override {
     return true;
   }
 
@@ -203,7 +203,7 @@ class ExecuteJavaProcessor : public core::Processor {
     return methodSignatures;
   }
 
-  virtual void notifyStop() override {
+  void notifyStop() override {
 
     auto localEnv = java_servicer_->attach();
 

--- a/extensions/jni/JVMCreator.h
+++ b/extensions/jni/JVMCreator.h
@@ -62,7 +62,7 @@ class JVMCreator : public minifi::core::CoreComponent {
 
   }
 
-  virtual void configure(const std::shared_ptr<Configure> &configuration) override {
+  void configure(const std::shared_ptr<Configure> &configuration) override {
     std::string pathListings, jvmOptionsStr;
 
     // assuming we have the options set and can access the JVMCreator

--- a/extensions/jni/jvm/JavaControllerService.h
+++ b/extensions/jni/jvm/JavaControllerService.h
@@ -66,7 +66,7 @@ class JavaControllerService : public core::controller::ControllerService, public
   static core::Property NarDeploymentDirectory;
   static core::Property NarDocumentDirectory;
 
-  virtual void initialize() override;
+  void initialize() override;
 
   void yield() override {
   }
@@ -79,7 +79,7 @@ class JavaControllerService : public core::controller::ControllerService, public
     return false;
   }
 
-  virtual void onEnable() override;
+  void onEnable() override;
 
   std::vector<std::string> getPaths() const {
     return classpaths_;
@@ -89,22 +89,22 @@ class JavaControllerService : public core::controller::ControllerService, public
     return loader->getObjectClass(name, jobj);
   }
 
-  virtual JavaClass loadClass(const std::string &class_name_) override {
+  JavaClass loadClass(const std::string &class_name_) override {
     std::string modifiedName = class_name_;
     modifiedName = utils::StringUtils::replaceAll(modifiedName, ".", "/");
     return loader->load_class(modifiedName);
   }
 
-  virtual JNIEnv *attach() override {
+  JNIEnv *attach() override {
     return loader->attach();
   }
-  virtual void detach() override {
+  void detach() override {
       loader->detach();
     }
 
 
 
-  virtual jobject getClassLoader() override {
+  jobject getClassLoader() override {
     return loader->getClassLoader();
   }
 

--- a/extensions/jni/jvm/JniReferenceObjects.h
+++ b/extensions/jni/jvm/JniReferenceObjects.h
@@ -52,7 +52,7 @@ class JniFlowFile : public core::WeakReference {
 
   virtual ~JniFlowFile() = default;
 
-  virtual void remove() override;
+  void remove() override;
 
   std::shared_ptr<core::FlowFile> get() const {
     return ref_;
@@ -182,7 +182,7 @@ class JniInputStream : public core::WeakReference {
 
   }
 
-  virtual void remove() override {
+  void remove() override {
     std::lock_guard<std::mutex> guard(mutex_);
     if (!removed_) {
       servicer_->attach()->DeleteGlobalRef(in_instance_);
@@ -223,7 +223,7 @@ class JniSession : public core::WeakReference {
         session_instance_(session_instance) {
   }
 
-  virtual void remove() override {
+  void remove() override {
     std::lock_guard<std::mutex> guard(session_mutex_);
     if (!removed_) {
       for (auto ff : global_ff_objects_) {
@@ -310,7 +310,7 @@ class JniSessionFactory : public core::WeakReference {
         factory_(factory) {
   }
 
-  virtual void remove() override {
+  void remove() override {
     std::lock_guard<std::mutex> guard(session_mutex_);
     // remove all of the sessions
     // this should spark their destructor

--- a/extensions/mqtt/processors/AbstractMQTTProcessor.h
+++ b/extensions/mqtt/processors/AbstractMQTTProcessor.h
@@ -94,7 +94,7 @@ class AbstractMQTTProcessor : public core::Processor {
    * @param sessionFactory process session factory that is used when creating
    * ProcessSession objects.
    */
-  virtual void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &factory) override;
+  void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &factory) override;
 
   // MQTT async callbacks
   static void msgDelivered(void *context, MQTTClient_deliveryToken dt) {

--- a/extensions/mqtt/processors/ConsumeMQTT.h
+++ b/extensions/mqtt/processors/ConsumeMQTT.h
@@ -100,7 +100,7 @@ class ConsumeMQTT : public processors::AbstractMQTTProcessor {
   void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
   // Initialize, over write by NiFi ConsumeMQTT
   void initialize(void) override;
-  bool enqueueReceiveMQTTMsg(MQTTClient_message *message) override;
+  virtual bool enqueueReceiveMQTTMsg(MQTTClient_message *message);
 
  protected:
   void getReceivedMQTTMsg(std::deque<MQTTClient_message *> &msg_queue) {

--- a/extensions/mqtt/processors/ConsumeMQTT.h
+++ b/extensions/mqtt/processors/ConsumeMQTT.h
@@ -100,7 +100,7 @@ class ConsumeMQTT : public processors::AbstractMQTTProcessor {
   void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
   // Initialize, over write by NiFi ConsumeMQTT
   void initialize(void) override;
-  virtual bool enqueueReceiveMQTTMsg(MQTTClient_message *message);
+  bool enqueueReceiveMQTTMsg(MQTTClient_message *message) override;
 
  protected:
   void getReceivedMQTTMsg(std::deque<MQTTClient_message *> &msg_queue) {

--- a/extensions/mqtt/processors/ConvertBase.h
+++ b/extensions/mqtt/processors/ConvertBase.h
@@ -61,14 +61,14 @@ class ConvertBase : public core::Processor, public minifi::c2::RESTProtocol {
   /**
    * Initialization of the processor
    */
-  virtual void initialize() override;
+  void initialize() override;
   /**
    * Function that's executed when the processor is scheduled.
    * @param context process context.
    * @param sessionFactory process session factory that is used when creating
    * ProcessSession objects.
    */
-  virtual void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
+  void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
  protected:
 
   /**

--- a/extensions/mqtt/processors/ConvertHeartBeat.h
+++ b/extensions/mqtt/processors/ConvertHeartBeat.h
@@ -61,7 +61,7 @@ public:
    * ProcessSession objects.
    */
 
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
 
 private:
   std::shared_ptr<logging::Logger> logger_;

--- a/extensions/mqtt/processors/ConvertJSONAck.h
+++ b/extensions/mqtt/processors/ConvertJSONAck.h
@@ -65,7 +65,7 @@ class ConvertJSONAck : public ConvertBase {
    * ProcessSession objects.
    */
 
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
 
  protected:
 

--- a/extensions/mqtt/processors/ConvertUpdate.h
+++ b/extensions/mqtt/processors/ConvertUpdate.h
@@ -65,7 +65,7 @@ public:
   /**
      * Initialization of the processor
      */
-    virtual void initialize() override;
+    void initialize() override;
   /**
    * Function that's executed when the processor is triggered.
    * @param context process context.
@@ -73,7 +73,7 @@ public:
    * ProcessSession objects.
    */
 
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
 
 protected:
   std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service_;

--- a/extensions/mqtt/protocol/MQTTC2Protocol.h
+++ b/extensions/mqtt/protocol/MQTTC2Protocol.h
@@ -54,17 +54,17 @@ class MQTTC2Protocol : public C2Protocol {
    * @param payload payload to consume.
    * @direction direction of operation.
    */
-  virtual C2Payload consumePayload(const std::string &url, const C2Payload &payload, Direction direction, bool async) override;
+  C2Payload consumePayload(const std::string &url, const C2Payload &payload, Direction direction, bool async) override;
 
-  virtual C2Payload consumePayload(const C2Payload &payload, Direction /*direction*/, bool /*async*/) override {
+  C2Payload consumePayload(const C2Payload &payload, Direction /*direction*/, bool /*async*/) override {
     return serialize(payload);
   }
 
-  virtual void update(const std::shared_ptr<Configure>& /*configure*/) override {
+  void update(const std::shared_ptr<Configure>& /*configure*/) override {
     // no op.
   }
 
-  virtual void initialize(core::controller::ControllerServiceProvider* controller, const std::shared_ptr<Configure> &configure) override;
+  void initialize(core::controller::ControllerServiceProvider* controller, const std::shared_ptr<Configure> &configure) override;
 
  protected:
 

--- a/extensions/opc/include/fetchopc.h
+++ b/extensions/opc/include/fetchopc.h
@@ -64,11 +64,11 @@ public:
     logger_ = logging::LoggerFactory<FetchOPCProcessor>::getLogger();
   }
 
-  virtual void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &factory) override;
+  void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &factory) override;
 
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
 
-  virtual void initialize(void) override;
+  void initialize(void) override;
 
 protected:
   bool nodeFoundCallBack(opc::Client& client, const UA_ReferenceDescription *ref, const std::string& path,

--- a/extensions/opc/include/opcbase.h
+++ b/extensions/opc/include/opcbase.h
@@ -49,7 +49,7 @@ class BaseOPCProcessor : public core::Processor {
   : Processor(name, uuid) {
   }
 
-  virtual void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &factory) override;
+  void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &factory) override;
 
  protected:
   virtual bool reconnect();

--- a/extensions/opc/include/putopc.h
+++ b/extensions/opc/include/putopc.h
@@ -69,11 +69,11 @@ class PutOPCProcessor : public BaseOPCProcessor {
     logger_ = logging::LoggerFactory<PutOPCProcessor>::getLogger();
   }
 
-  virtual void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &factory) override;
+  void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &factory) override;
 
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
 
-  virtual void initialize(void) override;
+  void initialize(void) override;
 
  private:
 

--- a/extensions/opencv/MotionDetector.h
+++ b/extensions/opencv/MotionDetector.h
@@ -54,9 +54,9 @@ class MotionDetector : public core::Processor {
   static core::Relationship Success;
   static core::Relationship Failure;
 
-  virtual void initialize(void) override;
-  virtual void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void initialize(void) override;
+  void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
 
   void notifyStop() override;
 

--- a/extensions/opencv/OpenCVLoader.h
+++ b/extensions/opencv/OpenCVLoader.h
@@ -45,24 +45,24 @@ class OpenCVObjectFactory : public core::ObjectFactory {
    * Gets the name of the object.
    * @return class name of processor
    */
-  virtual std::string getName() override{
+  std::string getName() override{
     return "OpenCVObjectFactory";
   }
 
-  virtual std::string getClassName() override{
+  std::string getClassName() override{
     return "OpenCVObjectFactory";
   }
   /**
    * Gets the class name for the object
    * @return class name for the processor.
    */
-  virtual std::vector<std::string> getClassNames() override{
+  std::vector<std::string> getClassNames() override{
     std::vector<std::string> class_names;
     class_names.push_back("CaptureRTSPFrame");
     return class_names;
   }
 
-  virtual std::unique_ptr<ObjectFactory> assign(const std::string &class_name) override{
+  std::unique_ptr<ObjectFactory> assign(const std::string &class_name) override{
     if (utils::StringUtils::equalsIgnoreCase(class_name, "CaptureRTSPFrame")) {
       return std::unique_ptr<ObjectFactory>(new core::DefautObjectFactory<minifi::processors::CaptureRTSPFrame>());
     } else {

--- a/extensions/pcap/CapturePacket.h
+++ b/extensions/pcap/CapturePacket.h
@@ -115,15 +115,15 @@ class CapturePacket : public core::Processor {
   // Supported Relationships
   static core::Relationship Success;
 
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
-  virtual void initialize() override;
-  virtual void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void initialize() override;
+  void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
 
   static void packet_callback(pcpp::RawPacket* packet, pcpp::PcapLiveDevice* dev, void* data);
 
  protected:
 
-  virtual void notifyStop() override {
+  void notifyStop() override {
     logger_->log_debug("Stopping capture");
     for (auto dev : device_list_) {
       dev->stopCapture();

--- a/extensions/script/python/PyProcCreator.h
+++ b/extensions/script/python/PyProcCreator.h
@@ -34,7 +34,7 @@ class PythonObjectFactory : public core::DefautObjectFactory<minifi::python::pro
   /**
    * Create a shared pointer to a new processor.
    */
-  virtual std::shared_ptr<core::CoreComponent> create(const std::string &name) override {
+  std::shared_ptr<core::CoreComponent> create(const std::string &name) override {
     auto ptr = std::static_pointer_cast<minifi::python::processors::ExecutePythonProcessor>(DefautObjectFactory::create(name));
     ptr->initialize();
     ptr->setProperty(minifi::python::processors::ExecutePythonProcessor::ScriptFile, file_);
@@ -44,7 +44,7 @@ class PythonObjectFactory : public core::DefautObjectFactory<minifi::python::pro
   /**
    * Create a shared pointer to a new processor.
    */
-  virtual std::shared_ptr<core::CoreComponent> create(const std::string &name, const utils::Identifier & uuid) override {
+  std::shared_ptr<core::CoreComponent> create(const std::string &name, const utils::Identifier & uuid) override {
     auto ptr = std::static_pointer_cast<minifi::python::processors::ExecutePythonProcessor>(DefautObjectFactory::create(name, uuid));
     ptr->initialize();
     ptr->setProperty(minifi::python::processors::ExecutePythonProcessor::ScriptFile, file_);
@@ -54,7 +54,7 @@ class PythonObjectFactory : public core::DefautObjectFactory<minifi::python::pro
   /**
    * Create a shared pointer to a new processor.
    */
-  virtual core::CoreComponent* createRaw(const std::string &name) override {
+  core::CoreComponent* createRaw(const std::string &name) override {
     auto ptr = dynamic_cast<minifi::python::processors::ExecutePythonProcessor*>(DefautObjectFactory::createRaw(name));
     ptr->initialize();
     ptr->setProperty(minifi::python::processors::ExecutePythonProcessor::ScriptFile, file_);
@@ -64,7 +64,7 @@ class PythonObjectFactory : public core::DefautObjectFactory<minifi::python::pro
   /**
    * Create a shared pointer to a new processor.
    */
-  virtual core::CoreComponent* createRaw(const std::string &name, const utils::Identifier &uuid) override {
+  core::CoreComponent* createRaw(const std::string &name, const utils::Identifier &uuid) override {
     auto ptr = dynamic_cast<minifi::python::processors::ExecutePythonProcessor*>(DefautObjectFactory::createRaw(name, uuid));
     ptr->initialize();
     ptr->setProperty(minifi::python::processors::ExecutePythonProcessor::ScriptFile, file_);

--- a/extensions/script/python/PythonCreator.h
+++ b/extensions/script/python/PythonCreator.h
@@ -63,7 +63,7 @@ class PythonCreator : public minifi::core::CoreComponent {
 
   }
 
-  virtual void configure(const std::shared_ptr<Configure> &configuration) override {
+  void configure(const std::shared_ptr<Configure> &configuration) override {
 
     python::PythonScriptEngine::initialize();
 

--- a/extensions/sensors/GetEnvironmentalSensors.h
+++ b/extensions/sensors/GetEnvironmentalSensors.h
@@ -62,9 +62,9 @@ class GetEnvironmentalSensors : public SensorBase {
   static core::Relationship Success;
   // Supported Properties
 
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
-  virtual void initialize() override;
-  virtual void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void initialize() override;
+  void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
 
  protected:
   virtual void notifyStop();

--- a/extensions/sensors/GetMovementSensors.h
+++ b/extensions/sensors/GetMovementSensors.h
@@ -60,8 +60,8 @@ class GetMovementSensors : public SensorBase {
   static core::Relationship Success;
   // Supported Properties
 
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
-  virtual void initialize() override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void initialize() override;
 
  private:
   std::shared_ptr<logging::Logger> logger_;

--- a/extensions/sensors/SensorBase.h
+++ b/extensions/sensors/SensorBase.h
@@ -59,9 +59,9 @@ class SensorBase : public core::Processor {
   static core::Relationship Success;
   // Supported Properties
 
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
-  virtual void initialize() override;
-  virtual void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void initialize() override;
+  void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
 
   class WriteCallback : public OutputStreamCallback {
      public:

--- a/extensions/sftp/processors/FetchSFTP.h
+++ b/extensions/sftp/processors/FetchSFTP.h
@@ -73,16 +73,16 @@ class FetchSFTP : public SFTPProcessorBase {
   static constexpr char const* ATTRIBUTE_SFTP_REMOTE_PORT = "sftp.remote.port";
   static constexpr char const* ATTRIBUTE_SFTP_REMOTE_FILENAME = "sftp.remote.filename";
 
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
-  virtual void initialize() override;
-  virtual void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void initialize() override;
+  void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
 
   class WriteCallback : public OutputStreamCallback {
    public:
     WriteCallback(const std::string& remote_file,
                  utils::SFTPClient& client);
     ~WriteCallback();
-    virtual int64_t process(const std::shared_ptr<io::BaseStream>& stream) override;
+    int64_t process(const std::shared_ptr<io::BaseStream>& stream) override;
 
    private:
     std::shared_ptr<logging::Logger> logger_;

--- a/extensions/sftp/processors/ListSFTP.h
+++ b/extensions/sftp/processors/ListSFTP.h
@@ -98,9 +98,9 @@ class ListSFTP : public SFTPProcessorBase {
 
   static const std::map<std::string, uint64_t> LISTING_LAG_MAP;
 
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
-  virtual void initialize() override;
-  virtual void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void initialize() override;
+  void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
 
  private:
 

--- a/extensions/sftp/processors/PutSFTP.h
+++ b/extensions/sftp/processors/PutSFTP.h
@@ -84,13 +84,13 @@ namespace processors {
   static core::Relationship Reject;
   static core::Relationship Failure;
 
-  virtual bool supportsDynamicProperties() override {
+  bool supportsDynamicProperties() override {
     return true;
   }
 
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
-  virtual void initialize() override;
-  virtual void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void initialize() override;
+  void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
 
   class ReadCallback : public InputStreamCallback {
    public:
@@ -98,7 +98,7 @@ namespace processors {
         utils::SFTPClient& client,
         const std::string& conflict_resolution);
     ~ReadCallback();
-    virtual int64_t process(const std::shared_ptr<io::BaseStream>& stream) override;
+    int64_t process(const std::shared_ptr<io::BaseStream>& stream) override;
 
    private:
     std::shared_ptr<logging::Logger> logger_;

--- a/extensions/sftp/processors/SFTPProcessorBase.h
+++ b/extensions/sftp/processors/SFTPProcessorBase.h
@@ -72,7 +72,7 @@ class SFTPProcessorBase : public core::Processor {
   static constexpr char const *PROXY_TYPE_HTTP = "HTTP";
   static constexpr char const *PROXY_TYPE_SOCKS = "SOCKS";
 
-  virtual void notifyStop() override;
+  void notifyStop() override;
 
  protected:
   std::shared_ptr<logging::Logger> logger_;

--- a/extensions/sql/services/DatabaseService.h
+++ b/extensions/sql/services/DatabaseService.h
@@ -60,7 +60,7 @@ class DatabaseService : public core::controller::ControllerService {
    */
   static core::Property ConnectionString;
 
-  virtual void initialize() override;
+  void initialize() override;
 
   void yield() override {
 
@@ -74,7 +74,7 @@ class DatabaseService : public core::controller::ControllerService {
     return false;
   }
 
-  virtual void onEnable() override;
+  void onEnable() override;
 
   virtual std::unique_ptr<sql::Connection> getConnection() const = 0;
 

--- a/extensions/sql/services/ODBCConnector.h
+++ b/extensions/sql/services/ODBCConnector.h
@@ -104,7 +104,7 @@ class ODBCService : public DatabaseService {
     initialize();
   }
 
-  virtual std::unique_ptr<sql::Connection> getConnection() const override;
+  std::unique_ptr<sql::Connection> getConnection() const override;
 
  private:
   std::shared_ptr<logging::Logger> logger_;

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.h
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.h
@@ -95,9 +95,9 @@ public:
   */
   void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
   //! OnTrigger method, implemented by NiFi ConsumeWindowsEventLog
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
   //! Initialize, overwrite by NiFi ConsumeWindowsEventLog
-  virtual void initialize(void) override;
+  void initialize(void) override;
   void notifyStop() override;
 
 protected:

--- a/extensions/windows-event-log/TailEventLog.h
+++ b/extensions/windows-event-log/TailEventLog.h
@@ -59,13 +59,13 @@ public:
    */
   void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
   // OnTrigger method, implemented by NiFi TailEventLog
-  virtual void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
+  void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
   // Initialize, over write by NiFi TailEventLog
-  virtual void initialize(void) override;
+  void initialize(void) override;
 
 protected:
 
-  virtual void notifyStop() override{
+  void notifyStop() override{
     CloseEventLog(log_handle_);
   }
 

--- a/extensions/windows-event-log/wel/MetadataWalker.h
+++ b/extensions/windows-event-log/wel/MetadataWalker.h
@@ -60,7 +60,7 @@ class MetadataWalker : public pugi::xml_tree_walker {
    * Overloaded function to visit a node
    * @param node Node that we are visiting.
    */
-  virtual bool for_each(pugi::xml_node &node) override;
+  bool for_each(pugi::xml_node &node) override;
 
   static std::string updateXmlMetadata(const std::string &xml, EVT_HANDLE metadata_ptr, EVT_HANDLE event_ptr, bool update_xml, bool resolve, const std::string &regex = "");
   


### PR DESCRIPTION
Automatic replacement on linter reported errors following this patterns:
> "virtual" is redundant since function is already declared as "override"  [readability/inheritance] [4]

Script used:
```bash
cat linter_errors.log | grep '"virtual" is redundant' | tr ":" " " | cut -d" " -f1,2 | sort -rn -k1 -k2 | less | xargs -n 2 sh -c 'sed -i "$2s/virtual //g" $1' sh
```

Manual edits (as separate commit) in:
> extensions/mqtt/processors/ConsumeMQTT.h
> extensions/sql/services/DatabaseService.h
