### PR TITLE
MINIFICPP-1493: Fixing incompatibility with gpsd versions >= 3.21

### DIFF
--- a/extensions/gps/GetGPS.cpp
+++ b/extensions/gps/GetGPS.cpp
@@ -86,6 +86,14 @@ void GetGPS::onSchedule(const std::shared_ptr<core::ProcessContext> &context, co
   logger_->log_trace("GPSD client scheduled");
 }
 
+int get_gps_status(struct gps_data_t* gps_data) {
+#if defined(GPSD_API_MAJOR_VERSION) && GPSD_API_MAJOR_VERSION >= 10
+  return gps_data->fix.status;
+#else
+  return gps_data->status;
+#endif
+}
+
 void GetGPS::onTrigger(const std::shared_ptr<core::ProcessContext>& /*context*/, const std::shared_ptr<core::ProcessSession> &session) {
   try {
     gpsmm gps_rec(gpsdHost_.c_str(), gpsdPort_.c_str());
@@ -106,7 +114,7 @@ void GetGPS::onTrigger(const std::shared_ptr<core::ProcessContext>& /*context*/,
         return;
       } else {
 
-        if (gpsdata->status > 0) {
+        if (get_gps_status(gpsdata) > 0) {
 
           if (gpsdata->fix.longitude != gpsdata->fix.longitude || gpsdata->fix.altitude != gpsdata->fix.altitude) {
             logger_->log_info("No GPS fix.");


### PR DESCRIPTION
gpsd 3.21 (released in 2020-08-04) moved gps_data_t->status to gps_fix_t.status
https://gitlab.com/gpsd/gpsd/commit/29991d6ffeb41ecfc8297db68bb68be0128c8514


---


Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
