### PR TITLE
MINIFICPP-1607 Add AttributesToJson processor

### DIFF
--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -105,7 +105,7 @@ In the list below, the names of required properties appear in bold. Any other pr
 | Name | Default Value | Allowable Values | Description |
 | - | - | - | - |
 |Attributes List|||Comma separated list of attributes to be included in the resulting JSON. If this value is left empty then all existing Attributes will be included. This list of attributes is case sensitive. If an attribute specified in the list is not found it will be be emitted to the resulting JSON with an empty string or NULL value.|
-|Attributes Regular Expression|||Regular expression that will be evaluated against the flow file attributes to select the matching attributes. This property can be used in combination with the attributes list property.|
+|Attributes Regular Expression|||Regular expression that will be evaluated against the flow file attributes to select the matching attributes. Both the matching attributes and the selected attributes from the Attributes List property will be written in the resulting JSON.|
 |**Destination**|flowfile-attribute|flowfile-attribute<br>flowfile-content<br>|Control if JSON value is written as a new flowfile attribute 'JSONAttributes' or written in the flowfile content. Writing to flowfile content will overwrite any existing flowfile content.|
 |**Include Core Attributes**|true||Determines if the FlowFile core attributes which are contained in every FlowFile should be included in the final JSON value generated.|
 |**Null Value**|false||If true a non existing or empty attribute will be NULL in the resulting JSON. If false an empty string will be placed in the JSON.|

--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -113,8 +113,7 @@ In the list below, the names of required properties appear in bold. Any other pr
 
 | Name | Description |
 | - | - |
-|success|Successfully converted attributes to JSON|
-|failure|Failed to convert attributes to JSON|
+|success|All FlowFiles received are routed to success|
 
 ## BinFiles
 

--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -108,7 +108,7 @@ In the list below, the names of required properties appear in bold. Any other pr
 |Attributes Regular Expression|||Regular expression that will be evaluated against the flow file attributes to select the matching attributes. Both the matching attributes and the selected attributes from the Attributes List property will be written in the resulting JSON.|
 |**Destination**|flowfile-attribute|flowfile-attribute<br>flowfile-content<br>|Control if JSON value is written as a new flowfile attribute 'JSONAttributes' or written in the flowfile content. Writing to flowfile content will overwrite any existing flowfile content.|
 |**Include Core Attributes**|true||Determines if the FlowFile core attributes which are contained in every FlowFile should be included in the final JSON value generated.|
-|**Null Value**|false||If true a non existing or empty attribute will be NULL in the resulting JSON. If false an empty string will be placed in the JSON.|
+|**Null Value**|false||If true a non existing selected attribute will be NULL in the resulting JSON. If false an empty string will be placed in the JSON.|
 ### Relationships
 
 | Name | Description |

--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -5,6 +5,7 @@
 
 - [AppendHostInfo](#appendhostinfo)
 - [ApplyTemplate](#applytemplate)
+- [AttributesToJSON](#AttributesToJSON)
 - [BinFiles](#binfiles)
 - [CapturePacket](#capturepacket)
 - [CaptureRTSPFrame](#capturertspframe)
@@ -92,6 +93,28 @@ In the list below, the names of required properties appear in bold. Any other pr
 | - | - |
 |success|success operational on the flow record|
 
+## AttributesToJSON
+
+### Description
+
+Generates a JSON representation of the input FlowFile Attributes. The resulting JSON can be written to either a new Attribute 'JSONAttributes' or written to the FlowFile as content.
+### Properties
+
+In the list below, the names of required properties appear in bold. Any other properties (not in bold) are considered optional. The table also indicates any default values, and whether a property supports the NiFi Expression Language.
+
+| Name | Default Value | Allowable Values | Description |
+| - | - | - | - |
+|Attributes List|||Comma separated list of attributes to be included in the resulting JSON. If this value is left empty then all existing Attributes will be included. This list of attributes is case sensitive. If an attribute specified in the list is not found it will be be emitted to the resulting JSON with an empty string or NULL value.|
+|Attributes Regular Expression|||Regular expression that will be evaluated against the flow file attributes to select the matching attributes. This property can be used in combination with the attributes list property.|
+|**Destination**|flowfile-attribute|flowfile-attribute<br>flowfile-content<br>|Control if JSON value is written as a new flowfile attribute 'JSONAttributes' or written in the flowfile content. Writing to flowfile content will overwrite any existing flowfile content.|
+|**Include Core Attributes**|true||Determines if the FlowFile core attributes which are contained in every FlowFile should be included in the final JSON value generated.|
+|**Null Value**|false||If true a non existing or empty attribute will be NULL in the resulting JSON. If false an empty string will be placed in the JSON.|
+### Relationships
+
+| Name | Description |
+| - | - |
+|success|Successfully converted attributes to JSON|
+|failure|Failed to convert attributes to JSON|
 
 ## BinFiles
 

--- a/docker/test/integration/MiNiFi_integration_test_driver.py
+++ b/docker/test/integration/MiNiFi_integration_test_driver.py
@@ -19,6 +19,7 @@ from minifi.validators.MultiFileOutputValidator import MultiFileOutputValidator
 from minifi.validators.SingleOrMultiFileOutputValidator import SingleOrMultiFileOutputValidator
 from minifi.validators.NoContentCheckFileNumberValidator import NoContentCheckFileNumberValidator
 from minifi.validators.NumFileRangeValidator import NumFileRangeValidator
+from minifi.validators.SingleJSONFileOutputValidator import SingleJSONFileOutputValidator
 
 
 class MiNiFi_integration_test():
@@ -204,6 +205,11 @@ class MiNiFi_integration_test():
 
     def check_for_single_file_with_content_generated(self, content, timeout_seconds):
         output_validator = SingleFileOutputValidator(content)
+        output_validator.set_output_dir(self.file_system_observer.get_output_dir())
+        self.check_output(timeout_seconds, output_validator, 1)
+
+    def check_for_single_json_file_with_content_generated(self, content, timeout_seconds):
+        output_validator = SingleJSONFileOutputValidator(content)
         output_validator.set_output_dir(self.file_system_observer.get_output_dir())
         self.check_output(timeout_seconds, output_validator, 1)
 

--- a/docker/test/integration/features/attributes_to_json.feature
+++ b/docker/test/integration/features/attributes_to_json.feature
@@ -4,7 +4,7 @@ Feature: Writing attribute data using AttributesToJSON processor
 
   Scenario: Write selected attribute data to file
     Given a GetFile processor with the "Input Directory" property set to "/tmp/input"
-    And a file with filename "test_file.log" and content "test_data%" is present in "/tmp/input"
+    And a file with filename "test_file.log" and content "test_data" is present in "/tmp/input"
     And a AttributesToJSON processor with the "Attributes List" property set to "filename,invalid"
     And the "Destination" property of the AttributesToJSON processor is set to "flowfile-content"
     And the "Null Value" property of the AttributesToJSON processor is set to "true"

--- a/docker/test/integration/features/attributes_to_json.feature
+++ b/docker/test/integration/features/attributes_to_json.feature
@@ -1,0 +1,15 @@
+Feature: Writing attribute data using AttributesToJSON processor
+  Background:
+    Given the content of "/tmp/output" is monitored
+
+  Scenario: Write selected attribute data to file
+    Given a GetFile processor with the "Input Directory" property set to "/tmp/input"
+    And a file with filename "test_file.log" and content "test_data%" is present in "/tmp/input"
+    And a AttributesToJSON processor with the "Attributes List" property set to "filename,invalid"
+    And the "Destination" property of the AttributesToJSON processor is set to "flowfile-content"
+    And the "Null Value" property of the AttributesToJSON processor is set to "true"
+    And a PutFile processor with the "Directory" property set to "/tmp/output"
+    And the "success" relationship of the GetFile processor is connected to the AttributesToJSON
+    And the "success" relationship of the AttributesToJSON processor is connected to the PutFile
+    When the MiNiFi instance starts up
+    Then a flowfile with the content "{"filename":"test_file.log","invalid":null}" is placed in the monitored directory in less than 10 seconds

--- a/docker/test/integration/features/attributes_to_json.feature
+++ b/docker/test/integration/features/attributes_to_json.feature
@@ -12,4 +12,4 @@ Feature: Writing attribute data using AttributesToJSON processor
     And the "success" relationship of the GetFile processor is connected to the AttributesToJSON
     And the "success" relationship of the AttributesToJSON processor is connected to the PutFile
     When the MiNiFi instance starts up
-    Then a flowfile with the content "{"filename":"test_file.log","invalid":null}" is placed in the monitored directory in less than 10 seconds
+    Then a flowfile with the JSON content "{"filename":"test_file.log","invalid":null}" is placed in the monitored directory in less than 10 seconds

--- a/docker/test/integration/minifi/processors/AttributesToJSON.py
+++ b/docker/test/integration/minifi/processors/AttributesToJSON.py
@@ -3,4 +3,4 @@ from ..core.Processor import Processor
 
 class AttributesToJSON(Processor):
     def __init__(self):
-        super(AttributesToJSON, self).__init__('AttributesToJSON', auto_terminate=['failure'])
+        super(AttributesToJSON, self).__init__('AttributesToJSON')

--- a/docker/test/integration/minifi/processors/AttributesToJSON.py
+++ b/docker/test/integration/minifi/processors/AttributesToJSON.py
@@ -1,0 +1,6 @@
+from ..core.Processor import Processor
+
+
+class AttributesToJSON(Processor):
+    def __init__(self):
+        super(AttributesToJSON, self).__init__('AttributesToJSON', auto_terminate=['failure'])

--- a/docker/test/integration/minifi/validators/SingleJSONFileOutputValidator.py
+++ b/docker/test/integration/minifi/validators/SingleJSONFileOutputValidator.py
@@ -1,0 +1,36 @@
+import logging
+import os
+import json
+
+from .FileOutputValidator import FileOutputValidator
+
+
+class SingleJSONFileOutputValidator(FileOutputValidator):
+    """
+    Validates the content of a single file in the given directory.
+    """
+
+    def __init__(self, expected_content):
+        self.expected_content = json.loads(expected_content)
+
+    def file_matches_json_content(self, dir_path, expected_json_content):
+        listing = os.listdir(dir_path)
+        if not listing:
+            return 0
+        for file_name in listing:
+            full_path = os.path.join(dir_path, file_name)
+            if not os.path.isfile(full_path):
+                continue
+            with open(full_path, 'r') as out_file:
+                file_json_content = json.loads(out_file.read())
+                return file_json_content == expected_json_content
+        return False
+
+    def validate(self):
+        full_dir = os.path.join(self.output_dir)
+        logging.info("Output folder: %s", full_dir)
+
+        if not os.path.isdir(full_dir):
+            return False
+
+        return self.get_num_files(full_dir) == 1 and self.file_matches_json_content(full_dir, self.expected_content)

--- a/docker/test/integration/steps/steps.py
+++ b/docker/test/integration/steps/steps.py
@@ -508,6 +508,12 @@ def step_impl(context, content, duration):
     context.test.check_for_single_file_with_content_generated(content, timeparse(duration))
 
 
+@then("a flowfile with the JSON content \"{content}\" is placed in the monitored directory in less than {duration}")
+@then("a flowfile with the JSON content '{content}' is placed in the monitored directory in less than {duration}")
+def step_impl(context, content, duration):
+    context.test.check_for_single_json_file_with_content_generated(content, timeparse(duration))
+
+
 @then("at least one flowfile with the content \"{content}\" is placed in the monitored directory in less than {duration}")
 @then("at least one flowfile with the content '{content}' is placed in the monitored directory in less than {duration}")
 def step_impl(context, content, duration):

--- a/extensions/standard-processors/processors/AttributesToJSON.cpp
+++ b/extensions/standard-processors/processors/AttributesToJSON.cpp
@@ -86,7 +86,7 @@ void AttributesToJSON::onSchedule(core::ProcessContext* context, core::ProcessSe
   attribute_list_ = utils::StringUtils::split(attributes, ",");
   context->getProperty(AttributesRegularExpression.getName(), attributes_regular_expression_str_);
   if (!attributes_regular_expression_str_.empty()) {
-    attributes_regular_expression_ = std::regex(attributes_regular_expression_str_);
+    attributes_regular_expression_ = utils::Regex(attributes_regular_expression_str_);
   }
   context->getProperty(Destination.getName(), destination_);
   context->getProperty(IncludeCoreAttributes.getName(), include_core_attributes_);
@@ -97,11 +97,11 @@ bool AttributesToJSON::isCoreAttributeToBeFiltered(const std::string& attribute)
   return !include_core_attributes_ && CORE_ATTRIBUTES.find(attribute) != CORE_ATTRIBUTES.end();
 }
 
-bool AttributesToJSON::matchesAttributeRegex(const std::string& attribute) const {
-  return attributes_regular_expression_str_.empty() || std::regex_search(attribute, attributes_regular_expression_);
+bool AttributesToJSON::matchesAttributeRegex(const std::string& attribute) {
+  return attributes_regular_expression_str_.empty() || attributes_regular_expression_.match(attribute);
 }
 
-void AttributesToJSON::addAttributeToJson(rapidjson::Document& document, const std::string& key, const std::string& value) const {
+void AttributesToJSON::addAttributeToJson(rapidjson::Document& document, const std::string& key, const std::string& value) {
   if (isCoreAttributeToBeFiltered(key)) {
     logger_->log_debug("Core attribute '%s' will not be included in the attributes JSON.", key);
     return;
@@ -118,7 +118,7 @@ void AttributesToJSON::addAttributeToJson(rapidjson::Document& document, const s
   document.AddMember(json_key, json_val, document.GetAllocator());
 }
 
-std::string AttributesToJSON::buildAttributeJsonData(std::map<std::string, std::string>&& attributes) const {
+std::string AttributesToJSON::buildAttributeJsonData(std::map<std::string, std::string>&& attributes) {
   auto root = rapidjson::Document(rapidjson::kObjectType);
   if (!attribute_list_.empty()) {
     for (const auto& attribute : attribute_list_) {

--- a/extensions/standard-processors/processors/AttributesToJSON.cpp
+++ b/extensions/standard-processors/processors/AttributesToJSON.cpp
@@ -108,7 +108,7 @@ std::unordered_set<std::string> AttributesToJSON::getAttributesToBeWritten(const
 
   if (attributes_regular_expression_) {
     for (const auto& [key, value] : flowfile_attributes) {
-      if (!isCoreAttributeToBeFiltered(key) && std::regex_search(key, attributes_regular_expression_.value())) {
+      if (!isCoreAttributeToBeFiltered(key) && std::regex_match(key, attributes_regular_expression_.value())) {
         attributes.insert(key);
       }
     }

--- a/extensions/standard-processors/processors/AttributesToJSON.cpp
+++ b/extensions/standard-processors/processors/AttributesToJSON.cpp
@@ -103,14 +103,12 @@ std::unordered_set<std::string> AttributesToJSON::getAttributesToBeWritten(core:
   std::unordered_set<std::string> attributes;
 
   for (const auto& attribute : attribute_list_) {
-    if (!isCoreAttributeToBeFiltered(attribute)) {
-      attributes.insert(attribute);
-    }
+    attributes.insert(attribute);
   }
 
   if (attributes_regular_expression_) {
     for (const auto& [key, value] : *flowfile_attributes) {
-      if (!isCoreAttributeToBeFiltered(key) && std::regex_match(key, attributes_regular_expression_.value())) {
+      if (std::regex_match(key, attributes_regular_expression_.value())) {
         attributes.insert(key);
       }
     }

--- a/extensions/standard-processors/processors/AttributesToJSON.cpp
+++ b/extensions/standard-processors/processors/AttributesToJSON.cpp
@@ -83,10 +83,10 @@ void AttributesToJSON::initialize() {
 void AttributesToJSON::onSchedule(core::ProcessContext* context, core::ProcessSessionFactory* /*sessionFactory*/) {
   std::string attributes;
   context->getProperty(AttributesList.getName(), attributes);
-  attribute_list_ = utils::StringUtils::split(attributes, ",");
+  attribute_list_ = utils::StringUtils::splitRemovingEmpty(attributes, ",");
   context->getProperty(AttributesRegularExpression.getName(), attributes_regular_expression_str_);
   if (!attributes_regular_expression_str_.empty()) {
-    attributes_regular_expression_ = utils::Regex(attributes_regular_expression_str_);
+    attributes_regular_expression_ = std::regex(attributes_regular_expression_str_);
   }
   write_to_attribute_ = utils::parsePropertyWithAllowableValuesOrThrow(*context, Destination.getName(), DESTINATIONS) == "flowfile-attribute";
   context->getProperty(IncludeCoreAttributes.getName(), include_core_attributes_);
@@ -98,7 +98,7 @@ bool AttributesToJSON::isCoreAttributeToBeFiltered(const std::string& attribute)
 }
 
 bool AttributesToJSON::matchesAttributeRegex(const std::string& attribute) {
-  return attributes_regular_expression_str_.empty() || attributes_regular_expression_.match(attribute);
+  return attributes_regular_expression_str_.empty() || std::regex_search(attribute, attributes_regular_expression_);
 }
 
 void AttributesToJSON::addAttributeToJson(rapidjson::Document& document, const std::string& key, const std::string& value) {

--- a/extensions/standard-processors/processors/AttributesToJSON.cpp
+++ b/extensions/standard-processors/processors/AttributesToJSON.cpp
@@ -28,8 +28,6 @@ namespace nifi {
 namespace minifi {
 namespace processors {
 
-const std::unordered_set<std::string> AttributesToJSON::CORE_ATTRIBUTES(core::SpecialFlowAttribute::getSpecialFlowAttributes());
-
 const core::Property AttributesToJSON::AttributesList(
   core::PropertyBuilder::createProperty("Attributes List")
     ->withDescription("Comma separated list of attributes to be included in the resulting JSON. "
@@ -94,7 +92,7 @@ void AttributesToJSON::onSchedule(core::ProcessContext* context, core::ProcessSe
 }
 
 bool AttributesToJSON::isCoreAttributeToBeFiltered(const std::string& attribute) const {
-  return !include_core_attributes_ && CORE_ATTRIBUTES.find(attribute) != CORE_ATTRIBUTES.end();
+  return !include_core_attributes_ && core_attributes_.find(attribute) != core_attributes_.end();
 }
 
 bool AttributesToJSON::matchesAttributeRegex(const std::string& attribute) {

--- a/extensions/standard-processors/processors/AttributesToJSON.cpp
+++ b/extensions/standard-processors/processors/AttributesToJSON.cpp
@@ -19,9 +19,7 @@
  */
 #include "AttributesToJSON.h"
 
-#include "rapidjson/document.h"
 #include "rapidjson/writer.h"
-
 #include "utils/StringUtils.h"
 
 namespace org {
@@ -30,45 +28,43 @@ namespace nifi {
 namespace minifi {
 namespace processors {
 
-const std::set<std::string> AttributesToJSON::CORE_ATTRIBUTES({core::SpecialFlowAttribute::PATH, core::SpecialFlowAttribute::ABSOLUTE_PATH,
-  core::SpecialFlowAttribute::FILENAME, core::SpecialFlowAttribute::UUID, core::SpecialFlowAttribute::priority, core::SpecialFlowAttribute::MIME_TYPE,
-  core::SpecialFlowAttribute::DISCARD_REASON, core::SpecialFlowAttribute::ALTERNATE_IDENTIFIER, core::SpecialFlowAttribute::FLOW_ID});
+const std::unordered_set<std::string> AttributesToJSON::CORE_ATTRIBUTES(core::SpecialFlowAttribute::getSpecialFlowAttributes());
 
 const core::Property AttributesToJSON::AttributesList(
-    core::PropertyBuilder::createProperty("Attributes List")
-      ->withDescription("Comma separated list of attributes to be included in the resulting JSON. "
-                        "If this value is left empty then all existing Attributes will be included. This list of attributes is case sensitive. "
-                        "If an attribute specified in the list is not found it will be be emitted to the resulting JSON with an empty string or NULL value.")
-      ->build());
+  core::PropertyBuilder::createProperty("Attributes List")
+    ->withDescription("Comma separated list of attributes to be included in the resulting JSON. "
+                      "If this value is left empty then all existing Attributes will be included. This list of attributes is case sensitive. "
+                      "If an attribute specified in the list is not found it will be be emitted to the resulting JSON with an empty string or NULL value.")
+    ->build());
 
 const core::Property AttributesToJSON::AttributesRegularExpression(
-    core::PropertyBuilder::createProperty("Attributes Regular Expression")
-      ->withDescription("Regular expression that will be evaluated against the flow file attributes to select the matching attributes. "
-                        "This property can be used in combination with the attributes list property.")
-      ->build());
+  core::PropertyBuilder::createProperty("Attributes Regular Expression")
+    ->withDescription("Regular expression that will be evaluated against the flow file attributes to select the matching attributes. "
+                      "This property can be used in combination with the attributes list property.")
+    ->build());
 
 const core::Property AttributesToJSON::Destination(
-    core::PropertyBuilder::createProperty("Destination")
-      ->withDescription("Control if JSON value is written as a new flowfile attribute 'JSONAttributes' or written in the flowfile content. "
-                        "Writing to flowfile content will overwrite any existing flowfile content.")
-      ->isRequired(true)
-      ->withDefaultValue<std::string>("flowfile-attribute")
-      ->withAllowableValues<std::string>({"flowfile-attribute", "flowfile-content"})
-      ->build());
+  core::PropertyBuilder::createProperty("Destination")
+    ->withDescription("Control if JSON value is written as a new flowfile attribute 'JSONAttributes' or written in the flowfile content. "
+                      "Writing to flowfile content will overwrite any existing flowfile content.")
+    ->isRequired(true)
+    ->withDefaultValue<std::string>("flowfile-attribute")
+    ->withAllowableValues<std::string>({"flowfile-attribute", "flowfile-content"})
+    ->build());
 
 const core::Property AttributesToJSON::IncludeCoreAttributes(
-    core::PropertyBuilder::createProperty("Include Core Attributes")
-      ->withDescription("Determines if the FlowFile core attributes which are contained in every FlowFile should be included in the final JSON value generated.")
-      ->isRequired(true)
-      ->withDefaultValue<bool>(true)
-      ->build());
+  core::PropertyBuilder::createProperty("Include Core Attributes")
+    ->withDescription("Determines if the FlowFile core attributes which are contained in every FlowFile should be included in the final JSON value generated.")
+    ->isRequired(true)
+    ->withDefaultValue<bool>(true)
+    ->build());
 
 const core::Property AttributesToJSON::NullValue(
-    core::PropertyBuilder::createProperty("Null Value")
-      ->withDescription("If true a non existing or empty attribute will be NULL in the resulting JSON. If false an empty string will be placed in the JSON")
-      ->isRequired(true)
-      ->withDefaultValue<bool>(false)
-      ->build());
+  core::PropertyBuilder::createProperty("Null Value")
+    ->withDescription("If true a non existing or empty attribute will be NULL in the resulting JSON. If false an empty string will be placed in the JSON")
+    ->isRequired(true)
+    ->withDefaultValue<bool>(false)
+    ->build());
 
 core::Relationship AttributesToJSON::Success("success", "Successfully converted attributes to JSON");
 core::Relationship AttributesToJSON::Failure("failure", "Failed to convert attributes to JSON");
@@ -97,45 +93,56 @@ void AttributesToJSON::onSchedule(core::ProcessContext* context, core::ProcessSe
   context->getProperty(NullValue.getName(), null_value_);
 }
 
-void AttributesToJSON::onTrigger(core::ProcessContext* /*context*/, core::ProcessSession* session) {
-  auto flow_file = session->get();
-  if (!flow_file) {
+bool AttributesToJSON::isCoreAttributeToBeFiltered(const std::string& attribute) const {
+  return !include_core_attributes_ && CORE_ATTRIBUTES.find(attribute) != CORE_ATTRIBUTES.end();
+}
+
+bool AttributesToJSON::matchesAttributeRegex(const std::string& attribute) const {
+  return attributes_regular_expression_str_.empty() || std::regex_search(attribute, attributes_regular_expression_);
+}
+
+void AttributesToJSON::addAttributeToJson(rapidjson::Document& document, const std::string& key, const std::string& value) const {
+  if (isCoreAttributeToBeFiltered(key)) {
+    logger_->log_debug("Core attribute '%s' will not be included in the attributes JSON.", key);
     return;
   }
+  if (!matchesAttributeRegex(key)) {
+    logger_->log_debug("Attribute '%s' does not match the set regex, therefore it will not be included in the attributes JSON.", key);
+    return;
+  }
+  rapidjson::Value json_key(key.c_str(), document.GetAllocator());
+  rapidjson::Value json_val;
+  if (!value.empty() || !null_value_) {
+    json_val.SetString(value.c_str(), document.GetAllocator());
+  }
+  document.AddMember(json_key, json_val, document.GetAllocator());
+}
 
-  auto attributes = flow_file->getAttributes();
+std::string AttributesToJSON::buildAttributeJsonData(std::map<std::string, std::string>&& attributes) const {
   auto root = rapidjson::Document(rapidjson::kObjectType);
-
-  auto addAttributeToJson = [this, &root](const std::string& key, const std::string& value) {
-    if (!include_core_attributes_ && CORE_ATTRIBUTES.find(key) != CORE_ATTRIBUTES.end()) {
-      return;
-    }
-    if (!attributes_regular_expression_str_.empty() && !std::regex_search(key, attributes_regular_expression_)) {
-      return;
-    }
-    rapidjson::Value json_key(key.c_str(), root.GetAllocator());
-    rapidjson::Value json_val;
-    if (!value.empty() || !null_value_) {
-      json_val.SetString(value.c_str(), root.GetAllocator());
-    }
-    root.AddMember(json_key, json_val, root.GetAllocator());
-  };
-
   if (!attribute_list_.empty()) {
     for (const auto& attribute : attribute_list_) {
-      addAttributeToJson(attribute, attributes[attribute]);
+      addAttributeToJson(root, attribute, attributes[attribute]);
     }
   } else {
     for (const auto& kvp : attributes) {
-      addAttributeToJson(kvp.first, kvp.second);
+      addAttributeToJson(root, kvp.first, kvp.second);
     }
   }
 
   rapidjson::StringBuffer buffer;
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
   root.Accept(writer);
-  std::string json_data = buffer.GetString();
+  return buffer.GetString();
+}
 
+void AttributesToJSON::onTrigger(core::ProcessContext* /*context*/, core::ProcessSession* session) {
+  auto flow_file = session->get();
+  if (!flow_file) {
+    return;
+  }
+
+  auto json_data = buildAttributeJsonData(flow_file->getAttributes());
   if (destination_ == "flowfile-attribute") {
     logger_->log_debug("Writing the following attribute data to JSONAttributes attribute: %s", json_data);
     session->putAttribute(flow_file, "JSONAttributes", json_data);

--- a/extensions/standard-processors/processors/AttributesToJSON.cpp
+++ b/extensions/standard-processors/processors/AttributesToJSON.cpp
@@ -1,0 +1,158 @@
+/**
+ * @file AttributesToJSON.cpp
+ * AttributesToJSON class implementation
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "AttributesToJSON.h"
+
+#include "rapidjson/document.h"
+#include "rapidjson/writer.h"
+
+#include "utils/StringUtils.h"
+
+namespace org {
+namespace apache {
+namespace nifi {
+namespace minifi {
+namespace processors {
+
+const std::set<std::string> AttributesToJSON::CORE_ATTRIBUTES({core::SpecialFlowAttribute::PATH, core::SpecialFlowAttribute::ABSOLUTE_PATH,
+  core::SpecialFlowAttribute::FILENAME, core::SpecialFlowAttribute::UUID, core::SpecialFlowAttribute::priority, core::SpecialFlowAttribute::MIME_TYPE,
+  core::SpecialFlowAttribute::DISCARD_REASON, core::SpecialFlowAttribute::ALTERNATE_IDENTIFIER, core::SpecialFlowAttribute::FLOW_ID});
+
+const core::Property AttributesToJSON::AttributesList(
+    core::PropertyBuilder::createProperty("Attributes List")
+      ->withDescription("Comma separated list of attributes to be included in the resulting JSON. "
+                        "If this value is left empty then all existing Attributes will be included. This list of attributes is case sensitive. "
+                        "If an attribute specified in the list is not found it will be be emitted to the resulting JSON with an empty string or NULL value.")
+      ->build());
+
+const core::Property AttributesToJSON::AttributesRegularExpression(
+    core::PropertyBuilder::createProperty("Attributes Regular Expression")
+      ->withDescription("Regular expression that will be evaluated against the flow file attributes to select the matching attributes. "
+                        "This property can be used in combination with the attributes list property.")
+      ->build());
+
+const core::Property AttributesToJSON::Destination(
+    core::PropertyBuilder::createProperty("Destination")
+      ->withDescription("Control if JSON value is written as a new flowfile attribute 'JSONAttributes' or written in the flowfile content. "
+                        "Writing to flowfile content will overwrite any existing flowfile content.")
+      ->isRequired(true)
+      ->withDefaultValue<std::string>("flowfile-attribute")
+      ->withAllowableValues<std::string>({"flowfile-attribute", "flowfile-content"})
+      ->build());
+
+const core::Property AttributesToJSON::IncludeCoreAttributes(
+    core::PropertyBuilder::createProperty("Include Core Attributes")
+      ->withDescription("Determines if the FlowFile core attributes which are contained in every FlowFile should be included in the final JSON value generated.")
+      ->isRequired(true)
+      ->withDefaultValue<bool>(true)
+      ->build());
+
+const core::Property AttributesToJSON::NullValue(
+    core::PropertyBuilder::createProperty("Null Value")
+      ->withDescription("If true a non existing or empty attribute will be NULL in the resulting JSON. If false an empty string will be placed in the JSON")
+      ->isRequired(true)
+      ->withDefaultValue<bool>(false)
+      ->build());
+
+core::Relationship AttributesToJSON::Success("success", "Successfully converted attributes to JSON");
+core::Relationship AttributesToJSON::Failure("failure", "Failed to convert attributes to JSON");
+
+void AttributesToJSON::initialize() {
+  setSupportedProperties({
+    AttributesList,
+    AttributesRegularExpression,
+    Destination,
+    IncludeCoreAttributes,
+    NullValue
+  });
+  setSupportedRelationships({Success, Failure});
+}
+
+void AttributesToJSON::onSchedule(core::ProcessContext* context, core::ProcessSessionFactory* /*sessionFactory*/) {
+  std::string attributes;
+  context->getProperty(AttributesList.getName(), attributes);
+  attribute_list_ = utils::StringUtils::split(attributes, ",");
+  context->getProperty(AttributesRegularExpression.getName(), attributes_regular_expression_str_);
+  if (!attributes_regular_expression_str_.empty()) {
+    attributes_regular_expression_ = std::regex(attributes_regular_expression_str_);
+  }
+  context->getProperty(Destination.getName(), destination_);
+  context->getProperty(IncludeCoreAttributes.getName(), include_core_attributes_);
+  context->getProperty(NullValue.getName(), null_value_);
+}
+
+void AttributesToJSON::onTrigger(core::ProcessContext* /*context*/, core::ProcessSession* session) {
+  auto flow_file = session->get();
+  if (!flow_file) {
+    return;
+  }
+
+  auto attributes = flow_file->getAttributes();
+  auto root = rapidjson::Document(rapidjson::kObjectType);
+
+  auto addAttributeToJson = [this, &root](const std::string& key, const std::string& value) {
+    if (!include_core_attributes_ && CORE_ATTRIBUTES.find(key) != CORE_ATTRIBUTES.end()) {
+      return;
+    }
+    if (!attributes_regular_expression_str_.empty() && !std::regex_search(key, attributes_regular_expression_)) {
+      return;
+    }
+    rapidjson::Value json_key(key.c_str(), root.GetAllocator());
+    rapidjson::Value json_val;
+    if (!value.empty() || !null_value_) {
+      json_val.SetString(value.c_str(), root.GetAllocator());
+    }
+    root.AddMember(json_key, json_val, root.GetAllocator());
+  };
+
+  if (!attribute_list_.empty()) {
+    for (const auto& attribute : attribute_list_) {
+      addAttributeToJson(attribute, attributes[attribute]);
+    }
+  } else {
+    for (const auto& kvp : attributes) {
+      addAttributeToJson(kvp.first, kvp.second);
+    }
+  }
+
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  root.Accept(writer);
+  std::string json_data = buffer.GetString();
+
+  if (destination_ == "flowfile-attribute") {
+    logger_->log_debug("Writing the following attribute data to JSONAttributes attribute: %s", json_data);
+    session->putAttribute(flow_file, "JSONAttributes", json_data);
+  } else if (destination_ == "flowfile-content") {
+    logger_->log_debug("Writing the following attribute data to flowfile: %s", json_data);
+    AttributesToJSON::WriteCallback callback(json_data);
+    session->write(flow_file, &callback);
+  } else {
+    logger_->log_error("Unimplemented destination was set in AttributesToJSON's Destination property");
+    session->transfer(flow_file, Failure);
+  }
+
+  session->transfer(flow_file, Success);
+}
+
+}  // namespace processors
+}  // namespace minifi
+}  // namespace nifi
+}  // namespace apache
+}  // namespace org

--- a/extensions/standard-processors/processors/AttributesToJSON.cpp
+++ b/extensions/standard-processors/processors/AttributesToJSON.cpp
@@ -61,7 +61,7 @@ const core::Property AttributesToJSON::IncludeCoreAttributes(
 
 const core::Property AttributesToJSON::NullValue(
   core::PropertyBuilder::createProperty("Null Value")
-    ->withDescription("If true a non existing or empty attribute will be NULL in the resulting JSON. If false an empty string will be placed in the JSON")
+    ->withDescription("If true a non existing or empty attribute will be NULL in the resulting JSON. If false an empty string will be placed in the JSON.")
     ->isRequired(true)
     ->withDefaultValue<bool>(false)
     ->build());

--- a/extensions/standard-processors/processors/AttributesToJSON.h
+++ b/extensions/standard-processors/processors/AttributesToJSON.h
@@ -57,7 +57,6 @@ class AttributesToJSON : public core::Processor {
 
   // Supported Relationships
   static core::Relationship Success;
-  static core::Relationship Failure;
 
   void initialize() override;
   void onSchedule(core::ProcessContext *context, core::ProcessSessionFactory* sessionFactory) override;
@@ -89,7 +88,7 @@ class AttributesToJSON : public core::Processor {
   std::vector<std::string> attribute_list_;
   std::string attributes_regular_expression_str_;
   utils::Regex attributes_regular_expression_;
-  std::string destination_;
+  bool write_to_attribute_ = true;
   bool include_core_attributes_ = true;
   bool null_value_ = false;
 };

--- a/extensions/standard-processors/processors/AttributesToJSON.h
+++ b/extensions/standard-processors/processors/AttributesToJSON.h
@@ -21,10 +21,12 @@
 
 #include <vector>
 #include <string>
-#include <set>
+#include <unordered_set>
 #include <memory>
 #include <regex>
+#include <map>
 
+#include "rapidjson/document.h"
 #include "core/Processor.h"
 #include "core/Property.h"
 #include "core/logging/Logger.h"
@@ -37,7 +39,7 @@ namespace processors {
 
 class AttributesToJSON : public core::Processor {
  public:
-  static const std::set<std::string> CORE_ATTRIBUTES;
+  static const std::unordered_set<std::string> CORE_ATTRIBUTES;
 
   explicit AttributesToJSON(const std::string& name, const utils::Identifier& uuid = {})
       : core::Processor(name, uuid),
@@ -74,6 +76,11 @@ class AttributesToJSON : public core::Processor {
    private:
     std::string json_data_;
   };
+
+  bool isCoreAttributeToBeFiltered(const std::string& attribute) const;
+  bool matchesAttributeRegex(const std::string& attribute) const;
+  void addAttributeToJson(rapidjson::Document& document, const std::string& key, const std::string& value) const;
+  std::string buildAttributeJsonData(std::map<std::string, std::string>&& attributes) const;
 
   std::shared_ptr<logging::Logger> logger_;
   std::vector<std::string> attribute_list_;

--- a/extensions/standard-processors/processors/AttributesToJSON.h
+++ b/extensions/standard-processors/processors/AttributesToJSON.h
@@ -1,0 +1,94 @@
+/**
+ * @file AttributesToJSON.h
+ * AttributesToJSON class declaration
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <vector>
+#include <string>
+#include <set>
+#include <memory>
+#include <regex>
+
+#include "core/Processor.h"
+#include "core/Property.h"
+#include "core/logging/Logger.h"
+
+namespace org {
+namespace apache {
+namespace nifi {
+namespace minifi {
+namespace processors {
+
+class AttributesToJSON : public core::Processor {
+ public:
+  static const std::set<std::string> CORE_ATTRIBUTES;
+
+  explicit AttributesToJSON(const std::string& name, const utils::Identifier& uuid = {})
+      : core::Processor(name, uuid),
+        logger_(logging::LoggerFactory<AttributesToJSON>::getLogger()) {
+  }
+  static constexpr char const* ProcessorName = "AttributesToJSON";
+  // Supported Properties
+  static const core::Property AttributesList;
+  static const core::Property AttributesRegularExpression;
+  static const core::Property Destination;
+  static const core::Property IncludeCoreAttributes;
+  static const core::Property NullValue;
+
+  // Supported Relationships
+  static core::Relationship Success;
+  static core::Relationship Failure;
+
+  void initialize() override;
+  void onSchedule(core::ProcessContext *context, core::ProcessSessionFactory* sessionFactory) override;
+  void onTrigger(core::ProcessContext *context, core::ProcessSession *session) override;
+
+  core::annotation::Input getInputRequirement() const override {
+    return core::annotation::Input::INPUT_REQUIRED;
+  }
+
+ private:
+  class WriteCallback : public OutputStreamCallback {
+   public:
+    explicit WriteCallback(const std::string& json_data) : json_data_(json_data) {}
+    int64_t process(const std::shared_ptr<io::BaseStream>& stream) override {
+      const auto write_ret = stream->write(reinterpret_cast<const uint8_t*>(json_data_.data()), json_data_.length());
+      return io::isError(write_ret) ? -1 : gsl::narrow<int64_t>(write_ret);
+    }
+   private:
+    std::string json_data_;
+  };
+
+  std::shared_ptr<logging::Logger> logger_;
+  std::vector<std::string> attribute_list_;
+  std::string attributes_regular_expression_str_;
+  std::regex attributes_regular_expression_;
+  std::string destination_;
+  bool include_core_attributes_ = true;
+  bool null_value_ = false;
+};
+
+REGISTER_RESOURCE(AttributesToJSON, "Generates a JSON representation of the input FlowFile Attributes. "
+  "The resulting JSON can be written to either a new Attribute 'JSONAttributes' or written to the FlowFile as content.");
+
+}  // namespace processors
+}  // namespace minifi
+}  // namespace nifi
+}  // namespace apache
+}  // namespace org

--- a/extensions/standard-processors/processors/AttributesToJSON.h
+++ b/extensions/standard-processors/processors/AttributesToJSON.h
@@ -49,7 +49,7 @@ class AttributesToJSON : public core::Processor {
   static const core::Property NullValue;
 
   // Supported Relationships
-  static core::Relationship Success;
+  static const core::Relationship Success;
 
   SMART_ENUM(WriteDestination,
     (FLOWFILE_ATTRIBUTE, "flowfile-attribute"),
@@ -58,8 +58,7 @@ class AttributesToJSON : public core::Processor {
 
   explicit AttributesToJSON(const std::string& name, const utils::Identifier& uuid = {})
       : core::Processor(name, uuid),
-        logger_(logging::LoggerFactory<AttributesToJSON>::getLogger()),
-        core_attributes_(core::SpecialFlowAttribute::getSpecialFlowAttributes()) {
+        logger_(logging::LoggerFactory<AttributesToJSON>::getLogger()) {
   }
 
   void initialize() override;
@@ -83,12 +82,11 @@ class AttributesToJSON : public core::Processor {
   };
 
   bool isCoreAttributeToBeFiltered(const std::string& attribute) const;
-  std::unordered_set<std::string> getAttributesToBeWritten(const std::map<std::string, std::string>& flowfile_attributes) const;
+  std::unordered_set<std::string> getAttributesToBeWritten(core::FlowFile::AttributeMap* flowfile_attributes) const;
   void addAttributeToJson(rapidjson::Document& document, const std::string& key, const std::string& value);
-  std::string buildAttributeJsonData(std::map<std::string, std::string>&& flowfile_attributes);
+  std::string buildAttributeJsonData(core::FlowFile::AttributeMap* flowfile_attributes);
 
   std::shared_ptr<logging::Logger> logger_;
-  const std::unordered_set<std::string> core_attributes_;
   std::vector<std::string> attribute_list_;
   std::optional<std::regex> attributes_regular_expression_;
   WriteDestination write_destination_;

--- a/extensions/standard-processors/processors/AttributesToJSON.h
+++ b/extensions/standard-processors/processors/AttributesToJSON.h
@@ -21,6 +21,7 @@
 
 #include <vector>
 #include <string>
+#include <set>
 #include <unordered_set>
 #include <memory>
 #include <map>
@@ -39,6 +40,8 @@ namespace processors {
 
 class AttributesToJSON : public core::Processor {
  public:
+  static const std::set<std::string> DESTINATIONS;
+
   explicit AttributesToJSON(const std::string& name, const utils::Identifier& uuid = {})
       : core::Processor(name, uuid),
         logger_(logging::LoggerFactory<AttributesToJSON>::getLogger()),

--- a/extensions/standard-processors/processors/AttributesToJSON.h
+++ b/extensions/standard-processors/processors/AttributesToJSON.h
@@ -25,12 +25,12 @@
 #include <unordered_set>
 #include <memory>
 #include <map>
+#include <regex>
 
 #include "rapidjson/document.h"
 #include "core/Processor.h"
 #include "core/Property.h"
 #include "core/logging/Logger.h"
-#include "utils/RegexUtils.h"
 
 namespace org {
 namespace apache {
@@ -87,7 +87,7 @@ class AttributesToJSON : public core::Processor {
   const std::unordered_set<std::string> core_attributes_;
   std::vector<std::string> attribute_list_;
   std::string attributes_regular_expression_str_;
-  utils::Regex attributes_regular_expression_;
+  std::regex attributes_regular_expression_;
   bool write_to_attribute_ = true;
   bool include_core_attributes_ = true;
   bool null_value_ = false;

--- a/extensions/standard-processors/processors/AttributesToJSON.h
+++ b/extensions/standard-processors/processors/AttributesToJSON.h
@@ -31,6 +31,7 @@
 #include "core/Processor.h"
 #include "core/Property.h"
 #include "core/logging/Logger.h"
+#include "utils/Enum.h"
 
 namespace org {
 namespace apache {
@@ -40,14 +41,6 @@ namespace processors {
 
 class AttributesToJSON : public core::Processor {
  public:
-  static const std::set<std::string> DESTINATIONS;
-
-  explicit AttributesToJSON(const std::string& name, const utils::Identifier& uuid = {})
-      : core::Processor(name, uuid),
-        logger_(logging::LoggerFactory<AttributesToJSON>::getLogger()),
-        core_attributes_(core::SpecialFlowAttribute::getSpecialFlowAttributes()) {
-  }
-  static constexpr char const* ProcessorName = "AttributesToJSON";
   // Supported Properties
   static const core::Property AttributesList;
   static const core::Property AttributesRegularExpression;
@@ -57,6 +50,17 @@ class AttributesToJSON : public core::Processor {
 
   // Supported Relationships
   static core::Relationship Success;
+
+  SMART_ENUM(WriteDestination,
+    (FLOWFILE_ATTRIBUTE, "flowfile-attribute"),
+    (FLOWFILE_CONTENT, "flowfile-content")
+  )
+
+  explicit AttributesToJSON(const std::string& name, const utils::Identifier& uuid = {})
+      : core::Processor(name, uuid),
+        logger_(logging::LoggerFactory<AttributesToJSON>::getLogger()),
+        core_attributes_(core::SpecialFlowAttribute::getSpecialFlowAttributes()) {
+  }
 
   void initialize() override;
   void onSchedule(core::ProcessContext *context, core::ProcessSessionFactory* sessionFactory) override;
@@ -86,9 +90,8 @@ class AttributesToJSON : public core::Processor {
   std::shared_ptr<logging::Logger> logger_;
   const std::unordered_set<std::string> core_attributes_;
   std::vector<std::string> attribute_list_;
-  std::string attributes_regular_expression_str_;
-  std::regex attributes_regular_expression_;
-  bool write_to_attribute_ = true;
+  std::optional<std::regex> attributes_regular_expression_;
+  WriteDestination write_destination_;
   bool include_core_attributes_ = true;
   bool null_value_ = false;
 };

--- a/extensions/standard-processors/processors/AttributesToJSON.h
+++ b/extensions/standard-processors/processors/AttributesToJSON.h
@@ -83,9 +83,9 @@ class AttributesToJSON : public core::Processor {
   };
 
   bool isCoreAttributeToBeFiltered(const std::string& attribute) const;
-  bool matchesAttributeRegex(const std::string& attribute);
+  std::unordered_set<std::string> getAttributesToBeWritten(const std::map<std::string, std::string>& flowfile_attributes) const;
   void addAttributeToJson(rapidjson::Document& document, const std::string& key, const std::string& value);
-  std::string buildAttributeJsonData(std::map<std::string, std::string>&& attributes);
+  std::string buildAttributeJsonData(std::map<std::string, std::string>&& flowfile_attributes);
 
   std::shared_ptr<logging::Logger> logger_;
   const std::unordered_set<std::string> core_attributes_;

--- a/extensions/standard-processors/processors/AttributesToJSON.h
+++ b/extensions/standard-processors/processors/AttributesToJSON.h
@@ -82,9 +82,9 @@ class AttributesToJSON : public core::Processor {
   };
 
   bool isCoreAttributeToBeFiltered(const std::string& attribute) const;
-  std::unordered_set<std::string> getAttributesToBeWritten(core::FlowFile::AttributeMap* flowfile_attributes) const;
-  void addAttributeToJson(rapidjson::Document& document, const std::string& key, const std::string& value);
-  std::string buildAttributeJsonData(core::FlowFile::AttributeMap* flowfile_attributes);
+  std::optional<std::unordered_set<std::string>> getAttributesToBeWritten(const core::FlowFile::AttributeMap& flowfile_attributes) const;
+  void addAttributeToJson(rapidjson::Document& document, const std::string& key, const std::optional<std::string>& value);
+  std::string buildAttributeJsonData(const core::FlowFile::AttributeMap& flowfile_attributes);
 
   std::shared_ptr<logging::Logger> logger_;
   std::vector<std::string> attribute_list_;

--- a/extensions/standard-processors/processors/AttributesToJSON.h
+++ b/extensions/standard-processors/processors/AttributesToJSON.h
@@ -39,11 +39,10 @@ namespace processors {
 
 class AttributesToJSON : public core::Processor {
  public:
-  static const std::unordered_set<std::string> CORE_ATTRIBUTES;
-
   explicit AttributesToJSON(const std::string& name, const utils::Identifier& uuid = {})
       : core::Processor(name, uuid),
-        logger_(logging::LoggerFactory<AttributesToJSON>::getLogger()) {
+        logger_(logging::LoggerFactory<AttributesToJSON>::getLogger()),
+        core_attributes_(core::SpecialFlowAttribute::getSpecialFlowAttributes()) {
   }
   static constexpr char const* ProcessorName = "AttributesToJSON";
   // Supported Properties
@@ -83,6 +82,7 @@ class AttributesToJSON : public core::Processor {
   std::string buildAttributeJsonData(std::map<std::string, std::string>&& attributes);
 
   std::shared_ptr<logging::Logger> logger_;
+  const std::unordered_set<std::string> core_attributes_;
   std::vector<std::string> attribute_list_;
   std::string attributes_regular_expression_str_;
   utils::Regex attributes_regular_expression_;

--- a/extensions/standard-processors/processors/AttributesToJSON.h
+++ b/extensions/standard-processors/processors/AttributesToJSON.h
@@ -23,13 +23,13 @@
 #include <string>
 #include <unordered_set>
 #include <memory>
-#include <regex>
 #include <map>
 
 #include "rapidjson/document.h"
 #include "core/Processor.h"
 #include "core/Property.h"
 #include "core/logging/Logger.h"
+#include "utils/RegexUtils.h"
 
 namespace org {
 namespace apache {
@@ -78,14 +78,14 @@ class AttributesToJSON : public core::Processor {
   };
 
   bool isCoreAttributeToBeFiltered(const std::string& attribute) const;
-  bool matchesAttributeRegex(const std::string& attribute) const;
-  void addAttributeToJson(rapidjson::Document& document, const std::string& key, const std::string& value) const;
-  std::string buildAttributeJsonData(std::map<std::string, std::string>&& attributes) const;
+  bool matchesAttributeRegex(const std::string& attribute);
+  void addAttributeToJson(rapidjson::Document& document, const std::string& key, const std::string& value);
+  std::string buildAttributeJsonData(std::map<std::string, std::string>&& attributes);
 
   std::shared_ptr<logging::Logger> logger_;
   std::vector<std::string> attribute_list_;
   std::string attributes_regular_expression_str_;
-  std::regex attributes_regular_expression_;
+  utils::Regex attributes_regular_expression_;
   std::string destination_;
   bool include_core_attributes_ = true;
   bool null_value_ = false;

--- a/extensions/standard-processors/tests/unit/AttributesToJSONTests.cpp
+++ b/extensions/standard-processors/tests/unit/AttributesToJSONTests.cpp
@@ -43,7 +43,7 @@ class AttributesToJSONTestFixture {
     LogTestController::getInstance().setDebug<minifi::processors::UpdateAttribute>();
     LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
-    dir_ = minifi::utils::createTempDir(&test_controller_);
+    dir_ = test_controller_.createTempDirectory();
 
     plan_ = test_controller_.createPlan();
     getfile_ = plan_->addProcessor("GetFile", "GetFile");

--- a/extensions/standard-processors/tests/unit/AttributesToJSONTests.cpp
+++ b/extensions/standard-processors/tests/unit/AttributesToJSONTests.cpp
@@ -56,6 +56,7 @@ class AttributesToJSONTestFixture {
     plan_->setProperty(putfile_, org::apache::nifi::minifi::processors::PutFile::Directory.getName(), dir_);
 
     update_attribute_->setDynamicProperty("my_attribute", "my_value");
+    update_attribute_->setDynamicProperty("my_attribute_1", "my_value_1");
     update_attribute_->setDynamicProperty("other_attribute", "other_value");
     update_attribute_->setDynamicProperty("empty_attribute", "");
 
@@ -63,8 +64,9 @@ class AttributesToJSONTestFixture {
   }
 
   void assertJSONAttributesFromLog(const std::unordered_map<std::string, std::optional<std::string>>& expected_attributes) {
-    auto match = LogTestController::getInstance().matchesRegex("key:JSONAttributes value:(.*)").value();
-    assertAttributes(expected_attributes, match[1].str());
+    auto match = LogTestController::getInstance().matchesRegex("key:JSONAttributes value:(.*)");
+    REQUIRE(match);
+    assertAttributes(expected_attributes, (*match)[1].str());
   }
 
   void assertJSONAttributesFromFile(const std::unordered_map<std::string, std::optional<std::string>>& expected_attributes) {
@@ -125,6 +127,7 @@ TEST_CASE_METHOD(AttributesToJSONTestFixture, "Move all attributes to a flowfile
     {"filename", TEST_FILE_NAME},
     {"flow.id", "test"},
     {"my_attribute", "my_value"},
+    {"my_attribute_1", "my_value_1"},
     {"other_attribute", "other_value"},
     {"path", dir_ + utils::file::FileUtils::get_separator()}
   };
@@ -188,6 +191,7 @@ TEST_CASE_METHOD(AttributesToJSONTestFixture, "All empty attributes shall be wri
     {"filename", TEST_FILE_NAME},
     {"flow.id", "test"},
     {"my_attribute", "my_value"},
+    {"my_attribute_1", "my_value_1"},
     {"other_attribute", "other_value"},
     {"path", dir_ + utils::file::FileUtils::get_separator()}
   };
@@ -204,6 +208,7 @@ TEST_CASE_METHOD(AttributesToJSONTestFixture, "JSON attributes are written in fl
     {"filename", TEST_FILE_NAME},
     {"flow.id", "test"},
     {"my_attribute", "my_value"},
+    {"my_attribute_1", "my_value_1"},
     {"other_attribute", "other_value"},
     {"path", dir_ + utils::file::FileUtils::get_separator()}
   };
@@ -220,6 +225,7 @@ TEST_CASE_METHOD(AttributesToJSONTestFixture, "Do not include core attributes in
   const std::unordered_map<std::string, std::optional<std::string>> expected_attributes {
     {"empty_attribute", ""},
     {"my_attribute", "my_value"},
+    {"my_attribute_1", "my_value_1"},
     {"other_attribute", "other_value"}
   };
   assertJSONAttributesFromLog(expected_attributes);
@@ -270,7 +276,6 @@ TEST_CASE_METHOD(AttributesToJSONTestFixture, "Core attributes are filtered even
   REQUIRE(file_contents.size() == 1);
   REQUIRE(file_contents[0] == TEST_FILE_CONTENT);
 
-  REQUIRE(LogTestController::getInstance().contains("key:JSONAttributes value:{\"my_attribute\":\"my_value\"}"));
   const std::unordered_map<std::string, std::optional<std::string>> expected_attributes {
     {"my_attribute", "my_value"},
   };

--- a/extensions/standard-processors/tests/unit/AttributesToJSONTests.cpp
+++ b/extensions/standard-processors/tests/unit/AttributesToJSONTests.cpp
@@ -186,4 +186,9 @@ TEST_CASE_METHOD(AttributesToJSONTestFixture, "Regex selected attributes are wri
   REQUIRE(LogTestController::getInstance().contains("key:JSONAttributes value:{\"empty_attribute\":\"\",\"my_attribute\":\"my_value\"}"));
 }
 
+TEST_CASE_METHOD(AttributesToJSONTestFixture, "Invalid destination is set", "[AttributesToJSONTests]") {
+  plan_->setProperty(attribute_to_json_, org::apache::nifi::minifi::processors::AttributesToJSON::Destination.getName(), "invalid-destination");
+  REQUIRE_THROWS_AS(test_controller_.runSession(plan_), minifi::Exception);
+}
+
 }  // namespace

--- a/extensions/standard-processors/tests/unit/AttributesToJSONTests.cpp
+++ b/extensions/standard-processors/tests/unit/AttributesToJSONTests.cpp
@@ -68,14 +68,14 @@ class AttributesToJSONTestFixture {
   std::vector<std::string> getOutputFileContents() {
     std::vector<std::string> file_contents;
 
-    auto lambda = [&file_contents](const std::string& path, const std::string& filename) -> bool {
+    auto callback = [&file_contents](const std::string& path, const std::string& filename) -> bool {
       std::ifstream is(path + utils::file::FileUtils::get_separator() + filename, std::ifstream::binary);
       std::string file_content((std::istreambuf_iterator<char>(is)), std::istreambuf_iterator<char>());
       file_contents.push_back(file_content);
       return true;
     };
 
-    utils::file::FileUtils::list_dir(dir_, lambda, plan_->getLogger(), false);
+    utils::file::FileUtils::list_dir(dir_, callback, plan_->getLogger(), false);
 
     return file_contents;
   }
@@ -141,6 +141,7 @@ TEST_CASE_METHOD(AttributesToJSONTestFixture, "JSON attributes are written in fl
   REQUIRE(file_contents.size() == 1);
   REQUIRE(file_contents[0].size() == expected_content.size());
   REQUIRE(file_contents[0] == expected_content);
+  REQUIRE(!LogTestController::getInstance().contains("key:JSONAttributes", std::chrono::seconds(0), std::chrono::milliseconds(0)));
 }
 
 TEST_CASE_METHOD(AttributesToJSONTestFixture, "Do not include core attributes in JSON", "[AttributesToJSONTests]") {

--- a/extensions/standard-processors/tests/unit/AttributesToJSONTests.cpp
+++ b/extensions/standard-processors/tests/unit/AttributesToJSONTests.cpp
@@ -1,0 +1,166 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <string>
+#include <vector>
+
+#include "TestBase.h"
+#include "utils/TestUtils.h"
+#include "AttributesToJSON.h"
+#include "GetFile.h"
+#include "PutFile.h"
+#include "UpdateAttribute.h"
+#include "LogAttribute.h"
+
+namespace {
+
+class AttributesToJSONTestFixture {
+ public:
+  const std::string TEST_FILE_CONTENT = "test_content";
+  const std::string TEST_FILE_NAME = "tstFile.ext";
+
+  AttributesToJSONTestFixture() {
+    LogTestController::getInstance().setTrace<TestPlan>();
+    LogTestController::getInstance().setDebug<minifi::processors::AttributesToJSON>();
+    LogTestController::getInstance().setDebug<minifi::processors::GetFile>();
+    LogTestController::getInstance().setDebug<minifi::processors::PutFile>();
+    LogTestController::getInstance().setDebug<minifi::processors::UpdateAttribute>();
+    LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
+
+    dir_ = minifi::utils::createTempDir(&test_controller_);
+
+    plan_ = test_controller_.createPlan();
+    getfile_ = plan_->addProcessor("GetFile", "GetFile");
+    update_attribute_ = plan_->addProcessor("UpdateAttribute", "UpdateAttribute", core::Relationship("success", "description"), true);
+    attribute_to_json_ = plan_->addProcessor("AttributesToJSON", "AttributesToJSON", core::Relationship("success", "description"), true);
+    logattribute_ = plan_->addProcessor("LogAttribute", "LogAttribute", core::Relationship("success", "description"), true);
+    putfile_ = plan_->addProcessor("PutFile", "PutFile", core::Relationship("success", "description"), true);
+
+    plan_->setProperty(getfile_, org::apache::nifi::minifi::processors::GetFile::Directory.getName(), dir_);
+    plan_->setProperty(putfile_, org::apache::nifi::minifi::processors::PutFile::Directory.getName(), dir_);
+
+    update_attribute_->setDynamicProperty("my_attribute", "my_value");
+    update_attribute_->setDynamicProperty("other_attribute", "other_value");
+    update_attribute_->setDynamicProperty("empty_attribute", "");
+
+    std::fstream file;
+    std::stringstream ss;
+    ss << dir_ << utils::file::FileUtils::get_separator() << TEST_FILE_NAME;
+    file.open(ss.str(), std::ios::out);
+    file << TEST_FILE_CONTENT;
+    file.close();
+  }
+
+  std::vector<std::string> getOutputFileContents() {
+    std::vector<std::string> file_contents;
+
+    auto lambda = [&file_contents](const std::string& path, const std::string& filename) -> bool {
+      std::ifstream is(path + utils::file::FileUtils::get_separator() + filename, std::ifstream::binary);
+      std::string file_content((std::istreambuf_iterator<char>(is)), std::istreambuf_iterator<char>());
+      file_contents.push_back(file_content);
+      return true;
+    };
+
+    utils::file::FileUtils::list_dir(dir_, lambda, plan_->getLogger(), false);
+
+    return file_contents;
+  }
+
+ protected:
+  TestController test_controller_;
+  std::shared_ptr<TestPlan> plan_;
+  std::string dir_;
+  std::shared_ptr<core::Processor> getfile_;
+  std::shared_ptr<core::Processor> update_attribute_;
+  std::shared_ptr<core::Processor> attribute_to_json_;
+  std::shared_ptr<core::Processor> logattribute_;
+  std::shared_ptr<core::Processor> putfile_;
+};
+
+TEST_CASE_METHOD(AttributesToJSONTestFixture, "Move all attributes to a flowfile attribute", "[AttributesToJSONTests]") {
+  test_controller_.runSession(plan_);
+  auto file_contents = getOutputFileContents();
+
+  REQUIRE(file_contents.size() == 1);
+  REQUIRE(file_contents[0].size() == TEST_FILE_CONTENT.size());
+  REQUIRE(LogTestController::getInstance().contains("key:JSONAttributes value:{\"absolute.path\":\""+ dir_ + "/" + TEST_FILE_NAME + "\",\"empty_attribute\":\"\",\"filename\":\"" + TEST_FILE_NAME + "\",\"flow.id\":\"test\",\"my_attribute\":\"my_value\",\"other_attribute\":\"other_value\",\"path\":\"" + dir_ + "/\"}"));  // NOLINT
+}
+
+TEST_CASE_METHOD(AttributesToJSONTestFixture, "Move selected attributes to a flowfile attribute", "[AttributesToJSONTests]") {
+  plan_->setProperty(attribute_to_json_, org::apache::nifi::minifi::processors::AttributesToJSON::AttributesList.getName(), "my_attribute,non_existent_attribute");
+  test_controller_.runSession(plan_);
+  auto file_contents = getOutputFileContents();
+
+  REQUIRE(file_contents.size() == 1);
+  REQUIRE(file_contents[0].size() == TEST_FILE_CONTENT.size());
+  REQUIRE(LogTestController::getInstance().contains("key:JSONAttributes value:{\"my_attribute\":\"my_value\",\"non_existent_attribute\":\"\"}"));
+}
+
+TEST_CASE_METHOD(AttributesToJSONTestFixture, "Non-existent or empty selected attributes shall be written as null in JSON", "[AttributesToJSONTests]") {
+  plan_->setProperty(attribute_to_json_, org::apache::nifi::minifi::processors::AttributesToJSON::AttributesList.getName(), "my_attribute,non_existent_attribute,empty_attribute");
+  plan_->setProperty(attribute_to_json_, org::apache::nifi::minifi::processors::AttributesToJSON::NullValue.getName(), "true");
+  test_controller_.runSession(plan_);
+  auto file_contents = getOutputFileContents();
+
+  REQUIRE(file_contents.size() == 1);
+  REQUIRE(file_contents[0].size() == TEST_FILE_CONTENT.size());
+  REQUIRE(LogTestController::getInstance().contains("key:JSONAttributes value:{\"my_attribute\":\"my_value\",\"non_existent_attribute\":null,\"empty_attribute\":null}"));
+}
+
+TEST_CASE_METHOD(AttributesToJSONTestFixture, "All non-existent or empty attributes shall be written as null in JSON", "[AttributesToJSONTests]") {
+  plan_->setProperty(attribute_to_json_, org::apache::nifi::minifi::processors::AttributesToJSON::NullValue.getName(), "true");
+  test_controller_.runSession(plan_);
+  auto file_contents = getOutputFileContents();
+
+  REQUIRE(file_contents.size() == 1);
+  REQUIRE(file_contents[0].size() == TEST_FILE_CONTENT.size());
+  REQUIRE(LogTestController::getInstance().contains("key:JSONAttributes value:{\"absolute.path\":\""+ dir_ + "/" + TEST_FILE_NAME + "\",\"empty_attribute\":null,\"filename\":\"" + TEST_FILE_NAME + "\",\"flow.id\":\"test\",\"my_attribute\":\"my_value\",\"other_attribute\":\"other_value\",\"path\":\"" + dir_ + "/\"}"));  // NOLINT
+}
+
+TEST_CASE_METHOD(AttributesToJSONTestFixture, "JSON attributes are written in flowfile", "[AttributesToJSONTests]") {
+  plan_->setProperty(attribute_to_json_, org::apache::nifi::minifi::processors::AttributesToJSON::Destination.getName(), "flowfile-content");
+  test_controller_.runSession(plan_);
+  std::string expected_content = "{\"absolute.path\":\""+ dir_ + "/" + TEST_FILE_NAME + "\",\"empty_attribute\":\"\",\"filename\":\"" + TEST_FILE_NAME + "\",\"flow.id\":\"test\",\"my_attribute\":\"my_value\",\"other_attribute\":\"other_value\",\"path\":\"" + dir_ + "/\"}";  // NOLINT
+
+  auto file_contents = getOutputFileContents();
+
+  REQUIRE(file_contents.size() == 1);
+  REQUIRE(file_contents[0].size() == expected_content.size());
+  REQUIRE(file_contents[0] == expected_content);
+}
+
+TEST_CASE_METHOD(AttributesToJSONTestFixture, "Do not include core attributes in JSON", "[AttributesToJSONTests]") {
+  plan_->setProperty(attribute_to_json_, org::apache::nifi::minifi::processors::AttributesToJSON::IncludeCoreAttributes.getName(), "false");
+  test_controller_.runSession(plan_);
+  auto file_contents = getOutputFileContents();
+
+  REQUIRE(file_contents.size() == 1);
+  REQUIRE(file_contents[0].size() == TEST_FILE_CONTENT.size());
+  REQUIRE(LogTestController::getInstance().contains("key:JSONAttributes value:{\"empty_attribute\":\"\",\"my_attribute\":\"my_value\",\"other_attribute\":\"other_value\"}"));
+}
+
+TEST_CASE_METHOD(AttributesToJSONTestFixture, "Regex selected attributes are written in JSONAttributes attribute", "[AttributesToJSONTests]") {
+  plan_->setProperty(attribute_to_json_, org::apache::nifi::minifi::processors::AttributesToJSON::AttributesRegularExpression.getName(), "[a-z]+y_attribute");
+  test_controller_.runSession(plan_);
+  auto file_contents = getOutputFileContents();
+
+  REQUIRE(file_contents.size() == 1);
+  REQUIRE(file_contents[0].size() == TEST_FILE_CONTENT.size());
+  REQUIRE(LogTestController::getInstance().contains("key:JSONAttributes value:{\"empty_attribute\":\"\",\"my_attribute\":\"my_value\"}"));
+}
+
+}  // namespace

--- a/extensions/standard-processors/tests/unit/AttributesToJSONTests.cpp
+++ b/extensions/standard-processors/tests/unit/AttributesToJSONTests.cpp
@@ -162,7 +162,7 @@ TEST_CASE_METHOD(AttributesToJSONTestFixture, "Move selected attributes with spe
   assertJSONAttributesFromLog(expected_attributes);
 }
 
-TEST_CASE_METHOD(AttributesToJSONTestFixture, "Non-existent or empty selected attributes shall be written as null in JSON", "[AttributesToJSONTests]") {
+TEST_CASE_METHOD(AttributesToJSONTestFixture, "Non-existent selected attributes shall be written as null in JSON", "[AttributesToJSONTests]") {
   plan_->setProperty(attribute_to_json_, org::apache::nifi::minifi::processors::AttributesToJSON::AttributesList.getName(), "my_attribute,non_existent_attribute,empty_attribute");
   plan_->setProperty(attribute_to_json_, org::apache::nifi::minifi::processors::AttributesToJSON::NullValue.getName(), "true");
   test_controller_.runSession(plan_);
@@ -173,27 +173,7 @@ TEST_CASE_METHOD(AttributesToJSONTestFixture, "Non-existent or empty selected at
   const std::unordered_map<std::string, std::optional<std::string>> expected_attributes {
     {"my_attribute", "my_value"},
     {"non_existent_attribute", std::nullopt},
-    {"empty_attribute", std::nullopt}
-  };
-  assertJSONAttributesFromLog(expected_attributes);
-}
-
-TEST_CASE_METHOD(AttributesToJSONTestFixture, "All empty attributes shall be written as null in JSON", "[AttributesToJSONTests]") {
-  plan_->setProperty(attribute_to_json_, org::apache::nifi::minifi::processors::AttributesToJSON::NullValue.getName(), "true");
-  test_controller_.runSession(plan_);
-  auto file_contents = getOutputFileContents();
-  REQUIRE(file_contents.size() == 1);
-  REQUIRE(file_contents[0] == TEST_FILE_CONTENT);
-
-  const std::unordered_map<std::string, std::optional<std::string>> expected_attributes {
-    {"absolute.path", dir_ + utils::file::FileUtils::get_separator() + TEST_FILE_NAME},
-    {"empty_attribute", std::nullopt},
-    {"filename", TEST_FILE_NAME},
-    {"flow.id", "test"},
-    {"my_attribute", "my_value"},
-    {"my_attribute_1", "my_value_1"},
-    {"other_attribute", "other_value"},
-    {"path", dir_ + utils::file::FileUtils::get_separator()}
+    {"empty_attribute", ""}
   };
   assertJSONAttributesFromLog(expected_attributes);
 }

--- a/libminifi/include/core/FlowFile.h
+++ b/libminifi/include/core/FlowFile.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <optional>
 #include <set>
+#include <unordered_set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -310,6 +311,10 @@ struct SpecialFlowAttribute {
   static const std::string ALTERNATE_IDENTIFIER;
   // Flow identifier
   static const std::string FLOW_ID;
+
+  static std::unordered_set<std::string> getSpecialFlowAttributes() {
+    return {PATH, ABSOLUTE_PATH, FILENAME, UUID, priority, MIME_TYPE, DISCARD_REASON, ALTERNATE_IDENTIFIER, FLOW_ID};
+  }
 };
 
 }  // namespace core

--- a/libminifi/include/core/FlowFile.h
+++ b/libminifi/include/core/FlowFile.h
@@ -312,8 +312,11 @@ struct SpecialFlowAttribute {
   // Flow identifier
   static const std::string FLOW_ID;
 
-  static std::unordered_set<std::string> getSpecialFlowAttributes() {
-    return {PATH, ABSOLUTE_PATH, FILENAME, UUID, priority, MIME_TYPE, DISCARD_REASON, ALTERNATE_IDENTIFIER, FLOW_ID};
+  static const auto& getSpecialFlowAttributes() {
+    static const std::array<std::string_view, 9> SPECIAL_FLOW_ATTRIBUTES {
+      PATH, ABSOLUTE_PATH, FILENAME, UUID, priority, MIME_TYPE, DISCARD_REASON, ALTERNATE_IDENTIFIER, FLOW_ID
+    };
+    return SPECIAL_FLOW_ATTRIBUTES;
   }
 };
 

--- a/libminifi/test/TestBase.h
+++ b/libminifi/test/TestBase.h
@@ -27,6 +27,7 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include <regex>
 
 #include "ResourceClaim.h"
 #include "utils/file/FileUtils.h"
@@ -162,6 +163,31 @@ class LogTestController {
 
     logger_->log_info("%s %s in log output.", found ? "Successfully found" : "Failed to find", ending);
     return found;
+  }
+
+  std::optional<std::smatch> matchesRegex(const std::string &regex_str,
+                std::chrono::seconds timeout = std::chrono::seconds(3),
+                std::chrono::milliseconds sleep_interval = std::chrono::milliseconds(200)) {
+    if (regex_str.length() == 0) {
+      return std::nullopt;
+    }
+    auto start = std::chrono::system_clock::now();
+    bool found = false;
+    bool timed_out = false;
+    std::regex matcher_regex(regex_str);
+    std::smatch match;
+    do {
+      std::string str = log_output.str();
+      found = std::regex_search(str, match, matcher_regex);
+      auto now = std::chrono::system_clock::now();
+      timed_out = std::chrono::duration_cast<std::chrono::milliseconds>(now - start) > std::chrono::duration_cast<std::chrono::milliseconds>(timeout);
+      if (!found && !timed_out) {
+        std::this_thread::sleep_for(sleep_interval);
+      }
+    } while (!found && !timed_out);
+
+    logger_->log_info("%s %s in log output.", found ? "Successfully matched regex" : "Failed to match regex", regex_str);
+    return found ? std::make_optional<std::smatch>(match) : std::nullopt;
   }
 
   int countOccurrences(const std::string& pattern) {

--- a/libminifi/test/TestBase.h
+++ b/libminifi/test/TestBase.h
@@ -155,7 +155,7 @@ class LogTestController {
       std::string str = stream.str();
       found = (str.find(ending) != std::string::npos);
       auto now = std::chrono::system_clock::now();
-      timed_out = std::chrono::duration_cast<std::chrono::milliseconds>(now - start) > std::chrono::duration_cast<std::chrono::milliseconds>(timeout);
+      timed_out = (now - start > timeout);
       if (!found && !timed_out) {
         std::this_thread::sleep_for(sleep_interval);
       }
@@ -180,7 +180,7 @@ class LogTestController {
       std::string str = log_output.str();
       found = std::regex_search(str, match, matcher_regex);
       auto now = std::chrono::system_clock::now();
-      timed_out = std::chrono::duration_cast<std::chrono::milliseconds>(now - start) > std::chrono::duration_cast<std::chrono::milliseconds>(timeout);
+      timed_out = (now - start > timeout);
       if (!found && !timed_out) {
         std::this_thread::sleep_for(sleep_interval);
       }


### PR DESCRIPTION
Implementing `AttributesToJson` processor that generates a JSON representation of the input content attributes and writes them either in the `JSONAttributes` attribute or as the flowfile content.

https://issues.apache.org/jira/browse/MINIFICPP-1607

-----------------------------------------------------------------------------------------

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
