### PR TITLE
MINIFICPP-1595 Pin pip package versions to avoid incompatibility

### DIFF
--- a/docker/DockerVerify.sh
+++ b/docker/DockerVerify.sh
@@ -57,13 +57,7 @@ if ! command swig -version &> /dev/null; then
   exit 1
 fi
 
-pip install --upgrade \
-            behave==1.2.6 \
-            pytimeparse==1.1.8 \
-            docker==5.0.0 \
-            PyYAML==5.4.1 \
-            m2crypto==0.37.1 \
-            watchdog==2.1.2
+pip install -r "${docker_dir}/requirements.txt"
 JAVA_HOME="/usr/lib/jvm/default-jvm"
 export JAVA_HOME
 PATH="$PATH:/usr/lib/jvm/default-jvm/bin"

--- a/docker/DockerVerify.sh
+++ b/docker/DockerVerify.sh
@@ -58,12 +58,12 @@ if ! command swig -version &> /dev/null; then
 fi
 
 pip install --upgrade \
-            behave \
-            pytimeparse \
-            docker \
-            PyYAML \
-            m2crypto \
-            watchdog
+            behave==1.2.6 \
+            pytimeparse==1.1.8 \
+            docker==5.0.0 \
+            PyYAML==5.4.1 \
+            m2crypto==0.37.1 \
+            watchdog==2.1.2
 JAVA_HOME="/usr/lib/jvm/default-jvm"
 export JAVA_HOME
 PATH="$PATH:/usr/lib/jvm/default-jvm/bin"

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,0 +1,6 @@
+behave==1.2.6
+pytimeparse==1.1.8
+docker==5.0.0
+PyYAML==5.4.1
+m2crypto==0.37.1
+watchdog==2.1.2


### PR DESCRIPTION
Latest M2Crypto version 0.38.0 is not compatible with the latest Behave package. Pinning the pip package versions should fix this issue and avoid similar problems in the future.

Jira ticket: https://issues.apache.org/jira/browse/MINIFICPP-1595

--------------------------------------------------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
