### PR TITLE
MINIFICPP-1585 Rename enum values in ConsumeKafkaTests::PublishEvent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         run: |
           PATH %PATH%;C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64
           PATH %PATH%;C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Roslyn
-          win_build_vs.bat build /2019 /64 /CI /S /A /PDH /L /R
+          win_build_vs.bat build /2019 /64 /CI /S /A /PDH /K /L /R
         shell: cmd
       - name: test
         run: cd build && ctest --timeout 300 --parallel 8 -C Release --output-on-failure


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-1584

`TRANSACTION_COMMIT` is defined in `winnt.h` as a macro, so the build fails on Windows when `librdkafka` is enabled (using the `/K` flag).  I have renamed it, and a few other enum values for consistency.

Also added /K to the VS2019 Windows CI job, to make sure bugs like this get caught in the CI stage in the future.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
