### PR TITLE
MINIFICPP-1487 Add exponential backoff on failed flow files

### DIFF
--- a/C2.md
+++ b/C2.md
@@ -227,7 +227,7 @@ will forward responses and updates to the heartbeating agents.
 	  max concurrent tasks: 1
 	  scheduling strategy: TIMER_DRIVEN
 	  scheduling period: 10 msec
-	  penalization period: 30 sec
+	  penalization period: 5 sec
 	  yield period: 2 sec
 	  run duration nanos: 10 msec
 	  auto-terminated relationships list:
@@ -240,7 +240,7 @@ will forward responses and updates to the heartbeating agents.
 	  max concurrent tasks: 1
 	  scheduling strategy: TIMER_DRIVEN
 	  scheduling period: 10 msec
-	  penalization period: 30 sec
+	  penalization period: 5 sec
 	  yield period: 1 sec
 	  run duration nanos: 10 msec
 	  auto-terminated relationships list:
@@ -253,7 +253,7 @@ will forward responses and updates to the heartbeating agents.
 	  max concurrent tasks: 1
 	  scheduling strategy: TIMER_DRIVEN
 	  scheduling period: 10 msec
-	  penalization period: 30 sec
+	  penalization period: 5 sec
 	  yield period: 1 sec
 	  run duration nanos: 10 msec
 	  auto-terminated relationships list:
@@ -267,7 +267,7 @@ will forward responses and updates to the heartbeating agents.
 	  max concurrent tasks: 1
 	  scheduling strategy: TIMER_DRIVEN
 	  scheduling period: 10 msec
-	  penalization period: 30 sec
+	  penalization period: 5 sec
 	  yield period: 1 sec
 	  run duration nanos: 10 msec
 	  auto-terminated relationships list:
@@ -281,7 +281,7 @@ will forward responses and updates to the heartbeating agents.
 	  max concurrent tasks: 1
 	  scheduling strategy: TIMER_DRIVEN
 	  scheduling period: 100 msec
-	  penalization period: 30 sec
+	  penalization period: 5 sec
 	  yield period: 1 sec
 	  run duration nanos: 1 msec
 	  auto-terminated relationships list:

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -38,7 +38,7 @@ It's recommended to create your configuration in YAML format or configure the ag
           max concurrent tasks: 1
           scheduling strategy: TIMER_DRIVEN
           scheduling period: 1 sec
-          penalization period: 30 sec
+          penalization period: 5 sec
           yield period: 1 sec
           run duration nanos: 0
           auto-terminated relationships list:

--- a/examples/BidirectionalSiteToSite/README.md
+++ b/examples/BidirectionalSiteToSite/README.md
@@ -57,7 +57,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:

--- a/extensions/standard-processors/tests/unit/ManifestTests.cpp
+++ b/extensions/standard-processors/tests/unit/ManifestTests.cpp
@@ -169,7 +169,7 @@ TEST_CASE("Test Scheduling Defaults", "[schedDef]") {
     } else if ("defaultSchedulingStrategy" == child.name) {
       REQUIRE("TIMER_DRIVEN" == child.value.to_string());
     } else if ("penalizationPeriodMillis" == child.name) {
-      REQUIRE("30000" == child.value.to_string());
+      REQUIRE("5000" == child.value.to_string());
     } else if ("yieldDurationMillis" == child.name) {
       REQUIRE("1000" == child.value.to_string());
     } else {

--- a/extensions/standard-processors/tests/unit/ProcessorTests.cpp
+++ b/extensions/standard-processors/tests/unit/ProcessorTests.cpp
@@ -615,65 +615,131 @@ TEST_CASE("TestRPGValid", "[TestRPG6]") {
   testRPGBypass("", "8080", "8080", false);
 }
 
-TEST_CASE("A Processor detects correctly if it has incoming flow files it can process", "[isWorkAvailable]") {
+namespace {
+
+class ProcessorWithIncomingConnectionTest {
+ public:
+  ProcessorWithIncomingConnectionTest();
+  ~ProcessorWithIncomingConnectionTest();
+
+ protected:
+  std::shared_ptr<core::Processor> processor_;
+  std::shared_ptr<minifi::Connection> incoming_connection_;
+  std::shared_ptr<core::ProcessSession> session_;
+};
+
+ProcessorWithIncomingConnectionTest::ProcessorWithIncomingConnectionTest() {
   LogTestController::getInstance().setDebug<core::Processor>();
 
   const auto repo = std::make_shared<TestRepository>();
   const auto content_repo = std::make_shared<core::repository::VolatileContentRepository>();
   content_repo->initialize(std::make_shared<minifi::Configure>());
 
-  const std::shared_ptr<core::Processor> processor = std::make_shared<processors::LogAttribute>("test_processor");
-  const auto incoming_connection = std::make_shared<minifi::Connection>(repo, content_repo, "incoming_connection");
-  incoming_connection->addRelationship(core::Relationship{"success", ""});
-  incoming_connection->setDestinationUUID(processor->getUUID());
-  processor->addConnection(incoming_connection);
-  processor->initialize();
+  processor_ = std::make_shared<processors::LogAttribute>("test_processor");
+  incoming_connection_ = std::make_shared<minifi::Connection>(repo, content_repo, "incoming_connection");
+  incoming_connection_->addRelationship(core::Relationship{"success", ""});
+  incoming_connection_->setDestinationUUID(processor_->getUUID());
+  processor_->addConnection(incoming_connection_);
+  processor_->initialize();
 
-  const auto processor_node = std::make_shared<core::ProcessorNode>(processor);
+  const auto processor_node = std::make_shared<core::ProcessorNode>(processor_);
   const auto context = std::make_shared<core::ProcessContext>(processor_node, nullptr, repo, repo, content_repo);
   const auto session_factory = std::make_shared<core::ProcessSessionFactory>(context);
-  const auto session = session_factory->createSession();
+  session_ = session_factory->createSession();
+}
 
+ProcessorWithIncomingConnectionTest::~ProcessorWithIncomingConnectionTest() {
+  LogTestController::getInstance().reset();
+}
+
+}
+
+TEST_CASE_METHOD(ProcessorWithIncomingConnectionTest, "A Processor detects correctly if it has incoming flow files it can process", "[isWorkAvailable]") {
   SECTION("Initially, the queue is empty, so there is no work available") {
-    REQUIRE_FALSE(processor->isWorkAvailable());
+    REQUIRE_FALSE(processor_->isWorkAvailable());
   }
 
   SECTION("When a non-penalized flow file is queued, there is work available") {
-    const auto flow_file = session->create();
-    incoming_connection->put(flow_file);
+    const auto flow_file = session_->create();
+    incoming_connection_->put(flow_file);
 
-    REQUIRE(processor->isWorkAvailable());
+    REQUIRE(processor_->isWorkAvailable());
   }
 
   SECTION("When a penalized flow file is queued, there is no work available (until the penalty expires)") {
-    const auto flow_file = session->create();
-    session->penalize(flow_file);
-    incoming_connection->put(flow_file);
+    const auto flow_file = session_->create();
+    session_->penalize(flow_file);
+    incoming_connection_->put(flow_file);
 
-    REQUIRE_FALSE(processor->isWorkAvailable());
+    REQUIRE_FALSE(processor_->isWorkAvailable());
   }
 
   SECTION("If there is both a penalized and a non-penalized flow file queued, there is work available") {
-    const auto normal_flow_file = session->create();
-    incoming_connection->put(normal_flow_file);
+    const auto normal_flow_file = session_->create();
+    incoming_connection_->put(normal_flow_file);
 
-    const auto penalized_flow_file = session->create();
-    session->penalize(penalized_flow_file);
-    incoming_connection->put(penalized_flow_file);
+    const auto penalized_flow_file = session_->create();
+    session_->penalize(penalized_flow_file);
+    incoming_connection_->put(penalized_flow_file);
 
-    REQUIRE(processor->isWorkAvailable());
+    REQUIRE(processor_->isWorkAvailable());
   }
 
   SECTION("When a penalized flow file is queued, there is work available after the penalty expires") {
-    processor->setPenalizationPeriodMsec(10);
+    processor_->setPenalizationPeriodMsec(10);
 
-    const auto flow_file = session->create();
-    session->penalize(flow_file);
-    incoming_connection->put(flow_file);
+    const auto flow_file = session_->create();
+    session_->penalize(flow_file);
+    incoming_connection_->put(flow_file);
 
-    REQUIRE_FALSE(processor->isWorkAvailable());
+    REQUIRE_FALSE(processor_->isWorkAvailable());
     const auto penalty_has_expired = [flow_file] { return !flow_file->isPenalized(); };
     REQUIRE(utils::verifyEventHappenedInPollTime(std::chrono::seconds{1}, penalty_has_expired, std::chrono::milliseconds{10}));
-    REQUIRE(processor->isWorkAvailable());
+    REQUIRE(processor_->isWorkAvailable());
   }
+}
+
+TEST_CASE_METHOD(ProcessorWithIncomingConnectionTest, "A failed and re-penalized flow file does not block the incoming queue of the Processor", "[penalize]") {
+  const auto flow_file_1 = session_->create();
+  incoming_connection_->put(flow_file_1);
+  const auto flow_file_2 = session_->create();
+  incoming_connection_->put(flow_file_2);
+  const auto flow_file_3 = session_->create();
+  incoming_connection_->put(flow_file_3);
+
+  processor_->setPenalizationPeriodMsec(100);
+  const auto penalized_flow_file = session_->create();
+  session_->penalize(penalized_flow_file);  // first penalty duration is 100 ms
+  incoming_connection_->put(penalized_flow_file);
+  const auto penalty_has_expired = [penalized_flow_file] { return !penalized_flow_file->isPenalized(); };
+  REQUIRE(utils::verifyEventHappenedInPollTime(std::chrono::seconds{1}, penalty_has_expired, std::chrono::milliseconds{10}));
+
+  REQUIRE(incoming_connection_->isWorkAvailable());
+  std::set<std::shared_ptr<core::FlowFile>> expired_flow_files;
+  const auto next_flow_file_1 = incoming_connection_->poll(expired_flow_files);
+  REQUIRE(next_flow_file_1 == penalized_flow_file);
+
+  session_->penalize(penalized_flow_file);  // second penalty duration is 200 ms
+  incoming_connection_->put(penalized_flow_file);
+  std::this_thread::sleep_for(std::chrono::milliseconds{110});
+
+  REQUIRE(incoming_connection_->isWorkAvailable());
+  const auto next_flow_file_2 = incoming_connection_->poll(expired_flow_files);
+  REQUIRE(next_flow_file_2 != penalized_flow_file);
+  REQUIRE(next_flow_file_2 == flow_file_1);
+
+  REQUIRE(incoming_connection_->isWorkAvailable());
+  const auto next_flow_file_3 = incoming_connection_->poll(expired_flow_files);
+  REQUIRE(next_flow_file_3 != penalized_flow_file);
+  REQUIRE(next_flow_file_3 == flow_file_2);
+
+  REQUIRE(incoming_connection_->isWorkAvailable());
+  const auto next_flow_file_4 = incoming_connection_->poll(expired_flow_files);
+  REQUIRE(next_flow_file_4 != penalized_flow_file);
+  REQUIRE(next_flow_file_4 == flow_file_3);
+
+  REQUIRE(utils::verifyEventHappenedInPollTime(std::chrono::seconds{1}, penalty_has_expired, std::chrono::milliseconds{10}));
+  REQUIRE(incoming_connection_->isWorkAvailable());
+  const auto next_flow_file_5 = incoming_connection_->poll(expired_flow_files);
+  REQUIRE(next_flow_file_5 == penalized_flow_file);
 }

--- a/extensions/standard-processors/tests/unit/ProcessorTests.cpp
+++ b/extensions/standard-processors/tests/unit/ProcessorTests.cpp
@@ -652,7 +652,7 @@ ProcessorWithIncomingConnectionTest::~ProcessorWithIncomingConnectionTest() {
   LogTestController::getInstance().reset();
 }
 
-}
+}  // namespace
 
 TEST_CASE_METHOD(ProcessorWithIncomingConnectionTest, "A Processor detects correctly if it has incoming flow files it can process", "[isWorkAvailable]") {
   SECTION("Initially, the queue is empty, so there is no work available") {
@@ -686,7 +686,7 @@ TEST_CASE_METHOD(ProcessorWithIncomingConnectionTest, "A Processor detects corre
   }
 
   SECTION("When a penalized flow file is queued, there is work available after the penalty expires") {
-    processor_->setPenalizationPeriodMsec(10);
+    processor_->setPenalizationPeriod(std::chrono::milliseconds{10});
 
     const auto flow_file = session_->create();
     session_->penalize(flow_file);
@@ -707,7 +707,7 @@ TEST_CASE_METHOD(ProcessorWithIncomingConnectionTest, "A failed and re-penalized
   const auto flow_file_3 = session_->create();
   incoming_connection_->put(flow_file_3);
 
-  processor_->setPenalizationPeriodMsec(100);
+  processor_->setPenalizationPeriod(std::chrono::milliseconds{100});
   const auto penalized_flow_file = session_->create();
   session_->penalize(penalized_flow_file);  // first penalty duration is 100 ms
   incoming_connection_->put(penalized_flow_file);

--- a/extensions/standard-processors/tests/unit/RetryFlowFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/RetryFlowFileTests.cpp
@@ -103,7 +103,7 @@ class RetryFlowFileTest {
     std::shared_ptr<core::Processor> putfile_on_failure          = plan_->addProcessor("PutFile", "putfile_on_failure", {success}, false);
     std::shared_ptr<core::Processor> log_attribute               = plan_->addProcessor("LogAttribute", "log", {success}, false);
 
-    retryflowfile->setPenalizationPeriodMsec(0);
+    retryflowfile->setPenalizationPeriod(std::chrono::milliseconds{0});
 
     plan_->addConnection(generate, success, update);
     plan_->addConnection(update, success, retryflowfile);

--- a/extensions/standard-processors/tests/unit/YamlConfigurationTests.cpp
+++ b/extensions/standard-processors/tests/unit/YamlConfigurationTests.cpp
@@ -151,7 +151,7 @@ TEST_CASE("Test YAML Config Processing", "[YamlConfiguration]") {
       core::SchedulingStrategy::TIMER_DRIVEN == rootFlowConfig->findProcessorByName("TailFile")->getSchedulingStrategy());
   REQUIRE(1 == rootFlowConfig->findProcessorByName("TailFile")->getMaxConcurrentTasks());
   REQUIRE(1 * 1000 * 1000 * 1000 == rootFlowConfig->findProcessorByName("TailFile")->getSchedulingPeriodNano());
-  REQUIRE(30 * 1000 == rootFlowConfig->findProcessorByName("TailFile")->getPenalizationPeriodMsec());
+  REQUIRE(std::chrono::seconds(30) == rootFlowConfig->findProcessorByName("TailFile")->getPenalizationPeriod());
   REQUIRE(1 * 1000 == rootFlowConfig->findProcessorByName("TailFile")->getYieldPeriodMsec());
   REQUIRE(0 == rootFlowConfig->findProcessorByName("TailFile")->getRunDurationNano());
 
@@ -452,7 +452,7 @@ NiFi Properties Overrides: {}
   REQUIRE(core::SchedulingStrategy::TIMER_DRIVEN == rootFlowConfig->findProcessorByName("TailFile")->getSchedulingStrategy());
   REQUIRE(1 == rootFlowConfig->findProcessorByName("TailFile")->getMaxConcurrentTasks());
   REQUIRE(1 * 1000 * 1000 * 1000 == rootFlowConfig->findProcessorByName("TailFile")->getSchedulingPeriodNano());
-  REQUIRE(30 * 1000 == rootFlowConfig->findProcessorByName("TailFile")->getPenalizationPeriodMsec());
+  REQUIRE(std::chrono::seconds(30) == rootFlowConfig->findProcessorByName("TailFile")->getPenalizationPeriod());
   REQUIRE(1 * 1000 == rootFlowConfig->findProcessorByName("TailFile")->getYieldPeriodMsec());
   REQUIRE(0 == rootFlowConfig->findProcessorByName("TailFile")->getRunDurationNano());
 

--- a/extensions/standard-processors/tests/unit/YamlConfigurationTests.cpp
+++ b/extensions/standard-processors/tests/unit/YamlConfigurationTests.cpp
@@ -92,7 +92,7 @@ TEST_CASE("Test YAML Config Processing", "[YamlConfiguration]") {
       "      max concurrent tasks: 1\n"
       "      scheduling strategy: TIMER_DRIVEN\n"
       "      scheduling period: 1 sec\n"
-      "      penalization period: 30 sec\n"
+      "      penalization period: 5 sec\n"
       "      yield period: 1 sec\n"
       "      run duration nanos: 0\n"
       "      auto-terminated relationships list:\n"
@@ -151,7 +151,7 @@ TEST_CASE("Test YAML Config Processing", "[YamlConfiguration]") {
       core::SchedulingStrategy::TIMER_DRIVEN == rootFlowConfig->findProcessorByName("TailFile")->getSchedulingStrategy());
   REQUIRE(1 == rootFlowConfig->findProcessorByName("TailFile")->getMaxConcurrentTasks());
   REQUIRE(1 * 1000 * 1000 * 1000 == rootFlowConfig->findProcessorByName("TailFile")->getSchedulingPeriodNano());
-  REQUIRE(std::chrono::seconds(30) == rootFlowConfig->findProcessorByName("TailFile")->getPenalizationPeriod());
+  REQUIRE(std::chrono::seconds(5) == rootFlowConfig->findProcessorByName("TailFile")->getPenalizationPeriod());
   REQUIRE(1 * 1000 == rootFlowConfig->findProcessorByName("TailFile")->getYieldPeriodMsec());
   REQUIRE(0 == rootFlowConfig->findProcessorByName("TailFile")->getRunDurationNano());
 
@@ -256,7 +256,7 @@ Processors:
   max concurrent tasks: 1
   scheduling strategy: TIMER_DRIVEN
   scheduling period: 1 sec
-  penalization period: 30 sec
+  penalization period: 5 sec
   yield period: 1 sec
   run duration nanos: 0
   auto-terminated relationships list: []
@@ -382,7 +382,7 @@ Processors:
   max concurrent tasks: 1
   scheduling strategy: TIMER_DRIVEN
   scheduling period: 1 sec
-  penalization period: 30 sec
+  penalization period: 5 sec
   yield period: 1 sec
   run duration nanos: 0
   auto-terminated relationships list: []
@@ -452,7 +452,7 @@ NiFi Properties Overrides: {}
   REQUIRE(core::SchedulingStrategy::TIMER_DRIVEN == rootFlowConfig->findProcessorByName("TailFile")->getSchedulingStrategy());
   REQUIRE(1 == rootFlowConfig->findProcessorByName("TailFile")->getMaxConcurrentTasks());
   REQUIRE(1 * 1000 * 1000 * 1000 == rootFlowConfig->findProcessorByName("TailFile")->getSchedulingPeriodNano());
-  REQUIRE(std::chrono::seconds(30) == rootFlowConfig->findProcessorByName("TailFile")->getPenalizationPeriod());
+  REQUIRE(std::chrono::seconds(5) == rootFlowConfig->findProcessorByName("TailFile")->getPenalizationPeriod());
   REQUIRE(1 * 1000 == rootFlowConfig->findProcessorByName("TailFile")->getYieldPeriodMsec());
   REQUIRE(0 == rootFlowConfig->findProcessorByName("TailFile")->getRunDurationNano());
 

--- a/libminifi/include/core/Connectable.h
+++ b/libminifi/include/core/Connectable.h
@@ -74,9 +74,8 @@ class Connectable : public CoreComponent {
   // Check whether the relationship is auto terminated
   bool isAutoTerminated(const Relationship &relationship);
 
-  // Get Processor penalization period in MilliSecond
-  uint64_t getPenalizationPeriodMsec(void) const {
-    return (_penalizationPeriodMsec);
+  std::chrono::milliseconds getPenalizationPeriod() const {
+    return penalization_period_;
   }
 
   /**
@@ -162,7 +161,7 @@ class Connectable : public CoreComponent {
   // must hold the relationship_mutex_ before calling this
   std::shared_ptr<Connectable> getNextIncomingConnectionImpl(const std::lock_guard<std::mutex>& relationship_mutex_lock);
   // Penalization Period in MilliSecond
-  std::atomic<uint64_t> _penalizationPeriodMsec;
+  std::atomic<std::chrono::milliseconds> penalization_period_;
 
   uint8_t max_concurrent_tasks_;
 

--- a/libminifi/include/core/FlowFile.h
+++ b/libminifi/include/core/FlowFile.h
@@ -205,12 +205,10 @@ class FlowFile : public CoreComponent, public ReferenceContainer {
     offset_ = offset;
   }
 
-  /**
-   * Sets the penalty expiration
-   * @param penaltyExp new penalty expiration
-   */
-  void setPenaltyExpiration(const uint64_t penaltyExp) {
-    penaltyExpiration_ms_ = penaltyExp;
+  template<typename Rep, typename Period>
+  void penalize(std::chrono::duration<Rep, Period> duration) {
+    const auto penalty_expiration = std::chrono::system_clock::now() + duration;
+    penaltyExpiration_ms_ = std::chrono::duration_cast<std::chrono::milliseconds>(penalty_expiration.time_since_epoch()).count();
   }
 
   uint64_t getPenaltyExpiration() const {
@@ -271,7 +269,7 @@ class FlowFile : public CoreComponent, public ReferenceContainer {
   // Offset to the content
   uint64_t offset_;
   // Penalty expiration
-  uint64_t penaltyExpiration_ms_;
+  int64_t penaltyExpiration_ms_;
   // Attributes key/values pairs for the flow record
   AttributeMap attributes_;
   // Pointer to the associated content resource claim

--- a/libminifi/include/core/Processor.h
+++ b/libminifi/include/core/Processor.h
@@ -137,9 +137,9 @@ class Processor : public Connectable, public ConfigurableComponent, public std::
   uint64_t getYieldPeriodMsec() const {
     return (yield_period_msec_);
   }
-  // Set Processor penalization period in MilliSecond
-  void setPenalizationPeriodMsec(uint64_t period) {
-    _penalizationPeriodMsec = period;
+
+  void setPenalizationPeriod(std::chrono::milliseconds period) {
+    penalization_period_ = period;
   }
 
   // Set Processor Maximum Concurrent Tasks

--- a/libminifi/include/core/ProcessorConfig.h
+++ b/libminifi/include/core/ProcessorConfig.h
@@ -35,10 +35,8 @@ namespace core {
 #define DEFAULT_SCHEDULING_PERIOD_MILLIS 1000
 #define DEFAULT_RUN_DURATION 0
 #define DEFAULT_MAX_CONCURRENT_TASKS 1
-#define DEFAULT_PENALIZATION_PERIOD 1
-// Default yield period in second
 #define DEFAULT_YIELD_PERIOD_SECONDS 1
-#define DEFAULT_PENALIZATION_PERIOD_SECONDS 30
+constexpr std::chrono::seconds DEFAULT_PENALIZATION_PERIOD{30};
 
 struct ProcessorConfig {
   std::string id;

--- a/libminifi/include/core/ProcessorConfig.h
+++ b/libminifi/include/core/ProcessorConfig.h
@@ -36,7 +36,7 @@ namespace core {
 #define DEFAULT_RUN_DURATION 0
 #define DEFAULT_MAX_CONCURRENT_TASKS 1
 #define DEFAULT_YIELD_PERIOD_SECONDS 1
-constexpr std::chrono::seconds DEFAULT_PENALIZATION_PERIOD{30};
+constexpr std::chrono::seconds DEFAULT_PENALIZATION_PERIOD{5};
 
 struct ProcessorConfig {
   std::string id;

--- a/libminifi/include/core/ProcessorNode.h
+++ b/libminifi/include/core/ProcessorNode.h
@@ -217,9 +217,8 @@ class ProcessorNode : public ConfigurableComponent, public Connectable {
     processor_->setUUID(uuid);
   }
 
-// Get Processor penalization period in MilliSecond
-  uint64_t getPenalizationPeriodMsec(void) {
-    return processor_->getPenalizationPeriodMsec();
+  std::chrono::milliseconds getPenalizationPeriod() {
+    return processor_->getPenalizationPeriod();
   }
 
   /**

--- a/libminifi/include/core/state/nodes/SchedulingNodes.h
+++ b/libminifi/include/core/state/nodes/SchedulingNodes.h
@@ -85,7 +85,7 @@ class SchedulingDefaults : public DeviceInformation {
 
     SerializedResponseNode penalizationPeriod;
     penalizationPeriod.name = "penalizationPeriodMillis";
-    penalizationPeriod.value = DEFAULT_PENALIZATION_PERIOD_SECONDS*1000;
+    penalizationPeriod.value = std::chrono::duration_cast<std::chrono::milliseconds>(core::DEFAULT_PENALIZATION_PERIOD).count();
 
     schedulingDefaults.children.push_back(penalizationPeriod);
 

--- a/libminifi/include/core/state/nodes/SchedulingNodes.h
+++ b/libminifi/include/core/state/nodes/SchedulingNodes.h
@@ -85,7 +85,7 @@ class SchedulingDefaults : public DeviceInformation {
 
     SerializedResponseNode penalizationPeriod;
     penalizationPeriod.name = "penalizationPeriodMillis";
-    penalizationPeriod.value = std::chrono::duration_cast<std::chrono::milliseconds>(core::DEFAULT_PENALIZATION_PERIOD).count();
+    penalizationPeriod.value = std::chrono::milliseconds{core::DEFAULT_PENALIZATION_PERIOD}.count();
 
     schedulingDefaults.children.push_back(penalizationPeriod);
 

--- a/libminifi/src/core/FlowFile.cpp
+++ b/libminifi/src/core/FlowFile.cpp
@@ -36,16 +36,17 @@ std::shared_ptr<utils::IdGenerator> FlowFile::id_generator_ = utils::IdGenerator
 std::shared_ptr<utils::NonRepeatingStringGenerator> FlowFile::numeric_id_generator_ = std::make_shared<utils::NonRepeatingStringGenerator>();
 std::shared_ptr<logging::Logger> FlowFile::logger_ = logging::LoggerFactory<FlowFile>::getLogger();
 
-FlowFile::FlowFile()
+FlowFile::FlowFile(std::shared_ptr<utils::timeutils::Clock> clock)
     : CoreComponent("FlowFile"),
       size_(0),
       stored(false),
       offset_(0),
       last_queue_date_(0),
-      penaltyExpiration_ms_(0),
+      penalty_expiration_timestamp_(0),
       event_time_(0),
       claim_(nullptr),
-      marked_delete_(false) {
+      marked_delete_(false),
+      clock_(std::move(clock)) {
   id_ = numeric_id_generator_->generateId();
   entry_date_ = utils::timeutils::getTimeMillis();
   event_time_ = entry_date_;
@@ -61,10 +62,12 @@ FlowFile& FlowFile::operator=(const FlowFile& other) {
   lineage_Identifiers_ = other.lineage_Identifiers_;
   last_queue_date_ = other.last_queue_date_;
   size_ = other.size_;
-  penaltyExpiration_ms_ = other.penaltyExpiration_ms_;
+  penalty_expiration_timestamp_ = other.penalty_expiration_timestamp_;
   attributes_ = other.attributes_;
   claim_ = other.claim_;
   connection_ = other.connection_;
+  clock_ = other.clock_;
+  penalty_multiplier_ = other.penalty_multiplier_;
   return *this;
 }
 

--- a/libminifi/src/core/ProcessSession.cpp
+++ b/libminifi/src/core/ProcessSession.cpp
@@ -705,12 +705,13 @@ void ProcessSession::commit() {
       if (record->isDeleted()) {
         continue;
       }
-
+      record->resetPenaltyMultiplier();
       connection = record->getConnection();
       if ((connection) != nullptr) {
         connectionQueues[connection].push_back(record);
       }
     }
+
     for (const auto &it : _addedFlowFiles) {
       auto record = it.second;
       logger_->log_trace("See %s in %s", record->getUUIDStr(), "_addedFlowFiles");
@@ -722,12 +723,13 @@ void ProcessSession::commit() {
         connectionQueues[connection].push_back(record);
       }
     }
-    // Process the clone flow files
+
     for (const auto &record : _clonedFlowFiles) {
       logger_->log_trace("See %s in %s", record->getUUIDStr(), "_clonedFlowFiles");
       if (record->isDeleted()) {
         continue;
       }
+      record->resetPenaltyMultiplier();
       connection = record->getConnection();
       if ((connection) != nullptr) {
         connectionQueues[connection].push_back(record);

--- a/libminifi/src/core/ProcessSession.cpp
+++ b/libminifi/src/core/ProcessSession.cpp
@@ -198,9 +198,9 @@ void ProcessSession::removeAttribute(const std::shared_ptr<core::FlowFile> &flow
 }
 
 void ProcessSession::penalize(const std::shared_ptr<core::FlowFile> &flow) {
-  uint64_t penalization_period = process_context_->getProcessorNode()->getPenalizationPeriodMsec();
-  logging::LOG_INFO(logger_) << "Penalizing " << flow->getUUIDStr() << " for " << penalization_period << "ms at " << process_context_->getProcessorNode()->getName();
-  flow->setPenaltyExpiration(utils::timeutils::getTimeMillis() + penalization_period);
+  const std::chrono::milliseconds penalization_period = process_context_->getProcessorNode()->getPenalizationPeriod();
+  logging::LOG_INFO(logger_) << "Penalizing " << flow->getUUIDStr() << " for " << penalization_period.count() << "ms at " << process_context_->getProcessorNode()->getName();
+  flow->penalize(penalization_period);
 }
 
 void ProcessSession::transfer(const std::shared_ptr<core::FlowFile> &flow, Relationship relationship) {

--- a/libminifi/src/core/Processor.cpp
+++ b/libminifi/src/core/Processor.cpp
@@ -61,7 +61,7 @@ Processor::Processor(const std::string& name)
   scheduling_period_nano_ = MINIMUM_SCHEDULING_NANOS;
   run_duration_nano_ = DEFAULT_RUN_DURATION;
   yield_period_msec_ = DEFAULT_YIELD_PERIOD_SECONDS * 1000;
-  _penalizationPeriodMsec = DEFAULT_PENALIZATION_PERIOD_SECONDS * 1000;
+  penalization_period_ = DEFAULT_PENALIZATION_PERIOD;
   max_concurrent_tasks_ = DEFAULT_MAX_CONCURRENT_TASKS;
   active_tasks_ = 0;
   yield_expiration_ = 0;
@@ -82,7 +82,7 @@ Processor::Processor(const std::string& name, const utils::Identifier &uuid)
   scheduling_period_nano_ = MINIMUM_SCHEDULING_NANOS;
   run_duration_nano_ = DEFAULT_RUN_DURATION;
   yield_period_msec_ = DEFAULT_YIELD_PERIOD_SECONDS * 1000;
-  _penalizationPeriodMsec = DEFAULT_PENALIZATION_PERIOD_SECONDS * 1000;
+  penalization_period_ = DEFAULT_PENALIZATION_PERIOD;
   max_concurrent_tasks_ = DEFAULT_MAX_CONCURRENT_TASKS;
   active_tasks_ = 0;
   yield_expiration_ = 0;

--- a/libminifi/src/core/yaml/YamlConfiguration.cpp
+++ b/libminifi/src/core/yaml/YamlConfiguration.cpp
@@ -248,7 +248,7 @@ void YamlConfiguration::parseProcessorNodeYaml(YAML::Node processorsNode, core::
 
         if (core::Property::StringToTime(procCfg.penalizationPeriod, penalizationPeriod, unit) && core::Property::ConvertTimeUnitToMS(penalizationPeriod, unit, penalizationPeriod)) {
           logger_->log_debug("convert: parseProcessorNode: penalizationPeriod => [%" PRId64 "] ms", penalizationPeriod);
-          processor->setPenalizationPeriodMsec(penalizationPeriod);
+          processor->setPenalizationPeriod(std::chrono::milliseconds{penalizationPeriod});
         }
 
         if (core::Property::StringToTime(procCfg.yieldPeriod, yieldPeriod, unit) && core::Property::ConvertTimeUnitToMS(yieldPeriod, unit, yieldPeriod)) {

--- a/libminifi/test/resources/C2PauseResumeTest.yml
+++ b/libminifi/test/resources/C2PauseResumeTest.yml
@@ -26,7 +26,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -43,7 +43,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: response

--- a/libminifi/test/resources/C2VerifyHeartbeatAndStop.yml
+++ b/libminifi/test/resources/C2VerifyHeartbeatAndStop.yml
@@ -26,7 +26,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -39,7 +39,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: response

--- a/libminifi/test/resources/C2VerifyHeartbeatAndStopSecure.yml
+++ b/libminifi/test/resources/C2VerifyHeartbeatAndStopSecure.yml
@@ -26,7 +26,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -39,7 +39,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: response

--- a/libminifi/test/resources/C2VerifyServeResults.yml
+++ b/libminifi/test/resources/C2VerifyServeResults.yml
@@ -26,7 +26,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -43,7 +43,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: response

--- a/libminifi/test/resources/C2VerifyServeResultsSecure.yml
+++ b/libminifi/test/resources/C2VerifyServeResultsSecure.yml
@@ -26,7 +26,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -39,7 +39,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: response

--- a/libminifi/test/resources/CoapC2VerifyServe.yml
+++ b/libminifi/test/resources/CoapC2VerifyServe.yml
@@ -26,7 +26,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -39,7 +39,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: response

--- a/libminifi/test/resources/TestBad.yml
+++ b/libminifi/test/resources/TestBad.yml
@@ -26,7 +26,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -39,7 +39,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: response

--- a/libminifi/test/resources/TestC2DescribeCoreComponentState.yml
+++ b/libminifi/test/resources/TestC2DescribeCoreComponentState.yml
@@ -26,7 +26,7 @@ Processors:
     max concurrent tasks: 1
     scheduling strategy: TIMER_DRIVEN
     scheduling period: 1 sec
-    penalization period: 30 sec
+    penalization period: 5 sec
     yield period: 1 sec
     run duration nanos: 0
     auto-terminated relationships list: success
@@ -36,7 +36,7 @@ Processors:
     max concurrent tasks: 1
     scheduling strategy: TIMER_DRIVEN
     scheduling period: 1 sec
-    penalization period: 30 sec
+    penalization period: 5 sec
     yield period: 1 sec
     run duration nanos: 0
     auto-terminated relationships list: success

--- a/libminifi/test/resources/TestControllerServices.yml
+++ b/libminifi/test/resources/TestControllerServices.yml
@@ -27,7 +27,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:

--- a/libminifi/test/resources/TestEnvironmental.yml
+++ b/libminifi/test/resources/TestEnvironmental.yml
@@ -37,7 +37,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: response

--- a/libminifi/test/resources/TestGetTCPSecure.yml
+++ b/libminifi/test/resources/TestGetTCPSecure.yml
@@ -42,7 +42,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: response

--- a/libminifi/test/resources/TestGetTCPSecureEmptyPass.yml
+++ b/libminifi/test/resources/TestGetTCPSecureEmptyPass.yml
@@ -42,7 +42,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: response

--- a/libminifi/test/resources/TestGetTCPSecureWithFilePass.yml
+++ b/libminifi/test/resources/TestGetTCPSecureWithFilePass.yml
@@ -42,7 +42,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: response

--- a/libminifi/test/resources/TestGetTCPSecureWithPass.yml
+++ b/libminifi/test/resources/TestGetTCPSecureWithPass.yml
@@ -42,7 +42,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: response

--- a/libminifi/test/resources/TestHTTPGet.yml
+++ b/libminifi/test/resources/TestHTTPGet.yml
@@ -26,7 +26,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -43,7 +43,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: response

--- a/libminifi/test/resources/TestHTTPGetSecure.yml
+++ b/libminifi/test/resources/TestHTTPGetSecure.yml
@@ -26,7 +26,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -45,7 +45,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: response

--- a/libminifi/test/resources/TestHTTPPost.yml
+++ b/libminifi/test/resources/TestHTTPPost.yml
@@ -26,7 +26,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -37,7 +37,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -50,7 +50,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 2 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -68,7 +68,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: success

--- a/libminifi/test/resources/TestHTTPPostChunkedEncoding.yml
+++ b/libminifi/test/resources/TestHTTPPostChunkedEncoding.yml
@@ -26,7 +26,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -37,7 +37,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -50,7 +50,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: 
@@ -70,7 +70,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: 

--- a/libminifi/test/resources/TestHTTPSiteToSite.yml
+++ b/libminifi/test/resources/TestHTTPSiteToSite.yml
@@ -24,7 +24,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 5 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 10 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -37,7 +37,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 10 sec
       run duration nanos: 0
       auto-terminated relationships list:

--- a/libminifi/test/resources/TestKafkaOnSchedule.yml
+++ b/libminifi/test/resources/TestKafkaOnSchedule.yml
@@ -37,7 +37,7 @@ Processors:
     max concurrent tasks: 1
     scheduling strategy: TIMER_DRIVEN
     scheduling period: 100 sec
-    penalization period: 30 sec
+    penalization period: 5 sec
     yield period: 1 sec
     run duration nanos: 0
     auto-terminated relationships list:

--- a/libminifi/test/resources/TestNull.yml
+++ b/libminifi/test/resources/TestNull.yml
@@ -26,7 +26,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -39,7 +39,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: response

--- a/libminifi/test/resources/TestOnScheduleRetry.yml
+++ b/libminifi/test/resources/TestOnScheduleRetry.yml
@@ -27,7 +27,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 100 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:

--- a/libminifi/test/resources/TestPcap.yml
+++ b/libminifi/test/resources/TestPcap.yml
@@ -38,7 +38,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: response

--- a/libminifi/test/resources/TestPcapLinux.yml
+++ b/libminifi/test/resources/TestPcapLinux.yml
@@ -38,7 +38,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: response

--- a/libminifi/test/resources/TestProvenanceReporting.yml
+++ b/libminifi/test/resources/TestProvenanceReporting.yml
@@ -27,7 +27,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:

--- a/libminifi/test/resources/TestSite2SiteRest.yml
+++ b/libminifi/test/resources/TestSite2SiteRest.yml
@@ -24,7 +24,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 10 sec
       run duration nanos: 0
       auto-terminated relationships list:

--- a/libminifi/test/resources/TestSite2SiteRestSecure.yml
+++ b/libminifi/test/resources/TestSite2SiteRestSecure.yml
@@ -24,7 +24,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 10 sec
       run duration nanos: 0
       auto-terminated relationships list:

--- a/libminifi/test/resources/TestTailFile.yml
+++ b/libminifi/test/resources/TestTailFile.yml
@@ -26,7 +26,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 100 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -38,7 +38,7 @@ Processors:
       class: org.apache.nifi.processors.standard.LogAttribute
       max concurrent tasks: 1
       scheduling strategy: EVENT_DRIVEN
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: 

--- a/libminifi/test/resources/TestTailFileCron.yml
+++ b/libminifi/test/resources/TestTailFileCron.yml
@@ -26,7 +26,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: CRON_DRIVEN
       scheduling period: "* * * * *"
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -38,7 +38,7 @@ Processors:
       class: org.apache.nifi.processors.standard.LogAttribute
       max concurrent tasks: 1
       scheduling strategy: EVENT_DRIVEN
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list: 

--- a/libminifi/test/resources/TestTimeoutHTTPSiteToSite.yml
+++ b/libminifi/test/resources/TestTimeoutHTTPSiteToSite.yml
@@ -24,7 +24,7 @@ Processors:
     max concurrent tasks: 1
     scheduling strategy: TIMER_DRIVEN
     scheduling period: 2 sec
-    penalization period: 30 sec
+    penalization period: 5 sec
     yield period: 10 sec
     run duration nanos: 0
     auto-terminated relationships list:

--- a/libminifi/test/resources/TestUpdateAttribute.yml
+++ b/libminifi/test/resources/TestUpdateAttribute.yml
@@ -26,7 +26,7 @@ Processors:
       max concurrent tasks: 1
       scheduling strategy: TIMER_DRIVEN
       scheduling period: 1 sec
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:
@@ -36,7 +36,7 @@ Processors:
       class: org.apache.nifi.processors.standard.UpdateAttribute
       max concurrent tasks: 1
       scheduling strategy: EVENT_DRIVEN
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       Properties:
@@ -46,7 +46,7 @@ Processors:
       class: org.apache.nifi.processors.standard.RouteOnAttribute
       max concurrent tasks: 1
       scheduling strategy: EVENT_DRIVEN
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       Properties:
@@ -56,7 +56,7 @@ Processors:
       class: org.apache.nifi.processors.standard.UpdateAttribute
       max concurrent tasks: 1
       scheduling strategy: EVENT_DRIVEN
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       Properties:
@@ -67,7 +67,7 @@ Processors:
       class: org.apache.nifi.processors.standard.LogAttribute
       max concurrent tasks: 1
       scheduling strategy: EVENT_DRIVEN
-      penalization period: 30 sec
+      penalization period: 5 sec
       yield period: 1 sec
       run duration nanos: 0
       auto-terminated relationships list:

--- a/libminifi/test/unit/ConnectionTests.cpp
+++ b/libminifi/test/unit/ConnectionTests.cpp
@@ -53,9 +53,7 @@ TEST_CASE("Connection::poll() works correctly", "[poll]") {
     SECTION("with expiration duration") { connection->setFlowExpirationDuration(1000); }
 
     const auto flow_file = std::make_shared<core::FlowFile>();
-    const auto future_time = std::chrono::system_clock::now() + std::chrono::seconds{10};
-    const auto future_time_ms_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(future_time.time_since_epoch()).count();
-    flow_file->setPenaltyExpiration(future_time_ms_since_epoch);
+    flow_file->penalize(std::chrono::seconds{10});
     connection->put(flow_file);
     REQUIRE(nullptr == connection->poll(expired_flow_files));
   }
@@ -74,9 +72,7 @@ TEST_CASE("Connection::poll() works correctly", "[poll]") {
     SECTION("with expiration duration") { connection->setFlowExpirationDuration(1000); }
 
     const auto penalized_flow_file = std::make_shared<core::FlowFile>();
-    const auto future_time = std::chrono::system_clock::now() + std::chrono::seconds{10};
-    const auto future_time_ms_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(future_time.time_since_epoch()).count();
-    penalized_flow_file->setPenaltyExpiration(future_time_ms_since_epoch);
+    penalized_flow_file->penalize(std::chrono::seconds{10});
     connection->put(penalized_flow_file);
 
     const auto flow_file = std::make_shared<core::FlowFile>();

--- a/libminifi/test/unit/FlowFileQueueTests.cpp
+++ b/libminifi/test/unit/FlowFileQueueTests.cpp
@@ -44,7 +44,7 @@ TEST_CASE("A flow file can be moved into the FlowFileQueue", "[FlowFileQueue][po
   utils::FlowFileQueue queue;
 
   auto penalized_flow_file = std::make_shared<core::FlowFile>();
-  penalized_flow_file->setPenaltyExpiration(utils::timeutils::getTimeMillis() + 100);
+  penalized_flow_file->penalize(std::chrono::milliseconds{100});
   queue.push(std::move(penalized_flow_file));
 
   queue.push(std::make_shared<core::FlowFile>());
@@ -86,18 +86,17 @@ class PenaltyHasExpired {
 
 TEST_CASE("Penalized flow files are popped from the FlowFileQueue in the order their penalties expire", "[FlowFileQueue][pop]") {
   utils::FlowFileQueue queue;
-  const auto now = utils::timeutils::getTimeMillis();
   const auto flow_file_1 = std::make_shared<core::FlowFile>();
-  flow_file_1->setPenaltyExpiration(now + 70);
+  flow_file_1->penalize(std::chrono::milliseconds{70});
   queue.push(flow_file_1);
   const auto flow_file_2 = std::make_shared<core::FlowFile>();
-  flow_file_2->setPenaltyExpiration(now + 50);
+  flow_file_2->penalize(std::chrono::milliseconds{50});
   queue.push(flow_file_2);
   const auto flow_file_3 = std::make_shared<core::FlowFile>();
-  flow_file_3->setPenaltyExpiration(now + 80);
+  flow_file_3->penalize(std::chrono::milliseconds{80});
   queue.push(flow_file_3);
   const auto flow_file_4 = std::make_shared<core::FlowFile>();
-  flow_file_4->setPenaltyExpiration(now + 60);
+  flow_file_4->penalize(std::chrono::milliseconds{60});
   queue.push(flow_file_4);
 
   REQUIRE_FALSE(queue.canBePopped());
@@ -124,7 +123,7 @@ TEST_CASE("Penalized flow files are popped from the FlowFileQueue in the order t
 TEST_CASE("If a penalized then a non-penalized flow file is added to the FlowFileQueue, pop() returns the correct one", "[FlowFileQueue][pop]") {
   utils::FlowFileQueue queue;
   const auto penalized_flow_file = std::make_shared<core::FlowFile>();
-  penalized_flow_file->setPenaltyExpiration(utils::timeutils::getTimeMillis() + 10);
+  penalized_flow_file->penalize(std::chrono::milliseconds{10});
   queue.push(penalized_flow_file);
   const auto flow_file = std::make_shared<core::FlowFile>();
   queue.push(flow_file);
@@ -149,7 +148,7 @@ TEST_CASE("If a penalized then a non-penalized flow file is added to the FlowFil
 TEST_CASE("Force pop on FlowFileQueue returns the flow files, whether penalized or not", "[FlowFileQueue][forcePop]") {
   utils::FlowFileQueue queue;
   const auto penalized_flow_file = std::make_shared<core::FlowFile>();
-  penalized_flow_file->setPenaltyExpiration(utils::timeutils::getTimeMillis() + 10);
+  penalized_flow_file->penalize(std::chrono::milliseconds{10});
   queue.push(penalized_flow_file);
   const auto flow_file = std::make_shared<core::FlowFile>();
   queue.push(flow_file);

--- a/libminifi/test/unit/FlowFileTests.cpp
+++ b/libminifi/test/unit/FlowFileTests.cpp
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "core/FlowFile.h"
+#include "../TestBase.h"
+#include "utils/TestUtils.h"
+
+TEST_CASE("Repeated penalization doubles the penalty duration of FlowFiles", "[penalize]") {
+  const auto TIMESTAMP = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch());
+  const auto PENALTY_DURATION = std::chrono::seconds{30};
+
+  const auto clock = std::make_shared<utils::ManualClock>();
+  clock->advance(TIMESTAMP);
+
+  core::FlowFile flow_file{clock};
+
+  SECTION("Initially, the penalty expiration is zero") {
+    REQUIRE(flow_file.getPenaltyExpiration() == 0);
+  }
+
+  SECTION("When first penalized, a single penalty duration is added") {
+    flow_file.penalize(PENALTY_DURATION);
+    REQUIRE(std::chrono::milliseconds(flow_file.getPenaltyExpiration()) == TIMESTAMP + PENALTY_DURATION);
+  }
+
+  SECTION("For the second penalty, the penalty duration is doubled") {
+    flow_file.penalize(PENALTY_DURATION);
+
+    std::chrono::milliseconds TIME_ELAPSED{13000};
+    clock->advance(TIME_ELAPSED);
+    flow_file.penalize(PENALTY_DURATION);
+
+    REQUIRE(std::chrono::milliseconds(flow_file.getPenaltyExpiration()) == TIMESTAMP + TIME_ELAPSED + 2 * PENALTY_DURATION);
+  }
+
+  SECTION("For the third penalty, the penalty duration is quadrupled") {
+    flow_file.penalize(PENALTY_DURATION);
+
+    std::chrono::milliseconds TIME_ELAPSED_1{77000};
+    clock->advance(TIME_ELAPSED_1);
+    flow_file.penalize(PENALTY_DURATION);
+
+    std::chrono::milliseconds TIME_ELAPSED_2{45000};
+    clock->advance(TIME_ELAPSED_2);
+    flow_file.penalize(PENALTY_DURATION);
+
+    REQUIRE(std::chrono::milliseconds(flow_file.getPenaltyExpiration()) == TIMESTAMP + TIME_ELAPSED_1 + TIME_ELAPSED_2 + 4 * PENALTY_DURATION);
+  }
+
+  SECTION("The maximum penalty duration is 1000 times the default duration") {
+    for (int i = 0; i < 100; ++i) {
+      flow_file.penalize(PENALTY_DURATION);
+    }
+    REQUIRE(std::chrono::milliseconds(flow_file.getPenaltyExpiration()) == TIMESTAMP + 1000 * PENALTY_DURATION);
+  }
+
+  SECTION("After the multiplier is reset, the duration of the next penalty is the same as the first one") {
+    flow_file.penalize(PENALTY_DURATION);
+    flow_file.penalize(PENALTY_DURATION);
+    flow_file.penalize(PENALTY_DURATION);
+    flow_file.resetPenaltyMultiplier();
+    flow_file.penalize(PENALTY_DURATION);
+    REQUIRE(std::chrono::milliseconds(flow_file.getPenaltyExpiration()) == TIMESTAMP + PENALTY_DURATION);
+  }
+}


### PR DESCRIPTION
#1013 had a bug; see https://issues.apache.org/jira/browse/MINIFICPP-1487?focusedCommentId=17297967

In this PR, I changed the duration of repeated flow file penalties to be double of the previous one, up to a limit of 1000 times the original.  This will ensure that we won't always retry the same faulty flow file after an exception thrown in `Processor::onTrigger()`.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
