### PR TITLE
MINIFICPP-1610 fix PublishKafka::notifyStop + reduce PublishKafkaOnScheduleTests runtime ~30s -> ~1.5s

### DIFF
--- a/extensions/librdkafka/tests/PublishKafkaOnScheduleTests.cpp
+++ b/extensions/librdkafka/tests/PublishKafkaOnScheduleTests.cpp
@@ -34,7 +34,7 @@ class PublishKafkaOnScheduleTests : public IntegrationBase {
         const auto result = utils::StringUtils::countOccurrences(logs, "value 1 is outside allowed range 1000..1000000000");
         const int occurrences = result.second;
         return 1 < occurrences;
-      }));
+      }, std::chrono::milliseconds{10}));
       flowController_->updatePropertyValue("kafka", minifi::processors::PublishKafka::MaxMessageSize.getName(), "1999");
       const std::vector<std::string> must_appear_byorder_msgs = {"notifyStop called",
           "Successfully configured PublishKafka",

--- a/libminifi/test/resources/TestKafkaOnSchedule.yml
+++ b/libminifi/test/resources/TestKafkaOnSchedule.yml
@@ -19,7 +19,7 @@
 
 Flow Controller:
   name: MiNiFi Flow
-  onschedule retry interval: 1000 ms
+  onschedule retry interval: 100 ms
 Processors:
   - name: generate
     id: 2438e3c8-015a-1000-79ca-83af40ec1991
@@ -27,33 +27,27 @@ Processors:
     max concurrent tasks: 1
     scheduling strategy: TIMER_DRIVEN
     scheduling period: 1 sec
-    penalization period: 30 sec
-    yield period: 1 sec
-    run duration nanos: 0
-    auto-terminated relationships list:
-    Properties:
-
-  - Properties:
-#      Batch Size: 1234
-      Client Name: lmn
-#      Compress Codec: none
-#      Delivery Guarantee: '1'
-      Known Brokers: localhost:9092
-      Max Request Size: '1'
-#      Message Timeout: 5 sec
-#      Request Timeout: 10 sec
-      Topic Name: test
-    class: org.apache.nifi.processors.standard.PublishKafka
+    penalization period: 300 msec
+    yield period: 100 msec
+    auto-terminated relationships list: []
+  - class: org.apache.nifi.processors.standard.PublishKafka
     id: 3744352b-6eb1-4677-98a6-353417a90496
     name: kafka
     max concurrent tasks: 1
-    scheduling strategy: TIMER_DRIVEN
-    scheduling period: 100 sec
-    penalization period: 30 sec
-    yield period: 1 sec
-    run duration nanos: 0
-    auto-terminated relationships list:
-
+    scheduling strategy: EVENT_DRIVEN
+    penalization period: 300 msec
+    yield period: 100 msec
+    auto-terminated relationships list: [success, failure]
+    Properties:
+      Client Name: lmn
+      #      Compress Codec: none
+      #      Delivery Guarantee: '1'
+      Known Brokers: localhost:9092
+      Max Request Size: '1'
+      Message Timeout: 300 msec
+      Request Timeout: 300 msec
+      Topic Name: test
+      Queue Buffering Max Time: 50 msec
 Connections:
   - name: conn
     id: 2438e3c8-015a-1000-79ca-83af40ec1997
@@ -62,7 +56,6 @@ Connections:
     source relationship name: success
     destination name: kafka
     destination id: 3744352b-6eb1-4677-98a6-353417a90496
-    source relationship name: success
     max work queue size: 0
     max work queue data size: 1 MB
     flowfile expiration: 60 sec


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-1610

With MINIFICPP-1351, I introduced a connection lock before the message lock to avoid a race condition on closing the connection. It went before the message lock, because when both are taken, connection lock has to come first to avoid a deadlock.
This caused notifyStop to wait until the messages in flight timed out and onTrigger stopped before being able to take the connection lock, then the message lock, then interrupt the messages, thus defeating the interruption.

This issue is about fixing the situation by first taking the message lock without the connection lock, interrupting the messages, then releasing the lock and taking the connection lock (and getting it after onTrigger terminated early, thanks to the interruptions) and terminating the connection.

Aside from that, I made an effort to reduce the runtime of PublishKafkaOnScheduleTests when no local kafka nodes are running. It tries to connect to one and waits for timeout, but the test doesn't need an actual running broker, this is just a side effect. Reduced timeouts, the runtime went from ~30sec to ~1.5sec.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
