### PR TITLE
MINIFICPP-1557 Fix CPU usage percentage calculation and extend verification

### DIFF
--- a/extensions/http-curl/tests/HTTPHandlers.h
+++ b/extensions/http-curl/tests/HTTPHandlers.h
@@ -430,7 +430,7 @@ class HeartbeatHandler : public ServerAwareHandler {
       rapidjson::Document root;
       rapidjson::ParseResult result = root.Parse(post_data.data(), post_data.size());
       if (!result) {
-        throw std::runtime_error("JSON parse error: " + std::string(rapidjson::GetParseError_En(result.Code())) + "\n JSON data: " + post_data);
+        throw std::runtime_error(fmt::format("JSON parse error: {0}\n JSON data: {1}", std::string(rapidjson::GetParseError_En(result.Code())), post_data));
       }
       std::string operation = root["operation"].GetString();
       if (operation == "heartbeat") {

--- a/libminifi/src/utils/ProcessCpuUsageTracker.cpp
+++ b/libminifi/src/utils/ProcessCpuUsageTracker.cpp
@@ -69,6 +69,9 @@ bool ProcessCpuUsageTracker::isCurrentQuerySameAsPrevious() const {
 
 double ProcessCpuUsageTracker::getProcessCpuUsageBetweenLastTwoQueries() const {
   clock_t cpu_times_diff = cpu_times_ - previous_cpu_times_;
+  if (cpu_times_diff == 0) {
+    return -1.0;
+  }
   clock_t sys_cpu_times_diff = sys_cpu_times_ - previous_sys_cpu_times_;
   clock_t user_cpu_times_diff = user_cpu_times_ - previous_user_cpu_times_;
   double percent = static_cast<double>(sys_cpu_times_diff + user_cpu_times_diff) / static_cast<double>(cpu_times_diff);
@@ -124,6 +127,9 @@ void ProcessCpuUsageTracker::queryCpuTimes() {
 
 double ProcessCpuUsageTracker::getProcessCpuUsageBetweenLastTwoQueries() const {
   uint64_t cpu_times_diff = cpu_times_ - previous_cpu_times_;
+  if (cpu_times_diff == 0) {
+    return -1.0;
+  }
   uint64_t sys_cpu_times_diff = sys_cpu_times_ - previous_sys_cpu_times_;
   uint64_t user_cpu_times_diff = user_cpu_times_ - previous_user_cpu_times_;
   double percent = static_cast<double>(sys_cpu_times_diff + user_cpu_times_diff) / static_cast<double>(cpu_times_diff);

--- a/libminifi/src/utils/ProcessCpuUsageTracker.cpp
+++ b/libminifi/src/utils/ProcessCpuUsageTracker.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include <thread>
+#include <algorithm>
 
 namespace org {
 namespace apache {
@@ -71,7 +72,7 @@ double ProcessCpuUsageTracker::getProcessCpuUsageBetweenLastTwoQueries() const {
   clock_t sys_cpu_times_diff = sys_cpu_times_ - previous_sys_cpu_times_;
   clock_t user_cpu_times_diff = user_cpu_times_ - previous_user_cpu_times_;
   double percent = static_cast<double>(sys_cpu_times_diff + user_cpu_times_diff) / static_cast<double>(cpu_times_diff);
-  percent = percent / std::thread::hardware_concurrency();
+  percent = percent / (std::max)(static_cast<uint32_t>(1), std::thread::hardware_concurrency());
   return percent;
 }
 
@@ -126,7 +127,7 @@ double ProcessCpuUsageTracker::getProcessCpuUsageBetweenLastTwoQueries() const {
   uint64_t sys_cpu_times_diff = sys_cpu_times_ - previous_sys_cpu_times_;
   uint64_t user_cpu_times_diff = user_cpu_times_ - previous_user_cpu_times_;
   double percent = static_cast<double>(sys_cpu_times_diff + user_cpu_times_diff) / static_cast<double>(cpu_times_diff);
-  percent = percent / std::thread::hardware_concurrency();
+  percent = percent / (std::max)(static_cast<uint32_t>(1), std::thread::hardware_concurrency());
   return percent;
 }
 #endif

--- a/libminifi/src/utils/ProcessCpuUsageTracker.cpp
+++ b/libminifi/src/utils/ProcessCpuUsageTracker.cpp
@@ -72,7 +72,7 @@ double ProcessCpuUsageTracker::getProcessCpuUsageBetweenLastTwoQueries() const {
   clock_t sys_cpu_times_diff = sys_cpu_times_ - previous_sys_cpu_times_;
   clock_t user_cpu_times_diff = user_cpu_times_ - previous_user_cpu_times_;
   double percent = static_cast<double>(sys_cpu_times_diff + user_cpu_times_diff) / static_cast<double>(cpu_times_diff);
-  percent = percent / (std::max)(static_cast<uint32_t>(1), std::thread::hardware_concurrency());
+  percent = percent / (std::max)(uint32_t{1}, std::thread::hardware_concurrency());
   return percent;
 }
 
@@ -127,7 +127,7 @@ double ProcessCpuUsageTracker::getProcessCpuUsageBetweenLastTwoQueries() const {
   uint64_t sys_cpu_times_diff = sys_cpu_times_ - previous_sys_cpu_times_;
   uint64_t user_cpu_times_diff = user_cpu_times_ - previous_user_cpu_times_;
   double percent = static_cast<double>(sys_cpu_times_diff + user_cpu_times_diff) / static_cast<double>(cpu_times_diff);
-  percent = percent / (std::max)(static_cast<uint32_t>(1), std::thread::hardware_concurrency());
+  percent = percent / (std::max)(uint32_t{1}, std::thread::hardware_concurrency());
   return percent;
 }
 #endif

--- a/libminifi/src/utils/SystemCpuUsageTracker.cpp
+++ b/libminifi/src/utils/SystemCpuUsageTracker.cpp
@@ -75,8 +75,11 @@ double SystemCpuUsageTracker::getCpuUsageBetweenLastTwoQueries() const {
   uint64_t total_user_low_diff = total_user_low_ - previous_total_user_low_;
   uint64_t total_system_diff = total_sys_ - previous_total_sys_;
   uint64_t total_idle_diff = total_idle_ - previous_total_idle_;
-  uint64_t total_diff =  total_user_diff + total_user_low_diff + total_system_diff;
-  double percent = static_cast<double>(total_diff)/static_cast<double>(total_diff+total_idle_diff);
+  uint64_t total_diff = total_user_diff + total_user_low_diff + total_system_diff;
+  if (total_diff + total_idle_diff == 0) {
+    return -1.0;
+  }
+  double percent = static_cast<double>(total_diff) / static_cast<double>(total_diff + total_idle_diff);
 
   return percent;
 }
@@ -126,6 +129,9 @@ double SystemCpuUsageTracker::getCpuUsageBetweenLastTwoQueries() const {
   uint64_t total_sys_diff = total_sys_ - previous_total_sys_;
   uint64_t total_idle_diff = total_idle_ - previous_total_idle_;
   uint64_t total_diff = total_user_diff + total_sys_diff;
+  if (total_diff == 0) {
+    return -1.0;
+  }
   double percent = static_cast<double>(total_diff - total_idle_diff) / static_cast<double>(total_diff);
 
   return percent;
@@ -176,8 +182,10 @@ bool SystemCpuUsageTracker::isCurrentQuerySameAsPrevious() const {
 double SystemCpuUsageTracker::getCpuUsageBetweenLastTwoQueries() const {
   uint64_t total_ticks_since_last_time = total_ticks_-previous_total_ticks_;
   uint64_t idle_ticks_since_last_time  = idle_ticks_-previous_idle_ticks_;
-
-  double percent = static_cast<double>(total_ticks_since_last_time-idle_ticks_since_last_time)/static_cast<double>(total_ticks_since_last_time);
+  if (total_ticks_since_last_time == 0) {
+    return -1.0;
+  }
+  double percent = static_cast<double>(total_ticks_since_last_time - idle_ticks_since_last_time) / static_cast<double>(total_ticks_since_last_time);
 
   return percent;
 }

--- a/libminifi/test/unit/CpuUsageTest.cpp
+++ b/libminifi/test/unit/CpuUsageTest.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Test System CPU Utilization", "[testcpuusage]") {
 
   org::apache::nifi::minifi::utils::SystemCpuUsageTracker hostTracker;
   org::apache::nifi::minifi::utils::ProcessCpuUsageTracker processTracker;
-  int vCores = std::thread::hardware_concurrency();
+  auto vCores = (std::max)(uint32_t{1}, std::thread::hardware_concurrency());
   auto test_start = std::chrono::system_clock::now();
   for (int i = 0; i < number_of_rounds; ++i) {
     {


### PR DESCRIPTION
`std::thread::hardware_concurrency` can return with 0 if the value is not well defined or not computable, which can cause zero division in the calculation of the CPU usage. The total time difference calculations can also be zero that can also cause zero division. This happened quite often in github's virtual environments, that resulted in the heartbeat payload JSON to be truncated, and the invalid JSON caused the test to fail transiently. 

The test is also updated to include more information of the parsing failure and to avoid any timing issues when the server is shut down.

-------------------------------------------------------------------------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
