### PR TITLE
MINIFICPP-1586-`make linter` gives errors when it is run in an unpack…

### DIFF
--- a/thirdparty/google-styleguide/run_linter.py
+++ b/thirdparty/google-styleguide/run_linter.py
@@ -15,7 +15,7 @@ for include_path in args.includePaths:
         list_of_files += [os.path.join(dir_path, file_name)]
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
-repository_path = os.path.abspath(os.path.join(script_dir, '..', '..'))
+repository_path = os.path.abspath(os.path.join(script_dir, os.pardir, os.pardir))
 
 arg_list = list()
 arg_list.append("--linelength=200")

--- a/thirdparty/google-styleguide/run_linter.py
+++ b/thirdparty/google-styleguide/run_linter.py
@@ -2,9 +2,7 @@ import argparse
 import os
 import cpplint
 
-script_dir = os.path.dirname(os.path.realpath(__file__))
 parser = argparse.ArgumentParser()
-
 parser.add_argument('-i', '--includePaths', nargs="+", help='Run linter check in these directories')
 parser.add_argument('-q', '--quiet', action='store_true', help='Don\'t print anything if no errors are found.')
 args = parser.parse_args()
@@ -16,7 +14,8 @@ for include_path in args.includePaths:
       if (".h" in file_name) or (".cpp" in file_name):
         list_of_files += [os.path.join(dir_path, file_name)]
 
-repository_path = script_dir + "../../"
+script_dir = os.path.dirname(os.path.realpath(__file__))
+repository_path = os.path.abspath(os.path.join(script_dir, '..', '..'))
 
 arg_list = list()
 arg_list.append("--linelength=200")


### PR DESCRIPTION
…ed release tarball

MINIFICPP-1586-keeping script_dir variable

MINIFICPP-1586-Removed '/' from sub-directories

MINIFICPP-1586-`make linter` gives errors when it is run in an unpacked released tarball

MINIFICPP-1586-new line at the end

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [X] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
