### PR TITLE
MINIFICPP-1531 Use release build type for Ubuntu 20.04 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
           sudo apt install -y ccache libfl-dev libpcap-dev libboost-all-dev
           echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
-        run: ./bootstrap.sh -e -t && cd build  && cmake -DUSE_SHARED_LIBS= -DENABLE_BUSTACHE=ON -DENABLE_SQLITE=ON -DENABLE_PCAP=ON -DSTRICT_GSL_CHECKS=AUDIT -DFAIL_ON_WARNINGS=ON .. && make -j4 VERBOSE=1  && make test ARGS="--timeout 300 -j2 --output-on-failure"
+        run: ./bootstrap.sh -e -t && cd build  && cmake -DUSE_SHARED_LIBS= -DCMAKE_BUILD_TYPE=Release -DENABLE_BUSTACHE=ON -DENABLE_SQLITE=ON -DENABLE_PCAP=ON -DSTRICT_GSL_CHECKS=AUDIT -DFAIL_ON_WARNINGS=ON .. && make -j4 VERBOSE=1  && make test ARGS="--timeout 300 -j2 --output-on-failure"
   ubuntu_20_04_all_clang:
     name: "ubuntu-20.04-all-clang"
     runs-on: ubuntu-20.04
@@ -181,7 +181,7 @@ jobs:
           sudo apt install -y ccache libfl-dev libpcap-dev libboost-all-dev openjdk-8-jdk maven libusb-1.0-0-dev libpng-dev libgps-dev
           echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
-        run: ./bootstrap.sh -e -t && cd build  && cmake -DUSE_SHARED_LIBS= -DENABLE_OPENWSMAN=ON -DENABLE_OPENCV=ON -DENABLE_MQTT=ON -DENABLE_GPS=ON -DENABLE_USB_CAMERA=ON -DENABLE_LIBRDKAFKA=ON -DENABLE_OPC=ON -DENABLE_SFTP=ON -DENABLE_MQTT=ON -DENABLE_COAP=ON -DENABLE_PYTHON=ON -DENABLE_SQL=ON -DENABLE_AWS=ON -DSTRICT_GSL_CHECKS=AUDIT -DFAIL_ON_WARNINGS=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .. &&  cmake --build . --parallel 4  && make test ARGS="--timeout 300 -j8 --output-on-failure"
+        run: ./bootstrap.sh -e -t && cd build  && cmake -DUSE_SHARED_LIBS= -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENWSMAN=ON -DENABLE_OPENCV=ON -DENABLE_MQTT=ON -DENABLE_GPS=ON -DENABLE_USB_CAMERA=ON -DENABLE_LIBRDKAFKA=ON -DENABLE_OPC=ON -DENABLE_SFTP=ON -DENABLE_MQTT=ON -DENABLE_COAP=ON -DENABLE_PYTHON=ON -DENABLE_SQL=ON -DENABLE_AWS=ON -DSTRICT_GSL_CHECKS=AUDIT -DFAIL_ON_WARNINGS=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .. &&  cmake --build . --parallel 4  && make test ARGS="--timeout 300 -j8 --output-on-failure"
   ubuntu_16_04_all:
     name: "ubuntu-16.04-all"
     runs-on: ubuntu-16.04

--- a/controller/Controller.h
+++ b/controller/Controller.h
@@ -146,7 +146,7 @@ int getJstacks(std::unique_ptr<minifi::io::Socket> socket, std::ostream &out) {
 
     for (uint64_t i = 0; i < size; i++) {
       std::string name;
-      uint64_t lines;
+      uint64_t lines = 0;
       socket->read(name);
       socket->read(lines);
       for (uint64_t j = 0; j < lines; j++) {

--- a/extensions/http-curl/tests/HTTPHandlers.h
+++ b/extensions/http-curl/tests/HTTPHandlers.h
@@ -416,6 +416,7 @@ class HeartbeatHandler : public ServerAwareHandler {
       }
     }
     assert(found);
+    (void)found;  // unused in release builds
   }
 
   virtual void handleHeartbeat(const rapidjson::Document& root, struct mg_connection *) {
@@ -431,6 +432,7 @@ class HeartbeatHandler : public ServerAwareHandler {
       rapidjson::Document root;
       rapidjson::ParseResult ok = root.Parse(post_data.data(), post_data.size());
       assert(ok);
+      (void)ok;  // unused in release builds
       std::string operation = root["operation"].GetString();
       if (operation == "heartbeat") {
         handleHeartbeat(root, conn);

--- a/libminifi/test/aws-tests/ListS3Tests.cpp
+++ b/libminifi/test/aws-tests/ListS3Tests.cpp
@@ -69,7 +69,7 @@ TEST_CASE_METHOD(ListS3TestsFixture, "Test required property not set", "[awsS3Er
     plan->setProperty(s3_processor, "Region", "");
   }
 
-  REQUIRE_THROWS_AS(test_controller.runSession(plan, true), minifi::Exception);
+  REQUIRE_THROWS_AS(test_controller.runSession(plan, true), minifi::Exception&);
 }
 
 TEST_CASE_METHOD(ListS3TestsFixture, "Test proxy setting", "[awsS3Proxy]") {

--- a/libminifi/test/rocksdb-tests/RepoTests.cpp
+++ b/libminifi/test/rocksdb-tests/RepoTests.cpp
@@ -342,6 +342,7 @@ TEST_CASE("Test FlowFile Restore", "[TestFFR6]") {
     return newFlow != nullptr;
   };
   assert(verifyEventHappenedInPollTime(std::chrono::seconds(10), flowFileArrivedInOutput, std::chrono::milliseconds(50)));
+  (void)flowFileArrivedInOutput;  // unused in release builds
   REQUIRE(expiredFiles.empty());
 
   LogTestController::getInstance().reset();

--- a/nanofi/include/sitetosite/CPeer.h
+++ b/nanofi/include/sitetosite/CPeer.h
@@ -73,9 +73,8 @@ static inline void setHostName(struct SiteToSiteCPeer * peer, const char * hostn
   peer->_host = (char*)malloc(host_len + 1);  // +1 for trailing zero
   peer->_url = (char*)malloc(host_len + 14);  // +1 for trailing zero, 1 for ':', at most 5 for port, 7 for "nifi://" suffix
   memset(peer->_url, 0, host_len + 14);  // make sure to have zero padding no matter the length of the port
-  strncpy(peer->_host, hostname, host_len);
+  snprintf(peer->_host, host_len + 1, "%s", hostname);
   snprintf(peer->_url, host_len + 14, "nifi://%s:", hostname);
-  peer->_host[host_len] = '\0';
   if(peer->_port != 0) {
     snprintf(peer->_url + host_len + 8, 6, "%d", peer->_port);
   }


### PR DESCRIPTION
Ubuntu 20.04 jobs were changed to use Release build type to avoid running out of 14GB disk space limit on Github runners.

Additional issues found with release build were fixed (and also new issues discovered with updated GCC version 9.3 on Ubuntu 20.04).

Debug build is kept in ubuntu_16_04_all job:
`2021-03-19T08:17:19.9628133Z -- CMAKE_BUILD_TYPE not given; setting to 'Debug'`

------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
