### PR TITLE
MINIFICPP-1609 Handle bash in the same way as patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,9 @@ function(append_third_party_passthrough_args OUTPUT EXTERNALPROJECT_CMAKE_ARGS)
 	set(${OUTPUT} ${EXTERNALPROJECT_CMAKE_ARGS} PARENT_SCOPE)
 endfunction()
 
+# Find bash executable
+find_package(Bash REQUIRED)
+
 # Find patch executable
 find_package(Patch REQUIRED)
 

--- a/Windows.md
+++ b/Windows.md
@@ -25,7 +25,7 @@ The project previously required OpenSSL to be installed. If you follow our build
 
  - Visual Studio 2019
  - [CMake](https://cmake.org/download/)
- - [Git](https://git-scm.com/download/win)
+ - [Git](https://git-scm.com/download/win) (the build process requires the bash.exe and patch.exe tools packaged with Git)
  - (Optional) [WiX Toolset](https://wixtoolset.org/releases/) (only for building the MSI)
  - (Optional) JDK (only for JNI support)
 

--- a/cmake/BundledAzureSdkCpp.cmake
+++ b/cmake/BundledAzureSdkCpp.cmake
@@ -18,7 +18,7 @@
 function(use_bundled_libazure SOURCE_DIR BINARY_DIR)
     set(PATCH_FILE1 "${SOURCE_DIR}/thirdparty/azure-sdk-cpp-for-cpp/azure-sdk-for-cpp-old-compiler.patch")
     set(PATCH_FILE2 "${SOURCE_DIR}/thirdparty/azure-sdk-cpp-for-cpp/fix-illegal-qualified-name-in-member.patch")
-    set(PC bash -c "set -x &&\
+    set(PC ${Bash_EXECUTABLE} -c "set -x &&\
             (\"${Patch_EXECUTABLE}\" -p1 -R -s -f --dry-run -i \"${PATCH_FILE1}\" || \"${Patch_EXECUTABLE}\" -p1 -N -i \"${PATCH_FILE1}\") &&\
             (\"${Patch_EXECUTABLE}\" -p1 -R -s -f --dry-run -i \"${PATCH_FILE2}\" || \"${Patch_EXECUTABLE}\" -p1 -N -i \"${PATCH_FILE2}\") ")
 

--- a/cmake/BundledOSSPUUID.cmake
+++ b/cmake/BundledOSSPUUID.cmake
@@ -22,7 +22,7 @@ function(use_bundled_osspuuid SOURCE_DIR BINARY_DIR)
 
     # Define patch step
     # if already applied, reverse application should succeed
-    set(PC bash -c "set -x && (\"${Patch_EXECUTABLE}\" -p1 -N -i \"${SOURCE_DIR}/thirdparty/ossp-uuid/ossp-uuid-mac-fix.patch\" &&\
+    set(PC ${Bash_EXECUTABLE} -c "set -x && (\"${Patch_EXECUTABLE}\" -p1 -N -i \"${SOURCE_DIR}/thirdparty/ossp-uuid/ossp-uuid-mac-fix.patch\" &&\
             \"${Patch_EXECUTABLE}\" -p1 -N -i \"${SOURCE_DIR}/thirdparty/ossp-uuid/ossp-uuid-no-prog.patch\") ||\
             (\"${Patch_EXECUTABLE}\" -p1 -R --dry-run -i \"${SOURCE_DIR}/thirdparty/ossp-uuid/ossp-uuid-mac-fix.patch\" &&\
             \"${Patch_EXECUTABLE}\" -p1 -R --dry-run -i \"${SOURCE_DIR}/thirdparty/ossp-uuid/ossp-uuid-no-prog.patch\")")

--- a/cmake/FindBash.cmake
+++ b/cmake/FindBash.cmake
@@ -1,0 +1,75 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindBash
+---------
+
+This is a modified version of FindPatch.cmake.
+
+The module defines the following variables:
+
+``Bash_EXECUTABLE``
+  Path to the bash command-line executable.
+``Bash_FOUND``
+  True if the bash command-line executable was found.
+
+The following :prop_tgt:`IMPORTED` targets are also defined:
+
+``Bash::bash``
+  The command-line executable.
+
+Example usage:
+
+.. code-block:: cmake
+
+   find_package(Bash)
+   if(Bash_FOUND)
+     message("Bash found: ${Bash_EXECUTABLE}")
+   endif()
+#]=======================================================================]
+
+set(_doc "Bash command line executable")
+
+if(CMAKE_HOST_WIN32)
+  # First search the directories under the user's AppData
+  set(_bash_path
+    "$ENV{LOCALAPPDATA}/Programs/Git/bin"
+    "$ENV{LOCALAPPDATA}/Programs/Git/usr/bin"
+    "$ENV{APPDATA}/Programs/Git/bin"
+    "$ENV{APPDATA}/Programs/Git/usr/bin"
+    )
+  find_program(Bash_EXECUTABLE
+    NAMES bash
+    NO_DEFAULT_PATH
+    PATHS ${_bash_path}
+    DOC ${_doc}
+    )
+
+  # Now look for installations in Git/ directories under typical installation
+  # prefixes on Windows.
+  find_program(Bash_EXECUTABLE
+    NAMES bash
+    NO_SYSTEM_ENVIRONMENT_PATH
+    PATH_SUFFIXES Git/usr/bin Git/bin GnuWin32/bin
+    DOC ${_doc}
+    )
+
+  unset(_bash_path)
+else()
+  find_program(Bash_EXECUTABLE
+    NAMES bash
+    DOC ${_doc}
+    )
+endif()
+
+if(Bash_EXECUTABLE AND NOT TARGET Bash::bash)
+  add_executable(Bash::bash IMPORTED)
+  set_property(TARGET Bash::bash PROPERTY IMPORTED_LOCATION ${Bash_EXECUTABLE})
+endif()
+
+unset(_doc)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Bash
+                                  REQUIRED_VARS Bash_EXECUTABLE)


### PR DESCRIPTION
When building Minifi with Azure on Windows, `cmake/BundledAzureSdkCpp.cmake` assumed that `bash` was on the PATH.  My local Git for Windows installation includes `bash.exe`, but it is not on the PATH.  Also, my Windows machine contains a `bash.exe` in `C:\Windows\System32`, which does not work the same way as Git Bash, so that had to be excluded.

https://issues.apache.org/jira/browse/MINIFICPP-1609

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
