### PR TITLE
MINIFICPP-1592 Make sure rolled over file gets older timestamp in test

### DIFF
--- a/extensions/standard-processors/tests/unit/TailFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/TailFileTests.cpp
@@ -1618,6 +1618,7 @@ TEST_CASE("TailFile reads from a single file when Initial Start Position is set 
   LogTestController::getInstance().resetStream(LogTestController::getInstance().log_output);
 
   const std::string DATA_IN_NEW_FILE = "data in new file\n";
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));  // make sure the new file gets newer modification time
   appendTempFile(dir, TMP_FILE, NEW_TAIL_DATA);
   renameTempFile(dir, TMP_FILE, ROLLED_OVER_TMP_FILE);
   createTempFile(dir, TMP_FILE, DATA_IN_NEW_FILE);


### PR DESCRIPTION
TailFileTests scenario "TailFile reads from a single file when Initial Start Position is set to Current Time with rollover" could transiently fail because of the rounding of the timestamps could potentially make the rolled over file seem newer than the tailed file in the test. Similarly to other test cases the added delay makes the test stable. After 5000 runs the issues did not appear when previously it always appeared in less than 200 runs.

Jira ticket: https://issues.apache.org/jira/browse/MINIFICPP-1592

----------------------------------------------------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
