### PR TITLE
MINIFICPP-1556 Fix setting partial or invalid credentials in AWS credentials service

### DIFF
--- a/extensions/aws/controllerservices/AWSCredentialsService.cpp
+++ b/extensions/aws/controllerservices/AWSCredentialsService.cpp
@@ -76,18 +76,11 @@ void AWSCredentialsService::onEnable() {
   }
 }
 
-Aws::Auth::AWSCredentials AWSCredentialsService::getAWSCredentials() {
-  if (aws_credentials_.IsExpiredOrEmpty()) {
-    cacheCredentials();
+minifi::utils::optional<Aws::Auth::AWSCredentials> AWSCredentialsService::getAWSCredentials() {
+  if (!aws_credentials_ || aws_credentials_->IsExpiredOrEmpty()) {
+    aws_credentials_ = aws_credentials_provider_.getAWSCredentials();
   }
   return aws_credentials_;
-}
-
-void AWSCredentialsService::cacheCredentials() {
-  auto aws_credentials_result = aws_credentials_provider_.getAWSCredentials();
-  if (aws_credentials_result) {
-    aws_credentials_ = aws_credentials_result.value();
-  }
 }
 
 }  // namespace controllers

--- a/extensions/aws/controllerservices/AWSCredentialsService.cpp
+++ b/extensions/aws/controllerservices/AWSCredentialsService.cpp
@@ -61,15 +61,19 @@ void AWSCredentialsService::initialize() {
 
 void AWSCredentialsService::onEnable() {
   std::string value;
-  getProperty(AccessKey.getName(), value);
-  aws_credentials_provider_.setAccessKey(value);
-  getProperty(SecretKey.getName(), value);
-  aws_credentials_provider_.setSecretKey(value);
-  getProperty(CredentialsFile.getName(), value);
-  aws_credentials_provider_.setCredentialsFile(value);
+  if (getProperty(AccessKey.getName(), value)) {
+    aws_credentials_provider_.setAccessKey(value);
+  }
+  if (getProperty(SecretKey.getName(), value)) {
+    aws_credentials_provider_.setSecretKey(value);
+  }
+  if (getProperty(CredentialsFile.getName(), value)) {
+    aws_credentials_provider_.setCredentialsFile(value);
+  }
   bool use_default_credentials = false;
-  getProperty(UseDefaultCredentials.getName(), use_default_credentials);
-  aws_credentials_provider_.setUseDefaultCredentials(use_default_credentials);
+  if (getProperty(UseDefaultCredentials.getName(), use_default_credentials)) {
+    aws_credentials_provider_.setUseDefaultCredentials(use_default_credentials);
+  }
 }
 
 Aws::Auth::AWSCredentials AWSCredentialsService::getAWSCredentials() {

--- a/extensions/aws/controllerservices/AWSCredentialsService.h
+++ b/extensions/aws/controllerservices/AWSCredentialsService.h
@@ -24,6 +24,7 @@
 #include "aws/core/auth/AWSCredentials.h"
 
 #include "utils/AWSInitializer.h"
+#include "utils/OptionalUtils.h"
 #include "core/Resource.h"
 #include "core/controller/ControllerService.h"
 #include "core/logging/LoggerConfiguration.h"
@@ -68,15 +69,13 @@ class AWSCredentialsService : public core::controller::ControllerService {
 
   void onEnable() override;
 
-  Aws::Auth::AWSCredentials getAWSCredentials();
+  minifi::utils::optional<Aws::Auth::AWSCredentials> getAWSCredentials();
 
  private:
   friend class ::AWSCredentialsServiceTestAccessor;
 
-  void cacheCredentials();
-
   const utils::AWSInitializer& AWS_INITIALIZER = utils::AWSInitializer::get();
-  Aws::Auth::AWSCredentials aws_credentials_;
+  minifi::utils::optional<Aws::Auth::AWSCredentials> aws_credentials_;
   AWSCredentialsProvider aws_credentials_provider_;
 };
 

--- a/extensions/aws/processors/S3Processor.cpp
+++ b/extensions/aws/processors/S3Processor.cpp
@@ -147,7 +147,7 @@ minifi::utils::optional<Aws::Auth::AWSCredentials> S3Processor::getAWSCredential
     return minifi::utils::nullopt;
   }
 
-  return minifi::utils::make_optional<Aws::Auth::AWSCredentials>(aws_credentials_service->getAWSCredentials());
+  return aws_credentials_service->getAWSCredentials();
 }
 
 minifi::utils::optional<Aws::Auth::AWSCredentials> S3Processor::getAWSCredentials(

--- a/extensions/aws/processors/S3Processor.cpp
+++ b/extensions/aws/processors/S3Processor.cpp
@@ -159,19 +159,21 @@ minifi::utils::optional<Aws::Auth::AWSCredentials> S3Processor::getAWSCredential
     return service_cred.value();
   }
 
-  std::string access_key;
-  context->getProperty(AccessKey, access_key, flow_file);
   aws::AWSCredentialsProvider aws_credentials_provider;
-  aws_credentials_provider.setAccessKey(access_key);
-  std::string secret_key;
-  context->getProperty(SecretKey, secret_key, flow_file);
-  aws_credentials_provider.setSecretKey(secret_key);
-  std::string credential_file;
-  context->getProperty(CredentialsFile.getName(), credential_file);
-  aws_credentials_provider.setCredentialsFile(credential_file);
+  std::string value;
+  if (context->getProperty(AccessKey, value, flow_file)) {
+    aws_credentials_provider.setAccessKey(value);
+  }
+  if (context->getProperty(SecretKey, value, flow_file)) {
+    aws_credentials_provider.setSecretKey(value);
+  }
+  if (context->getProperty(CredentialsFile.getName(), value)) {
+    aws_credentials_provider.setCredentialsFile(value);
+  }
   bool use_default_credentials = false;
-  context->getProperty(UseDefaultCredentials.getName(), use_default_credentials);
-  aws_credentials_provider.setUseDefaultCredentials(use_default_credentials);
+  if (context->getProperty(UseDefaultCredentials.getName(), use_default_credentials)) {
+    aws_credentials_provider.setUseDefaultCredentials(use_default_credentials);
+  }
 
   return aws_credentials_provider.getAWSCredentials();
 }

--- a/libminifi/test/aws-tests/AWSCredentialsServiceTest.cpp
+++ b/libminifi/test/aws-tests/AWSCredentialsServiceTest.cpp
@@ -56,12 +56,12 @@ TEST_CASE_METHOD(AWSCredentialsServiceTestAccessor, "Test expired credentials ar
   REQUIRE(aws_credentials_impl->getAWSCredentials());
   REQUIRE(aws_credentials_impl->getAWSCredentials()->GetAWSAccessKeyId() == "key");
   REQUIRE(aws_credentials_impl->getAWSCredentials()->GetAWSSecretKey() == "secret");
-  REQUIRE(!aws_credentials_impl->getAWSCredentials()->IsExpired());
+  REQUIRE_FALSE(aws_credentials_impl->getAWSCredentials()->IsExpired());
 
   // Expire credentials
   get_aws_credentials_(*aws_credentials_impl)->SetExpiration(Aws::Utils::DateTime(0.0));
   REQUIRE(get_aws_credentials_(*aws_credentials_impl)->IsExpired());
 
   // Check for credential refresh
-  REQUIRE(!aws_credentials_impl->getAWSCredentials()->IsExpired());
+  REQUIRE_FALSE(aws_credentials_impl->getAWSCredentials()->IsExpired());
 }

--- a/libminifi/test/aws-tests/AWSCredentialsServiceTest.cpp
+++ b/libminifi/test/aws-tests/AWSCredentialsServiceTest.cpp
@@ -53,6 +53,7 @@ TEST_CASE_METHOD(AWSCredentialsServiceTestAccessor, "Test expired credentials ar
   auto aws_credentials_impl = std::static_pointer_cast<minifi::aws::controllers::AWSCredentialsService>(aws_credentials_service->getControllerServiceImplementation());
 
   // Check intial credentials
+  REQUIRE(aws_credentials_impl->getAWSCredentials());
   REQUIRE(aws_credentials_impl->getAWSCredentials()->GetAWSAccessKeyId() == "key");
   REQUIRE(aws_credentials_impl->getAWSCredentials()->GetAWSSecretKey() == "secret");
   REQUIRE(!aws_credentials_impl->getAWSCredentials()->IsExpired());

--- a/libminifi/test/aws-tests/AWSCredentialsServiceTest.cpp
+++ b/libminifi/test/aws-tests/AWSCredentialsServiceTest.cpp
@@ -53,14 +53,14 @@ TEST_CASE_METHOD(AWSCredentialsServiceTestAccessor, "Test expired credentials ar
   auto aws_credentials_impl = std::static_pointer_cast<minifi::aws::controllers::AWSCredentialsService>(aws_credentials_service->getControllerServiceImplementation());
 
   // Check intial credentials
-  REQUIRE(aws_credentials_impl->getAWSCredentials().GetAWSAccessKeyId() == "key");
-  REQUIRE(aws_credentials_impl->getAWSCredentials().GetAWSSecretKey() == "secret");
-  REQUIRE(!aws_credentials_impl->getAWSCredentials().IsExpired());
+  REQUIRE(aws_credentials_impl->getAWSCredentials()->GetAWSAccessKeyId() == "key");
+  REQUIRE(aws_credentials_impl->getAWSCredentials()->GetAWSSecretKey() == "secret");
+  REQUIRE(!aws_credentials_impl->getAWSCredentials()->IsExpired());
 
   // Expire credentials
-  get_aws_credentials_(*aws_credentials_impl).SetExpiration(Aws::Utils::DateTime(0.0));
-  REQUIRE(get_aws_credentials_(*aws_credentials_impl).IsExpired());
+  get_aws_credentials_(*aws_credentials_impl)->SetExpiration(Aws::Utils::DateTime(0.0));
+  REQUIRE(get_aws_credentials_(*aws_credentials_impl)->IsExpired());
 
   // Check for credential refresh
-  REQUIRE(!aws_credentials_impl->getAWSCredentials().IsExpired());
+  REQUIRE(!aws_credentials_impl->getAWSCredentials()->IsExpired());
 }

--- a/libminifi/test/aws-tests/PutS3ObjectTests.cpp
+++ b/libminifi/test/aws-tests/PutS3ObjectTests.cpp
@@ -34,10 +34,10 @@ class PutS3ObjectTestsFixture : public FlowProcessorS3TestsFixture<minifi::aws::
   }
 
   void checkEmptyPutObjectResults() {
-    REQUIRE(!LogTestController::getInstance().contains("key:s3.version value:", std::chrono::seconds(0), std::chrono::milliseconds(0)));
-    REQUIRE(!LogTestController::getInstance().contains("key:s3.etag value:", std::chrono::seconds(0), std::chrono::milliseconds(0)));
-    REQUIRE(!LogTestController::getInstance().contains("key:s3.expiration value:", std::chrono::seconds(0), std::chrono::milliseconds(0)));
-    REQUIRE(!LogTestController::getInstance().contains("key:s3.sseAlgorithm value:", std::chrono::seconds(0), std::chrono::milliseconds(0)));
+    REQUIRE_FALSE(LogTestController::getInstance().contains("key:s3.version value:", std::chrono::seconds(0), std::chrono::milliseconds(0)));
+    REQUIRE_FALSE(LogTestController::getInstance().contains("key:s3.etag value:", std::chrono::seconds(0), std::chrono::milliseconds(0)));
+    REQUIRE_FALSE(LogTestController::getInstance().contains("key:s3.expiration value:", std::chrono::seconds(0), std::chrono::milliseconds(0)));
+    REQUIRE_FALSE(LogTestController::getInstance().contains("key:s3.sseAlgorithm value:", std::chrono::seconds(0), std::chrono::milliseconds(0)));
   }
 };
 
@@ -115,7 +115,7 @@ TEST_CASE_METHOD(PutS3ObjectTestsFixture, "Test incomplete credentials in creden
   REQUIRE(verifyLogLinePresenceInPollTime(std::chrono::seconds(3), "AWS Credentials have not been set!"));
 
   // Test that no invalid credentials file was set from previous properties
-  REQUIRE(!LogTestController::getInstance().contains("load configure file failed", std::chrono::seconds(0), std::chrono::milliseconds(0)));
+  REQUIRE_FALSE(LogTestController::getInstance().contains("load configure file failed", std::chrono::seconds(0), std::chrono::milliseconds(0)));
 }
 
 TEST_CASE_METHOD(PutS3ObjectTestsFixture, "Check default client configuration", "[awsS3ClientConfig]") {

--- a/libminifi/test/aws-tests/PutS3ObjectTests.cpp
+++ b/libminifi/test/aws-tests/PutS3ObjectTests.cpp
@@ -111,10 +111,10 @@ TEST_CASE_METHOD(PutS3ObjectTestsFixture, "Test incomplete credentials in creden
   setBucket();
   plan->setProperty(aws_credentials_service, "Secret Key", "secret");
   setCredentialsService();
-  test_controller.runSession(plan, true);
-  REQUIRE(verifyLogLinePresenceInPollTime(std::chrono::seconds(3), "No AWS credentials were set."));
+  REQUIRE_THROWS_AS(test_controller.runSession(plan, true), minifi::Exception&);
+  REQUIRE(verifyLogLinePresenceInPollTime(std::chrono::seconds(3), "AWS Credentials have not been set!"));
 
-  // Test that no invalid credentials file was set
+  // Test that no invalid credentials file was set from previous properties
   REQUIRE(!LogTestController::getInstance().contains("load configure file failed", std::chrono::seconds(0), std::chrono::milliseconds(0)));
 }
 

--- a/libminifi/test/aws-tests/PutS3ObjectTests.cpp
+++ b/libminifi/test/aws-tests/PutS3ObjectTests.cpp
@@ -107,6 +107,17 @@ TEST_CASE_METHOD(PutS3ObjectTestsFixture, "Test required property not set", "[aw
   REQUIRE_THROWS_AS(test_controller.runSession(plan, true), minifi::Exception&);
 }
 
+TEST_CASE_METHOD(PutS3ObjectTestsFixture, "Test incomplete credentials in credentials service", "[awsS3Config]") {
+  setBucket();
+  plan->setProperty(aws_credentials_service, "Secret Key", "secret");
+  setCredentialsService();
+  test_controller.runSession(plan, true);
+  REQUIRE(verifyLogLinePresenceInPollTime(std::chrono::seconds(3), "No AWS credentials were set."));
+
+  // Test that no invalid credentials file was set
+  REQUIRE(!LogTestController::getInstance().contains("load configure file failed", std::chrono::seconds(0), std::chrono::milliseconds(0)));
+}
+
 TEST_CASE_METHOD(PutS3ObjectTestsFixture, "Check default client configuration", "[awsS3ClientConfig]") {
   setRequiredProperties();
   test_controller.runSession(plan, true);

--- a/libminifi/test/aws-tests/S3TestsFixture.h
+++ b/libminifi/test/aws-tests/S3TestsFixture.h
@@ -29,6 +29,7 @@
 #include "utils/file/FileUtils.h"
 #include "MockS3RequestSender.h"
 #include "utils/TestUtils.h"
+#include "AWSCredentialsProvider.h"
 
 using org::apache::nifi::minifi::utils::createTempDir;
 
@@ -52,6 +53,7 @@ class S3TestsFixture {
     LogTestController::getInstance().setTrace<minifi::core::ProcessSession>();
     LogTestController::getInstance().setDebug<processors::LogAttribute>();
     LogTestController::getInstance().setTrace<T>();
+    LogTestController::getInstance().setDebug<minifi::aws::AWSCredentialsProvider>();
 
     // Build MiNiFi processing graph
     plan = test_controller.createPlan();


### PR DESCRIPTION
The issue addressed is when partial credentials were set for AWS in the credentials service it could happen that the credential files property was set with the value of a previous property.

Another issue addressed is if the credentials in the credentials service were empty or invalid they were used in the S3 processors. Now instead the S3 processors fail before trying to use the invalid credentials.

-----------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
