### PR TITLE
MINIFICPP-1515 - Add integration tests testing different flowfile sizes in a simple flow

### DIFF
--- a/docker/test/integration/MiNiFi_integration_test_driver.py
+++ b/docker/test/integration/MiNiFi_integration_test_driver.py
@@ -22,6 +22,7 @@ from minifi.core.utils import decode_escaped_str
 
 from minifi.validators.SingleFileContentHashValidator import SingleFileContentHashValidator
 
+
 class MiNiFi_integration_test():
     def __init__(self, image_store):
         self.test_id = str(uuid.uuid4())

--- a/docker/test/integration/MiNiFi_integration_test_driver.py
+++ b/docker/test/integration/MiNiFi_integration_test_driver.py
@@ -163,10 +163,10 @@ class MiNiFi_integration_test():
         output_validator.set_output_dir(self.file_system_observer.get_output_dir())
         self.check_output(timeout_seconds, output_validator, 1)
 
-    def check_for_file_with_matching_hash_content_generated(self, timeout_seconds, subdir=''):
+    def check_for_file_with_matching_hash_content_generated(self, timeout_seconds):
         output_validator = SingleFileContentHashValidator(self.saved_md5_hash)
         output_validator.set_output_dir(self.file_system_observer.get_output_dir())
-        self.check_output(timeout_seconds, output_validator, 1, subdir)
+        self.check_output(timeout_seconds, output_validator, 1)
 
     def check_output_force_wait(self, timeout_seconds, output_validator):
         time.sleep(timeout_seconds)

--- a/docker/test/integration/MiNiFi_integration_test_driver.py
+++ b/docker/test/integration/MiNiFi_integration_test_driver.py
@@ -20,6 +20,7 @@ from minifi.validators.SingleJSONFileOutputValidator import SingleJSONFileOutput
 
 from minifi.core.utils import decode_escaped_str
 
+from minifi.validators.SingleFileContentHashValidator import SingleFileContentHashValidator
 
 class MiNiFi_integration_test():
     def __init__(self, image_store):
@@ -109,6 +110,10 @@ class MiNiFi_integration_test():
         test_data = decode_escaped_str(test_data)
         self.docker_directory_bindings.put_file_to_docker_path(self.test_id, path, file_name, test_data.encode('utf-8'))
 
+    def add_large_test_file_save_hash(self, path, data_size):
+        file_name = str(uuid.uuid4())
+        self.saved_md5_hash = self.docker_directory_bindings.generate_file_to_docker_path_and_calc_md5_checksum(self.test_id, path, file_name, data_size)
+
     def put_test_resource(self, file_name, contents):
         self.docker_directory_bindings.put_test_resource(self.test_id, file_name, contents)
 
@@ -157,6 +162,11 @@ class MiNiFi_integration_test():
         output_validator = EmptyFilesOutPutValidator()
         output_validator.set_output_dir(self.file_system_observer.get_output_dir())
         self.check_output(timeout_seconds, output_validator, 1)
+
+    def check_for_file_with_matching_hash_content_generated(self, timeout_seconds, subdir=''):
+        output_validator = SingleFileContentHashValidator(self.saved_md5_hash)
+        output_validator.set_output_dir(self.file_system_observer.get_output_dir())
+        self.check_output(timeout_seconds, output_validator, 1, subdir)
 
     def check_output_force_wait(self, timeout_seconds, output_validator):
         time.sleep(timeout_seconds)

--- a/docker/test/integration/features/file_system_operations.feature
+++ b/docker/test/integration/features/file_system_operations.feature
@@ -38,3 +38,19 @@ Feature: File system operations are handled by the GetFile and PutFile processor
     And a file with the content "test" is present in "/tmp/input"
     When the MiNiFi instance starts up
     Then a flowfile with the content "test" is placed in the monitored directory in less than 10 seconds
+
+  Scenario Outline: MiNiFi is capable of manipulating flowfiles of different sizes
+    Given a GetFile processor with the "Input Directory" property set to "/tmp/input"
+    And a file with <file size> of content is present in "/tmp/input"
+    And a PutFile processor with the "Directory" property set to "/tmp/output"
+    And the "success" relationship of the GetFile processor is connected to the PutFile
+    When the MiNiFi instance starts up
+    Then a flowfile with matching content is placed in the monitored directory in less than 20 seconds
+
+  Examples: File size
+    | file size |
+    | 10 B      |
+    | 1.5 KiB   |
+    | 10 MiB    |
+    | 1.0 GiB   |
+    | 2.1 GiB   |

--- a/docker/test/integration/features/file_system_operations.feature
+++ b/docker/test/integration/features/file_system_operations.feature
@@ -45,7 +45,7 @@ Feature: File system operations are handled by the GetFile and PutFile processor
     And a PutFile processor with the "Directory" property set to "/tmp/output"
     And the "success" relationship of the GetFile processor is connected to the PutFile
     When the MiNiFi instance starts up
-    Then a flowfile with matching content is placed in the monitored directory in less than 20 seconds
+    Then a flowfile with matching content is placed in the monitored directory in less than 60 seconds
 
   Examples: File size
     | file size |

--- a/docker/test/integration/minifi/core/DockerTestDirectoryBindings.py
+++ b/docker/test/integration/minifi/core/DockerTestDirectoryBindings.py
@@ -4,6 +4,7 @@ import shutil
 
 from .HashUtils import md5
 
+
 class DockerTestDirectoryBindings:
     def __init__(self):
         self.data_directories = {}
@@ -118,6 +119,7 @@ class DockerTestDirectoryBindings:
                 else:
                     file.write(os.urandom(bytes_to_write))
                     bytes_to_write = 0
+        os.chmod(file_abs_path, 0o0777)
         return md5(file_abs_path)
 
     def get_out_subdir(self, test_id, dir):

--- a/docker/test/integration/minifi/core/FileSystemObserver.py
+++ b/docker/test/integration/minifi/core/FileSystemObserver.py
@@ -1,9 +1,8 @@
 import logging
 import time
+
 from threading import Event
-
 from watchdog.observers import Observer
-
 from .OutputEventHandler import OutputEventHandler
 
 

--- a/docker/test/integration/minifi/core/HashUtils.py
+++ b/docker/test/integration/minifi/core/HashUtils.py
@@ -1,0 +1,8 @@
+import hashlib
+
+def md5(fname):
+    hash_md5 = hashlib.md5()
+    with open(fname, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_md5.update(chunk)
+    return hash_md5.hexdigest()

--- a/docker/test/integration/minifi/core/HashUtils.py
+++ b/docker/test/integration/minifi/core/HashUtils.py
@@ -1,5 +1,6 @@
 import hashlib
 
+
 def md5(fname):
     hash_md5 = hashlib.md5()
     with open(fname, "rb") as f:

--- a/docker/test/integration/minifi/core/OutputEventHandler.py
+++ b/docker/test/integration/minifi/core/OutputEventHandler.py
@@ -18,8 +18,6 @@ class OutputEventHandler(FileSystemEventHandler):
     def on_created(self, event):
         if os.path.isfile(event.src_path):
             logging.info("Output file created: " + event.src_path)
-            with open(os.path.abspath(event.src_path), "r") as out_file:
-                logging.info("Contents: %s", out_file.read())
             with self.files_created_lock:
                 self.files_created += 1
         self.done_event.set()
@@ -27,8 +25,6 @@ class OutputEventHandler(FileSystemEventHandler):
     def on_modified(self, event):
         if os.path.isfile(event.src_path):
             logging.info("Output file modified: " + event.src_path)
-            with open(os.path.abspath(event.src_path), "r") as out_file:
-                logging.info("Contents: %s", out_file.read())
 
     def on_deleted(self, event):
         logging.info("Output file deleted: " + event.src_path)

--- a/docker/test/integration/minifi/validators/SingleFileContentHashValidator.py
+++ b/docker/test/integration/minifi/validators/SingleFileContentHashValidator.py
@@ -27,17 +27,16 @@ class SingleFileContentHashValidator(FileOutputValidator):
 
         listing = listdir(full_dir)
         if listing:
-            for l in listing:
-                logging.info("name:: %s", l)
-            out_file_name = listing[0]
-            logging.info("dir %s -- name %s", full_dir, out_file_name)
-            full_path = join(full_dir, out_file_name)
-            if not os.path.isfile(full_path):
-                return self.valid
-            
-            actual_md5_hash = md5(full_path)
-            logging.info("expected hash: %s -- actual: %s", self.expected_md5_hash, actual_md5_hash)
-            if self.expected_md5_hash == actual_md5_hash:
-                self.valid = True
-
+            all_matches = True
+            for out_file_name in listing:
+                logging.info("dir %s -- name %s", full_dir, out_file_name)
+                full_path = join(full_dir, out_file_name)
+                if not os.path.isfile(full_path):
+                    all_matches = False
+                    break
+                actual_md5_hash = md5(full_path)
+                logging.info("expected hash: %s -- actual: %s", self.expected_md5_hash, actual_md5_hash)
+                if self.expected_md5_hash != actual_md5_hash:
+                    all_matches = False
+            self.valid = all_matches
         return self.valid

--- a/docker/test/integration/minifi/validators/SingleFileContentHashValidator.py
+++ b/docker/test/integration/minifi/validators/SingleFileContentHashValidator.py
@@ -1,0 +1,43 @@
+import logging
+import os
+
+from os import listdir
+from os.path import join
+
+from .FileOutputValidator import FileOutputValidator
+from ..core.HashUtils import md5
+
+class SingleFileContentHashValidator(FileOutputValidator):
+    """
+    Validates the content of a single file in the given directory.
+    """
+
+    def __init__(self, expected_md5_hash, subdir=''):
+        self.valid = False
+        self.expected_md5_hash = expected_md5_hash
+        self.subdir = subdir
+
+    def validate(self):
+        self.valid = False
+        full_dir = os.path.join(self.output_dir, self.subdir)
+        logging.info("Output folder: %s", full_dir)
+
+        if not os.path.isdir(full_dir):
+            return self.valid
+
+        listing = listdir(full_dir)
+        if listing:
+            for l in listing:
+                logging.info("name:: %s", l)
+            out_file_name = listing[0]
+            logging.info("dir %s -- name %s", full_dir, out_file_name)
+            full_path = join(full_dir, out_file_name)
+            if not os.path.isfile(full_path):
+                return self.valid
+            
+            actual_md5_hash = md5(full_path)
+            logging.info("expected hash: %s -- actual: %s", self.expected_md5_hash, actual_md5_hash)
+            if self.expected_md5_hash == actual_md5_hash:
+                self.valid = True
+
+        return self.valid

--- a/docker/test/integration/minifi/validators/SingleFileContentHashValidator.py
+++ b/docker/test/integration/minifi/validators/SingleFileContentHashValidator.py
@@ -1,42 +1,36 @@
 import logging
 import os
 
-from os import listdir
-from os.path import join
-
 from .FileOutputValidator import FileOutputValidator
 from ..core.HashUtils import md5
+
 
 class SingleFileContentHashValidator(FileOutputValidator):
     """
     Validates the content of a single file in the given directory.
     """
-
-    def __init__(self, expected_md5_hash, subdir=''):
-        self.valid = False
+    def __init__(self, expected_md5_hash):
         self.expected_md5_hash = expected_md5_hash
-        self.subdir = subdir
+
+    def file_matches_expected_hash(self, dir_path):
+        listing = os.listdir(dir_path)
+        if not listing:
+            return 0
+        for file_name in listing:
+            full_path = os.path.join(dir_path, file_name)
+            if not os.path.isfile(full_path):
+                continue
+
+            actual_md5_hash = md5(full_path)
+            logging.info("expected hash: %s -- actual: %s", self.expected_md5_hash, actual_md5_hash)
+            if self.expected_md5_hash == actual_md5_hash:
+                return True
+        return False
 
     def validate(self):
-        self.valid = False
-        full_dir = os.path.join(self.output_dir, self.subdir)
-        logging.info("Output folder: %s", full_dir)
+        logging.info("Output folder: %s", self.output_dir)
 
-        if not os.path.isdir(full_dir):
-            return self.valid
+        if not os.path.isdir(self.output_dir):
+            return False
 
-        listing = listdir(full_dir)
-        if listing:
-            all_matches = True
-            for out_file_name in listing:
-                logging.info("dir %s -- name %s", full_dir, out_file_name)
-                full_path = join(full_dir, out_file_name)
-                if not os.path.isfile(full_path):
-                    all_matches = False
-                    break
-                actual_md5_hash = md5(full_path)
-                logging.info("expected hash: %s -- actual: %s", self.expected_md5_hash, actual_md5_hash)
-                if self.expected_md5_hash != actual_md5_hash:
-                    all_matches = False
-            self.valid = all_matches
-        return self.valid
+        return self.get_num_files(self.output_dir) == 1 and self.file_matches_expected_hash(self.output_dir)

--- a/docker/test/integration/steps/steps.py
+++ b/docker/test/integration/steps/steps.py
@@ -210,6 +210,11 @@ def step_impl(context):
 def step_impl(context, content, path):
     context.test.add_test_data(path, content)
 
+@given("a file with {size} of content is present in \"{path}\"")
+def step_impl(context, size, path):
+    context.test.add_large_test_file_save_hash(path, size)
+
+# NiFi setups
 
 @given("an empty file is present in \"{path}\"")
 def step_impl(context, path):
@@ -503,12 +508,14 @@ def step_impl(context, duration, contents):
 def step_impl(context, lower_bound, upper_bound, duration):
     context.test.check_for_num_file_range_generated(lower_bound, upper_bound, timeparse(duration))
 
-
 @then("{number_of_files:d} flowfiles are placed in the monitored directory in {duration}")
 @then("{number_of_files:d} flowfile is placed in the monitored directory in {duration}")
 def step_impl(context, number_of_files, duration):
     context.test.check_for_multiple_files_generated(number_of_files, timeparse(duration))
 
+@then("a flowfile with matching content is placed in the monitored directory in less than {duration}")
+def step_impl(context, duration):
+    context.test.check_for_file_with_matching_hash_content_generated(timeparse(duration))
 
 @then("at least one empty flowfile is placed in the monitored directory in less than {duration}")
 def step_impl(context, duration):

--- a/docker/test/integration/steps/steps.py
+++ b/docker/test/integration/steps/steps.py
@@ -210,12 +210,13 @@ def step_impl(context):
 def step_impl(context, content, path):
     context.test.add_test_data(path, content)
 
+
 @given("a file with {size} of content is present in \"{path}\"")
 def step_impl(context, size, path):
     context.test.add_large_test_file_save_hash(path, size)
 
-# NiFi setups
 
+# NiFi setups
 @given("an empty file is present in \"{path}\"")
 def step_impl(context, path):
     context.test.add_test_data(path, "")
@@ -508,14 +509,17 @@ def step_impl(context, duration, contents):
 def step_impl(context, lower_bound, upper_bound, duration):
     context.test.check_for_num_file_range_generated(lower_bound, upper_bound, timeparse(duration))
 
+
 @then("{number_of_files:d} flowfiles are placed in the monitored directory in {duration}")
 @then("{number_of_files:d} flowfile is placed in the monitored directory in {duration}")
 def step_impl(context, number_of_files, duration):
     context.test.check_for_multiple_files_generated(number_of_files, timeparse(duration))
 
+
 @then("a flowfile with matching content is placed in the monitored directory in less than {duration}")
 def step_impl(context, duration):
     context.test.check_for_file_with_matching_hash_content_generated(timeparse(duration))
+
 
 @then("at least one empty flowfile is placed in the monitored directory in less than {duration}")
 def step_impl(context, duration):


### PR DESCRIPTION
Issues with big flowfiles were reported on [stack overflow](https://stackoverflow.com/questions/66330866/minifi-getfile-processor-fails-to-get-large-files/66334615?noredirect=1#comment117275399_66334615).

Seems like this is related to twi issues, one a narrowing exception happens when trying to determine the length of the file to be written into the content repository, and another is that we use `_stat` on windows even though we should be using `_stat64` to query files larger than 2GB.

In order to avoid these issues to reappear, we should add some integration test coverage.

This PR will be in draft status until the mentioned issues are fixed. Also, currently integration test logs are bloated for scenario outline based testing, this is to be fixed as [part of this task](https://issues.apache.org/jira/browse/MINIFICPP-1515).