### PR TITLE
MINIFICPP-1438 Fix transient failures of FlowControllerTests

### DIFF
--- a/libminifi/test/flow-tests/FlowControllerTests.cpp
+++ b/libminifi/test/flow-tests/FlowControllerTests.cpp
@@ -154,17 +154,16 @@ TEST_CASE("Flow shutdown waits for a while", "[TestFlow2]") {
   testController.startFlow();
 
   // wait for the source processor to enqueue its flowFiles
-  std::size_t flow_file_count = 0;
-  auto flowFilesEnqueued = [&] { flow_file_count = root->getTotalFlowFileCount(); return flow_file_count >= 3; };
+  auto flowFilesEnqueued = [&] { return root->getTotalFlowFileCount() >= 3; };
   REQUIRE(verifyWithBusyWait(std::chrono::milliseconds{500}, flowFilesEnqueued));
 
-  REQUIRE(sourceProc->trigger_count.load() >= flow_file_count / 3);
+  REQUIRE(sourceProc->trigger_count.load() >= 1);
 
   execSinkPromise.set_value();
   controller->stop();
 
-  REQUIRE(sourceProc->trigger_count.load() >= flow_file_count / 3);
-  REQUIRE(sinkProc->trigger_count.load() >= flow_file_count);
+  REQUIRE(sourceProc->trigger_count.load() >= 1);
+  REQUIRE(sinkProc->trigger_count.load() >= 3);
 }
 
 TEST_CASE("Flow stopped after grace period", "[TestFlow3]") {
@@ -192,17 +191,16 @@ TEST_CASE("Flow stopped after grace period", "[TestFlow3]") {
   testController.startFlow();
 
   // wait for the source processor to enqueue its flowFiles
-  std::size_t flow_file_count = 0;
-  auto flowFilesEnqueued = [&] { flow_file_count = root->getTotalFlowFileCount(); return flow_file_count >= 3; };
+  auto flowFilesEnqueued = [&] { return root->getTotalFlowFileCount() >= 3; };
   REQUIRE(verifyWithBusyWait(std::chrono::milliseconds{500}, flowFilesEnqueued));
 
-  REQUIRE(sourceProc->trigger_count.load() >= flow_file_count / 3);
+  REQUIRE(sourceProc->trigger_count.load() >= 1);
 
   execSinkPromise.set_value();
   controller->stop();
 
-  REQUIRE(sourceProc->trigger_count.load() >= flow_file_count / 3);
-  REQUIRE(sinkProc->trigger_count.load() >= flow_file_count / 3);
+  REQUIRE(sourceProc->trigger_count.load() >= 1);
+  REQUIRE(sinkProc->trigger_count.load() >= 1);
 }
 
 TEST_CASE("Extend the waiting period during shutdown", "[TestFlow4]") {
@@ -233,10 +231,10 @@ TEST_CASE("Extend the waiting period during shutdown", "[TestFlow4]") {
 
   // wait for the source processor to enqueue its flowFiles
   std::size_t flow_file_count = 0;
-  auto flowFilesEnqueued = [&] { flow_file_count = root->getTotalFlowFileCount(); return flow_file_count >= 3; };
+  auto flowFilesEnqueued = [&] { return root->getTotalFlowFileCount() >= 3; };
   REQUIRE(verifyWithBusyWait(std::chrono::milliseconds{500}, flowFilesEnqueued));
 
-  REQUIRE(sourceProc->trigger_count.load() >= flow_file_count / 3);
+  REQUIRE(sourceProc->trigger_count.load() >= 1);
 
   std::thread shutdownThread([&]{
     execSinkPromise.set_value();
@@ -260,6 +258,6 @@ TEST_CASE("Extend the waiting period during shutdown", "[TestFlow4]") {
 
   shutdownThread.join();
 
-  REQUIRE(sourceProc->trigger_count.load() >= flow_file_count / 3);
-  REQUIRE(sinkProc->trigger_count.load() >= flow_file_count);
+  REQUIRE(sourceProc->trigger_count.load() >= 1);
+  REQUIRE(sinkProc->trigger_count.load() >= 3);
 }

--- a/libminifi/test/flow-tests/FlowControllerTests.cpp
+++ b/libminifi/test/flow-tests/FlowControllerTests.cpp
@@ -154,16 +154,17 @@ TEST_CASE("Flow shutdown waits for a while", "[TestFlow2]") {
   testController.startFlow();
 
   // wait for the source processor to enqueue its flowFiles
-  auto flowFilesEnqueued = [&] {return root->getTotalFlowFileCount() == 3;};
-  REQUIRE(verifyWithBusyWait(std::chrono::milliseconds{200}, flowFilesEnqueued));
+  std::size_t flow_file_count = 0;
+  auto flowFilesEnqueued = [&] { flow_file_count = root->getTotalFlowFileCount(); return flow_file_count >= 3; };
+  REQUIRE(verifyWithBusyWait(std::chrono::milliseconds{500}, flowFilesEnqueued));
 
-  REQUIRE(sourceProc->trigger_count.load() == 1);
+  REQUIRE(sourceProc->trigger_count.load() >= flow_file_count / 3);
 
   execSinkPromise.set_value();
   controller->stop();
 
-  REQUIRE(sourceProc->trigger_count.load() == 1);
-  REQUIRE(sinkProc->trigger_count.load() == 3);
+  REQUIRE(sourceProc->trigger_count.load() >= flow_file_count / 3);
+  REQUIRE(sinkProc->trigger_count.load() >= flow_file_count);
 }
 
 TEST_CASE("Flow stopped after grace period", "[TestFlow3]") {
@@ -191,16 +192,17 @@ TEST_CASE("Flow stopped after grace period", "[TestFlow3]") {
   testController.startFlow();
 
   // wait for the source processor to enqueue its flowFiles
-  auto flowFilesEnqueued = [&] {return root->getTotalFlowFileCount() == 3;};
-  REQUIRE(verifyWithBusyWait(std::chrono::milliseconds{200}, flowFilesEnqueued));
+  std::size_t flow_file_count = 0;
+  auto flowFilesEnqueued = [&] { flow_file_count = root->getTotalFlowFileCount(); return flow_file_count >= 3; };
+  REQUIRE(verifyWithBusyWait(std::chrono::milliseconds{500}, flowFilesEnqueued));
 
-  REQUIRE(sourceProc->trigger_count.load() == 1);
+  REQUIRE(sourceProc->trigger_count.load() >= flow_file_count / 3);
 
   execSinkPromise.set_value();
   controller->stop();
 
-  REQUIRE(sourceProc->trigger_count.load() == 1);
-  REQUIRE(sinkProc->trigger_count.load() == 1);
+  REQUIRE(sourceProc->trigger_count.load() >= flow_file_count / 3);
+  REQUIRE(sinkProc->trigger_count.load() >= flow_file_count / 3);
 }
 
 TEST_CASE("Extend the waiting period during shutdown", "[TestFlow4]") {
@@ -230,10 +232,11 @@ TEST_CASE("Extend the waiting period during shutdown", "[TestFlow4]") {
   testController.startFlow();
 
   // wait for the source processor to enqueue its flowFiles
-  auto flowFilesEnqueued = [&] {return root->getTotalFlowFileCount() == 3;};
-  REQUIRE(verifyWithBusyWait(std::chrono::milliseconds{200}, flowFilesEnqueued));
+  std::size_t flow_file_count = 0;
+  auto flowFilesEnqueued = [&] { flow_file_count = root->getTotalFlowFileCount(); return flow_file_count >= 3; };
+  REQUIRE(verifyWithBusyWait(std::chrono::milliseconds{500}, flowFilesEnqueued));
 
-  REQUIRE(sourceProc->trigger_count.load() == 1);
+  REQUIRE(sourceProc->trigger_count.load() >= flow_file_count / 3);
 
   std::thread shutdownThread([&]{
     execSinkPromise.set_value();
@@ -257,6 +260,6 @@ TEST_CASE("Extend the waiting period during shutdown", "[TestFlow4]") {
 
   shutdownThread.join();
 
-  REQUIRE(sourceProc->trigger_count.load() == 1);
-  REQUIRE(sinkProc->trigger_count.load() == 3);
+  REQUIRE(sourceProc->trigger_count.load() >= flow_file_count / 3);
+  REQUIRE(sinkProc->trigger_count.load() >= flow_file_count);
 }


### PR DESCRIPTION
Depending on the scheduling of the threads sometimes the 200ms timeout was not enough to notify the processor of the inserted flowfiles. This was increased to 500ms. Unfortunately it could also occur due to the scheduling that more than 3 flowfiles are inserted in the allocated time at the point of any of the checks. Due to this issue the checks were changed to only check the lower limit of the required trigger counts.

-----------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
