### PR TITLE
MINIFICPP-1606 Fix the reading of large flow files

### DIFF
--- a/extensions/libarchive/MergeContent.h
+++ b/extensions/libarchive/MergeContent.h
@@ -77,11 +77,13 @@ class BinaryConcatenationMerge : public MergeBin {
         std::deque<std::shared_ptr<core::FlowFile>> &flows, FlowFileSerializer& serializer) :
       header_(header), footer_(footer), demarcator_(demarcator), flows_(flows), serializer_(serializer) {
     }
+
     std::string &header_;
     std::string &footer_;
     std::string &demarcator_;
     std::deque<std::shared_ptr<core::FlowFile>> &flows_;
     FlowFileSerializer& serializer_;
+
     int64_t process(const std::shared_ptr<io::BaseStream>& stream) override {
       size_t write_size_sum = 0;
       if (!header_.empty()) {
@@ -98,7 +100,7 @@ class BinaryConcatenationMerge : public MergeBin {
             return -1;
           write_size_sum += write_ret;
         }
-        int len = serializer_.serialize(flow, stream);
+        const auto len = serializer_.serialize(flow, stream);
         if (len < 0)
           return len;
         write_size_sum += gsl::narrow<size_t>(len);
@@ -231,7 +233,7 @@ class ArchiveMerge {
             }
           }
         }
-        int ret = serializer_.serialize(flow, std::make_shared<ArchiveWriter>(arch, entry));
+        const auto ret = serializer_.serialize(flow, std::make_shared<ArchiveWriter>(arch, entry));
         if (ret < 0) {
           return ret;
         }

--- a/libminifi/include/core/ProcessSession.h
+++ b/libminifi/include/core/ProcessSession.h
@@ -94,7 +94,7 @@ class ProcessSession : public ReferenceContainer {
   // Remove Flow File
   void remove(const std::shared_ptr<core::FlowFile> &flow);
   // Execute the given read callback against the content
-  int read(const std::shared_ptr<core::FlowFile> &flow, InputStreamCallback *callback);
+  int64_t read(const std::shared_ptr<core::FlowFile> &flow, InputStreamCallback *callback);
   // Execute the given write callback against the content
   void write(const std::shared_ptr<core::FlowFile> &flow, OutputStreamCallback *callback);
   // Replace content with buffer

--- a/libminifi/include/serialization/FlowFileSerializer.h
+++ b/libminifi/include/serialization/FlowFileSerializer.h
@@ -42,11 +42,11 @@ class InputStreamCallback;
 
 class FlowFileSerializer {
  public:
-  using FlowFileReader = std::function<int(const std::shared_ptr<core::FlowFile>&, InputStreamCallback*)>;
+  using FlowFileReader = std::function<int64_t(const std::shared_ptr<core::FlowFile>&, InputStreamCallback*)>;
 
   explicit FlowFileSerializer(FlowFileReader reader) : reader_(std::move(reader)) {}
 
-  virtual int serialize(const std::shared_ptr<core::FlowFile>& flowFile, const std::shared_ptr<io::OutputStream>& out) = 0;
+  virtual int64_t serialize(const std::shared_ptr<core::FlowFile>& flowFile, const std::shared_ptr<io::OutputStream>& out) = 0;
 
   virtual ~FlowFileSerializer() = default;
 

--- a/libminifi/include/serialization/FlowFileV3Serializer.h
+++ b/libminifi/include/serialization/FlowFileV3Serializer.h
@@ -41,7 +41,7 @@ class FlowFileV3Serializer : public FlowFileSerializer {
  public:
   using FlowFileSerializer::FlowFileSerializer;
 
-  int serialize(const std::shared_ptr<core::FlowFile>& flowFile, const std::shared_ptr<io::OutputStream>& out) override;
+  int64_t serialize(const std::shared_ptr<core::FlowFile>& flowFile, const std::shared_ptr<io::OutputStream>& out) override;
 };
 
 } /* namespace minifi */

--- a/libminifi/include/serialization/PayloadSerializer.h
+++ b/libminifi/include/serialization/PayloadSerializer.h
@@ -31,7 +31,7 @@ class PayloadSerializer : public FlowFileSerializer {
  public:
   using FlowFileSerializer::FlowFileSerializer;
 
-  int serialize(const std::shared_ptr<core::FlowFile>& flowFile, const std::shared_ptr<io::OutputStream>& out) override;
+  int64_t serialize(const std::shared_ptr<core::FlowFile>& flowFile, const std::shared_ptr<io::OutputStream>& out) override;
 };
 
 } /* namespace minifi */

--- a/libminifi/src/core/ProcessSession.cpp
+++ b/libminifi/src/core/ProcessSession.cpp
@@ -290,7 +290,7 @@ void ProcessSession::append(const std::shared_ptr<core::FlowFile> &flow, OutputS
   }
 }
 
-int ProcessSession::read(const std::shared_ptr<core::FlowFile> &flow, InputStreamCallback *callback) {
+int64_t ProcessSession::read(const std::shared_ptr<core::FlowFile> &flow, InputStreamCallback *callback) {
   try {
     std::shared_ptr<ResourceClaim> claim = nullptr;
 
@@ -317,7 +317,7 @@ int ProcessSession::read(const std::shared_ptr<core::FlowFile> &flow, InputStrea
     if (ret < 0) {
       throw Exception(FILE_OPERATION_EXCEPTION, "Failed to process flowfile content");
     }
-    return gsl::narrow<int>(ret);
+    return ret;
   } catch (std::exception &exception) {
     logger_->log_debug("Caught Exception %s", exception.what());
     throw;

--- a/libminifi/src/serialization/FlowFileV3Serializer.cpp
+++ b/libminifi/src/serialization/FlowFileV3Serializer.cpp
@@ -61,7 +61,7 @@ size_t FlowFileV3Serializer::writeString(const std::string &str, const std::shar
   return sum;
 }
 
-int FlowFileV3Serializer::serialize(const std::shared_ptr<core::FlowFile>& flowFile, const std::shared_ptr<io::OutputStream>& out) {
+int64_t FlowFileV3Serializer::serialize(const std::shared_ptr<core::FlowFile>& flowFile, const std::shared_ptr<io::OutputStream>& out) {
   size_t sum = 0;
   {
     const auto ret = out->write(MAGIC_HEADER, sizeof(MAGIC_HEADER));
@@ -98,7 +98,7 @@ int FlowFileV3Serializer::serialize(const std::shared_ptr<core::FlowFile>& flowF
     if (ret < 0) return -1;
     sum += gsl::narrow<size_t>(ret);
   }
-  return gsl::narrow<int>(sum);
+  return gsl::narrow<int64_t>(sum);
 }
 
 } /* namespace minifi */

--- a/libminifi/src/serialization/PayloadSerializer.cpp
+++ b/libminifi/src/serialization/PayloadSerializer.cpp
@@ -24,7 +24,7 @@ namespace apache {
 namespace nifi {
 namespace minifi {
 
-int PayloadSerializer::serialize(const std::shared_ptr<core::FlowFile>& flowFile, const std::shared_ptr<io::OutputStream>& out) {
+int64_t PayloadSerializer::serialize(const std::shared_ptr<core::FlowFile>& flowFile, const std::shared_ptr<io::OutputStream>& out) {
   InputStreamPipe pipe(out);
   return reader_(flowFile, &pipe);
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-1606

Since `ProcessSession::read()` returns the size of the flow file, and its return type was `int`, we still couldn't handle flow files larger than around 2 GB, even after #1015, #1028 and #1083.

I have changed the return type to `int64_t`, which I think fixes the issue.  It could have been `size_t` as in #1028 and #1083, but most of the existing code around this (eg. `InputStreamCallback::process()`) use `int64_t`, so this looked like a more logical choice, requiring a smaller code change.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
