### PR TITLE
MINIFICPP-1571 nanofi: fix strncpy warnings

### DIFF
--- a/nanofi/src/api/ecu.c
+++ b/nanofi/src/api/ecu.c
@@ -272,10 +272,7 @@ void on_trigger_tailfilechunk(processor_session * ps, processor_context * ctx) {
 
         props = (struct proc_properties *)malloc(sizeof(struct proc_properties));
         memset(props, 0, sizeof(struct proc_properties));
-        int len = strlen(file_path);
-        props->file_path = (char *)malloc((len + 1) * sizeof(char));
-        strncpy(props->file_path, file_path, len);
-        props->file_path[len] = '\0';
+        props->file_path = strdup(file_path);
         props->chunk_size = chunk_size_value;
         add_processor_properties(uuid_str, props);
     }
@@ -402,10 +399,7 @@ struct proc_properties * get_properties(const char * uuid, processor_context * c
         }
     }
 
-    int len = strlen(file_path);
-    props->file_path = (char *)malloc((len + 1) * sizeof(char));
-    strncpy(props->file_path, file_path, len);
-    props->file_path[len] = '\0';
+    props->file_path = strdup(file_path);
     props->delimiter = delim;
 
     add_processor_properties(uuid, props);


### PR DESCRIPTION
false positives

[MINIFICPP-1571 fix nanofi warnings -Wstringop-truncation](https://issues.apache.org/jira/browse/MINIFICPP-1571)

Replaced string copies with `strdup`, which is not part of ISO/ANSI C, but part of POSIX and is implemented on MS Windows as well.

___

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
