### PR TITLE
MINIFICPP-1569 Readd test running in Windows builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           PATH %PATH%;C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86
           PATH %PATH%;C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\Roslyn
-          win_build_vs.bat build /CI /S /A /Z /PDH
+          win_build_vs.bat build /CI /S /A /Z /PDH /R
         shell: cmd
       - name: test
         run: cd build && ctest --timeout 300 --parallel 8 -C Release --output-on-failure
@@ -152,7 +152,7 @@ jobs:
         run: |
           PATH %PATH%;C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64
           PATH %PATH%;C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Roslyn
-          win_build_vs.bat build /2019 /64 /CI /S /A /PDH /L
+          win_build_vs.bat build /2019 /64 /CI /S /A /PDH /L /R
         shell: cmd
       - name: test
         run: cd build && ctest --timeout 300 --parallel 8 -C Release --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           PATH %PATH%;C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86
           PATH %PATH%;C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\Roslyn
-          win_build_vs.bat build /CI /S /A /Z /PDH /T
+          win_build_vs.bat build /CI /S /A /Z /PDH
         shell: cmd
       - name: test
         run: cd build && ctest --timeout 300 --parallel 8 -C Release --output-on-failure
@@ -152,7 +152,7 @@ jobs:
         run: |
           PATH %PATH%;C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64
           PATH %PATH%;C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Roslyn
-          win_build_vs.bat build /2019 /64 /CI /S /A /PDH /T /L
+          win_build_vs.bat build /2019 /64 /CI /S /A /PDH /L
         shell: cmd
       - name: test
         run: cd build && ctest --timeout 300 --parallel 8 -C Release --output-on-failure

--- a/Windows.md
+++ b/Windows.md
@@ -65,6 +65,7 @@ After the build directory it will take optional parameters modifying the CMake c
 | /C | Enables CoAP |
 | /A | Enables AWS |
 | /Z | Enables Azure |
+| /L | Enables Linter |
 | /PDH | Enables Performance Monitor |
 | /M | Creates installer with merge modules |
 | /64 | Creates 64-bit build instead of a 32-bit one |

--- a/Windows.md
+++ b/Windows.md
@@ -56,7 +56,8 @@ After the build directory it will take optional parameters modifying the CMake c
 
 | Argument | Effect |
 |----------|------------------------------------------------|
-| /T | Disables tests |
+| /T | Disables building tests |
+| /R | Disables automatic test running after build |
 | /P | Enables MSI creation |
 | /K | Enables Kafka extension |
 | /J | Enables JNI |
@@ -76,7 +77,7 @@ Examples:
  - 32-bit build with kafka, disabling tests, enabling MSI creation: `win_build_vs.bat build32 /T /K /P`
  - 64-bit build with JNI, with debug symbols: `win_build_vs.bat build64 /64 /J /D`
 
-`win_build_vs.bat` requires either a Visual Studio 2017 or a Visual Studio 2019 (if called with the `/2019` flag) build environment to be set up. With Visual Studio 2017 use the `x86 Native Tools Command Prompt for VS 2017` for 32-bit, or the `x64 Native Tools Command Prompt for VS 2017` for 64-bit builds. 
+`win_build_vs.bat` requires either a Visual Studio 2017 or a Visual Studio 2019 (if called with the `/2019` flag) build environment to be set up. With Visual Studio 2017 use the `x86 Native Tools Command Prompt for VS 2017` for 32-bit, or the `x64 Native Tools Command Prompt for VS 2017` for 64-bit builds.
 For Visual Studio 2019 use the `x86 Native Tools Command Prompt for VS 2019`, or the `x64 Native Tools Command Prompt for VS 2019` for 32-bit and 64-bit builds respectively.
 
 ## Building directly with CMake

--- a/win_build_vs.bat
+++ b/win_build_vs.bat
@@ -21,6 +21,7 @@ if [%1]==[] goto usage
 
 set builddir=%1
 set skiptests=OFF
+set runtests=OFF
 set cmake_build_type=Release
 set build_platform=Win32
 set build_kafka=OFF
@@ -43,6 +44,7 @@ for %%x in (%*) do (
     set /A arg_counter+=1
     echo %%~x
     if [%%~x] EQU [/T]           set skiptests=ON
+    if [%%~x] EQU [/R]           set runtests=ON
     if [%%~x] EQU [/P]           set cpack=ON
     if [%%~x] EQU [/K]           set build_kafka=ON
     if [%%~x] EQU [/J]           set build_JNI=ON
@@ -72,8 +74,10 @@ if [%cpack%] EQU [ON] (
     IF !ERRORLEVEL! NEQ 0 ( popd & exit /b !ERRORLEVEL! )
 )
 if [%skiptests%] NEQ [ON] (
-    ctest --timeout 300 --parallel 8 -C %cmake_build_type% --output-on-failure
-    IF !ERRORLEVEL! NEQ 0 ( popd & exit /b !ERRORLEVEL! )
+    if [%runtests%] EQU [ON] (
+        ctest --timeout 300 --parallel 8 -C %cmake_build_type% --output-on-failure
+        IF !ERRORLEVEL! NEQ 0 ( popd & exit /b !ERRORLEVEL! )
+    )
 )
 popd
 goto :eof

--- a/win_build_vs.bat
+++ b/win_build_vs.bat
@@ -21,7 +21,7 @@ if [%1]==[] goto usage
 
 set builddir=%1
 set skiptests=OFF
-set runtests=OFF
+set skiptestrun=OFF
 set cmake_build_type=Release
 set build_platform=Win32
 set build_kafka=OFF
@@ -44,7 +44,7 @@ for %%x in (%*) do (
     set /A arg_counter+=1
     echo %%~x
     if [%%~x] EQU [/T]           set skiptests=ON
-    if [%%~x] EQU [/R]           set runtests=ON
+    if [%%~x] EQU [/R]           set skiptestrun=ON
     if [%%~x] EQU [/P]           set cpack=ON
     if [%%~x] EQU [/K]           set build_kafka=ON
     if [%%~x] EQU [/J]           set build_JNI=ON
@@ -74,7 +74,7 @@ if [%cpack%] EQU [ON] (
     IF !ERRORLEVEL! NEQ 0 ( popd & exit /b !ERRORLEVEL! )
 )
 if [%skiptests%] NEQ [ON] (
-    if [%runtests%] EQU [ON] (
+    if [%skiptestrun%] NEQ [ON] (
         ctest --timeout 300 --parallel 8 -C %cmake_build_type% --output-on-failure
         IF !ERRORLEVEL! NEQ 0 ( popd & exit /b !ERRORLEVEL! )
     )


### PR DESCRIPTION
Jira ticket: https://issues.apache.org/jira/browse/MINIFICPP-1569

In PR #1069 the Windows build was changed to separate the `build` and the `test` phases, but the change also removed the building of the tests, so they are not found in the `test` phase:

```
Run cd build && ctest --timeout 300 --parallel 8 -C Release --output-on-failure
Test project D:/a/nifi-minifi-cpp/nifi-minifi-cpp/build
No tests were found!!!
```

---------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
