### PR TITLE
MINIFICPP-1513 - Increase timeouts for behave tests involving http proxies, clean up logging

### DIFF
--- a/docker/DockerVerify.sh
+++ b/docker/DockerVerify.sh
@@ -72,7 +72,7 @@ export PATH
 PYTHONPATH="${PYTHONPATH}:${docker_dir}/test/integration"
 export PYTHONPATH
 
-BEHAVE_OPTS="-f pretty --logging-level INFO --no-capture"
+BEHAVE_OPTS="-f pretty --logging-level INFO --logging-clear-handlers"
 
 cd "${docker_dir}/test/integration"
 exec 

--- a/docker/test/integration/MiNiFi_integration_test_driver.py
+++ b/docker/test/integration/MiNiFi_integration_test_driver.py
@@ -22,7 +22,6 @@ from minifi.validators.SingleFileOutputValidator import SingleFileOutputValidato
 
 class MiNiFi_integration_test():
     def __init__(self, context):
-        logging.info("MiNiFi_integration_test init")
         self.test_id = str(uuid.uuid4())
         self.clusters = {}
 

--- a/docker/test/integration/environment.py
+++ b/docker/test/integration/environment.py
@@ -11,7 +11,6 @@ def raise_exception(exception):
 
 @fixture
 def test_driver_fixture(context):
-    logging.info("Integration test setup")
     context.test = MiNiFi_integration_test(context)
     yield context.test
     logging.info("Integration test teardown...")

--- a/docker/test/integration/features/http.feature
+++ b/docker/test/integration/features/http.feature
@@ -40,7 +40,7 @@ Feature: Sending data using InvokeHTTP to a receiver using ListenHTTP
     And the "success" relationship of the ListenHTTP processor is connected to the PutFile
 
     When all instances start up
-    Then a flowfile with the content "test" is placed in the monitored directory in less than 60 seconds
+    Then a flowfile with the content "test" is placed in the monitored directory in less than 120 seconds
     And no errors were generated on the "http-proxy" regarding "http://minifi-listen:8080/contentListener"
 
   Scenario: A MiNiFi instance and transfers hashed data to another MiNiFi instance

--- a/docker/test/integration/features/s3.feature
+++ b/docker/test/integration/features/s3.feature
@@ -40,7 +40,7 @@ Feature: Sending data from MiNiFi-C++ to an AWS server
     And the http proxy server "http-proxy" is set up 
     When all instances start up
 
-    Then a flowfile with the content "test" is placed in the monitored directory in less than 90 seconds
+    Then a flowfile with the content "test" is placed in the monitored directory in less than 150 seconds
     And the object on the "s3" s3 server is "LH_O#L|FD<FASD{FO#@$#$%^ \"#\"$L%:\"@#$L\":test_data#$#%#$%?{\"F{"
     And the object content type on the "s3" s3 server is "application/octet-stream" and the object metadata matches use metadata
     And no errors were generated on the "http-proxy" regarding "http://s3-server:9090/test_bucket/test_object_key"
@@ -102,7 +102,7 @@ Feature: Sending data from MiNiFi-C++ to an AWS server
 
     When all instances start up
 
-    Then a flowfile with the content "test" is placed in the monitored directory in less than 120 seconds
+    Then a flowfile with the content "test" is placed in the monitored directory in less than 150 seconds
     And the object bucket on the "s3" s3 server is empty
     And no errors were generated on the "http-proxy" regarding "http://s3-server:9090/test_bucket/test_object_key"
 
@@ -151,5 +151,5 @@ Feature: Sending data from MiNiFi-C++ to an AWS server
 
     When all instances start up
 
-    Then a flowfile with the content "test" is placed in the monitored directory in less than 120 seconds
+    Then a flowfile with the content "test" is placed in the monitored directory in less than 150 seconds
     And no errors were generated on the "http-proxy" regarding "http://s3-server:9090/test_bucket/test_object_key"

--- a/docker/test/integration/minifi/core/DockerTestDirectoryBindings.py
+++ b/docker/test/integration/minifi/core/DockerTestDirectoryBindings.py
@@ -55,7 +55,6 @@ class DockerTestDirectoryBindings:
 
     @staticmethod
     def create_directory(dir):
-        logging.info("Creating tmp dir: %s", dir)
         os.makedirs(dir)
         os.chmod(dir, 0o777)
 


### PR DESCRIPTION
Currently python based the integration tests instantiate separate loggers. This makes it difficult to capture logging when multiple test are run with the integration tests (eg. single Scenario Outline with multiple examples).

Also, tests involving http proxies seem to occasionally time out/fail on Github Actions. The timeout issue is mitigated by increasing the execution time limit. The failure is related to improperly recognized `stdout` encoding (see example below, this is not linked to using behave). In case of encoding is not recognized `utf8` will used as fallback value.

![image](https://user-images.githubusercontent.com/64011968/109475230-bc122480-7a75-11eb-900f-d51dba9bf64b.png)