### PR TITLE
MINIFICPP-1605 Always refresh AWS credentials through default credentials chain

### DIFF
--- a/extensions/aws/AWSCredentialsProvider.cpp
+++ b/extensions/aws/AWSCredentialsProvider.cpp
@@ -44,6 +44,10 @@ void AWSCredentialsProvider::setUseDefaultCredentials(bool use_default_credentia
   use_default_credentials_ = use_default_credentials;
 }
 
+bool AWSCredentialsProvider::getUseDefaultCredentials() const {
+  return use_default_credentials_;
+}
+
 void AWSCredentialsProvider::setAccessKey(const std::string &access_key) {
   access_key_ = access_key;
 }

--- a/extensions/aws/AWSCredentialsProvider.h
+++ b/extensions/aws/AWSCredentialsProvider.h
@@ -46,6 +46,7 @@ class AWSCredentialsProvider {
   void setAccessKey(const std::string &access_key);
   void setSecretKey(const std::string &secret_key);
   void setCredentialsFile(const std::string &credentials_file);
+  bool getUseDefaultCredentials() const;
   minifi::utils::optional<Aws::Auth::AWSCredentials> getAWSCredentials();
 
  private:

--- a/extensions/aws/controllerservices/AWSCredentialsService.cpp
+++ b/extensions/aws/controllerservices/AWSCredentialsService.cpp
@@ -77,7 +77,7 @@ void AWSCredentialsService::onEnable() {
 }
 
 minifi::utils::optional<Aws::Auth::AWSCredentials> AWSCredentialsService::getAWSCredentials() {
-  if (!aws_credentials_ || aws_credentials_->IsExpiredOrEmpty()) {
+  if (aws_credentials_provider_.getUseDefaultCredentials() || !aws_credentials_ || aws_credentials_->IsExpiredOrEmpty()) {
     aws_credentials_ = aws_credentials_provider_.getAWSCredentials();
   }
   return aws_credentials_;

--- a/libminifi/test/aws-tests/AWSCredentialsServiceTest.cpp
+++ b/libminifi/test/aws-tests/AWSCredentialsServiceTest.cpp
@@ -101,4 +101,4 @@ TEST_CASE_METHOD(AWSCredentialsServiceTestAccessor, "Test credentials from defau
   REQUIRE_FALSE(aws_credentials_impl->getAWSCredentials()->IsExpired());
 }
 
-}
+}  // namespace


### PR DESCRIPTION
Due to a time skew problem when using temporary AWS credentials like instance profiles the credentials may expire on AWS side even though it can be non-expired when checked on client side. Because of this when using default credentials chain we should let the AWS SDK handle the caching and renewing the credentials and not cache manually on client side.

Jira ticket: https://issues.apache.org/jira/browse/MINIFICPP-1605

--------------------------------------------------------------------------------------------

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
