### PR TITLE
MINIFICPP-1598 Add delay in test for Kafka consumer synchronization

### DIFF
--- a/docker/test/integration/steps/steps.py
+++ b/docker/test/integration/steps/steps.py
@@ -444,6 +444,9 @@ def step_impl(context, content, topic_name, semicolon_separated_headers):
 @when("the Kafka consumer is registered in kafka broker \"{cluster_name}\"")
 def step_impl(context, cluster_name):
     context.test.wait_for_kafka_consumer_to_be_registered(cluster_name)
+    # After the consumer is registered there is still some time needed for consumer-broker synchronization
+    # Unfortunately there are no additional log messages that could be checked for this
+    time.sleep(2)
 
 
 @then("a flowfile with the content \"{content}\" is placed in the monitored directory in less than {duration}")


### PR DESCRIPTION
Fixes transient failure of "latest offset reset" test scenario in Kafka tests.

Jira ticket: https://issues.apache.org/jira/browse/MINIFICPP-1598

------------------------------------------------------------------------

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
