### PR TITLE
MINIFICPP-1203 - Linter reported redundand blank lines

### DIFF
--- a/controller/Controller.h
+++ b/controller/Controller.h
@@ -140,7 +140,6 @@ int getJstacks(std::unique_ptr<minifi::io::Socket> socket, std::ostream &out) {
   uint8_t resp = 0;
   socket->read(&resp, 1);
   if (resp == minifi::c2::Operation::DESCRIBE) {
-
     uint64_t size = 0;
     socket->read(size);
 
@@ -234,7 +233,6 @@ int listConnections(std::unique_ptr<minifi::io::Socket> socket, std::ostream &ou
 }
 
 std::shared_ptr<core::controller::ControllerService> getControllerService(const std::shared_ptr<minifi::Configure> &configuration, const std::string &service_name) {
-
   std::string prov_repo_class = "provenancerepository";
   std::string flow_repo_class = "flowfilerepository";
   std::string nifi_configuration_class_name = "yamlconfiguration";
@@ -280,7 +278,6 @@ std::shared_ptr<core::controller::ControllerService> getControllerService(const 
 }
 
 void printManifest(const std::shared_ptr<minifi::Configure> &configuration) {
-
   std::string prov_repo_class = "volatileprovenancerepository";
   std::string flow_repo_class = "volatileflowfilerepository";
   std::string nifi_configuration_class_name = "yamlconfiguration";

--- a/controller/Controller.h
+++ b/controller/Controller.h
@@ -154,7 +154,6 @@ int getJstacks(std::unique_ptr<minifi::io::Socket> socket, std::ostream &out) {
         socket->read(line);
         out << name << " -- " << line << std::endl;
       }
-
     }
   }
   return 0;

--- a/controller/MiNiFiController.cpp
+++ b/controller/MiNiFiController.cpp
@@ -39,7 +39,6 @@
 #include "cxxopts.hpp"
 
 int main(int argc, char **argv) {
-
   std::shared_ptr<logging::Logger> logger = logging::LoggerConfiguration::getConfiguration().getLogger("controller");
 
   const std::string minifiHome = determineMinifiHome(logger);

--- a/controller/MiNiFiController.cpp
+++ b/controller/MiNiFiController.cpp
@@ -179,7 +179,6 @@ int main(int argc, char **argv) {
         if (getConnectionSize(std::move(socket), std::cout, component) < 0)
           std::cout << "Could not connect to remote host " << host << ":" << port << std::endl;
       }
-
     }
 
     if (result.count("l") > 0) {
@@ -192,7 +191,6 @@ int main(int argc, char **argv) {
         if (listConnections(std::move(socket), std::cout, show_headers) < 0)
           std::cout << "Could not connect to remote host " << host << ":" << port << std::endl;
       }
-
     }
 
     if (result.count("getfull") > 0) {

--- a/extensions/bootstrap/bootstrap.cpp
+++ b/extensions/bootstrap/bootstrap.cpp
@@ -46,7 +46,6 @@ int main(int argc, char **argv) {
       generateC2Docs(result["inputc2docs"].as<std::string>(),result["outputc2docs"].as<std::string>());
       std::cout << "Generated docs at " << result["outputc2docs"].as<std::string>() << std::endl;
     }
-
   }catch (const std::exception &exc) {
       // catch anything thrown within try block that derives from std::exception
       std::cerr << exc.what() << std::endl;

--- a/extensions/bustache/TemplateLoader.h
+++ b/extensions/bustache/TemplateLoader.h
@@ -55,7 +55,6 @@ class TemplateFactory : public core::ObjectFactory {
   }
 
   static bool added;
-
 };
 
 extern "C" {

--- a/extensions/coap/COAPLoader.h
+++ b/extensions/coap/COAPLoader.h
@@ -81,7 +81,6 @@ class COAPObjectFactory : public core::ObjectFactory {
   }
 
   static bool added;
-
 };
 
 extern "C" {

--- a/extensions/coap/controllerservice/CoapConnector.cpp
+++ b/extensions/coap/controllerservice/CoapConnector.cpp
@@ -69,7 +69,6 @@ void CoapConnectorService::onEnable() {
     if (configuration_->get("nifi.c2.agent.coap.host", host_) && configuration_->get("nifi.c2.agent.coap.port", port_str)) {
       core::Property::StringToInt(port_str, port_);
     }
-
   }
 }
 

--- a/extensions/coap/controllerservice/CoapConnector.h
+++ b/extensions/coap/controllerservice/CoapConnector.h
@@ -106,7 +106,6 @@ class CoapConnectorService : public core::controller::ControllerService {
   unsigned int port_{ 0 };
 
   std::shared_ptr<logging::Logger> logger_{ logging::LoggerFactory<CoapConnectorService>::getLogger() };
-
 };
 
 } /* namespace controllers */

--- a/extensions/coap/controllerservice/CoapMessaging.h
+++ b/extensions/coap/controllerservice/CoapMessaging.h
@@ -93,14 +93,12 @@ class CoapMessaging {
     ptrs.data_received = receiveMessage;
     ptrs.received_error = receiveError;
     init_coap_api(this, &ptrs);
-
   }
   // connector mutex. mutable since it's used within hasResponse.
   mutable std::mutex connector_mutex_;
   // map of messages based on the context. We only allow a single message per context
   // at any given time.
   std::unordered_map<coap_context_t*, CoapResponse> messages_;
-
 };
 
 } /* namespace controllers */

--- a/extensions/coap/controllerservice/CoapResponse.h
+++ b/extensions/coap/controllerservice/CoapResponse.h
@@ -52,7 +52,6 @@ class CoapResponse {
       : code_(code),
         size_(0),
         data_(nullptr) {
-
   }
 
   CoapResponse(const CoapResponse &other) = delete;

--- a/extensions/coap/nanofi/coap_functions.c
+++ b/extensions/coap/nanofi/coap_functions.c
@@ -80,7 +80,6 @@ int create_session(coap_context_t **ctx, coap_session_t **session, const char *n
     *session = coap_new_client_session(*ctx, 0x00, dst_addr, proto);
     return 0;
   }
-
 }
 
 int create_endpoint_context(coap_context_t **ctx, const char *node, const char *port) {
@@ -180,7 +179,6 @@ void response_handler(struct coap_context_t *ctx, struct coap_session_t *session
         global_ptrs.received_error(receiver, ctx, received->code);
     }
   }
-
 }
 
 int resolve_address(const struct coap_str_const_t *server, struct sockaddr *destination) {

--- a/extensions/coap/nanofi/coap_server.c
+++ b/extensions/coap/nanofi/coap_server.c
@@ -49,7 +49,6 @@ CoapEndpoint* create_endpoint(CoapServerContext * const server, const char * con
     coap_delete_str_const(path);
   }
   return endpoint;
-
 }
 
 int8_t add_endpoint(CoapEndpoint * const endpoint, uint8_t method, coap_method_handler_t handler) {

--- a/extensions/coap/protocols/CoapC2Protocol.cpp
+++ b/extensions/coap/protocols/CoapC2Protocol.cpp
@@ -150,7 +150,6 @@ int CoapProtocol::writeHeartbeat(io::BaseStream *stream, const minifi::c2::C2Pay
 
       stream->write(bucketId);
       stream->write(flowId);
-
     } catch (const minifi::c2::PayloadParseException &pe) {
       logger_->log_error("Parser exception occurred, but is ignorable, reason %s", pe.what());
       // okay to ignore
@@ -209,7 +208,6 @@ minifi::c2::C2Payload CoapProtocol::serialize(const minifi::c2::C2Payload &paylo
     require_registration_ = false;
 
     return minifi::c2::C2Payload(payload.getOperation(), state::UpdateState::READ_COMPLETE);
-
   }
 
   uint16_t version = 0;

--- a/extensions/coap/protocols/CoapC2Protocol.cpp
+++ b/extensions/coap/protocols/CoapC2Protocol.cpp
@@ -256,7 +256,6 @@ minifi::c2::C2Payload CoapProtocol::serialize(const minifi::c2::C2Payload &paylo
     logger_->log_trace("Received ack. version %d. number of operations %d", version, size);
     minifi::c2::C2Payload new_payload(payload.getOperation(), state::UpdateState::NESTED);
     for (int i = 0; i < size; i++) {
-
       uint8_t operationType;
       uint16_t argsize = 0;
       std::string operand, id;

--- a/extensions/coap/protocols/CoapC2Protocol.h
+++ b/extensions/coap/protocols/CoapC2Protocol.h
@@ -136,7 +136,6 @@ class CoapProtocol : public minifi::c2::RESTSender {
   static uint8_t REGISTRATION_MSG[8];
 
   std::shared_ptr<logging::Logger> logger_;
-
 };
 } /* namespace c2 */
 } /* namespace coap */

--- a/extensions/coap/server/CoapServer.h
+++ b/extensions/coap/server/CoapServer.h
@@ -206,7 +206,6 @@ class CoapServer : public core::Connectable {
 
   static void handle_response_with_passthrough(coap_context_t* /*ctx*/, struct coap_resource_t *resource, coap_session_t *session, coap_pdu_t *request, coap_binary_t* /*token*/, coap_string_t* /*query*/,
                                                coap_pdu_t *response) {
-
     auto fx = functions_.find(resource);
     if (fx != functions_.end()) {
       auto message = create_coap_message(request);

--- a/extensions/coap/server/CoapServer.h
+++ b/extensions/coap/server/CoapServer.h
@@ -48,7 +48,6 @@ class CoapQuery {
   CoapQuery(const std::string &query, std::unique_ptr<CoapMessage, decltype(&free_coap_message)> message)
       : query_(query),
         message_(std::move(message)) {
-
   }
   virtual ~CoapQuery() = default;
   CoapQuery(const CoapQuery &qry) = delete;
@@ -69,7 +68,6 @@ class CoapResponse {
       : code_(code),
         data_(std::move(data)),
         size_(size) {
-
   }
 
   int getCode() const {
@@ -130,7 +128,6 @@ class CoapServer : public core::Connectable {
         coap_check_notify(server_->ctx);
       }
       return 0;
-
     });
   }
 
@@ -195,7 +192,6 @@ class CoapServer : public core::Connectable {
   void waitForWork(uint64_t timeoutMs);
 
   virtual void yield() {
-
   }
 
   /**
@@ -222,9 +218,7 @@ class CoapServer : public core::Connectable {
       if (coap_send(session, response) == COAP_INVALID_TID) {
         printf("error while returning response");
       }
-
     }
-
   }
 
   std::future<uint64_t> future;

--- a/extensions/coap/tests/CoapC2VerifyHeartbeat.cpp
+++ b/extensions/coap/tests/CoapC2VerifyHeartbeat.cpp
@@ -114,7 +114,6 @@ class VerifyCoAPServer : public CoapIntegrationBase {
     server->add_endpoint(minifi::coap::Method::Post, [](minifi::coap::CoapQuery)->minifi::coap::CoapResponse {
       minifi::coap::CoapResponse response(205,0x00,0);
       return response;
-
     });
 
     {
@@ -158,7 +157,6 @@ class VerifyCoAPServer : public CoapIntegrationBase {
         minifi::coap::CoapResponse response(500,0,0);
         return response;
       }
-
     });
     server->start();
     configuration->set("c2.enable", "true");

--- a/extensions/expression-language/Expression.cpp
+++ b/extensions/expression-language/Expression.cpp
@@ -91,7 +91,6 @@ Expression make_dynamic(const std::function<Value(const Parameters &params, cons
 
 Expression make_dynamic_attr(const std::string &attribute_id) {
   return make_dynamic([attribute_id](const Parameters &params, const std::vector<Expression>& /*sub_exprs*/) -> Value {
-
     std::string result;
     const auto cur_flow_file = params.flow_file.lock();
     if (cur_flow_file && cur_flow_file->getAttribute(attribute_id, result)) {
@@ -948,7 +947,6 @@ Value expr_random(const std::vector<Value>& /*args*/) {
 
 template<Value T(const std::vector<Value> &)>
 Expression make_dynamic_function_incomplete(const std::string &function_name, const std::vector<Expression> &args, std::size_t num_args) {
-
   if (args.size() < num_args) {
     std::stringstream message_ss;
     message_ss << "Expression language function " << function_name << " called with " << args.size() << " argument(s), but " << num_args << " are required";
@@ -1558,7 +1556,6 @@ Expression make_dynamic_function(const std::string &function_name, const std::ve
 }
 
 Expression make_function_composition(const Expression &arg, const std::vector<std::pair<std::string, std::vector<Expression>>> &chain) {
-
   auto expr = arg;
 
   for (const auto &chain_part : chain) {

--- a/extensions/expression-language/ExpressionLoader.h
+++ b/extensions/expression-language/ExpressionLoader.h
@@ -61,7 +61,6 @@ class ExpressionObjectFactory : public core::ObjectFactory {
   }
 
   static bool added;
-
 };
 
 extern "C" {

--- a/extensions/expression-language/ProcessContextExpr.cpp
+++ b/extensions/expression-language/ProcessContextExpr.cpp
@@ -43,7 +43,6 @@ bool ProcessContextExpr::getProperty(const Property &property, std::string &valu
 }
 
 bool ProcessContextExpr::getDynamicProperty(const Property &property, std::string &value, const std::shared_ptr<FlowFile> &flow_file) {
-
   if (!property.supportsExpressionLangauge()) {
     return ProcessContext::getDynamicProperty(property.getName(), value);
   }

--- a/extensions/expression-language/impl/expression/Expression.h
+++ b/extensions/expression-language/impl/expression/Expression.h
@@ -57,7 +57,6 @@ struct Parameters {
   Parameters(std::shared_ptr<core::FlowFile> ff = nullptr) {
     flow_file = ff;
   }
-
 };
 
 class Expression;

--- a/extensions/gps/GetGPS.cpp
+++ b/extensions/gps/GetGPS.cpp
@@ -113,9 +113,7 @@ void GetGPS::onTrigger(const std::shared_ptr<core::ProcessContext>& /*context*/,
         logger_->log_error("Read error");
         return;
       } else {
-
         if (get_gps_status(gpsdata) > 0) {
-
           if (gpsdata->fix.longitude != gpsdata->fix.longitude || gpsdata->fix.altitude != gpsdata->fix.altitude) {
             logger_->log_info("No GPS fix.");
             continue;

--- a/extensions/gps/GetGPS.cpp
+++ b/extensions/gps/GetGPS.cpp
@@ -155,7 +155,6 @@ void GetGPS::onTrigger(const std::shared_ptr<core::ProcessContext>& /*context*/,
         }
       }
     }
-
   } catch (std::exception &exception) {
     logger_->log_error("GetGPS Caught Exception %s", exception.what());
     throw;

--- a/extensions/gps/GetGPSLoader.h
+++ b/extensions/gps/GetGPSLoader.h
@@ -56,7 +56,6 @@ class GpsFactory : public core::ObjectFactory {
   }
 
   static bool added;
-
 };
 
 extern "C" {

--- a/extensions/http-curl/HTTPCurlLoader.h
+++ b/extensions/http-curl/HTTPCurlLoader.h
@@ -94,7 +94,6 @@ class HttpCurlObjectFactory : public core::ObjectFactory {
   }
 
   static bool added;
-
 };
 
 extern "C" {

--- a/extensions/http-curl/protocols/AgentPrinter.cpp
+++ b/extensions/http-curl/protocols/AgentPrinter.cpp
@@ -84,7 +84,6 @@ rapidjson::Value AgentPrinter::serializeJsonPayload(const C2Payload &payload, ra
   std::map<std::string, std::list<rapidjson::Value*>> children;
   bool print = payload.getLabel() == "agentManifest";
   for (const auto &nested_payload : payload.getNestedPayloads()) {
-
     rapidjson::Value* child_payload = new rapidjson::Value(serializeJsonPayload(nested_payload, alloc));
     children[nested_payload.getLabel()].push_back(child_payload);
   }
@@ -125,7 +124,6 @@ rapidjson::Value AgentPrinter::serializeJsonPayload(const C2Payload &payload, ra
   mergePayloadContent(json_payload, payload, alloc);
 
   if (print) {
-
     rapidjson::StringBuffer buffer;
     rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(buffer);
     json_payload.Accept(writer);

--- a/extensions/http-curl/protocols/AgentPrinter.cpp
+++ b/extensions/http-curl/protocols/AgentPrinter.cpp
@@ -87,7 +87,6 @@ rapidjson::Value AgentPrinter::serializeJsonPayload(const C2Payload &payload, ra
 
     rapidjson::Value* child_payload = new rapidjson::Value(serializeJsonPayload(nested_payload, alloc));
     children[nested_payload.getLabel()].push_back(child_payload);
-
   }
 
   // child_vector is Pair<string, vector<Value*>>

--- a/extensions/http-curl/protocols/RESTReceiver.h
+++ b/extensions/http-curl/protocols/RESTReceiver.h
@@ -55,7 +55,6 @@ class RESTReceiver : public RESTProtocol, public HeartBeatReporter {
  protected:
 
   class ListeningProtocol : public CivetHandler {
-
    public:
     ListeningProtocol() = default;
 

--- a/extensions/http-curl/protocols/RESTReceiver.h
+++ b/extensions/http-curl/protocols/RESTReceiver.h
@@ -82,7 +82,6 @@ class RESTReceiver : public RESTProtocol, public HeartBeatReporter {
    protected:
     std::mutex reponse_mutex_;
     std::string resp_;
-
   };
 
   std::unique_ptr<CivetServer> start_webserver(const std::string &port, std::string &rooturi, CivetHandler *handler, std::string &ca_cert);

--- a/extensions/http-curl/sitetosite/HTTPProtocol.cpp
+++ b/extensions/http-curl/sitetosite/HTTPProtocol.cpp
@@ -106,7 +106,6 @@ std::shared_ptr<Transaction> HttpSiteToSiteClient::createTransaction(TransferDir
 
 int HttpSiteToSiteClient::readResponse(const std::shared_ptr<Transaction> &transaction, RespondCode &code, std::string &message) {
   if (current_code == FINISH_TRANSACTION) {
-
     if (transaction->getDirection() == SEND) {
       auto stream = dynamic_cast<io::HttpStream*>(peer_->getStream());
       stream->close();
@@ -124,7 +123,6 @@ int HttpSiteToSiteClient::readResponse(const std::shared_ptr<Transaction> &trans
     }
   } else if (transaction->getDirection() == RECEIVE) {
     if (transaction->getState() == TRANSACTION_STARTED || transaction->getState() == DATA_EXCHANGED) {
-
       if (current_code == CONFIRM_TRANSACTION && transaction->getState() == DATA_EXCHANGED) {
         auto stream = dynamic_cast<io::HttpStream*>(peer_->getStream());
         if (!stream->isFinished()) {
@@ -222,7 +220,6 @@ bool HttpSiteToSiteClient::transmitPayload(const std::shared_ptr<core::ProcessCo
 }
 
 void HttpSiteToSiteClient::tearDown() {
-
   if (peer_state_ >= ESTABLISHED) {
     logger_->log_debug("Site2Site Protocol tearDown");
   }

--- a/extensions/http-curl/sitetosite/HTTPProtocol.cpp
+++ b/extensions/http-curl/sitetosite/HTTPProtocol.cpp
@@ -166,7 +166,6 @@ int HttpSiteToSiteClient::readResponse(const std::shared_ptr<Transaction> &trans
     return 1;
   }
   return SiteToSiteClient::readResponse(transaction, code, message);
-
 }
 // write respond
 int HttpSiteToSiteClient::writeResponse(const std::shared_ptr<Transaction> &transaction, RespondCode code, std::string message) {
@@ -230,7 +229,6 @@ void HttpSiteToSiteClient::tearDown() {
   known_transactions_.clear();
   peer_->Close();
   peer_state_ = IDLE;
-
 }
 
 void HttpSiteToSiteClient::closeTransaction(const utils::Identifier &transactionID) {

--- a/extensions/http-curl/sitetosite/HTTPProtocol.h
+++ b/extensions/http-curl/sitetosite/HTTPProtocol.h
@@ -57,7 +57,6 @@ typedef struct Site2SitePeerStatus {
 
 // HttpSiteToSiteClient Class
 class HttpSiteToSiteClient : public sitetosite::SiteToSiteClient {
-
   static constexpr char const* PROTOCOL_VERSION_HEADER = "x-nifi-site-to-site-protocol-version";
  public:
 

--- a/extensions/http-curl/sitetosite/PeersEntity.h
+++ b/extensions/http-curl/sitetosite/PeersEntity.h
@@ -114,7 +114,6 @@ class PeersEntity {
       logger->log_debug("General exception occurred");
       return false;
     }
-
   }
 };
 

--- a/extensions/http-curl/tests/HTTPHandlers.h
+++ b/extensions/http-curl/tests/HTTPHandlers.h
@@ -296,7 +296,6 @@ class FlowFileResponder : public ServerAwareHandler {
       mg_printf(conn, "HTTP/1.1 200 OK\r\nConnection: "
                 "close\r\nContent-Length: 0\r\n");
       mg_printf(conn, "Content-Type: text/plain\r\n\r\n");
-
     }
     return true;
   }
@@ -412,7 +411,6 @@ class HeartbeatHandler : public ServerAwareHandler {
           assert(std::find(classes.begin(), classes.end(), proc.class_name_) != std::end(classes));
           found = true;
         }
-
       }
     }
     assert(found);

--- a/extensions/http-curl/tests/HTTPHandlers.h
+++ b/extensions/http-curl/tests/HTTPHandlers.h
@@ -85,7 +85,6 @@ class PeerResponder : public ServerAwareHandler {
   }
 
   bool handleGet(CivetServer* /*server*/, struct mg_connection *conn) override {
-
 #ifdef WIN32
     std::string hostname = org::apache::nifi::minifi::io::Socket::getMyHostName();
 #else
@@ -136,7 +135,6 @@ class TransactionResponder : public ServerAwareHandler {
         input_port(input_port),
         port_id(std::move(port_id)),
         flow_files_feed_(nullptr) {
-
     if (input_port) {
       transaction_id_str = "fe4a3a42-53b6-4af1-a80d-6fdfe60de96";
       transaction_id_str += std::to_string(transaction_id.load());
@@ -263,7 +261,6 @@ class FlowFileResponder : public ServerAwareHandler {
   }
 
   bool handleGet(CivetServer* /*server*/, struct mg_connection *conn) override {
-
     if (flow_files_feed_->size_approx() > 0) {
       std::shared_ptr<FlowObj> flowobj;
       std::vector<std::shared_ptr<FlowObj>> flows;
@@ -400,7 +397,6 @@ class HeartbeatHandler : public ServerAwareHandler {
       assert(bundle.HasMember("artifact"));
       std::string str = bundle["artifact"].GetString();
       if (str == "minifi-standard-processors") {
-
         std::vector<std::string> classes;
         for (auto &proc : bundle["componentManifest"]["processors"].GetArray()) {
           classes.push_back(proc["type"].GetString());

--- a/extensions/http-curl/tests/TestServer.h
+++ b/extensions/http-curl/tests/TestServer.h
@@ -51,7 +51,6 @@ class TestServer{
   };
  public:
   TestServer(std::string &port, std::string &rooturi, CivetHandler *handler, CivetCallbacks *callbacks, std::string& /*cert*/, std::string &ca_cert) {
-
     if (!mg_check_feature(2)) {
       throw std::runtime_error("Error: Embedded example built with SSL support, "
                                "but civetweb library build without.\n");

--- a/extensions/jni/ExecuteJavaControllerService.cpp
+++ b/extensions/jni/ExecuteJavaControllerService.cpp
@@ -66,7 +66,6 @@ void ExecuteJavaControllerService::initialize() {
   if (!existingValue.empty()) {
     setProperty(NiFiControllerService, existingValue);
   }
-
 }
 
 ExecuteJavaControllerService::~ExecuteJavaControllerService() = default;
@@ -104,7 +103,6 @@ void ExecuteJavaControllerService::onEnable() {
   } catch (std::runtime_error &re) {
     // this can be ignored.
   }
-
 }
 
 } /* namespace controllers */

--- a/extensions/jni/ExecuteJavaProcessor.cpp
+++ b/extensions/jni/ExecuteJavaProcessor.cpp
@@ -184,7 +184,6 @@ void ExecuteJavaProcessor::onTrigger(const std::shared_ptr<core::ProcessContext>
   if (ClassRegistrar::getRegistrar().registerClasses(env, java_servicer_, "org/apache/nifi/processor/JniFlowFile", getFlowFileSignatures())) {
     static auto ffc = java_servicer_->loadClass("org/apache/nifi/processor/JniFlowFile");
     java_servicer_->putNativeFunctionMapping<JniFlowFile>(env, ffc);
-
   }
   if (ClassRegistrar::getRegistrar().registerClasses(env, java_servicer_, "org/apache/nifi/processor/JniInputStream", getInputStreamSignatures())) {
     static auto jin = java_servicer_->loadClass("org/apache/nifi/processor/JniInputStream");

--- a/extensions/jni/ExecuteJavaProcessor.cpp
+++ b/extensions/jni/ExecuteJavaProcessor.cpp
@@ -157,7 +157,6 @@ void ExecuteJavaProcessor::onSchedule(const std::shared_ptr<core::ProcessContext
   java_servicer_->setReference<minifi::jni::JniProcessContext>(env, context_instance_, &jpc);
 
   try {
-
     for (const auto &onScheduledName : onScheduledNames) {
       current_processor_class.callVoidMethod(env, clazzInstance, onScheduledName.first.c_str(), onScheduledName.second, context_instance_);
     }

--- a/extensions/jni/ExecuteJavaProcessor.h
+++ b/extensions/jni/ExecuteJavaProcessor.h
@@ -119,7 +119,6 @@ class ExecuteJavaProcessor : public core::Processor {
     if (methodSignatures.empty()) {
       methodSignatures.addSignature({ "read", "()I", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniInputStream_read) });
       methodSignatures.addSignature({ "readWithOffset", "([BII)I", reinterpret_cast<void*>(&Java_org_apache_nifi_processor_JniInputStream_readWithOffset) });
-
     }
     return methodSignatures;
   }
@@ -233,7 +232,6 @@ class ExecuteJavaProcessor : public core::Processor {
     if (init_context_.lookup_ref_) {
       localEnv->DeleteGlobalRef(init_context_.lookup_ref_);
     }
-
   }
 
  private:
@@ -246,7 +244,6 @@ class ExecuteJavaProcessor : public core::Processor {
       }
     }
     return nullptr;
-
   }
 
   JniSessionFactory *setFactory(const std::shared_ptr<core::ProcessSessionFactory> &ptr, jobject obj) {
@@ -254,7 +251,6 @@ class ExecuteJavaProcessor : public core::Processor {
     JniSessionFactory *factory = new JniSessionFactory(ptr, java_servicer_, obj);
     session_factories_.push_back(factory);
     return factory;
-
   }
 
   JNINativeMethod registerNativeMethod(const std::string &name, const std::string &params, const void *ptr);
@@ -292,7 +288,6 @@ class ExecuteJavaProcessor : public core::Processor {
   JniControllerServiceLookup csl_;
 
   JniInitializationContext init_context_;
-
 };
 
 REGISTER_RESOURCE(ExecuteJavaProcessor, "ExecuteJavaClass runs NiFi processors given a provided system path ");

--- a/extensions/jni/ExecuteJavaProcessor.h
+++ b/extensions/jni/ExecuteJavaProcessor.h
@@ -203,7 +203,6 @@ class ExecuteJavaProcessor : public core::Processor {
   }
 
   void notifyStop() override {
-
     auto localEnv = java_servicer_->attach();
 
     auto onStoppedName = java_servicer_->getAnnotation(class_name_, "OnStopped");

--- a/extensions/jni/JNILoader.h
+++ b/extensions/jni/JNILoader.h
@@ -70,7 +70,6 @@ class JNIFactory : public core::ObjectFactory {
   static minifi::jni::JVMLoader jvm;
 
   static bool added;
-
 }
 ;
 

--- a/extensions/jni/JVMCreator.h
+++ b/extensions/jni/JVMCreator.h
@@ -59,7 +59,6 @@ class JVMCreator : public minifi::core::CoreComponent {
       logger_->log_debug("Adding path %s", path);
       minifi::utils::file::FileUtils::addFilesMatchingExtension(logger_, path, ".jar", classpaths_);
     }
-
   }
 
   void configure(const std::shared_ptr<Configure> &configuration) override {

--- a/extensions/jni/JavaException.h
+++ b/extensions/jni/JavaException.h
@@ -60,7 +60,6 @@ class JavaException : public std::exception {
 };
 
 static std::string getMessage(JNIEnv *env, jthrowable throwable) {
-
   jclass clazz = env->FindClass("java/lang/Throwable");
 
   jmethodID getMessage = env->GetMethodID(clazz, "toString", "()Ljava/lang/String;");

--- a/extensions/jni/JavaException.h
+++ b/extensions/jni/JavaException.h
@@ -57,7 +57,6 @@ class JavaException : public std::exception {
  private:
   // JavaException detailed information
   std::string message_;
-
 };
 
 static std::string getMessage(JNIEnv *env, jthrowable throwable) {

--- a/extensions/jni/jvm/JVMLoader.h
+++ b/extensions/jni/jvm/JVMLoader.h
@@ -376,7 +376,6 @@ class JVMLoader {
       store_error();
       if (EnumProcessModules(current_process_id, allModules,
               sizeof(allModules), &cbNeeded) != 0) {
-
         for (uint32_t i = 0; i < cbNeeded / sizeof(HMODULE); i++) {
           TCHAR szModName[MAX_PATH];
 

--- a/extensions/jni/jvm/JVMLoader.h
+++ b/extensions/jni/jvm/JVMLoader.h
@@ -291,7 +291,6 @@ class JVMLoader {
     auto field = env->GetFieldID(classref, fieldStr.c_str(), arg.c_str());
     auto fieldName = fieldStr + arg;
     getClassMapping().putField(name, fieldName, field);
-
   }
 
  protected:
@@ -410,7 +409,6 @@ class JVMLoader {
     SetErrorMode(uMode);
 
     return (void *)object;
-
   }
 
   int dlclose(void *handle) {

--- a/extensions/jni/jvm/JavaClass.h
+++ b/extensions/jni/jvm/JavaClass.h
@@ -42,7 +42,6 @@ namespace jni {
  *
  */
 class JavaClass {
-
  public:
 
   JavaClass()

--- a/extensions/jni/jvm/JavaClass.h
+++ b/extensions/jni/jvm/JavaClass.h
@@ -104,14 +104,12 @@ class JavaClass {
   void registerMethods(JNIEnv *env, JNINativeMethod *methods, size_t size) {
     env->RegisterNatives(class_ref_, methods, size);
     ThrowIf(env);
-
   }
 
   void registerMethods(JNIEnv *env, JavaSignatures &signatures) {
     auto methods = signatures.getSignatures();
     env->RegisterNatives(class_ref_, methods, signatures.getSize());
     ThrowIf(env);
-
   }
 
   template<typename ... Args>

--- a/extensions/jni/jvm/JavaControllerService.cpp
+++ b/extensions/jni/jvm/JavaControllerService.cpp
@@ -106,7 +106,6 @@ void JavaControllerService::onEnable() {
   narClassLoaderClazz = loadClass("org/apache/nifi/processor/JniClassLoader");
 
   nar_loader_ = std::unique_ptr<NarClassLoader>(new NarClassLoader(shared_from_this(), narClassLoaderClazz, nardir, narscratch, nardocs));
-
 }
 
 } /* namespace controllers */

--- a/extensions/jni/jvm/JavaControllerService.h
+++ b/extensions/jni/jvm/JavaControllerService.h
@@ -162,7 +162,6 @@ class JavaControllerService : public core::controller::ControllerService, public
   JVMLoader *loader;
 
   std::shared_ptr<logging::Logger> logger_;
-
 };
 
 REGISTER_RESOURCE(JavaControllerService, "Allows specification of nars to be used within referenced processors. ");

--- a/extensions/jni/jvm/JniBundle.h
+++ b/extensions/jni/jvm/JniBundle.h
@@ -74,7 +74,6 @@ class JniBundle {
  private:
   std::vector<ClassDescription> descriptions_;
   struct BundleDetails details_;
-
 };
 
 } /* namespace jni */

--- a/extensions/jni/jvm/JniBundle.h
+++ b/extensions/jni/jvm/JniBundle.h
@@ -40,7 +40,6 @@ namespace jni {
  * bundles and MiNiFi C++ bundles.
  */
 class JniBundle {
-
  public:
 
   explicit JniBundle(struct BundleDetails details)

--- a/extensions/jni/jvm/JniConfigurationContext.h
+++ b/extensions/jni/jvm/JniConfigurationContext.h
@@ -43,7 +43,6 @@ class ConfigurationContext : public core::controller::ControllerService {
 };
 
 struct JniConfigurationContext {
-
   std::shared_ptr<ConfigurationContext> service_reference_;
 };
 

--- a/extensions/jni/jvm/JniFlowFile.cpp
+++ b/extensions/jni/jvm/JniFlowFile.cpp
@@ -46,7 +46,6 @@ JNIEXPORT jlong JNICALL Java_org_apache_nifi_processor_JniFlowFile_getId(JNIEnv 
   THROW_IF_NULL(ff, env, NO_FF_OBJECT);
   jlong id = ff->getId();
   return id;
-
 }
 JNIEXPORT jlong JNICALL Java_org_apache_nifi_processor_JniFlowFile_getEntryDate(JNIEnv *env, jobject obj) {
   minifi::jni::JniFlowFile *ptr = minifi::jni::JVMLoader::getInstance()->getReference<minifi::jni::JniFlowFile>(env, obj);

--- a/extensions/jni/jvm/JniFlowFile.cpp
+++ b/extensions/jni/jvm/JniFlowFile.cpp
@@ -39,7 +39,6 @@ extern "C" {
 #endif
 
 JNIEXPORT jlong JNICALL Java_org_apache_nifi_processor_JniFlowFile_getId(JNIEnv *env, jobject obj) {
-
   minifi::jni::JniFlowFile *ptr = minifi::jni::JVMLoader::getInstance()->getReference<minifi::jni::JniFlowFile>(env, obj);
 
   auto ff = ptr->get();
@@ -120,7 +119,6 @@ JNIEXPORT jstring JNICALL  Java_org_apache_nifi_processor_JniFlowFile_getUUIDStr
 }
 
 JNIEXPORT jobject JNICALL Java_org_apache_nifi_processor_JniFlowFile_getAttributes(JNIEnv *env, jobject obj) {
-
   minifi::jni::JniFlowFile *ptr = minifi::jni::JVMLoader::getInstance()->getReference<minifi::jni::JniFlowFile>(env, obj);
 
   auto ff = ptr->get();

--- a/extensions/jni/jvm/JniMethod.h
+++ b/extensions/jni/jvm/JniMethod.h
@@ -36,7 +36,6 @@ namespace jni {
  * to contain the method signatures in internal objects.
  */
 class JavaMethodSignature {
-
  public:
   JavaMethodSignature(const JavaMethodSignature &other) = delete;
   JavaMethodSignature(JavaMethodSignature &&other) = default;

--- a/extensions/jni/jvm/JniProcessSession.cpp
+++ b/extensions/jni/jvm/JniProcessSession.cpp
@@ -62,7 +62,6 @@ JNIEXPORT jobject JNICALL Java_org_apache_nifi_processor_JniProcessSession_creat
   minifi::jni::JVMLoader::getInstance()->setReference(ff_instance, env, rawFlow);
 
   return ff_instance;
-
 }
 
 JNIEXPORT jobject JNICALL Java_org_apache_nifi_processor_JniProcessSession_readFlowFile(JNIEnv *env, jobject obj, jobject ff) {
@@ -94,7 +93,6 @@ JNIEXPORT jobject JNICALL Java_org_apache_nifi_processor_JniProcessSession_readF
   }
 
   return nullptr;
-
 }
 
 JNIEXPORT jint JNICALL Java_org_apache_nifi_processor_JniInputStream_read(JNIEnv *env, jobject obj) {
@@ -142,7 +140,6 @@ JNIEXPORT jboolean JNICALL Java_org_apache_nifi_processor_JniProcessSession_writ
   }
 
   return false;
-
 }
 
 JNIEXPORT jobject JNICALL Java_org_apache_nifi_processor_JniProcessSession_clone(JNIEnv *env, jobject obj, jobject prevff) {
@@ -174,7 +171,6 @@ JNIEXPORT jobject JNICALL Java_org_apache_nifi_processor_JniProcessSession_clone
   }
 
   return nullptr;
-
 }
 
 JNIEXPORT jobject JNICALL Java_org_apache_nifi_processor_JniProcessSession_get(JNIEnv *env, jobject obj) {
@@ -237,7 +233,6 @@ JNIEXPORT jobject JNICALL Java_org_apache_nifi_processor_JniProcessSession_putAt
   }
 
   return ff;
-
 }
 
 JNIEXPORT void JNICALL Java_org_apache_nifi_processor_JniProcessSession_transfer(JNIEnv *env, jobject obj, jobject ff, jstring relationship) {
@@ -295,7 +290,6 @@ JNIEXPORT jobject JNICALL Java_org_apache_nifi_processor_JniProcessSession_creat
   }
 
   return nullptr;
-
 }
 
 JNIEXPORT void JNICALL Java_org_apache_nifi_processor_JniProcessSession_commit(JNIEnv *env, jobject obj) {
@@ -367,7 +361,6 @@ JNIEXPORT void JNICALL Java_org_apache_nifi_processor_JniProcessSession_remove(J
   if (ptr->get()) {
     session->getSession()->remove(ptr->get());
   }
-
 }
 
 JNIEXPORT jobject JNICALL  Java_org_apache_nifi_processor_JniProcessSession_penalize(JNIEnv *env, jobject obj, jobject ff) {
@@ -432,7 +425,6 @@ JNIEXPORT jobject JNICALL  Java_org_apache_nifi_processor_JniProcessSession_clon
   }
 
   return nullptr;
-
 }
 
 JNIEXPORT jboolean JNICALL Java_org_apache_nifi_processor_JniProcessSession_append(JNIEnv *env, jobject obj, jobject ff, jbyteArray byteArray) {
@@ -460,7 +452,6 @@ JNIEXPORT jboolean JNICALL Java_org_apache_nifi_processor_JniProcessSession_appe
   }
 
   return false;
-
 }
 
 #ifdef __cplusplus

--- a/extensions/jni/jvm/JniProcessSession.cpp
+++ b/extensions/jni/jvm/JniProcessSession.cpp
@@ -72,7 +72,6 @@ JNIEXPORT jobject JNICALL Java_org_apache_nifi_processor_JniProcessSession_readF
   minifi::jni::JniSession *session = minifi::jni::JVMLoader::getPtr<minifi::jni::JniSession>(env, obj);
   minifi::jni::JniFlowFile *ptr = minifi::jni::JVMLoader::getInstance()->getReference<minifi::jni::JniFlowFile>(env, ff);
   if (ptr->get()) {
-
     auto jincls = minifi::jni::JVMLoader::getInstance()->load_class("org/apache/nifi/processor/JniInputStream", env);
 
     auto jin = jincls.newInstance(env);

--- a/extensions/jni/jvm/JniReferenceObjects.h
+++ b/extensions/jni/jvm/JniReferenceObjects.h
@@ -47,7 +47,6 @@ class JniFlowFile : public core::WeakReference {
         ff_object(ff),
         ref_(ref),
         servicer_(servicer) {
-
   }
 
   virtual ~JniFlowFile() = default;
@@ -82,7 +81,6 @@ class JniFlowFile : public core::WeakReference {
   std::shared_ptr<core::FlowFile> ref_;
 
   std::shared_ptr<JavaServicer> servicer_;
-
 };
 
 /**
@@ -99,7 +97,6 @@ class JniByteOutStream : public minifi::OutputStreamCallback {
   JniByteOutStream(jbyte *bytes, size_t length)
       : bytes_(bytes),
         length_(length) {
-
   }
 
   virtual ~JniByteOutStream() = default;
@@ -156,7 +153,6 @@ class JniByteInputStream : public minifi::InputStreamCallback {
       writtenOffset += actual;
 
       remaining -= actual;
-
     } while (remaining > 0);
 
     return read;
@@ -179,7 +175,6 @@ class JniInputStream : public core::WeakReference {
         in_instance_(in_instance),
         jbi_(std::move(jbi)),
         servicer_(servicer) {
-
   }
 
   void remove() override {
@@ -189,7 +184,6 @@ class JniInputStream : public core::WeakReference {
       removed_ = true;
       jbi_ = nullptr;
     }
-
   }
 
   int64_t read(char &arr) {
@@ -237,7 +231,6 @@ class JniSession : public core::WeakReference {
       servicer_->attach()->DeleteGlobalRef(session_instance_);
       removed_ = true;
     }
-
   }
 
   std::shared_ptr<core::ProcessSession> &getSession() {
@@ -358,7 +351,6 @@ class JniSessionFactory : public core::WeakReference {
   std::vector<std::shared_ptr<JniSession>> sessions_;
   // we own the java object
   jobject java_object_;
-
 };
 
 

--- a/extensions/jni/jvm/NarClassLoader.h
+++ b/extensions/jni/jvm/NarClassLoader.h
@@ -272,7 +272,6 @@ class NarClassLoader {
     // assuming we have the bundle, we need to get the coordinate.
 
     return JniBundle();
-
   }
 
   std::vector<ClassDescription> getDescriptions(JNIEnv *env, jclass jni_bundle_clazz, jobject bundle) {
@@ -336,7 +335,6 @@ class NarClassLoader {
               builder = builder->isRequired(getBoolmethod("isRequired", property_descriptor_clazz, env, propertyDescriptorObj));
               core::Property prop(builder->build());
               description.class_properties_.insert(std::make_pair(prop.getName(), prop));
-
             }
           }
         }
@@ -360,7 +358,6 @@ class NarClassLoader {
             core::Relationship relationship(relName, relDesc);
 
             description.class_relationships_.push_back(relationship);
-
           }
         }
       }
@@ -372,12 +369,10 @@ class NarClassLoader {
       AgentDocs::putDescription(type, classDescription);
 
       return description;
-
     }
     // assuming we have the bundle, we need to get the coordinate.
 
     return ClassDescription("unknown");
-
   }
 
   struct BundleDetails getCoordinateDetails(JNIEnv *env, jclass jni_bundle_clazz, jobject bundle) {
@@ -400,7 +395,6 @@ class NarClassLoader {
         details.group = getGroup(bundle_coordinate, env, jcoordinate);
         details.version = getVersion(bundle_coordinate, env, jcoordinate);
       }
-
     }
 
     return details;
@@ -450,7 +444,6 @@ class NarClassLoader {
     auto coordinate = env->CallObjectMethod(jdetail, getCoordinateMethod);
     ThrowIf(env);
     return coordinate;
-
   }
 
   jobject getDetails(jclass bundle_details, JNIEnv *env, jobject bundle) {
@@ -461,7 +454,6 @@ class NarClassLoader {
     auto details = env->CallObjectMethod(bundle, getDetailsMethod);
     ThrowIf(env);
     return details;
-
   }
 
   jobject getComponents(jclass bundle_details, JNIEnv *env, jobject bundle) {
@@ -472,7 +464,6 @@ class NarClassLoader {
     auto details = env->CallObjectMethod(bundle, getDetailsMethod);
     ThrowIf(env);
     return details;
-
   }
 
   std::shared_ptr<logging::Logger> logger_;

--- a/extensions/jni/jvm/NarClassLoader.h
+++ b/extensions/jni/jvm/NarClassLoader.h
@@ -35,7 +35,6 @@ namespace minifi {
 namespace jni {
 
 class NarClassLoader {
-
  public:
 
   NarClassLoader(std::shared_ptr<minifi::jni::JavaServicer> servicer, JavaClass &clazz, const std::string &dir_name, const std::string &scratch_nar_dir, const std::string &docs_dir)
@@ -100,7 +99,6 @@ class NarClassLoader {
       }
     }
     {
-
       jmethodID mthd = env->GetMethodID(class_ref_.getReference(), "getSignature", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
       if (mthd == nullptr) {
         ThrowIf(env);
@@ -221,10 +219,8 @@ class NarClassLoader {
     size_t size = getSize(list_class, env, obj);
 
     for (size_t i = 0; i < size; i++) {
-
       JniBundle bundle = getBundle(list_class, env, obj, i);
       for (const auto &cd : bundle.getDescriptions()) {
-
         auto lastOfIdx = cd.class_name_.find_last_of(".");
         if (lastOfIdx != std::string::npos) {
           lastOfIdx++;  // if a value is found, increment to move beyond the .
@@ -275,7 +271,6 @@ class NarClassLoader {
   }
 
   std::vector<ClassDescription> getDescriptions(JNIEnv *env, jclass jni_bundle_clazz, jobject bundle) {
-
     std::vector<ClassDescription> descriptions;
     auto jni_component_clazz = getClass("org.apache.nifi.processor.JniComponent");
 
@@ -304,7 +299,6 @@ class NarClassLoader {
     auto component = env->CallObjectMethod(list, mthd, index);
     minifi::jni::ThrowIf(env);
     if (component != nullptr) {
-
       auto type = getStringMethod("getType", jni_component_clazz, env, component);
       auto isControllerService = getBoolmethod("isControllerService", jni_component_clazz, env, component);
       ClassDescription description(type);
@@ -376,7 +370,6 @@ class NarClassLoader {
   }
 
   struct BundleDetails getCoordinateDetails(JNIEnv *env, jclass jni_bundle_clazz, jobject bundle) {
-
     auto bundle_details = getClass("org.apache.nifi.bundle.BundleDetails");
     auto bundle_coordinate = getClass("org.apache.nifi.bundle.BundleCoordinate");
     struct BundleDetails details;
@@ -388,7 +381,6 @@ class NarClassLoader {
     auto jdetails = getDetails(jni_bundle_clazz, env, bundle);
 
     if (nullptr != jdetails) {
-
       auto jcoordinate = getCoordinate(bundle_details, env, jdetails);
       if (nullptr != jcoordinate) {
         details.artifact = getArtifact(bundle_coordinate, env, jcoordinate);

--- a/extensions/libarchive/ArchiveLoader.h
+++ b/extensions/libarchive/ArchiveLoader.h
@@ -71,7 +71,6 @@ class ArchiveFactory : public core::ObjectFactory {
   }
 
   static bool added;
-
 };
 
 extern "C" {

--- a/extensions/libarchive/BinFiles.h
+++ b/extensions/libarchive/BinFiles.h
@@ -95,7 +95,6 @@ class Bin {
           maxEntries_ = count;
           minEntries_ = count;
         } catch (...) {
-
         }
       }
     }

--- a/extensions/libarchive/FocusArchiveEntry.cpp
+++ b/extensions/libarchive/FocusArchiveEntry.cpp
@@ -125,7 +125,6 @@ void FocusArchiveEntry::onTrigger(core::ProcessContext *context, core::ProcessSe
     std::string stackStr = archiveStack.toJsonString();
   
     flowFile->setAttribute("lens.archive.stack", stackStr);
-
   }
 
   // Update filename attribute to that of focused entry

--- a/extensions/libarchive/UnfocusArchiveEntry.cpp
+++ b/extensions/libarchive/UnfocusArchiveEntry.cpp
@@ -52,7 +52,6 @@ void UnfocusArchiveEntry::initialize() {
 }
 
 void UnfocusArchiveEntry::onTrigger(core::ProcessContext *context, core::ProcessSession *session) {
-
   auto flowFile = session->get();
 
   if (!flowFile) {

--- a/extensions/mqtt/MQTTLoader.h
+++ b/extensions/mqtt/MQTTLoader.h
@@ -78,7 +78,6 @@ class MQTTFactory : public core::ObjectFactory {
   }
 
   static bool added;
-
 };
 
 extern "C" {

--- a/extensions/mqtt/controllerservice/MQTTControllerService.cpp
+++ b/extensions/mqtt/controllerservice/MQTTControllerService.cpp
@@ -74,7 +74,6 @@ void MQTTControllerService::onEnable() {
       // call reconnect to bootstrap
       this->reconnect();
     }
-
   }
 }
 

--- a/extensions/mqtt/controllerservice/MQTTControllerService.h
+++ b/extensions/mqtt/controllerservice/MQTTControllerService.h
@@ -106,7 +106,6 @@ class MQTTControllerService : public core::controller::ControllerService {
   virtual void initialize();
 
   void yield() {
-
   }
 
   int send(const std::string &topic, const std::vector<uint8_t> &data) {
@@ -315,7 +314,6 @@ class MQTTControllerService : public core::controller::ControllerService {
   std::shared_ptr<controllers::SSLContextService> ssl_context_service_;
 
   std::shared_ptr<logging::Logger> logger_;
-
 };
 
 } /* namespace controllers */

--- a/extensions/mqtt/processors/ConvertBase.h
+++ b/extensions/mqtt/processors/ConvertBase.h
@@ -77,7 +77,6 @@ class ConvertBase : public core::Processor, public minifi::c2::RESTProtocol {
   std::shared_ptr<controllers::MQTTControllerService> mqtt_service_;
 
   std::string listening_topic;
-
 };
 
 } /* namespace processors */

--- a/extensions/mqtt/processors/ConvertHeartBeat.cpp
+++ b/extensions/mqtt/processors/ConvertHeartBeat.cpp
@@ -65,7 +65,6 @@ void ConvertHeartBeat::onTrigger(const std::shared_ptr<core::ProcessContext> &co
   if (!received_heartbeat) {
     context->yield();
   }
-
 }
 
 } /* namespace processors */

--- a/extensions/mqtt/processors/ConvertJSONAck.cpp
+++ b/extensions/mqtt/processors/ConvertJSONAck.cpp
@@ -52,7 +52,6 @@ std::string ConvertJSONAck::parseTopicName(const std::string &json) {
       }
     }
   } catch (...) {
-
   }
   return topic;
 }
@@ -81,7 +80,6 @@ void ConvertJSONAck::onTrigger(const std::shared_ptr<core::ProcessContext> &cont
     topic = parseTopicName(std::string(callback.buffer_.data(), callback.buffer_.size()));
 
     session->transfer(flow, Success);
-
   }
   flow = session->get();
 
@@ -101,11 +99,9 @@ void ConvertJSONAck::onTrigger(const std::shared_ptr<core::ProcessContext> &cont
     auto stream = c2::PayloadSerializer::serialize(1,payload);
 
     mqtt_service_->send(topic, stream->getBuffer(), stream->size());
-
   }
 
   session->transfer(flow, Success);
-
 }
 
 } /* namespace processors */

--- a/extensions/mqtt/processors/ConvertUpdate.cpp
+++ b/extensions/mqtt/processors/ConvertUpdate.cpp
@@ -83,7 +83,6 @@ void ConvertUpdate::onTrigger(const std::shared_ptr<core::ProcessContext> &conte
   if (!received_update) {
     context->yield();
   }
-
 }
 
 void ConvertUpdate::initialize() {

--- a/extensions/mqtt/processors/ConvertUpdate.cpp
+++ b/extensions/mqtt/processors/ConvertUpdate.cpp
@@ -38,7 +38,6 @@ void ConvertUpdate::onTrigger(const std::shared_ptr<core::ProcessContext> &conte
   while (mqtt_service_->get(100, listening_topic, update)) {
     // first we have the input topic string followed by the update URI
     if (update.size() > 0) {
-
       io::BufferStream stream(update.data(), update.size());
 
       std::string returnTopic, url;

--- a/extensions/mqtt/protocol/MQTTC2Protocol.h
+++ b/extensions/mqtt/protocol/MQTTC2Protocol.h
@@ -86,7 +86,6 @@ class MQTTC2Protocol : public C2Protocol {
   // mqtt controller serviec name.
   std::string controller_service_name_;
 
-
 };
 } /* namespace c2 */
 } /* namespace minifi */

--- a/extensions/opc/include/fetchopc.h
+++ b/extensions/opc/include/fetchopc.h
@@ -98,7 +98,6 @@ private:
   std::mutex onTriggerMutex_;
   std::vector<UA_NodeId> translatedNodeIDs_;  // Only used when user provides path, path->nodeid translation is only done once
   std::unordered_map<std::string, std::string> node_timestamp_;  // Key = Full path, Value = Timestamp
-
 };
 
 REGISTER_RESOURCE(FetchOPCProcessor, "Fetches OPC-UA node");

--- a/extensions/opc/src/fetchopc.cpp
+++ b/extensions/opc/src/fetchopc.cpp
@@ -182,7 +182,6 @@ namespace processors {
       logger_->log_warn("Found no variables when traversing the specified node. No flowfiles are generated. Yielding...");
       yield();
     }
-
   }
 
   bool FetchOPCProcessor::nodeFoundCallBack(opc::Client& /*client*/, const UA_ReferenceDescription *ref, const std::string& path,

--- a/extensions/opc/src/opc.cpp
+++ b/extensions/opc/src/opc.cpp
@@ -117,7 +117,6 @@ namespace {
 Client::Client(std::shared_ptr<core::logging::Logger> logger, const std::string& applicationURI,
                const std::vector<char>& certBuffer, const std::vector<char>& keyBuffer,
                const std::vector<std::vector<char>>& trustBuffers) {
-
   client_ = UA_Client_new();
   if (certBuffer.empty()) {
     UA_ClientConfig_setDefault(UA_Client_getConfig(client_));

--- a/extensions/opc/src/putopc.cpp
+++ b/extensions/opc/src/putopc.cpp
@@ -150,7 +150,6 @@ namespace processors {
     std::string typestr;
     context->getProperty(ValueType.getName(), typestr);
     nodeDataType_ = opc::StringToOPCDataTypeMap.at(typestr);  // This throws, but allowed values are generated based on this map -> that's a really unexpected error
-
   }
 
   void PutOPCProcessor::onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) {

--- a/extensions/opencv/CaptureRTSPFrame.cpp
+++ b/extensions/opencv/CaptureRTSPFrame.cpp
@@ -76,7 +76,6 @@ void CaptureRTSPFrame::initialize() {
 }
 
 void CaptureRTSPFrame::onSchedule(core::ProcessContext *context, core::ProcessSessionFactory* /*sessionFactory*/) {
-
   std::string value;
 
   if (context->getProperty(RTSPUsername.getName(), value)) {
@@ -121,7 +120,6 @@ void CaptureRTSPFrame::onSchedule(core::ProcessContext *context, core::ProcessSe
 
 void CaptureRTSPFrame::onTrigger(const std::shared_ptr<core::ProcessContext> &context,
                                  const std::shared_ptr<core::ProcessSession> &session) {
-
   std::unique_lock<std::mutex> lock(mutex_, std::try_to_lock);
   if (!lock.owns_lock()) {
     logger_->log_info("Cannot process due to an unfinished onTrigger");

--- a/extensions/opencv/CaptureRTSPFrame.cpp
+++ b/extensions/opencv/CaptureRTSPFrame.cpp
@@ -117,7 +117,6 @@ void CaptureRTSPFrame::onSchedule(core::ProcessContext *context, core::ProcessSe
   }
 
   rtsp_url_ = rtspURI;
-
 }
 
 void CaptureRTSPFrame::onTrigger(const std::shared_ptr<core::ProcessContext> &context,
@@ -172,7 +171,6 @@ void CaptureRTSPFrame::onTrigger(const std::shared_ptr<core::ProcessContext> &co
     logger_->log_error("Unable to read from capture handle on RTSP stream");
     session->transfer(flow_file, Failure);
   }
-
 }
 
 void CaptureRTSPFrame::notifyStop() {

--- a/extensions/opencv/CaptureRTSPFrame.h
+++ b/extensions/opencv/CaptureRTSPFrame.h
@@ -128,7 +128,6 @@ class CaptureRTSPFrame : public core::Processor {
 //  std::mutex mutex_;
 //
 //  std::shared_ptr<minifi::controllers::SSLContextService> ssl_service_;
-
 };
 
 REGISTER_RESOURCE(CaptureRTSPFrame, "Captures a frame from the RTSP stream at specified intervals."); // NOLINT

--- a/extensions/opencv/CaptureRTSPFrame.h
+++ b/extensions/opencv/CaptureRTSPFrame.h
@@ -34,7 +34,6 @@ namespace minifi {
 namespace processors {
 
 class CaptureRTSPFrame : public core::Processor {
-
  public:
 
   explicit CaptureRTSPFrame(const std::string &name, utils::Identifier uuid = utils::Identifier())

--- a/extensions/opencv/MotionDetector.h
+++ b/extensions/opencv/MotionDetector.h
@@ -37,7 +37,6 @@ namespace minifi {
 namespace processors {
 
 class MotionDetector : public core::Processor {
-
  public:
 
   explicit MotionDetector(const std::string &name, utils::Identifier uuid = utils::Identifier())

--- a/extensions/opencv/OpenCVLoader.h
+++ b/extensions/opencv/OpenCVLoader.h
@@ -75,7 +75,6 @@ class OpenCVObjectFactory : public core::ObjectFactory {
   }
 
   static bool added;
-
 };
 
 extern "C" {

--- a/extensions/pcap/CapturePacket.cpp
+++ b/extensions/pcap/CapturePacket.cpp
@@ -75,14 +75,12 @@ void CapturePacket::packet_callback(pcpp::RawPacket* packet, pcpp::PcapLiveDevic
   CapturePacketMechanism *capture;
 
   if (capture_mechanism->source.try_dequeue(capture)) {
-
     // if needed - write the packet to the output pcap file
 
     if (capture->writer_ != nullptr) {
       capture->writer_->writePacket(*packet);
 
       if (capture->incrementAndCheck()) {
-
         capture->writer_->close();
 
         auto new_capture = create_new_capture(capture->getBasePath(), capture->getMaxSize());

--- a/extensions/pcap/CapturePacket.cpp
+++ b/extensions/pcap/CapturePacket.cpp
@@ -93,7 +93,6 @@ void CapturePacket::packet_callback(pcpp::RawPacket* packet, pcpp::PcapLiveDevic
       } else {
         capture_mechanism->source.enqueue(capture);
       }
-
     }
   }
 }

--- a/extensions/pcap/PcapLoader.h
+++ b/extensions/pcap/PcapLoader.h
@@ -56,7 +56,6 @@ class PcapFactory : public core::ObjectFactory {
   }
 
   static bool added;
-
 };
 
 extern "C" {

--- a/extensions/rocksdb-repos/DatabaseContentRepository.h
+++ b/extensions/rocksdb-repos/DatabaseContentRepository.h
@@ -64,7 +64,6 @@ class StringAppender : public rocksdb::AssociativeMergeOperator {
   }
 
  private:
-
 };
 
 /**
@@ -108,7 +107,6 @@ class DatabaseContentRepository : public core::ContentRepository, public core::C
   bool exists(const minifi::ResourceClaim &streamId) override;
 
   void yield() override {
-
   }
 
   /**

--- a/extensions/rocksdb-repos/ProvenanceRepository.h
+++ b/extensions/rocksdb-repos/ProvenanceRepository.h
@@ -168,7 +168,6 @@ class ProvenanceRepository : public core::Repository, public std::enable_shared_
     size_t requested_batch = max_size;
     max_size = 0;
     for (it->SeekToFirst(); it->Valid(); it->Next()) {
-
       if (max_size >= requested_batch)
         break;
       std::shared_ptr<core::SerializableComponent> eventRead = lambda();

--- a/extensions/rocksdb-repos/ProvenanceRepository.h
+++ b/extensions/rocksdb-repos/ProvenanceRepository.h
@@ -39,7 +39,6 @@ class ProvenanceRepository : public core::Repository, public std::enable_shared_
  public:
   ProvenanceRepository(std::string name, utils::Identifier /*uuid*/)
       : ProvenanceRepository(name){
-
   }
   // Constructor
   /*!

--- a/extensions/rocksdb-repos/RocksDBLoader.h
+++ b/extensions/rocksdb-repos/RocksDBLoader.h
@@ -74,7 +74,6 @@ class RocksDBFactory : public core::ObjectFactory {
   }
 
   static bool added;
-
 };
 
 extern "C" {

--- a/extensions/rocksdb-repos/RocksDbStream.h
+++ b/extensions/rocksdb-repos/RocksDbStream.h
@@ -99,7 +99,6 @@ class RocksDbStream : public io::BaseStream {
  private:
 
   std::shared_ptr<logging::Logger> logger_;
-
 };
 
 } /* namespace io */

--- a/extensions/script/python/PythonCreator.h
+++ b/extensions/script/python/PythonCreator.h
@@ -60,7 +60,6 @@ class PythonCreator : public minifi::core::CoreComponent {
     for (const auto &path : pathOrFiles) {
       utils::file::FileUtils::addFilesMatchingExtension(logger_, path, ".py", classpaths_);
     }
-
   }
 
   void configure(const std::shared_ptr<Configure> &configuration) override {
@@ -135,13 +134,9 @@ class PythonCreator : public minifi::core::CoreComponent {
           } catch (const std::exception &e) {
             logger_->log_warn("Cannot load %s because of %s", scriptName, e.what());
           }
-
         }
-
       }
-
     }
-
   }
 
  private:

--- a/extensions/script/python/PythonCreator.h
+++ b/extensions/script/python/PythonCreator.h
@@ -63,7 +63,6 @@ class PythonCreator : public minifi::core::CoreComponent {
   }
 
   void configure(const std::shared_ptr<Configure> &configuration) override {
-
     python::PythonScriptEngine::initialize();
 
     auto engine = std::make_shared<python::PythonScriptEngine>();

--- a/extensions/script/python/PythonScriptEngine.h
+++ b/extensions/script/python/PythonScriptEngine.h
@@ -40,7 +40,6 @@ namespace python {
 namespace py = pybind11;
 
 struct Interpreter {
-
   Interpreter()
       : guard_(false) {
   }

--- a/extensions/sensors/GetEnvironmentalSensors.cpp
+++ b/extensions/sensors/GetEnvironmentalSensors.cpp
@@ -80,7 +80,6 @@ void GetEnvironmentalSensors::onSchedule(const std::shared_ptr<core::ProcessCont
   } else {
     throw std::runtime_error("RTPressure could not be initialized");
   }
-
 }
 
 void GetEnvironmentalSensors::notifyStop() {
@@ -132,7 +131,6 @@ void GetEnvironmentalSensors::onTrigger(const std::shared_ptr<core::ProcessConte
         ss << std::fixed << std::setprecision(2) << data.temperature;
         flow_file_->addAttribute("TEMPERATURE", ss.str());
       }
-
     }
   } else {
     logger_->log_trace("Could not read pressure sensors");
@@ -144,7 +142,6 @@ void GetEnvironmentalSensors::onTrigger(const std::shared_ptr<core::ProcessConte
     session->write(flow_file_, &callback);
     session->transfer(flow_file_, Success);
   }
-
 }
 
 } /* namespace processors */

--- a/extensions/sensors/GetEnvironmentalSensors.cpp
+++ b/extensions/sensors/GetEnvironmentalSensors.cpp
@@ -90,7 +90,6 @@ void GetEnvironmentalSensors::notifyStop() {
 GetEnvironmentalSensors::~GetEnvironmentalSensors() = default;
 
 void GetEnvironmentalSensors::onTrigger(const std::shared_ptr<core::ProcessContext>& /*context*/, const std::shared_ptr<core::ProcessSession>& session) {
-
   auto flow_file_ = session->create();
 
   if (imu->IMURead()) {
@@ -137,7 +136,6 @@ void GetEnvironmentalSensors::onTrigger(const std::shared_ptr<core::ProcessConte
   }
 
   if (have_sensor) {
-
     WriteCallback callback("GetEnvironmentalSensors");
     session->write(flow_file_, &callback);
     session->transfer(flow_file_, Success);

--- a/extensions/sensors/SensorBase.cpp
+++ b/extensions/sensors/SensorBase.cpp
@@ -59,7 +59,6 @@ void SensorBase::onSchedule(const std::shared_ptr<core::ProcessContext>& /*conte
   } else {
     throw std::runtime_error("RTIMU could not be initialized");
   }
-
 }
 
 SensorBase::~SensorBase() = default;

--- a/extensions/sensors/SensorLoader.h
+++ b/extensions/sensors/SensorLoader.h
@@ -59,7 +59,6 @@ class SensorFactory : public core::ObjectFactory {
   }
 
   static bool added;
-
 }
 ;
 

--- a/extensions/sftp/SFTPLoader.h
+++ b/extensions/sftp/SFTPLoader.h
@@ -71,7 +71,6 @@ class SFTPFactory : public core::ObjectFactory {
   }
 
   static bool added;
-
 };
 
 extern "C" {

--- a/extensions/sql/services/DatabaseService.h
+++ b/extensions/sql/services/DatabaseService.h
@@ -63,7 +63,6 @@ class DatabaseService : public core::controller::ControllerService {
   void initialize() override;
 
   void yield() override {
-
   }
 
   bool isRunning() override {
@@ -92,7 +91,6 @@ class DatabaseService : public core::controller::ControllerService {
  private:
 
   std::shared_ptr<logging::Logger> logger_;
-
 };
 
 } /* namespace controllers */

--- a/extensions/tensorflow/TFExtractTopLabels.cpp
+++ b/extensions/tensorflow/TFExtractTopLabels.cpp
@@ -58,7 +58,6 @@ void TFExtractTopLabels::onTrigger(const std::shared_ptr<core::ProcessContext> &
   }
 
   try {
-
     // Read labels
     std::string tf_type;
     flow_file->getAttribute("tf.type", tf_type);

--- a/extensions/tensorflow/TFExtractTopLabels.cpp
+++ b/extensions/tensorflow/TFExtractTopLabels.cpp
@@ -111,7 +111,6 @@ void TFExtractTopLabels::onTrigger(const std::shared_ptr<core::ProcessContext> &
     }
 
     session->transfer(flow_file, Success);
-
   } catch (std::exception &exception) {
     logger_->log_error("Caught Exception %s", exception.what());
     session->transfer(flow_file, Failure);

--- a/extensions/usb-camera/GetUSBCamera.cpp
+++ b/extensions/usb-camera/GetUSBCamera.cpp
@@ -424,7 +424,6 @@ int64_t GetUSBCamera::PNGWriteCallback::process(const std::shared_ptr<io::BaseSt
   }
 
   try {
-
     png_set_write_fn(png, this, [](png_structp out_png,
                                    png_bytep out_data,
                                    png_size_t num_bytes) {

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
@@ -214,7 +214,6 @@ void ConsumeWindowsEventLog::initialize() {
 }
 
 bool ConsumeWindowsEventLog::insertHeaderName(wel::METADATA_NAMES &header, const std::string &key, const std::string & value) const {
-
   wel::METADATA name = wel::WindowsEventLogMetadata::getMetadataFromString(key);
 
   if (name != wel::METADATA::UNKNOWN) {
@@ -598,7 +597,6 @@ bool ConsumeWindowsEventLog::createEventRender(EVT_HANDLE hEvent, EventRender& e
     auto message = handler.getEventMessage(hEvent);
 
     if (!message.empty()) {
-
       for (const auto &mapEntry : walker.getIdentifiers()) {
         // replace the identifiers with their translated strings.
         if (mapEntry.first.empty() || mapEntry.second.empty()) {

--- a/extensions/windows-event-log/TailEventLog.cpp
+++ b/extensions/windows-event-log/TailEventLog.cpp
@@ -68,7 +68,6 @@ void TailEventLog::onSchedule(const std::shared_ptr<core::ProcessContext> &conte
   log_handle_ = OpenEventLog(NULL, log_source_.c_str());
 
   logger_->log_trace("TailEventLog configured to tail %s",log_source_);
-
 }
 
 void TailEventLog::onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) {
@@ -131,7 +130,6 @@ void TailEventLog::onTrigger(const std::shared_ptr<core::ProcessContext> &contex
     logger_->log_trace("Yielding due to error");
     context->yield();
   }
-
 }
 } /* namespace processors */
 } /* namespace minifi */

--- a/extensions/windows-event-log/TailEventLog.cpp
+++ b/extensions/windows-event-log/TailEventLog.cpp
@@ -71,7 +71,6 @@ void TailEventLog::onSchedule(const std::shared_ptr<core::ProcessContext> &conte
 }
 
 void TailEventLog::onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) {
-  
   if (log_handle_ == nullptr) {
     logger_->log_debug("Handle could not be created for %s", log_source_);
   }
@@ -94,7 +93,6 @@ void TailEventLog::onTrigger(const std::shared_ptr<core::ProcessContext> &contex
       context->yield();
     }
     while (bytes_to_read > 0) {
-
       auto flowFile = session->create();
       if (flowFile == nullptr)
         return;

--- a/extensions/windows-event-log/wel/MetadataWalker.cpp
+++ b/extensions/windows-event-log/wel/MetadataWalker.cpp
@@ -64,7 +64,6 @@ bool MetadataWalker::for_each(pugi::xml_node &node) {
       }
       node.text().set(nodeText.c_str());
     }
-
   }
   else if (node_name == "TimeCreated") {
     metadata_["TimeCreated"] = node.attribute("SystemTime").value();

--- a/extensions/windows-event-log/wel/MetadataWalker.h
+++ b/extensions/windows-event-log/wel/MetadataWalker.h
@@ -97,7 +97,6 @@ class MetadataWalker : public pugi::xml_tree_walker {
   std::map<std::string, std::string> metadata_;
   std::map<std::string, std::string> fields_values_;
   std::map<std::string, std::string> replaced_identifiers_;
-
 };
 
 } /* namespace wel */

--- a/extensions/windows-event-log/wel/WindowsEventLog.cpp
+++ b/extensions/windows-event-log/wel/WindowsEventLog.cpp
@@ -105,7 +105,6 @@ void WindowsEventLogMetadataImpl::renderMetadata() {
       default:
         event_type_index_ = 0;
     };
-
   }
   else {
     event_type_ = "N/A";

--- a/libminifi/test/TestBase.h
+++ b/libminifi/test/TestBase.h
@@ -132,7 +132,6 @@ class LogTestController {
         setLevel(name, level);
       }
     }
-
   }
 
   bool contains(const std::string &ending, std::chrono::seconds timeout = std::chrono::seconds(3), std::chrono::milliseconds sleep_interval = std::chrono::milliseconds(200)) {
@@ -211,7 +210,6 @@ class LogTestController {
       config->initialize(my_properties_);
       logger_ = config->getLogger(core::getClassName<LogTestController>());
     }
-
   }
 
   void setLevel(const std::string name, spdlog::level::level_enum level);
@@ -413,7 +411,6 @@ class TestController {
                       nullptr) {
 
     while (plan->runNextProcessor(verify) && runToCompletion) {
-
     }
   }
 

--- a/libminifi/test/TestBase.h
+++ b/libminifi/test/TestBase.h
@@ -409,7 +409,6 @@ class TestController {
 
   void runSession(std::shared_ptr<TestPlan> &plan, bool runToCompletion = true, std::function<void(const std::shared_ptr<core::ProcessContext>&, const std::shared_ptr<core::ProcessSession>&)> verify =
                       nullptr) {
-
     while (plan->runNextProcessor(verify) && runToCompletion) {
     }
   }

--- a/libminifi/test/Utils.h
+++ b/libminifi/test/Utils.h
@@ -61,5 +61,4 @@ void verifyJSON(const std::string& actual_str, const std::string& expected_str, 
   } else {
     matchJSON(actual, expected);
   }
-
 }

--- a/libminifi/test/integration/IntegrationBase.h
+++ b/libminifi/test/integration/IntegrationBase.h
@@ -49,7 +49,6 @@ class IntegrationBase {
   virtual void testSetup() = 0;
 
   virtual void shutdownBeforeFlowController() {
-
   }
 
   const std::shared_ptr<minifi::Configure>& getConfiguration() const {
@@ -70,15 +69,12 @@ class IntegrationBase {
   }
 
   virtual void queryRootProcessGroup(std::shared_ptr<core::ProcessGroup> /*pg*/) {
-
   }
 
   virtual void configureFullHeartbeat() {
-
   }
 
   virtual void updateProperties(std::shared_ptr<minifi::FlowController> /*fc*/) {
-
   }
 
   void configureSecurity();

--- a/libminifi/test/unit/MockClasses.h
+++ b/libminifi/test/unit/MockClasses.h
@@ -30,12 +30,10 @@ class MockControllerService : public core::controller::ControllerService {
  public:
   explicit MockControllerService(const std::string &name, const utils::Identifier &  uuid)
       : ControllerService(name, uuid) {
-
   }
 
   explicit MockControllerService(const std::string &name)
       : ControllerService(name) {
-
   }
   MockControllerService() = default;
 
@@ -55,7 +53,6 @@ class MockControllerService : public core::controller::ControllerService {
   }
 
   void yield() {
-
   }
 
   bool isRunning() {
@@ -89,7 +86,6 @@ class MockProcessor : public core::Processor {
     std::set<core::Property> properties;
     properties.insert(property);
     setSupportedProperties(properties);
-
   }
 
   // OnTrigger method, implemented by NiFi Processor Designer
@@ -111,14 +107,12 @@ class MockProcessor : public core::Processor {
 
       // verify we have access to the controller service
       // and verify that we can execute it.
-
     }
   }
 
   bool isYield() override {
     return false;
   }
-
 };
 
 #endif /* LIBMINIFI_TEST_UNIT_MOCKCLASSES_H_ */

--- a/libminifi/test/unit/MockClasses.h
+++ b/libminifi/test/unit/MockClasses.h
@@ -90,11 +90,9 @@ class MockProcessor : public core::Processor {
 
   // OnTrigger method, implemented by NiFi Processor Designer
   void onTrigger(core::ProcessContext *context, core::ProcessSession* /*session*/) override {
-
     std::string linked_service = "";
     getProperty("linkedService", linked_service);
     if (!IsNullOrEmpty(linked_service)) {
-
       std::shared_ptr<core::controller::ControllerService> service = context->getControllerService(linked_service);
       std::lock_guard<std::mutex> lock(control_mutex);
       if (!disabled.load()) {

--- a/libminifi/test/unit/ProvenanceTestHelper.h
+++ b/libminifi/test/unit/ProvenanceTestHelper.h
@@ -238,7 +238,6 @@ class TestFlowRepository : public core::Repository {
 };
 
 class TestFlowController : public minifi::FlowController {
-
  public:
   TestFlowController(std::shared_ptr<core::Repository> repo, std::shared_ptr<core::Repository> flow_file_repo, std::shared_ptr<core::ContentRepository> /*content_repo*/)
       : minifi::FlowController(repo, flow_file_repo, std::make_shared<minifi::Configure>(), nullptr, std::make_shared<core::repository::VolatileContentRepository>(), "", true) {

--- a/libminifi/test/unit/SiteToSiteHelper.h
+++ b/libminifi/test/unit/SiteToSiteHelper.h
@@ -62,7 +62,6 @@ class SiteToSiteResponder : public minifi::io::BaseStream {
   int read(uint8_t *value, int len) override {
     return server_responses_.read(value, len);
   }
-
 };
 
 #endif /* LIBMINIFI_TEST_UNIT_SITE2SITE_HELPER_H_ */

--- a/main/AgentDocs.cpp
+++ b/main/AgentDocs.cpp
@@ -120,7 +120,6 @@ void AgentDocs::generate(const std::string &docsdir, std::ostream &genStream) {
     }
 
     outfile << std::endl;
-
   }
 
   std::map<std::string,std::string> fileList;

--- a/main/AgentDocs.cpp
+++ b/main/AgentDocs.cpp
@@ -54,7 +54,6 @@ std::string AgentDocs::extractClassName(const std::string &processor) const {
 void AgentDocs::generate(const std::string &docsdir, std::ostream &genStream) {
   std::map<std::string, ClassDescription> processorSet;
   for (const auto &group : minifi::AgentBuild::getExtensions()) {
-
     struct Components descriptions = BuildDescription::getClassDescriptions(group);
     for (const auto &processorName : descriptions.processors_) {
       processorSet.insert(std::make_pair(extractClassName(processorName.class_name_), processorName));

--- a/main/MiNiFiMain.cpp
+++ b/main/MiNiFiMain.cpp
@@ -78,7 +78,6 @@ sem_t *running;
 #ifdef WIN32
 BOOL WINAPI consoleSignalHandler(DWORD signal) {
   if (signal == CTRL_C_EVENT || signal == CTRL_BREAK_EVENT) {
-    
     sem_post(running);
     if (sem_wait(running) == -1)
       perror("sem_wait");
@@ -156,7 +155,6 @@ int main(int argc, char **argv) {
 
   running = sem_open("/MiNiFiMain", O_CREAT, 0644, 0);
   if (running == SEM_FAILED || running == 0) {
-
     logger->log_error("could not initialize semaphore");
     perror("initialization failure");
   }

--- a/nanofi/ecu/log_aggregator.c
+++ b/nanofi/ecu/log_aggregator.c
@@ -32,7 +32,6 @@
 #include <sys/stat.h>
 
 int main(int argc, char** argv) {
-
     if (argc < 7) {
         printf("Error: must run ./log_aggregator <file> <interval> <delimiter> <hostname> <tcp port number> <nifi port uuid>\n");
         exit(1);

--- a/nanofi/ecu/tailfile_chunk.c
+++ b/nanofi/ecu/tailfile_chunk.c
@@ -27,7 +27,6 @@
 #include <stdio.h>
 
 int main(int argc, char** argv) {
-
     if (argc < 7) {
         printf("Error: must run ./tailfile_chunk <file> <interval> <chunksize> <hostname> <tcp port number> <nifi port uuid>\n");
         exit(1);

--- a/nanofi/ecu/tailfile_delimited.c
+++ b/nanofi/ecu/tailfile_delimited.c
@@ -27,7 +27,6 @@
 #include <stdio.h>
 
 int main(int argc, char** argv) {
-
     if (argc < 7) {
         printf("Error: must run ./tailfile_delimited <file> <interval> <delimiter> <hostname> <tcp port number> <nifi port uuid>\n");
         exit(1);

--- a/nanofi/examples/generate_flow.c
+++ b/nanofi/examples/generate_flow.c
@@ -27,7 +27,6 @@
  * This is an example of the C API that transmits a flow file to a remote instance.
  */
 int main(int argc, char **argv) {
-
   if (argc < 3) {
     printf("Error: must run ./generate_flow <instance> <remote port> \n");
     exit(1);

--- a/nanofi/examples/hash_file.c
+++ b/nanofi/examples/hash_file.c
@@ -63,7 +63,6 @@ void custom_processor_logic(processor_session * ps, processor_context * ctx) {
 }
 
 int main(int argc, char **argv) {
-
   if (argc < 2) {
     printf("Error: must run ./hash_file <file>\n");
     exit(1);

--- a/nanofi/examples/terminate_handler.c
+++ b/nanofi/examples/terminate_handler.c
@@ -31,7 +31,6 @@ void example_terminate_handler() {
 }
 
 int main() {
-
   nifi_port port;
 
   port.port_id = "12345";

--- a/nanofi/examples/transmit_flow.c
+++ b/nanofi/examples/transmit_flow.c
@@ -67,7 +67,6 @@ void transfer_file_or_directory(nifi_instance *instance, char *file_or_dir) {
  * This is an example of the C API that transmits a flow file to a remote instance.
  */
 int main(int argc, char **argv) {
-
   if (argc < 4) {
     printf("Error: must run ./transmit_flow <instance> <remote port> <file or directory>\n");
     exit(1);

--- a/nanofi/examples/transmit_payload.c
+++ b/nanofi/examples/transmit_payload.c
@@ -26,7 +26,6 @@
 #include "sitetosite/CRawSocketProtocol.h"
 
 int main(int argc, char **argv) {
-
   if (argc < 4) {
     printf("Error: must run ./transmit_payload <host> <port> <nifi port>\n");
     exit(1);

--- a/nanofi/include/blocks/comms.h
+++ b/nanofi/include/blocks/comms.h
@@ -32,7 +32,6 @@ enum {
 typedef int transmission_stop(void *);
 
 uint8_t transmit_to_nifi(nifi_instance *instance, flow *flow, transmission_stop *stop_callback) {
-
   flow_file_record *record = 0x00;
   do {
     record = get_next_flow_file(instance, flow);

--- a/nanofi/include/core/cstructs.h
+++ b/nanofi/include/core/cstructs.h
@@ -47,7 +47,6 @@ typedef struct {
  * Nifi instance struct
  */
 typedef struct {
-
   void *instance_ptr;
 
   nifi_port port;

--- a/nanofi/include/core/cstructs.h
+++ b/nanofi/include/core/cstructs.h
@@ -51,7 +51,6 @@ typedef struct {
   void *instance_ptr;
 
   nifi_port port;
-
 } nifi_instance;
 
 /****
@@ -122,7 +121,6 @@ typedef struct {
   void * ffp;
 
   uint8_t keepContent;
-
 } flow_file_record;
 
 typedef struct flow flow;

--- a/nanofi/include/cxx/C2CallbackAgent.h
+++ b/nanofi/include/cxx/C2CallbackAgent.h
@@ -44,7 +44,6 @@ typedef int c2_ag_stop_callback(char *);
 typedef int c2_ag_start_callback(char *);
 
 class C2CallbackAgent : public c2::C2Agent {
-
  public:
 
   explicit C2CallbackAgent(

--- a/nanofi/include/cxx/C2CallbackAgent.h
+++ b/nanofi/include/cxx/C2CallbackAgent.h
@@ -71,7 +71,6 @@ class C2CallbackAgent : public c2::C2Agent {
 
  private:
     std::shared_ptr<logging::Logger> logger_;
-
 };
 
 } /* namesapce c2 */

--- a/nanofi/include/cxx/CallbackProcessor.h
+++ b/nanofi/include/cxx/CallbackProcessor.h
@@ -86,7 +86,6 @@ class CallbackProcessor : public core::Processor {
  private:
   // Logger
   std::shared_ptr<logging::Logger> logger_{ logging::LoggerFactory<CallbackProcessor>::getLogger() };
-
 };
 
 REGISTER_RESOURCE(CallbackProcessor, "");

--- a/nanofi/include/cxx/Instance.h
+++ b/nanofi/include/cxx/Instance.h
@@ -52,7 +52,6 @@ class ProcessorLink {
  public:
   explicit ProcessorLink(const std::shared_ptr<core::Processor> &processor)
       : processor_(processor) {
-
   }
 
   const std::shared_ptr<core::Processor> &getProcessor() {

--- a/nanofi/include/cxx/Instance.h
+++ b/nanofi/include/cxx/Instance.h
@@ -69,7 +69,6 @@ class Instance {
       : no_op_repo_(std::make_shared<minifi::core::Repository>()),
         url_(url),
         configure_(std::make_shared<Configure>()) {
-
     if (repo_class_name == "filesystemrepository") {
         content_repo_ = std::make_shared<minifi::core::repository::FileSystemRepository>();
     } else {

--- a/nanofi/include/cxx/ReflexiveSession.h
+++ b/nanofi/include/cxx/ReflexiveSession.h
@@ -64,7 +64,6 @@ class ReflexiveSession : public ProcessSession{
   //
   // Get the FlowFile from the highest priority queue
   std::shared_ptr<core::FlowFile> ff;
-
 };
 
 } /* namespace core */

--- a/nanofi/include/sitetosite/CPeer.h
+++ b/nanofi/include/sitetosite/CPeer.h
@@ -40,7 +40,6 @@ void closePeer(struct SiteToSiteCPeer * peer);
 
 // Site2SitePeer Class
 struct SiteToSiteCPeer {
-
   cstream * _stream;
 
   // URL

--- a/nanofi/include/sitetosite/CSiteToSite.h
+++ b/nanofi/include/sitetosite/CSiteToSite.h
@@ -222,7 +222,6 @@ typedef struct {
 
 // Transaction Class
 typedef struct {
-
   // Number of current transfers
   int current_transfers_;
   // number of total seen transfers

--- a/nanofi/src/api/ecu.c
+++ b/nanofi/src/api/ecu.c
@@ -22,7 +22,6 @@ processor_params * procparams = NULL;
 volatile sig_atomic_t stopped = 0;
 
 void free_proc_params(const char * uuid) {
-
     struct processor_params * pp = NULL;
     HASH_FIND_STR(procparams, uuid, pp);
     if (pp) {

--- a/nanofi/src/core/file_utils.c
+++ b/nanofi/src/core/file_utils.c
@@ -62,7 +62,6 @@ char * concat_path(const char * parent, const char * child) {
 }
 
 void remove_directory(const char * dir_path) {
-
     if (!is_directory(dir_path)) {
         if (unlink(dir_path) == -1) {
             printf("Could not remove file %s\n", dir_path);

--- a/nanofi/src/cxx/Plan.cpp
+++ b/nanofi/src/cxx/Plan.cpp
@@ -55,7 +55,6 @@ std::shared_ptr<core::Processor> ExecutionPlan::addSimpleCallback(void *obj, std
 std::shared_ptr<core::Processor> ExecutionPlan::addCallback(void *obj,
     std::function<void(core::ProcessSession*, core::ProcessContext *)> ontrigger_callback,
     std::function<void(core::ProcessContext *)> onschedule_callback) {
-
   if (finalized) {
     return nullptr;
   }
@@ -280,7 +279,6 @@ std::shared_ptr<core::Processor> ExecutionPlan::createProcessor(const std::strin
 std::shared_ptr<core::Processor> ExecutionPlan::createCallback(void *obj,
     std::function<void(core::ProcessSession*, core::ProcessContext *)> ontrigger_callback,
     std::function<void(core::ProcessContext *)> onschedule_callback) {
-
   auto ptr = createProcessor(CallbackProcessorName, CallbackProcessorName);
   if (!ptr)
     return nullptr;

--- a/nanofi/src/sitetosite/CRawSocketProtocol.c
+++ b/nanofi/src/sitetosite/CRawSocketProtocol.c
@@ -548,7 +548,6 @@ int complete(struct CRawSiteToSiteClient * client, const char * transactionID) {
 }
 
 int confirm(struct CRawSiteToSiteClient * client, const char * transactionID) {
-
   if (client->_peer_state != READY) {
     bootstrap(client);
   }
@@ -690,7 +689,6 @@ int confirm(struct CRawSiteToSiteClient * client, const char * transactionID) {
 }
 
   int16_t sendPacket(struct CRawSiteToSiteClient * client, const char * transactionID, CDataPacket *packet, flow_file_record * ff) {
-
     if (client->_peer_state != READY) {
       bootstrap(client);
     }

--- a/nanofi/tests/CLogAggregatorTests.cpp
+++ b/nanofi/tests/CLogAggregatorTests.cpp
@@ -109,7 +109,6 @@ TEST_CASE("Test string tokenizer only delimiter character string", "[stringToken
  */
 
 TEST_CASE("Test string tokenizer for a delimited string less than 4096 bytes", "[testDelimitedStringTokenizer]") {
-
     std::vector<std::string> slist = {"this", "is a", "delimited", "string", ""};
     std::string delimitedString = join_strings(slist, "-");
     int len = strlen(delimitedString.c_str());
@@ -180,7 +179,6 @@ TEST_CASE("Test string tokenizer for string starting and ending with delimited c
  */
 
 TEST_CASE("Simple log aggregator test", "[testLogAggregator]") {
-
     const char * content = "hello world";
     FileManager fm("test.txt");
     fm.Write(content);
@@ -257,7 +255,6 @@ TEST_CASE("Test tail file with less than 4096 delimited chars", "[testLogAggrega
 // Although there is no delimiter within the string that is at least 4096 bytes long,
 // tail_file still creates a flow file for the first 4096 bytes.
 TEST_CASE("Test tail file having 4096 bytes without delimiter", "[testLogAggregateFile4096Chars]") {
-
     FileManager fm("test.txt");
     const std::string s = fm.WriteNChars(4096, 'a');
     const std::string filePath = fm.getFilePath();
@@ -274,7 +271,6 @@ TEST_CASE("Test tail file having 4096 bytes without delimiter", "[testLogAggrega
 // tail_file creates a flow file for each subsequent 4096 byte chunk. It leaves the last chunk
 // if it is smaller than 4096 bytes and not delimited
 TEST_CASE("Test tail file having more than 4096 bytes without delimiter", "[testLogAggregarteFileMoreThan4096Chars]") {
-
     FileManager fm("test.txt");
     const std::string s1 = fm.WriteNChars(4096, 'a');
     const std::string s2 = fm.WriteNChars(4096, 'b');
@@ -298,7 +294,6 @@ TEST_CASE("Test tail file having more than 4096 bytes without delimiter", "[test
 }
 
 TEST_CASE("Test tail file having more than 4096 bytes with delimiter", "[testLogAggregateWithDelimitedString]") {
-
     FileManager fm("test.txt");
     const std::string s1 = fm.WriteNChars(4096, 'a');
     const std::string d1 = fm.WriteNChars(2, ';');
@@ -321,7 +316,6 @@ TEST_CASE("Test tail file having more than 4096 bytes with delimiter", "[testLog
 }
 
 TEST_CASE("Test tail file having more than 4096 bytes with delimiter and second chunk less than 4096", "[testLogAggregateDelimited]") {
-
     FileManager fm("test.txt");
     const std::string s1 = fm.WriteNChars(4096, 'a');
     const std::string d1 = fm.WriteNChars(2, ';');
@@ -345,7 +339,6 @@ TEST_CASE("Test tail file having more than 4096 bytes with delimiter and second 
 }
 
 TEST_CASE("Test tail file having more than 4096 bytes with delimiter and second chunk more than 4096", "[testLogAggregateDelimited]") {
-
     FileManager fm("test.txt");
     const std::string s1 = fm.WriteNChars(4096, 'a');
     const std::string d1 = fm.WriteNChars(2, ';');

--- a/nanofi/tests/CSite2SiteTests.cpp
+++ b/nanofi/tests/CSite2SiteTests.cpp
@@ -61,7 +61,6 @@ struct TransferState {
   std::atomic<bool> handshake_data_processed{false};
   std::atomic<bool> transer_completed{false};
   std::atomic<bool> data_processed{false};
-
 };
 
 void wait_until(std::atomic<bool>& b) {


### PR DESCRIPTION
Removed linter reported redundant blank lines at the beginning/end of code blocks when cpplint is enabled on the whole project.

Turn off ignore-whitespace to review the PR.