### PR TITLE
[oneliner] MINIFICPP-1542 fix race condition in Connection::isWorkAvailable

### DIFF
--- a/libminifi/include/Connection.h
+++ b/libminifi/include/Connection.h
@@ -167,6 +167,7 @@ class Connection : public core::Connectable, public std::enable_shared_from_this
   void yield() override {}
 
   bool isWorkAvailable() override {
+    const std::lock_guard<std::mutex> lock{mutex_};
     return queue_.isWorkAvailable();
   }
 


### PR DESCRIPTION
[MINIFICPP-1542](https://issues.apache.org/jira/browse/MINIFICPP-1542)

> Connection::isWorkAvailable accesses its FlowFileQueue without proper locking, resulting in unsynchronized access to the queue and a race condition. I was lucky enough to get a segfault when comparing the penalty expiration of a flow file from the top of the queue that has already been destructed and its memory released back to the OS.

--------

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
