### PR TITLE
MINIFICPP-1600 Unify temporary directory creation in tests

### DIFF
--- a/encrypt-config/tests/CMakeLists.txt
+++ b/encrypt-config/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ foreach(testfile ${ENCRYPT_CONFIG_TESTS})
   target_include_directories(${testfilename} BEFORE PRIVATE "${CMAKE_SOURCE_DIR}/libminifi/test")
 
   target_wholearchive_library(${testfilename} minifi)
-  target_link_libraries(${testfilename} ${CATCH_MAIN_LIB})
+  target_link_libraries(${testfilename} ${CATCH_MAIN_LIB} ${TEST_BASE_LIB})
   add_test(NAME ${testfilename} COMMAND ${testfilename} WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 
   math(EXPR ENCRYPT_CONFIG_TEST_COUNT "${ENCRYPT_CONFIG_TEST_COUNT}+1")

--- a/encrypt-config/tests/ConfigFileTests.cpp
+++ b/encrypt-config/tests/ConfigFileTests.cpp
@@ -179,8 +179,8 @@ TEST_CASE("ConfigFile can write to a new file", "[encrypt-config][writeTo]") {
   ConfigFile test_file{std::ifstream{"resources/minifi.properties"}};
   test_file.update("nifi.bored.yield.duration", "20 millis");
 
-  char format[] = "/tmp/ConfigFileTests.tmp.XXXXXX";
-  std::string temp_dir = utils::file::create_temp_directory(format);
+  TestController test_controller;
+  std::string temp_dir = test_controller.createTempDirectory();
   auto remove_directory = gsl::finally([&temp_dir]() { utils::file::delete_dir(temp_dir); });
   std::string file_path = utils::file::concat_path(temp_dir, "minifi.properties");
 

--- a/extensions/civetweb/tests/ListenHTTPTests.cpp
+++ b/extensions/civetweb/tests/ListenHTTPTests.cpp
@@ -57,8 +57,7 @@ class ListenHTTPTestsFixture {
     LogTestController::getInstance().setDebug<minifi::controllers::SSLContextService>();
 
     // Create temporary directories
-    char tmp_dir_format[] = "/tmp/gt.XXXXXX";
-    tmp_dir = testController.createTempDirectory(tmp_dir_format);
+    tmp_dir = testController.createTempDirectory();
     REQUIRE(!tmp_dir.empty());
 
     // Define test input file

--- a/extensions/coap/tests/CoapC2VerifyHeartbeat.cpp
+++ b/extensions/coap/tests/CoapC2VerifyHeartbeat.cpp
@@ -59,8 +59,7 @@ class VerifyCoAPServer : public CoapIntegrationBase {
  public:
   explicit VerifyCoAPServer(bool isSecure)
       : isSecure(isSecure) {
-    char format[] = "/tmp/ssth.XXXXXX";
-    dir = testController.createTempDirectory(format);
+    dir = testController.createTempDirectory();
   }
 
   void testSetup() override {

--- a/extensions/expression-language/tests/ExpressionLanguageTests.cpp
+++ b/extensions/expression-language/tests/ExpressionLanguageTests.cpp
@@ -193,14 +193,12 @@ TEST_CASE("GetFile PutFile dynamic attribute", "[expressionLanguageTestGetFilePu
   auto plan = testController.createPlan(conf);
   auto repo = std::make_shared<TestRepository>();
 
-  char format[] = "/tmp/gt.XXXXXX";
-  std::string in_dir = testController.createTempDirectory(format);
+  std::string in_dir = testController.createTempDirectory();
   REQUIRE(!in_dir.empty());
 
   std::string in_file(in_dir);
   in_file.append("/file");
-  char formatX[] = "/tmp/gt.XXXXXX";
-  std::string out_dir = testController.createTempDirectory(formatX);
+  std::string out_dir = testController.createTempDirectory();
   REQUIRE(!out_dir.empty());
 
   std::string out_file(out_dir);

--- a/extensions/http-curl/tests/C2ConfigEncryption.cpp
+++ b/extensions/http-curl/tests/C2ConfigEncryption.cpp
@@ -28,8 +28,7 @@ int main(int argc, char **argv) {
   const cmd_args args = parse_cmdline_args(argc, argv, "update");
   TestController controller;
   // copy config file to temporary location as it will get overridden
-  char tmp_format[] = "/var/tmp/c2.XXXXXX";
-  std::string home_path = controller.createTempDirectory(tmp_format);
+  std::string home_path = controller.createTempDirectory();
   std::string live_config_file = utils::file::FileUtils::concat_path(home_path, "config.yml");
   utils::file::FileUtils::copy_file(args.test_file, live_config_file);
   // the C2 server will update the flow with the contents of args.test_file

--- a/extensions/http-curl/tests/C2DescribeCoreComponentStateTest.cpp
+++ b/extensions/http-curl/tests/C2DescribeCoreComponentStateTest.cpp
@@ -28,8 +28,7 @@
 class VerifyC2DescribeCoreComponentState : public VerifyC2Describe {
  public:
   VerifyC2DescribeCoreComponentState() {
-    char format[] = "/var/tmp/ssth.XXXXXX";
-    temp_dir_ = testController.createTempDirectory(format);
+    temp_dir_ = testController.createTempDirectory();
 
     test_file_1_ = utils::file::FileUtils::concat_path(temp_dir_, "test1.txt");
     test_file_2_ = utils::file::FileUtils::concat_path(temp_dir_, "test2.txt");

--- a/extensions/http-curl/tests/C2FetchFlowIfMissingTest.cpp
+++ b/extensions/http-curl/tests/C2FetchFlowIfMissingTest.cpp
@@ -24,8 +24,7 @@
 
 int main(int argc, char **argv) {
   TestController controller;
-  char format[] = "/var/tmp/c2.XXXXXX";
-  std::string minifi_home = controller.createTempDirectory(format);
+  std::string minifi_home = controller.createTempDirectory();
   const cmd_args args = parse_cmdline_args(argc, argv);
   C2FlowProvider handler(args.test_file);
   VerifyFlowFetched harness(10000);

--- a/extensions/http-curl/tests/C2NullConfiguration.cpp
+++ b/extensions/http-curl/tests/C2NullConfiguration.cpp
@@ -36,8 +36,7 @@ class VerifyC2Server : public HTTPIntegrationBase {
  public:
   explicit VerifyC2Server(bool isSecure)
       : isSecure(isSecure) {
-    char format[] = "/tmp/ssth.XXXXXX";
-    dir = testController.createTempDirectory(format);
+    dir = testController.createTempDirectory();
   }
 
   void testSetup() override {

--- a/extensions/http-curl/tests/C2VerifyServeResults.cpp
+++ b/extensions/http-curl/tests/C2VerifyServeResults.cpp
@@ -32,8 +32,7 @@
 class VerifyC2Server : public HTTPIntegrationBase {
  public:
   VerifyC2Server() {
-    char format[] = "/tmp/ssth.XXXXXX";
-    dir = testController.createTempDirectory(format);
+    dir = testController.createTempDirectory();
   }
 
   void testSetup() override {

--- a/extensions/http-curl/tests/HTTPSiteToSiteTests.cpp
+++ b/extensions/http-curl/tests/HTTPSiteToSiteTests.cpp
@@ -38,8 +38,7 @@ class SiteToSiteTestHarness : public HTTPIntegrationBase {
  public:
   explicit SiteToSiteTestHarness(bool isSecure, std::chrono::milliseconds waitTime = std::chrono::milliseconds{2000})
       : HTTPIntegrationBase(waitTime.count()), isSecure(isSecure) {
-    char format[] = "/tmp/ssth.XXXXXX";
-    dir = testController.createTempDirectory(format);
+    dir = testController.createTempDirectory();
   }
 
   void testSetup() override {

--- a/extensions/http-curl/tests/HttpPostIntegrationTest.cpp
+++ b/extensions/http-curl/tests/HttpPostIntegrationTest.cpp
@@ -34,8 +34,7 @@
 class HttpTestHarness : public HTTPIntegrationBase {
  public:
   HttpTestHarness() : HTTPIntegrationBase(4000) {
-    char format[] = "/tmp/ssth.XXXXXX";
-    dir = testController.createTempDirectory(format);
+    dir = testController.createTempDirectory();
   }
 
   void testSetup() override {

--- a/extensions/http-curl/tests/SiteToSiteRestTest.cpp
+++ b/extensions/http-curl/tests/SiteToSiteRestTest.cpp
@@ -65,8 +65,7 @@ class SiteToSiteTestHarness : public HTTPIntegrationBase {
  public:
   explicit SiteToSiteTestHarness(bool isSecure)
       : isSecure(isSecure) {
-    char format[] = "/tmp/ssth.XXXXXX";
-    dir = testController.createTempDirectory(format);
+    dir = testController.createTempDirectory();
   }
 
   void testSetup() override {

--- a/extensions/http-curl/tests/TimeoutHTTPSiteToSiteTests.cpp
+++ b/extensions/http-curl/tests/TimeoutHTTPSiteToSiteTests.cpp
@@ -39,8 +39,7 @@ class SiteToSiteTestHarness : public HTTPIntegrationBase {
  public:
   explicit SiteToSiteTestHarness(bool isSecure, std::chrono::milliseconds waitTime = std::chrono::milliseconds{1000})
       : HTTPIntegrationBase(waitTime.count()), isSecure(isSecure) {
-    char format[] = "/tmp/ssth.XXXXXX";
-    dir = testController.createTempDirectory(format);
+    dir = testController.createTempDirectory();
   }
 
   void testSetup() override {

--- a/extensions/http-curl/tests/unit/InvokeHTTPTests.cpp
+++ b/extensions/http-curl/tests/unit/InvokeHTTPTests.cpp
@@ -47,8 +47,7 @@ TEST_CASE("HTTPTestsWithNoResourceClaimPOST", "[httptest1]") {
 
   std::shared_ptr<core::Processor> logAttribute = std::make_shared<org::apache::nifi::minifi::processors::LogAttribute>("logattribute");
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   std::shared_ptr<core::Processor> listenhttp = std::make_shared<org::apache::nifi::minifi::processors::ListenHTTP>("listenhttp");
   listenhttp->initialize();
@@ -168,8 +167,7 @@ TEST_CASE("HTTPTestsWithResourceClaimPOST", "[httptest1]") {
 
   std::shared_ptr<core::Processor> logAttribute = std::make_shared<org::apache::nifi::minifi::processors::LogAttribute>("logattribute");
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   std::shared_ptr<core::Processor> listenhttp = std::make_shared<org::apache::nifi::minifi::processors::ListenHTTP>("listenhttp");
   listenhttp->initialize();

--- a/extensions/http-curl/tests/unit/InvokeHTTPTests.cpp
+++ b/extensions/http-curl/tests/unit/InvokeHTTPTests.cpp
@@ -47,8 +47,6 @@ TEST_CASE("HTTPTestsWithNoResourceClaimPOST", "[httptest1]") {
 
   std::shared_ptr<core::Processor> logAttribute = std::make_shared<org::apache::nifi::minifi::processors::LogAttribute>("logattribute");
 
-  auto dir = testController.createTempDirectory();
-
   std::shared_ptr<core::Processor> listenhttp = std::make_shared<org::apache::nifi::minifi::processors::ListenHTTP>("listenhttp");
   listenhttp->initialize();
 
@@ -166,8 +164,6 @@ TEST_CASE("HTTPTestsWithResourceClaimPOST", "[httptest1]") {
   std::shared_ptr<core::Processor> getfileprocessor = std::make_shared<org::apache::nifi::minifi::processors::GetFile>("getfileCreate2");
 
   std::shared_ptr<core::Processor> logAttribute = std::make_shared<org::apache::nifi::minifi::processors::LogAttribute>("logattribute");
-
-  auto dir = testController.createTempDirectory();
 
   std::shared_ptr<core::Processor> listenhttp = std::make_shared<org::apache::nifi::minifi::processors::ListenHTTP>("listenhttp");
   listenhttp->initialize();

--- a/extensions/pdh/tests/PerformanceDataMonitorTests.cpp
+++ b/extensions/pdh/tests/PerformanceDataMonitorTests.cpp
@@ -37,7 +37,7 @@ class PerformanceDataMonitorTester {
  public:
   PerformanceDataMonitorTester() {
     LogTestController::getInstance().setTrace<TestPlan>();
-    dir_ = utils::createTempDir(&test_controller_);
+    dir_ = test_controller_.createTempDirectory();
     plan_ = test_controller_.createPlan();
     performance_monitor_ = plan_->addProcessor("PerformanceDataMonitor", "pdhsys");
     putfile_ = plan_->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);

--- a/extensions/sftp/tests/FetchSFTPTests.cpp
+++ b/extensions/sftp/tests/FetchSFTPTests.cpp
@@ -72,18 +72,15 @@ class FetchSFTPTestsFixture {
     LogTestController::getInstance().setDebug<processors::LogAttribute>();
     LogTestController::getInstance().setDebug<SFTPTestServer>();
 
-    // Create temporary directories
-    src_dir = testController.createTempDirectory();
     REQUIRE_FALSE(src_dir.empty());
-    dst_dir = testController.createTempDirectory();
     REQUIRE_FALSE(dst_dir.empty());
+    REQUIRE(plan);
 
     // Start SFTP server
     sftp_server = std::unique_ptr<SFTPTestServer>(new SFTPTestServer(src_dir));
     REQUIRE(true == sftp_server->start());
 
     // Build MiNiFi processing graph
-    plan = testController.createPlan();
     generate_flow_file = plan->addProcessor(
         "GenerateFlowFile",
         "GenerateFlowFile");
@@ -188,11 +185,11 @@ class FetchSFTPTestsFixture {
   }
 
  protected:
-  std::string src_dir;
-  std::string dst_dir;
-  std::unique_ptr<SFTPTestServer> sftp_server;
   TestController testController;
-  std::shared_ptr<TestPlan> plan;
+  std::string src_dir = testController.createTempDirectory();
+  std::string dst_dir = testController.createTempDirectory();
+  std::shared_ptr<TestPlan> plan = testController.createPlan();
+  std::unique_ptr<SFTPTestServer> sftp_server;
   std::shared_ptr<core::Processor> generate_flow_file;
   std::shared_ptr<core::Processor> update_attribute;
   std::shared_ptr<core::Processor> fetch_sftp;

--- a/extensions/sftp/tests/ListSFTPTests.cpp
+++ b/extensions/sftp/tests/ListSFTPTests.cpp
@@ -71,8 +71,6 @@ class ListSFTPTestsFixture {
     LogTestController::getInstance().setDebug<processors::LogAttribute>();
     LogTestController::getInstance().setDebug<SFTPTestServer>();
 
-    // Create temporary directories
-    src_dir = testController.createTempDirectory();
     REQUIRE_FALSE(src_dir.empty());
 
     // Start SFTP server
@@ -162,10 +160,10 @@ class ListSFTPTestsFixture {
   }
 
  protected:
-  std::string src_dir;
-  std::unique_ptr<SFTPTestServer> sftp_server;
   TestController testController;
+  std::string src_dir = testController.createTempDirectory();
   std::shared_ptr<TestPlan> plan;
+  std::unique_ptr<SFTPTestServer> sftp_server;
   std::shared_ptr<core::Processor> list_sftp;
   std::shared_ptr<core::Processor> log_attribute;
 };

--- a/extensions/sftp/tests/ListSFTPTests.cpp
+++ b/extensions/sftp/tests/ListSFTPTests.cpp
@@ -58,8 +58,7 @@
 
 class ListSFTPTestsFixture {
  public:
-  explicit ListSFTPTestsFixture(const std::shared_ptr<minifi::Configure>& configuration = nullptr)
-      : src_dir(strdup("/var/tmp/sftps.XXXXXX")) {
+  explicit ListSFTPTestsFixture(const std::shared_ptr<minifi::Configure>& configuration = nullptr) {
     LogTestController::getInstance().setTrace<TestPlan>();
     LogTestController::getInstance().setDebug<minifi::FlowController>();
     LogTestController::getInstance().setDebug<minifi::SchedulingAgent>();
@@ -73,8 +72,8 @@ class ListSFTPTestsFixture {
     LogTestController::getInstance().setDebug<SFTPTestServer>();
 
     // Create temporary directories
-    testController.createTempDirectory(src_dir);
-    REQUIRE(src_dir != nullptr);
+    src_dir = testController.createTempDirectory();
+    REQUIRE_FALSE(src_dir.empty());
 
     // Start SFTP server
     sftp_server = std::unique_ptr<SFTPTestServer>(new SFTPTestServer(src_dir));
@@ -85,13 +84,11 @@ class ListSFTPTestsFixture {
   }
 
   virtual ~ListSFTPTestsFixture() {
-    free(src_dir);
     LogTestController::getInstance().reset();
   }
 
   void createPlan(utils::Identifier* list_sftp_uuid = nullptr, const std::shared_ptr<minifi::Configure>& configuration = nullptr) {
-    char format[] = "/var/tmp/gt.XXXXXX";
-    const std::string state_dir = plan == nullptr ? minifi::utils::createTempDir(&testController, format) : plan->getStateDir();
+    const std::string state_dir = plan == nullptr ? testController.createTempDirectory() : plan->getStateDir();
 
     log_attribute.reset();
     list_sftp.reset();
@@ -165,7 +162,7 @@ class ListSFTPTestsFixture {
   }
 
  protected:
-  char *src_dir;
+  std::string src_dir;
   std::unique_ptr<SFTPTestServer> sftp_server;
   TestController testController;
   std::shared_ptr<TestPlan> plan;
@@ -221,7 +218,7 @@ TEST_CASE_METHOD(ListSFTPTestsFixture, "ListSFTP list non-readable dir", "[ListS
     return;
   }
   createFileWithModificationTimeDiff("nifi_test/tstFile.ext", "Test content 1");
-  REQUIRE(0 == chmod((std::string(src_dir) + "/vfs/nifi_test").c_str(), 0000));
+  REQUIRE(0 == chmod((src_dir + "/vfs/nifi_test").c_str(), 0000));
 
   testController.runSession(plan, true);
 
@@ -236,7 +233,7 @@ TEST_CASE_METHOD(ListSFTPTestsFixture, "ListSFTP list one file writes attributes
 
   testController.runSession(plan, true);
 
-  auto file = std::string(src_dir) + "/vfs/nifi_test/tstFile.ext";
+  auto file = src_dir + "/vfs/nifi_test/tstFile.ext";
   auto mtime = utils::file::FileUtils::last_write_time(file);
   std::string mtime_str;
   REQUIRE(true == utils::timeutils::getDateTimeStr(mtime, mtime_str));
@@ -367,8 +364,8 @@ TEST_CASE_METHOD(ListSFTPTestsFixture, "ListSFTP Path Filter Regex", "[ListSFTP]
 #ifndef WIN32
 TEST_CASE_METHOD(ListSFTPTestsFixture, "ListSFTP Follow symlink false file symlink", "[ListSFTP][follow-symlink]") {
   createFileWithModificationTimeDiff("nifi_test/file1.ext", "Test content 1");
-  auto file1 = std::string(src_dir) + "/vfs/nifi_test/file1.ext";
-  auto file2 = std::string(src_dir) + "/vfs/nifi_test/file2.ext";
+  auto file1 = src_dir + "/vfs/nifi_test/file1.ext";
+  auto file2 = src_dir + "/vfs/nifi_test/file2.ext";
   REQUIRE(0 == symlink(file1.c_str(), file2.c_str()));
 
   testController.runSession(plan, true);
@@ -383,8 +380,8 @@ TEST_CASE_METHOD(ListSFTPTestsFixture, "ListSFTP Follow symlink true file symlin
   plan->setProperty(list_sftp, "Follow symlink", "true");
 
   createFileWithModificationTimeDiff("nifi_test/file1.ext", "Test content 1");
-  auto file1 = std::string(src_dir) + "/vfs/nifi_test/file1.ext";
-  auto file2 = std::string(src_dir) + "/vfs/nifi_test/file2.ext";
+  auto file1 = src_dir + "/vfs/nifi_test/file1.ext";
+  auto file2 = src_dir + "/vfs/nifi_test/file2.ext";
   REQUIRE(0 == symlink(file1.c_str(), file2.c_str()));
 
   testController.runSession(plan, true);
@@ -399,8 +396,8 @@ TEST_CASE_METHOD(ListSFTPTestsFixture, "ListSFTP Follow symlink false directory 
   plan->setProperty(list_sftp, "Search Recursively", "true");
 
   createFileWithModificationTimeDiff("nifi_test/dir1/file1.ext", "Test content 1");
-  auto dir1 = std::string(src_dir) + "/vfs/nifi_test/dir1";
-  auto dir2 = std::string(src_dir) + "/vfs/nifi_test/dir2";
+  auto dir1 = src_dir + "/vfs/nifi_test/dir1";
+  auto dir2 = src_dir + "/vfs/nifi_test/dir2";
   REQUIRE(0 == symlink(dir1.c_str(), dir2.c_str()));
 
   testController.runSession(plan, true);
@@ -416,8 +413,8 @@ TEST_CASE_METHOD(ListSFTPTestsFixture, "ListSFTP Follow symlink true directory s
   plan->setProperty(list_sftp, "Follow symlink", "true");
 
   createFileWithModificationTimeDiff("nifi_test/dir1/file1.ext", "Test content 1");
-  auto dir1 = std::string(src_dir) + "/vfs/nifi_test/dir1";
-  auto dir2 = std::string(src_dir) + "/vfs/nifi_test/dir2";
+  auto dir1 = src_dir + "/vfs/nifi_test/dir1";
+  auto dir2 = src_dir + "/vfs/nifi_test/dir2";
   REQUIRE(0 == symlink(dir1.c_str(), dir2.c_str()));
 
   testController.runSession(plan, true);
@@ -495,7 +492,7 @@ TEST_CASE_METHOD(ListSFTPTestsFixture, "ListSFTP Tracking Timestamps one file an
 
   createFileWithModificationTimeDiff("nifi_test/file1.ext", "Test content 1");
 
-  auto file = std::string(src_dir) + "/vfs/nifi_test/file1.ext";
+  auto file = src_dir + "/vfs/nifi_test/file1.ext";
   auto mtime = utils::file::FileUtils::last_write_time(file);
 
   testController.runSession(plan, true);
@@ -523,7 +520,7 @@ TEST_CASE_METHOD(ListSFTPTestsFixture, "ListSFTP Tracking Timestamps one file ti
 
   createFileWithModificationTimeDiff("nifi_test/file1.ext", "Test content 1");
 
-  auto file = std::string(src_dir) + "/vfs/nifi_test/file1.ext";
+  auto file = src_dir + "/vfs/nifi_test/file1.ext";
   auto mtime = utils::file::FileUtils::last_write_time(file);
 
   testController.runSession(plan, true);
@@ -760,7 +757,7 @@ TEST_CASE_METHOD(ListSFTPTestsFixture, "ListSFTP Tracking Entities one file anot
 
   createFileWithModificationTimeDiff("nifi_test/file1.ext", "Test content 1");
 
-  auto file = std::string(src_dir) + "/vfs/nifi_test/file1.ext";
+  auto file = src_dir + "/vfs/nifi_test/file1.ext";
   auto mtime = utils::file::FileUtils::last_write_time(file);
 
   testController.runSession(plan, true);
@@ -786,7 +783,7 @@ TEST_CASE_METHOD(ListSFTPTestsFixture, "ListSFTP Tracking Entities one file time
 
   createFileWithModificationTimeDiff("nifi_test/file1.ext", "Test content 1");
 
-  auto file = std::string(src_dir) + "/vfs/nifi_test/file1.ext";
+  auto file = src_dir + "/vfs/nifi_test/file1.ext";
   auto mtime = utils::file::FileUtils::last_write_time(file);
 
   testController.runSession(plan, true);
@@ -819,7 +816,7 @@ TEST_CASE_METHOD(ListSFTPTestsFixture, "ListSFTP Tracking Entities one file size
 
   createFileWithModificationTimeDiff("nifi_test/file1.ext", "Test content 1");
 
-  auto file = std::string(src_dir) + "/vfs/nifi_test/file1.ext";
+  auto file = src_dir + "/vfs/nifi_test/file1.ext";
   auto mtime = utils::file::FileUtils::last_write_time(file);
 
   testController.runSession(plan, true);

--- a/extensions/sftp/tests/ListThenFetchSFTPTests.cpp
+++ b/extensions/sftp/tests/ListThenFetchSFTPTests.cpp
@@ -71,18 +71,15 @@ class ListThenFetchSFTPTestsFixture {
     LogTestController::getInstance().setDebug<processors::LogAttribute>();
     LogTestController::getInstance().setDebug<SFTPTestServer>();
 
-    // Create temporary directories
-    src_dir = testController.createTempDirectory();
     REQUIRE_FALSE(src_dir.empty());
-    dst_dir = testController.createTempDirectory();
     REQUIRE_FALSE(dst_dir.empty());
+    REQUIRE(plan);
 
     // Start SFTP server
     sftp_server = std::unique_ptr<SFTPTestServer>(new SFTPTestServer(src_dir));
     REQUIRE(true == sftp_server->start());
 
     // Build MiNiFi processing graph
-    plan = testController.createPlan();
     list_sftp = plan->addProcessor(
         "ListSFTP",
         "ListSFTP");
@@ -220,11 +217,11 @@ class ListThenFetchSFTPTestsFixture {
   }
 
  protected:
-  std::string src_dir;
-  std::string dst_dir;
-  std::unique_ptr<SFTPTestServer> sftp_server;
   TestController testController;
-  std::shared_ptr<TestPlan> plan;
+  std::string src_dir = testController.createTempDirectory();
+  std::string dst_dir = testController.createTempDirectory();
+  std::shared_ptr<TestPlan> plan = testController.createPlan();
+  std::unique_ptr<SFTPTestServer> sftp_server;
   std::shared_ptr<core::Processor> list_sftp;
   std::shared_ptr<core::Processor> fetch_sftp;
   std::shared_ptr<core::Processor> log_attribute;

--- a/extensions/sftp/tests/PutSFTPTests.cpp
+++ b/extensions/sftp/tests/PutSFTPTests.cpp
@@ -75,18 +75,15 @@ class PutSFTPTestsFixture {
     LogTestController::getInstance().setDebug<processors::LogAttribute>();
     LogTestController::getInstance().setDebug<SFTPTestServer>();
 
-    // Create temporary directories
-    src_dir = testController.createTempDirectory();
     REQUIRE_FALSE(src_dir.empty());
-    dst_dir = testController.createTempDirectory();
     REQUIRE_FALSE(dst_dir.empty());
+    REQUIRE(plan);
 
     // Start SFTP server
     sftp_server = std::unique_ptr<SFTPTestServer>(new SFTPTestServer(dst_dir));
     REQUIRE(true == sftp_server->start());
 
     // Build MiNiFi processing graph
-    plan = testController.createPlan();
     get_file = plan->addProcessor(
         "GetFile",
         "GetFile");
@@ -202,11 +199,11 @@ class PutSFTPTestsFixture {
   }
 
  protected:
-  std::string src_dir;
-  std::string dst_dir;
-  std::unique_ptr<SFTPTestServer> sftp_server;
   TestController testController;
-  std::shared_ptr<TestPlan> plan;
+  std::string src_dir = testController.createTempDirectory();
+  std::string dst_dir = testController.createTempDirectory();
+  std::shared_ptr<TestPlan> plan = testController.createPlan();
+  std::unique_ptr<SFTPTestServer> sftp_server;
   std::shared_ptr<core::Processor> get_file;
   std::shared_ptr<core::Processor> put;
 };

--- a/extensions/standard-processors/tests/integration/SecureSocketGetTCPTest.cpp
+++ b/extensions/standard-processors/tests/integration/SecureSocketGetTCPTest.cpp
@@ -55,8 +55,7 @@ class SecureSocketTest : public IntegrationBase {
  public:
   explicit SecureSocketTest(bool isSecure)
       : isSecure{ isSecure }, isRunning_{ false } {
-    char format[] = "/tmp/ssth.XXXXXX";
-    dir = testController.createTempDirectory(format);
+    dir = testController.createTempDirectory();
   }
 
   void testSetup() override {

--- a/extensions/standard-processors/tests/integration/TailFileTest.cpp
+++ b/extensions/standard-processors/tests/integration/TailFileTest.cpp
@@ -35,8 +35,7 @@
 class TailFileTestHarness : public IntegrationBase {
  public:
   TailFileTestHarness() : IntegrationBase(1000) {
-    char format[] = "/tmp/ssth.XXXXXX";
-    dir = testController.createTempDirectory(format);
+    dir = testController.createTempDirectory();
 
     statefile = dir + utils::file::FileUtils::get_separator();
     statefile += "statefile";

--- a/extensions/standard-processors/tests/unit/ExtractTextTests.cpp
+++ b/extensions/standard-processors/tests/unit/ExtractTextTests.cpp
@@ -64,9 +64,7 @@ TEST_CASE("Test usage of ExtractText", "[extracttextTest]") {
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<TestRepository> repo = std::make_shared<TestRepository>();
 
-  char dirtemplate[] = "/tmp/gt.XXXXXX";
-
-  auto temp_dir = testController.createTempDirectory(dirtemplate);
+  auto temp_dir = testController.createTempDirectory();
   REQUIRE(!temp_dir.empty());
   std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory.getName(), temp_dir);
@@ -134,9 +132,7 @@ TEST_CASE("Test usage of ExtractText in regex mode", "[extracttextRegexTest]") {
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<TestRepository> repo = std::make_shared<TestRepository>();
 
-  char dirtemplate[] = "/tmp/gt.XXXXXX";
-
-  auto dir = testController.createTempDirectory(dirtemplate);
+  auto dir = testController.createTempDirectory();
   REQUIRE(!dir.empty());
   std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory.getName(), dir);

--- a/extensions/standard-processors/tests/unit/GenerateFlowFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/GenerateFlowFileTests.cpp
@@ -32,8 +32,7 @@ TEST_CASE("GenerateFlowFileTest", "[generateflowfiletest]") {
   LogTestController::getInstance().setTrace<TestPlan>();
   LogTestController::getInstance().setWarn<minifi::processors::GenerateFlowFile>();
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
 
@@ -78,8 +77,7 @@ TEST_CASE("GenerateFlowFileWithNonUniqueBinaryData", "[generateflowfiletest]") {
   LogTestController::getInstance().setTrace<TestPlan>();
   LogTestController::getInstance().setWarn<minifi::processors::GenerateFlowFile>();
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
 
@@ -131,8 +129,7 @@ TEST_CASE("GenerateFlowFileTestEmpty", "[generateemptyfiletest]") {
   TestController testController;
   LogTestController::getInstance().setTrace<TestPlan>();
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
 
@@ -169,8 +166,7 @@ TEST_CASE("GenerateFlowFileCustomTextTest", "[generateflowfiletest]") {
   TestController test_controller;
   LogTestController::getInstance().setTrace<TestPlan>();
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = test_controller.createTempDirectory(format);
+  auto dir = test_controller.createTempDirectory();
 
   std::shared_ptr<TestPlan> plan = test_controller.createPlan();
 
@@ -207,8 +203,7 @@ TEST_CASE("GenerateFlowFileCustomTextEmptyTest", "[generateflowfiletest]") {
   TestController test_controller;
   LogTestController::getInstance().setTrace<TestPlan>();
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = test_controller.createTempDirectory(format);
+  auto dir = test_controller.createTempDirectory();
 
   std::shared_ptr<TestPlan> plan = test_controller.createPlan();
 

--- a/extensions/standard-processors/tests/unit/GetFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/GetFileTests.cpp
@@ -53,7 +53,7 @@ GetFileTestController::GetFileTestController() {
   test_plan_ = test_controller_.createPlan();
   auto repo = std::make_shared<TestRepository>();
 
-  auto temp_dir = utils::createTempDir(&test_controller_);
+  auto temp_dir = test_controller_.createTempDirectory();
   REQUIRE(!temp_dir.empty());
 
   // Define test input file
@@ -149,7 +149,7 @@ TEST_CASE("GetFileHiddenPropertyCheck", "[getFileProperty]") {
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
   auto plan = testController.createPlan();
 
-  auto temp_path = minifi::utils::createTempDir(&testController);
+  auto temp_path = testController.createTempDirectory();
   std::string in_file(temp_path + utils::file::FileUtils::get_separator() + "testfifo");
   std::string hidden_in_file(temp_path + utils::file::FileUtils::get_separator() + ".testfifo");
 

--- a/extensions/standard-processors/tests/unit/HashContentTest.cpp
+++ b/extensions/standard-processors/tests/unit/HashContentTest.cpp
@@ -68,9 +68,7 @@ TEST_CASE("Test usage of ExtractText", "[extracttextTest]") {
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<TestRepository> repo = std::make_shared<TestRepository>();
 
-  char dir[] = "/tmp/gt.XXXXXX";
-
-  auto tempdir = testController.createTempDirectory(dir);
+  auto tempdir = testController.createTempDirectory();
   REQUIRE(!tempdir.empty());
 
   std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
@@ -140,7 +138,7 @@ TEST_CASE("TestingFailOnEmptyProperty", "[HashContentPropertiesCheck]") {
   LogTestController::getInstance().setTrace<org::apache::nifi::minifi::processors::HashContent>();
   std::shared_ptr<TestPlan> plan = testController.createPlan();
 
-  auto tempdir = minifi::utils::createTempDir(&testController);
+  auto tempdir = testController.createTempDirectory();
   std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory.getName(), tempdir);
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::KeepSourceFile.getName(), "true");

--- a/extensions/standard-processors/tests/unit/ProcessorTests.cpp
+++ b/extensions/standard-processors/tests/unit/ProcessorTests.cpp
@@ -64,8 +64,7 @@ TEST_CASE("Test GetFileMultiple", "[getfileCreate3]") {
   std::shared_ptr<core::Repository> test_repo = std::make_shared<TestRepository>();
   std::shared_ptr<TestRepository> repo = std::static_pointer_cast<TestRepository>(test_repo);
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   utils::Identifier processoruuid = processor->getUUID();
   REQUIRE(processoruuid);
@@ -149,8 +148,7 @@ TEST_CASE("Test GetFile Ignore", "[getfileCreate3]") {
   std::shared_ptr<core::Repository> test_repo = std::make_shared<TestRepository>();
   std::shared_ptr<TestRepository> repo = std::static_pointer_cast<TestRepository>(test_repo);
 
-  char format[] = "/tmp/gt.XXXXXX";
-  const auto dir = testController.createTempDirectory(format);
+  const auto dir = testController.createTempDirectory();
 
   utils::Identifier processoruuid = processor->getUUID();
   REQUIRE(processoruuid);
@@ -295,8 +293,7 @@ TEST_CASE("LogAttributeTest", "[getfileCreate3]") {
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory.getName(), dir);
   testController.runSession(plan, false);
@@ -339,8 +336,7 @@ TEST_CASE("LogAttributeTestInvalid", "[TestLogAttribute]") {
 
   auto loggattr = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory.getName(), dir);
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::BatchSize.getName(), "1");
@@ -358,8 +354,7 @@ void testMultiplesLogAttribute(int fileCount, int flowsToLog, std::string verify
 
   auto loggattr = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   auto flowsToLogStr = std::to_string(flowsToLog);
   if (verifyStringFlowsLogged.empty())
@@ -426,9 +421,8 @@ TEST_CASE("Test Find file", "[getfileCreate3]") {
   std::shared_ptr<core::Processor> processorReport = std::make_shared<org::apache::nifi::minifi::core::reporting::SiteToSiteProvenanceReportingTask>(
       minifi::io::StreamFactory::getInstance(std::make_shared<org::apache::nifi::minifi::Configure>()), std::make_shared<org::apache::nifi::minifi::Configure>());
   plan->addProcessor(processorReport, "reporter", core::Relationship("success", "description"), false);
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
 
+  auto dir = testController.createTempDirectory();
   plan->setProperty(processor, org::apache::nifi::minifi::processors::GetFile::Directory.getName(), dir);
   testController.runSession(plan, false);
   auto records = plan->getProvenanceRecords();

--- a/extensions/standard-processors/tests/unit/PutFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/PutFileTests.cpp
@@ -65,10 +65,8 @@ TEST_CASE("PutFileTest", "[getfileputpfile]") {
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
-  char format2[] = "/tmp/ft.XXXXXX";
-  auto putfiledir = testController.createTempDirectory(format2);
+  const auto dir = testController.createTempDirectory();
+  const auto putfiledir = testController.createTempDirectory();
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory.getName(), dir);
   plan->setProperty(putfile, org::apache::nifi::minifi::processors::PutFile::Directory.getName(), putfiledir);
 
@@ -130,10 +128,8 @@ TEST_CASE("PutFileTestFileExists", "[getfileputpfile]") {
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("failure", "description"), true);
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
-  char format2[] = "/tmp/ft.XXXXXX";
-  auto putfiledir = testController.createTempDirectory(format2);
+  const auto dir = testController.createTempDirectory();
+  const auto putfiledir = testController.createTempDirectory();
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory.getName(), dir);
   plan->setProperty(putfile, org::apache::nifi::minifi::processors::PutFile::Directory.getName(), putfiledir);
 
@@ -195,10 +191,8 @@ TEST_CASE("PutFileTestFileExistsIgnore", "[getfileputpfile]") {
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
-  char format2[] = "/tmp/ft.XXXXXX";
-  auto putfiledir = testController.createTempDirectory(format2);
+  const auto dir = testController.createTempDirectory();
+  const auto putfiledir = testController.createTempDirectory();
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory.getName(), dir);
   plan->setProperty(putfile, org::apache::nifi::minifi::processors::PutFile::Directory.getName(), putfiledir);
   plan->setProperty(putfile, org::apache::nifi::minifi::processors::PutFile::ConflictResolution.getName(), "ignore");
@@ -263,10 +257,8 @@ TEST_CASE("PutFileTestFileExistsReplace", "[getfileputpfile]") {
 
   plan->addProcessor("LogAttribute", "logattribute", { core::Relationship("success", "d"), core::Relationship("failure", "d") }, true);
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
-  char format2[] = "/tmp/ft.XXXXXX";
-  auto putfiledir = testController.createTempDirectory(format2);
+  const auto dir = testController.createTempDirectory();
+  const auto putfiledir = testController.createTempDirectory();
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory.getName(), dir);
   plan->setProperty(putfile, org::apache::nifi::minifi::processors::PutFile::Directory.getName(), putfiledir);
   plan->setProperty(putfile, org::apache::nifi::minifi::processors::PutFile::ConflictResolution.getName(), "replace");
@@ -342,10 +334,8 @@ TEST_CASE("PutFileMaxFileCountTest", "[getfileputpfilemaxcount]") {
 
   plan->addProcessor("LogAttribute", "logattribute", { core::Relationship("success", "d"), core::Relationship("failure", "d") }, true);
 
-  char format[] = "/tmp/gt.XXXXXX";
-  const auto dir = testController.createTempDirectory(format);
-  char format2[] = "/tmp/ft.XXXXXX";
-  auto putfiledir = testController.createTempDirectory(format2);
+  const auto dir = testController.createTempDirectory();
+  const auto putfiledir = testController.createTempDirectory();
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory.getName(), dir);
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::BatchSize.getName(), "1");
   plan->setProperty(putfile, org::apache::nifi::minifi::processors::PutFile::Directory.getName(), putfiledir);
@@ -409,10 +399,8 @@ TEST_CASE("PutFileEmptyTest", "[EmptyFilePutTest]") {
 
   std::shared_ptr<core::Processor> putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
-  char format2[] = "/tmp/ft.XXXXXX";
-  auto putfiledir = testController.createTempDirectory(format2);
+  const auto dir = testController.createTempDirectory();
+  const auto putfiledir = testController.createTempDirectory();
 
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory.getName(), dir);
   plan->setProperty(putfile, org::apache::nifi::minifi::processors::PutFile::Directory.getName(), putfiledir);
@@ -444,10 +432,8 @@ TEST_CASE("TestPutFilePermissions", "[PutFilePermissions]") {
 
   std::shared_ptr<core::Processor> putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
-  char format2[] = "/tmp/ft.XXXXXX";
-  auto putfiledir = testController.createTempDirectory(format2) + utils::file::FileUtils::get_separator() + "test_dir";
+  const auto dir = testController.createTempDirectory();
+  const auto putfiledir = testController.createTempDirectory() + utils::file::FileUtils::get_separator() + "test_dir";
 
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory.getName(), dir);
   plan->setProperty(putfile, org::apache::nifi::minifi::processors::PutFile::Directory.getName(), putfiledir);
@@ -484,9 +470,9 @@ TEST_CASE("PutFileCreateDirectoryTest", "[PutFileProperties]") {
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
   // Define Directory
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
   // Defining a sub directory
-  auto putfiledir = minifi::utils::createTempDir(&testController) + utils::file::FileUtils::get_separator() + "test_dir";
+  auto putfiledir = testController.createTempDirectory() + utils::file::FileUtils::get_separator() + "test_dir";
 
   plan->setProperty(putfile, org::apache::nifi::minifi::processors::PutFile::Directory.getName(), putfiledir);
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory.getName(), dir);

--- a/extensions/standard-processors/tests/unit/RetryFlowFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/RetryFlowFileTests.cpp
@@ -85,8 +85,6 @@ class RetryFlowFileTest {
       optional<bool> processor_uuid_matches_flowfile) {
     reInitialize();
 
-    const std::string output_dir = testController_->createTempDirectory();
-
     // Relationships
     const core::Relationship success         {"success", "description"};
     const core::Relationship retry           {RetryFlowFile::Retry};

--- a/extensions/standard-processors/tests/unit/RetryFlowFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/RetryFlowFileTests.cpp
@@ -35,7 +35,6 @@
 #include "utils/TestUtils.h"
 
 namespace {
-using org::apache::nifi::minifi::utils::createTempDir;
 using org::apache::nifi::minifi::utils::optional;
 namespace FileUtils = org::apache::nifi::minifi::utils::file;
 
@@ -86,7 +85,7 @@ class RetryFlowFileTest {
       optional<bool> processor_uuid_matches_flowfile) {
     reInitialize();
 
-    const std::string output_dir = createTempDir(testController_.get());
+    const std::string output_dir = testController_->createTempDirectory();
 
     // Relationships
     const core::Relationship success         {"success", "description"};
@@ -140,9 +139,9 @@ class RetryFlowFileTest {
     plan_->setProperty(retryflowfile, "retries_exceeded_property_key_1", "retries_exceeded_property_value_1", true);
     plan_->setProperty(retryflowfile, "retries_exceeded_property_key_2", "retries_exceeded_property_value_2", true);
 
-    const std::string retry_dir            = createTempDir(testController_.get());
-    const std::string retries_exceeded_dir = createTempDir(testController_.get());
-    const std::string failure_dir          = createTempDir(testController_.get());
+    const std::string retry_dir            = testController_->createTempDirectory();
+    const std::string retries_exceeded_dir = testController_->createTempDirectory();
+    const std::string failure_dir          = testController_->createTempDirectory();
 
     plan_->setProperty(putfile_on_retry, PutFile::Directory.getName(), retry_dir);
     plan_->setProperty(putfile_on_retries_exceeded, PutFile::Directory.getName(), retries_exceeded_dir);

--- a/extensions/standard-processors/tests/unit/TailFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/TailFileTests.cpp
@@ -89,7 +89,7 @@ TEST_CASE("TailFile reads the file until the first delimiter", "[simple]") {
   std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
 
@@ -129,7 +129,7 @@ TEST_CASE("TailFile picks up the second line if a delimiter is written between r
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
 
@@ -172,7 +172,7 @@ TEST_CASE("TailFile re-reads the file if the state is deleted between runs", "[s
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
 
@@ -212,7 +212,7 @@ TEST_CASE("TailFile picks up the state correctly if it is rewritten between runs
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
 
@@ -280,7 +280,7 @@ TEST_CASE("TailFile converts the old-style state file to the new-style state", "
   auto logattribute = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
   plan->setProperty(logattribute, org::apache::nifi::minifi::processors::LogAttribute::FlowFilesToLog.getName(), "0");
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
   std::stringstream state_file;
   state_file << dir << utils::file::FileUtils::get_separator() << STATE_FILE;
 
@@ -389,7 +389,7 @@ TEST_CASE("TailFile picks up the new File to Tail if it is changed between runs"
   std::shared_ptr<core::Processor> log_attribute = plan->addProcessor("LogAttribute", "log_attribute", core::Relationship("success", "description"), true);
   plan->setProperty(log_attribute, org::apache::nifi::minifi::processors::LogAttribute::FlowFilesToLog.getName(), "0");
 
-  std::string directory = minifi::utils::createTempDir(&testController);
+  std::string directory = testController.createTempDirectory();
   std::string first_test_file = createTempFile(directory, "first.log", "my first log line\n");
   plan->setProperty(tail_file, org::apache::nifi::minifi::processors::TailFile::FileName.getName(), first_test_file);
   testController.runSession(plan, true);
@@ -422,7 +422,7 @@ TEST_CASE("TailFile picks up the new File to Tail if it is changed between runs 
   LogTestController::getInstance().setDebug<minifi::processors::TailFile>();
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
-  std::string directory = minifi::utils::createTempDir(&testController);
+  std::string directory = testController.createTempDirectory();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<core::Processor> tail_file = plan->addProcessor("TailFile", "tail_file");
@@ -478,7 +478,7 @@ TEST_CASE("TailFile finds the single input file in both Single and Multiple mode
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
   std::ofstream tmpfile;
@@ -515,7 +515,7 @@ TEST_CASE("TailFile picks up new files created between runs", "[multiple_file]")
   LogTestController::getInstance().setDebug<core::ProcessSession>();
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfile");
@@ -550,7 +550,7 @@ TEST_CASE("TailFile can handle input files getting removed", "[multiple_file]") 
   LogTestController::getInstance().setDebug<core::ProcessSession>();
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfile");
@@ -605,7 +605,7 @@ TEST_CASE("TailFile processes a very long line correctly", "[simple]") {
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
   std::ofstream tmpfile;
@@ -681,7 +681,7 @@ TEST_CASE("TailFile processes a long line followed by multiple newlines correctl
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
   std::stringstream temp_file;
   temp_file << dir << utils::file::FileUtils::get_separator() << TMP_FILE;
   std::ofstream tmpfile;
@@ -774,7 +774,7 @@ TEST_CASE("TailFile onSchedule throws in Multiple mode if the Base Directory doe
   }
 
   SECTION("Base Directory is set and it exists") {
-    std::string directory = minifi::utils::createTempDir(&testController);
+    std::string directory = testController.createTempDirectory();
 
     plan->setProperty(tailfile, processors::TailFile::BaseDirectory.getName(), directory);
     plan->setProperty(tailfile, processors::TailFile::LookupFrequency.getName(), "0 sec");
@@ -793,7 +793,7 @@ TEST_CASE("TailFile finds and finishes the renamed file and continues with the n
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
   auto plan = testController.createPlan();
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
   std::string in_file = dir + utils::file::FileUtils::get_separator() + "testfifo.txt";
 
   std::ofstream in_file_stream(in_file, std::ios::out | std::ios::binary);
@@ -859,7 +859,7 @@ TEST_CASE("TailFile finds and finishes multiple rotated files and continues with
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
   auto plan = testController.createPlan();
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
   std::string test_file = dir + utils::file::FileUtils::get_separator() + "fruits.log";
 
   std::ofstream test_file_stream_0(test_file, std::ios::binary);
@@ -916,7 +916,7 @@ TEST_CASE("TailFile ignores old rotated files", "[rotation]") {
   LogTestController::getInstance().setDebug<core::ProcessSession>();
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
-  const std::string dir = minifi::utils::createTempDir(&testController);
+  const std::string dir = testController.createTempDirectory();
   std::string log_file_name = dir + utils::file::FileUtils::get_separator() + "test.log";
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
@@ -961,7 +961,7 @@ TEST_CASE("TailFile rotation works with multiple input files", "[rotation][multi
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
   auto plan = testController.createPlan();
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
 
   createTempFile(dir, "fruit.log", "apple\npear\nbanana\n");
   createTempFile(dir, "animal.log", "bear\ngiraffe\n");
@@ -1025,7 +1025,7 @@ TEST_CASE("TailFile handles the Rolling Filename Pattern property correctly", "[
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
   auto plan = testController.createPlan();
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
   std::string test_file = createTempFile(dir, "test.log", "some stuff\n");
 
   // Build MiNiFi processing graph
@@ -1087,16 +1087,13 @@ TEST_CASE("TailFile finds and finishes the renamed file and continues with the n
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-
-  char log_dir_format[] = "/var/tmp/gt.XXXXXX";
-  auto log_dir = minifi::utils::createTempDir(&testController, log_dir_format);
+  auto log_dir = testController.createTempDirectory();
 
   std::string test_file_1 = createTempFile(log_dir, "test.1", "line one\nline two\nline three\n");  // old rotated file
   std::this_thread::sleep_for(std::chrono::seconds(1));
   std::string test_file = createTempFile(log_dir, "test.log", "line four\nline five\nline six\n");  // current log file
 
-  char state_dir_format[] = "/var/tmp/gt.XXXXXX";
-  auto state_dir = minifi::utils::createTempDir(&testController, state_dir_format);
+  auto state_dir = testController.createTempDirectory();
 
   utils::Identifier tail_file_uuid = utils::IdGenerator::getIdGenerator()->generate();
   const core::Relationship success_relationship{"success", "everything is fine"};
@@ -1146,7 +1143,7 @@ TEST_CASE("TailFile yields if no work is done", "[yield]") {
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  auto temp_directory = minifi::utils::createTempDir(&testController);
+  auto temp_directory = testController.createTempDirectory();
   auto plan = testController.createPlan();
   auto tail_file = plan->addProcessor("TailFile", "Tail");
   plan->setProperty(tail_file, processors::TailFile::Delimiter.getName(), "\n");
@@ -1219,7 +1216,7 @@ TEST_CASE("TailFile yields if no work is done on any files", "[yield][multiple_f
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  auto temp_directory = minifi::utils::createTempDir(&testController);
+  auto temp_directory = testController.createTempDirectory();
   auto plan = testController.createPlan();
   auto tail_file = plan->addProcessor("TailFile", "Tail");
   plan->setProperty(tail_file, processors::TailFile::Delimiter.getName(), "\n");
@@ -1276,7 +1273,7 @@ TEST_CASE("TailFile doesn't yield if work was done on rotated files only", "[yie
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  auto temp_directory = minifi::utils::createTempDir(&testController);
+  auto temp_directory = testController.createTempDirectory();
   std::string full_file_name = createTempFile(temp_directory, "test.log", "stuff\n");
 
   auto plan = testController.createPlan();
@@ -1335,7 +1332,7 @@ TEST_CASE("TailFile handles the Delimiter setting correctly", "[delimiter]") {
     LogTestController::getInstance().setTrace<processors::TailFile>();
     LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-    auto temp_directory = minifi::utils::createTempDir(&testController);
+    auto temp_directory = testController.createTempDirectory();
 
     std::string delimiter = test_case.second;
     std::string full_file_name = createTempFile(temp_directory, "test.log", "one" + delimiter + "two" + delimiter);
@@ -1369,7 +1366,7 @@ TEST_CASE("TailFile handles Unix/Windows line endings correctly", "[simple]") {
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  auto temp_directory = minifi::utils::createTempDir(&testController);
+  auto temp_directory = testController.createTempDirectory();
   std::string full_file_name = createTempFile(temp_directory, "test.log", "line1\nline two\n", std::ios::out);  // write in text mode
 
   auto plan = testController.createPlan();
@@ -1399,7 +1396,7 @@ TEST_CASE("TailFile can tail all files in a directory recursively", "[multiple]"
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  std::string base_directory = minifi::utils::createTempDir(&testController);
+  std::string base_directory = testController.createTempDirectory();
   std::string directory1 = base_directory + utils::file::FileUtils::get_separator() + "one";
   utils::file::FileUtils::create_dir(directory1);
   std::string directory11 = directory1 + utils::file::FileUtils::get_separator() + "one_child";
@@ -1450,7 +1447,7 @@ TEST_CASE("TailFile interprets the lookup frequency property correctly", "[multi
   LogTestController::getInstance().setTrace<processors::TailFile>();
   LogTestController::getInstance().setTrace<processors::LogAttribute>();
 
-  std::string directory = minifi::utils::createTempDir(&testController);
+  std::string directory = testController.createTempDirectory();
   createTempFile(directory, "test.red.log", "cherry\n");
 
   auto plan = testController.createPlan();
@@ -1525,7 +1522,7 @@ TEST_CASE("TailFile reads from a single file when Initial Start Position is set"
   std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
   std::shared_ptr<core::Processor> logattribute = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
   createTempFile(dir, ROLLED_OVER_TMP_FILE, ROLLED_OVER_TAIL_DATA);
   auto temp_file_path = createTempFile(dir, TMP_FILE, NEWLINE_FILE);
 
@@ -1602,7 +1599,7 @@ TEST_CASE("TailFile reads from a single file when Initial Start Position is set 
   std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
   std::shared_ptr<core::Processor> logattribute = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
   auto temp_file_path = createTempFile(dir, TMP_FILE, NEWLINE_FILE);
 
   plan->setProperty(logattribute, org::apache::nifi::minifi::processors::LogAttribute::FlowFilesToLog.getName(), "0");
@@ -1641,7 +1638,7 @@ TEST_CASE("TailFile reads multiple files when Initial Start Position is set", "[
   std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
   std::shared_ptr<core::Processor> logattribute = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
   createTempFile(dir, ROLLED_OVER_TMP_FILE, ROLLED_OVER_TAIL_DATA);
   createTempFile(dir, TMP_FILE, NEWLINE_FILE);
   const std::string TMP_FILE_2_DATA = "tmp_file_2_new_line_data\n";
@@ -1730,7 +1727,7 @@ TEST_CASE("Initial Start Position is set to invalid or empty value", "[initialSt
   std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
   std::shared_ptr<core::Processor> logattribute = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  auto dir = minifi::utils::createTempDir(&testController);
+  auto dir = testController.createTempDirectory();
   createTempFile(dir, ROLLED_OVER_TMP_FILE, ROLLED_OVER_TAIL_DATA);
   auto temp_file_path = createTempFile(dir, TMP_FILE, NEWLINE_FILE);
 

--- a/extensions/windows-event-log/tests/CWELTestUtils.h
+++ b/extensions/windows-event-log/tests/CWELTestUtils.h
@@ -56,7 +56,7 @@ class OutputFormatTestController : public TestController {
       test_plan->setProperty(cwel_processor, ConsumeWindowsEventLog::JSONFormat.getName(), json_format_.value());
     }
 
-    auto dir = utils::createTempDir(this);
+    auto dir = createTempDirectory();
 
     auto put_file = test_plan->addProcessor("PutFile", "putFile", Success, true);
     test_plan->setProperty(put_file, PutFile::Directory.getName(), dir);

--- a/libminifi/include/utils/TestUtils.h
+++ b/libminifi/include/utils/TestUtils.h
@@ -33,19 +33,6 @@ namespace nifi {
 namespace minifi {
 namespace utils {
 
-std::string createTempDir(TestController* testController, char* format = nullptr) {
-  std::string temp_dir;
-  if (format == nullptr) {
-    char dirtemplate[] = "/tmp/gt.XXXXXX";
-    temp_dir = testController->createTempDirectory(dirtemplate);
-  } else {
-    temp_dir = testController->createTempDirectory(format);
-  }
-  REQUIRE(!temp_dir.empty());
-  REQUIRE(file::FileUtils::is_directory(temp_dir.c_str()));
-  return temp_dir;
-}
-
 std::string putFileToDir(const std::string& dir_path, const std::string& file_name, const std::string& content) {
   std::string file_path(file::FileUtils::concat_path(dir_path, file_name));
   std::ofstream out_file(file_path, std::ios::binary | std::ios::out);
@@ -53,12 +40,6 @@ std::string putFileToDir(const std::string& dir_path, const std::string& file_na
     out_file << content;
   }
   return file_path;
-}
-
-std::string createTempDirWithFile(TestController* testController, const std::string& file_name, const std::string& content) {
-  std::string temp_dir = createTempDir(testController);
-  putFileToDir(temp_dir, file_name, content);
-  return temp_dir;
 }
 
 std::string getFileContent(const std::string& file_name) {

--- a/libminifi/test/TestBase.h
+++ b/libminifi/test/TestBase.h
@@ -436,20 +436,11 @@ class TestController {
     }
   }
 
-  /**
-   * format will be changed by mkdtemp, so don't rely on a shared variable.
-   */
-  std::string createTempDirectory(char *format) {
+  std::string createTempDirectory() {
+    char format[] = "/var/tmp/nifi-minifi-cpp.test.XXXXXX";
     const auto dir = utils::file::FileUtils::create_temp_directory(format);
     directories.push_back(dir);
     return dir;
-  }
-
-  template<size_t N>
-  utils::Path createTempDirectory(const char (&format)[N]) {
-    char buffer[N];
-    std::memcpy(buffer, format, N);
-    return utils::Path{createTempDirectory(static_cast<char*>(buffer))};
   }
 
  protected:

--- a/libminifi/test/archive-tests/CompressContentTests.cpp
+++ b/libminifi/test/archive-tests/CompressContentTests.cpp
@@ -206,8 +206,7 @@ class CompressTestController : public CompressDecompressionTestController {
 
  public:
   CompressTestController() {
-    char CompressionFormat[] = "/tmp/test.XXXXXX";
-    tempDir_ = get_global_controller().createTempDirectory(CompressionFormat);
+    tempDir_ = get_global_controller().createTempDirectory();
     REQUIRE(!tempDir_.empty());
     raw_content_path_ = utils::file::FileUtils::concat_path(tempDir_, "minifi-expect-compresscontent.txt");
     compressed_content_path_ = utils::file::FileUtils::concat_path(tempDir_, "minifi-compresscontent");
@@ -559,12 +558,10 @@ TEST_CASE_METHOD(TestController, "RawGzipCompressionDecompression", "[compressfi
   LogTestController::getInstance().setTrace<processors::PutFile>();
 
   // Create temporary directories
-  char format_src[] = "/tmp/archives.XXXXXX";
-  std::string src_dir = createTempDirectory(format_src);
+  std::string src_dir = createTempDirectory();
   REQUIRE(!src_dir.empty());
 
-  char format_dst[] = "/tmp/archived.XXXXXX";
-  std::string dst_dir = createTempDirectory(format_dst);
+  std::string dst_dir = createTempDirectory();
   REQUIRE(!dst_dir.empty());
 
   // Define files

--- a/libminifi/test/archive-tests/FocusArchiveTests.cpp
+++ b/libminifi/test/archive-tests/FocusArchiveTests.cpp
@@ -72,9 +72,9 @@ TEST_CASE("FocusArchive", "[testFocusArchive]") {
     std::shared_ptr<TestPlan> plan = testController.createPlan();
     std::shared_ptr<TestRepository> repo = std::make_shared<TestRepository>();
 
-    std::string dir1 = [&] {char format[] = "/tmp/gt.XXXXXX"; return testController.createTempDirectory(format); }();
-    std::string dir2 = [&] {char format[] = "/tmp/gt.XXXXXX"; return testController.createTempDirectory(format); }();
-    std::string dir3 = [&] {char format[] = "/tmp/gt.XXXXXX"; return testController.createTempDirectory(format); }();
+    std::string dir1 = testController.createTempDirectory();
+    std::string dir2 = testController.createTempDirectory();
+    std::string dir3 = testController.createTempDirectory();
 
     REQUIRE(!dir1.empty());
     REQUIRE(!dir2.empty());

--- a/libminifi/test/archive-tests/ManipulateArchiveTests.cpp
+++ b/libminifi/test/archive-tests/ManipulateArchiveTests.cpp
@@ -59,8 +59,8 @@ bool run_archive_test(OrderedTestArchive input_archive, OrderedTestArchive outpu
     std::shared_ptr<TestPlan> plan = testController.createPlan();
     std::shared_ptr<TestRepository> repo = std::make_shared<TestRepository>();
 
-    std::string dir1 = [&] {char format[] = "/tmp/gt.XXXXXX"; return testController.createTempDirectory(format); }();
-    std::string dir2 = [&] {char format[] = "/tmp/gt.XXXXXX"; return testController.createTempDirectory(format); }();
+    std::string dir1 = testController.createTempDirectory();
+    std::string dir2 = testController.createTempDirectory();
 
     REQUIRE(!dir1.empty());
     REQUIRE(!dir2.empty());

--- a/libminifi/test/archive-tests/MergeFileTests.cpp
+++ b/libminifi/test/archive-tests/MergeFileTests.cpp
@@ -52,8 +52,7 @@ void init_file_paths() {
   struct Initializer {
     Initializer() {
       static TestController global_controller;
-      char format[] = "/tmp/test.XXXXXX";
-      std::string tempDir = global_controller.createTempDirectory(format);
+      std::string tempDir = global_controller.createTempDirectory();
       FLOW_FILE = utils::file::FileUtils::concat_path(tempDir, "minifi-mergecontent");
       EXPECT_MERGE_CONTENT_FIRST = utils::file::FileUtils::concat_path(tempDir, "minifi-expect-mergecontent1.txt");
       EXPECT_MERGE_CONTENT_SECOND = utils::file::FileUtils::concat_path(tempDir, "minifi-expect-mergecontent2.txt");

--- a/libminifi/test/aws-tests/FetchS3ObjectTests.cpp
+++ b/libminifi/test/aws-tests/FetchS3ObjectTests.cpp
@@ -37,7 +37,7 @@ class FetchS3ObjectTestsFixture : public FlowProcessorS3TestsFixture<minifi::aws
       "PutFile",
       core::Relationship("success", "d"),
       true);
-    output_dir = createTempDir(&test_controller);
+    output_dir = test_controller.createTempDirectory();
     plan->setProperty(putfile, "Directory", output_dir);
   }
 

--- a/libminifi/test/aws-tests/S3TestsFixture.h
+++ b/libminifi/test/aws-tests/S3TestsFixture.h
@@ -34,8 +34,6 @@
 #include "utils/TestUtils.h"
 #include "AWSCredentialsProvider.h"
 
-using org::apache::nifi::minifi::utils::createTempDir;
-
 template<typename T>
 class S3TestsFixture {
  public:
@@ -73,7 +71,7 @@ class S3TestsFixture {
 
   template<typename Component>
   void setCredentialFile(const Component &component) {
-    auto temp_path = createTempDir(&test_controller);
+    auto temp_path = test_controller.createTempDirectory();
     REQUIRE(!temp_path.empty());
     std::string aws_credentials_file(temp_path + utils::file::FileUtils::get_separator() + "aws_creds.conf");
     std::ofstream aws_credentials_file_stream(aws_credentials_file);
@@ -138,7 +136,7 @@ class FlowProcessorS3TestsFixture : public S3TestsFixture<T> {
     LogTestController::getInstance().setTrace<processors::GetFile>();
     LogTestController::getInstance().setDebug<processors::UpdateAttribute>();
 
-    auto input_dir = createTempDir(&this->test_controller);
+    auto input_dir = this->test_controller.createTempDirectory();
     std::ofstream input_file_stream(input_dir + utils::file::FileUtils::get_separator() + INPUT_FILENAME);
     input_file_stream << INPUT_DATA;
     input_file_stream.close();

--- a/libminifi/test/azure-tests/PutAzureBlobStorageTests.cpp
+++ b/libminifi/test/azure-tests/PutAzureBlobStorageTests.cpp
@@ -98,8 +98,7 @@ class PutAzureBlobStorageTestsFixture {
     mock_blob_storage_ptr = mock_blob_storage.get();
     put_azure_blob_storage = std::shared_ptr<minifi::azure::processors::PutAzureBlobStorage>(
       new minifi::azure::processors::PutAzureBlobStorage("PutAzureBlobStorage", utils::Identifier(), std::move(mock_blob_storage)));
-    char input_dir_mask[] = "/tmp/gt.XXXXXX";
-    auto input_dir = test_controller.createTempDirectory(input_dir_mask);
+    auto input_dir = test_controller.createTempDirectory();
     std::ofstream input_file_stream(input_dir + utils::file::FileUtils::get_separator() + "input_data.log");
     input_file_stream << TEST_DATA;
     input_file_stream.close();

--- a/libminifi/test/flow-tests/SessionTests.cpp
+++ b/libminifi/test/flow-tests/SessionTests.cpp
@@ -40,8 +40,7 @@ TEST_CASE("Import null data") {
   LogTestController::getInstance().setTrace<core::repository::VolatileRepository<minifi::ResourceClaim::Path>>();
   LogTestController::getInstance().setTrace<core::repository::DatabaseContentRepository>();
 
-  char format[] = "/var/tmp/test.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   auto config = std::make_shared<minifi::Configure>();
   config->set(minifi::Configure::nifi_dbcontent_repository_directory_default, utils::file::FileUtils::concat_path(dir, "content_repository"));

--- a/libminifi/test/flow-tests/TestControllerWithFlow.h
+++ b/libminifi/test/flow-tests/TestControllerWithFlow.h
@@ -35,8 +35,7 @@ class TestControllerWithFlow: public TestController{
     LogTestController::getInstance().setTrace<minifi::TimerDrivenSchedulingAgent>();
     LogTestController::getInstance().setTrace<minifi::EventDrivenSchedulingAgent>();
 
-    char format[] = "/tmp/flowTest.XXXXXX";
-    std::string dir = createTempDirectory(format);
+    std::string dir = createTempDirectory();
 
     std::string yamlPath = utils::file::FileUtils::concat_path(dir, "config.yml");
     std::ofstream{yamlPath} << yamlConfigContent;

--- a/libminifi/test/gps-tests/GPSTests.cpp
+++ b/libminifi/test/gps-tests/GPSTests.cpp
@@ -51,8 +51,7 @@ TEST_CASE("GPSD Create", "[gpsdtest1]") {
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory.getName(), dir);
   testController.runSession(plan, false);

--- a/libminifi/test/keyvalue-tests/PersistableKeyValueStoreServiceTest.cpp
+++ b/libminifi/test/keyvalue-tests/PersistableKeyValueStoreServiceTest.cpp
@@ -61,9 +61,7 @@ class PersistableKeyValueStoreServiceTestsFixture {
     LogTestController::getInstance().setTrace<minifi::controllers::PersistableKeyValueStoreService>();
     LogTestController::getInstance().setTrace<minifi::controllers::AbstractAutoPersistingKeyValueStoreService>();
 
-    // Create temporary directories
-    char format[] = "/var/tmp/state.XXXXXX";
-    state_dir = testController.createTempDirectory(format);
+    state_dir = testController.createTempDirectory();
     REQUIRE(false == state_dir.empty());
 #ifdef WIN32
     REQUIRE(0 == _chdir(state_dir.c_str()));

--- a/libminifi/test/keyvalue-tests/UnorderedMapKeyValueStoreServiceTest.cpp
+++ b/libminifi/test/keyvalue-tests/UnorderedMapKeyValueStoreServiceTest.cpp
@@ -58,9 +58,7 @@ class UnorderedMapKeyValueStoreServiceTestFixture {
     LogTestController::getInstance().setTrace<minifi::controllers::PersistableKeyValueStoreService>();
     LogTestController::getInstance().setTrace<minifi::controllers::AbstractAutoPersistingKeyValueStoreService>();
 
-    // Create temporary directories
-    char format[] = "/var/tmp/state.XXXXXX";
-    const auto state_dir = testController.createTempDirectory(format);
+    const auto state_dir = testController.createTempDirectory();
     REQUIRE(!state_dir.empty());
 #ifdef WIN32
     REQUIRE(0 == _chdir(state_dir.c_str()));

--- a/libminifi/test/pcap-tests/PcapTest.cpp
+++ b/libminifi/test/pcap-tests/PcapTest.cpp
@@ -48,8 +48,7 @@
 class PcapTestHarness : public IntegrationBase {
  public:
   PcapTestHarness() {
-    char format[] = "/tmp/ssth.XXXXXX";
-    dir = testController.createTempDirectory(format);
+    dir = testController.createTempDirectory();
   }
 
   void testSetup() override {

--- a/libminifi/test/persistence-tests/PersistenceTests.cpp
+++ b/libminifi/test/persistence-tests/PersistenceTests.cpp
@@ -162,8 +162,7 @@ TEST_CASE("Processors Can Store FlowFiles", "[TestP1]") {
   LogTestController::getInstance().setTrace<minifi::FlowFileRecord>();
   LogTestController::getInstance().setTrace<core::repository::FlowFileRepository>();
 
-  char format[] = "/var/tmp/test.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   auto config = std::make_shared<minifi::Configure>();
   config->set(minifi::Configure::nifi_dbcontent_repository_directory_default, utils::file::FileUtils::concat_path(dir, "content_repository"));
@@ -265,8 +264,7 @@ TEST_CASE("Persisted flowFiles are updated on modification", "[TestP1]") {
   LogTestController::getInstance().setTrace<core::repository::VolatileRepository<minifi::ResourceClaim::Path>>();
   LogTestController::getInstance().setTrace<core::repository::DatabaseContentRepository>();
 
-  char format[] = "/var/tmp/test.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   auto config = std::make_shared<minifi::Configure>();
   config->set(minifi::Configure::nifi_dbcontent_repository_directory_default, utils::file::FileUtils::concat_path(dir, "content_repository"));

--- a/libminifi/test/rocksdb-tests/ContentSessionTests.cpp
+++ b/libminifi/test/rocksdb-tests/ContentSessionTests.cpp
@@ -31,8 +31,7 @@ template<typename ContentRepositoryClass>
 class ContentSessionController : public TestController {
  public:
   ContentSessionController() {
-    char format[] = "/var/tmp/content_repo.XXXXXX";
-    std::string contentRepoPath = createTempDirectory(format);
+    std::string contentRepoPath = createTempDirectory();
     auto config = std::make_shared<minifi::Configure>();
     config->set(minifi::Configure::nifi_dbcontent_repository_directory_default, contentRepoPath);
     contentRepository = std::make_shared<ContentRepositoryClass>();

--- a/libminifi/test/rocksdb-tests/DBContentRepositoryTests.cpp
+++ b/libminifi/test/rocksdb-tests/DBContentRepositoryTests.cpp
@@ -29,8 +29,7 @@
 
 TEST_CASE("Write Claim", "[TestDBCR1]") {
   TestController testController;
-  char format[] = "/var/tmp/testRepo.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
   auto content_repo = std::make_shared<core::repository::DatabaseContentRepository>();
 
   auto configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
@@ -70,8 +69,7 @@ TEST_CASE("Write Claim", "[TestDBCR1]") {
 
 TEST_CASE("Delete Claim", "[TestDBCR2]") {
   TestController testController;
-  char format[] = "/var/tmp/testRepo.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
   auto content_repo = std::make_shared<core::repository::DatabaseContentRepository>();
 
   auto configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
@@ -109,8 +107,7 @@ TEST_CASE("Delete Claim", "[TestDBCR2]") {
 
 TEST_CASE("Test Empty Claim", "[TestDBCR3]") {
   TestController testController;
-  char format[] = "/var/tmp/testRepo.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
   auto content_repo = std::make_shared<core::repository::DatabaseContentRepository>();
 
   auto configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
@@ -145,8 +142,7 @@ TEST_CASE("Test Empty Claim", "[TestDBCR3]") {
 
 TEST_CASE("Delete NonExistent Claim", "[TestDBCR4]") {
   TestController testController;
-  char format[] = "/var/tmp/testRepo.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
   auto content_repo = std::make_shared<core::repository::DatabaseContentRepository>();
 
   auto configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
@@ -186,8 +182,7 @@ TEST_CASE("Delete NonExistent Claim", "[TestDBCR4]") {
 
 TEST_CASE("Delete Remove Count Claim", "[TestDBCR5]") {
   TestController testController;
-  char format[] = "/var/tmp/testRepo.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
   auto content_repo = std::make_shared<core::repository::DatabaseContentRepository>();
 
   auto configuration = std::make_shared<org::apache::nifi::minifi::Configure>();

--- a/libminifi/test/rocksdb-tests/DBProvenanceRepositoryTests.cpp
+++ b/libminifi/test/rocksdb-tests/DBProvenanceRepositoryTests.cpp
@@ -62,9 +62,7 @@ void verifyMaxKeyCount(const minifi::provenance::ProvenanceRepository& repo, uin
 
 TEST_CASE("Test size limit", "[sizeLimitTest]") {
   TestController testController;
-
-  char dirtemplate[] = "/var/tmp/db.XXXXXX";
-  auto temp_dir = testController.createTempDirectory(dirtemplate);
+  auto temp_dir = testController.createTempDirectory();
   REQUIRE(!temp_dir.empty());
 
   // 60 sec, 100 KB - going to exceed the size limit
@@ -85,9 +83,7 @@ TEST_CASE("Test size limit", "[sizeLimitTest]") {
 
 TEST_CASE("Test time limit", "[timeLimitTest]") {
   TestController testController;
-
-  char dirtemplate[] = "/var/tmp/db.XXXXXX";
-  auto temp_dir = testController.createTempDirectory(dirtemplate);
+  auto temp_dir = testController.createTempDirectory();
   REQUIRE(!temp_dir.empty());
 
   // 1 sec, 100 MB - going to exceed TTL

--- a/libminifi/test/rocksdb-tests/EncryptionTests.cpp
+++ b/libminifi/test/rocksdb-tests/EncryptionTests.cpp
@@ -30,7 +30,7 @@ class FFRepoFixture : public TestController {
     LogTestController::getInstance().setDebug<minifi::FlowFileRecord>();
     LogTestController::getInstance().setDebug<minifi::Connection>();
     LogTestController::getInstance().setTrace<FlowFileRepository>();
-    home_ = createTempDirectory("/var/tmp/testRepo.XXXXXX");
+    home_ = utils::Path{createTempDirectory()};
     repo_dir_ = home_ / "flowfile_repo";
     checkpoint_dir_ = home_ / "checkpoint_dir";
     config_ = std::make_shared<minifi::Configure>();

--- a/libminifi/test/rocksdb-tests/RepoTests.cpp
+++ b/libminifi/test/rocksdb-tests/RepoTests.cpp
@@ -55,8 +55,7 @@ TEST_CASE("Test Repo Empty Value Attribute", "[TestFFR1]") {
   LogTestController::getInstance().setDebug<core::repository::FileSystemRepository>();
   LogTestController::getInstance().setDebug<core::repository::FlowFileRepository>();
   TestController testController;
-  char format[] = "/var/tmp/testRepo.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
   std::shared_ptr<core::repository::FlowFileRepository> repository = std::make_shared<core::repository::FlowFileRepository>("ff", REPOTEST_FLOWFILE_CHECKPOINT_DIR, dir, 0, 0, 1);
 
   repository->initialize(std::make_shared<minifi::Configure>());
@@ -78,8 +77,7 @@ TEST_CASE("Test Repo Empty Key Attribute ", "[TestFFR2]") {
   LogTestController::getInstance().setDebug<core::repository::FileSystemRepository>();
   LogTestController::getInstance().setDebug<core::repository::FlowFileRepository>();
   TestController testController;
-  char format[] = "/var/tmp/testRepo.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
   std::shared_ptr<core::repository::FlowFileRepository> repository = std::make_shared<core::repository::FlowFileRepository>("ff", REPOTEST_FLOWFILE_CHECKPOINT_DIR, dir, 0, 0, 1);
 
   repository->initialize(std::make_shared<minifi::Configure>());
@@ -102,8 +100,7 @@ TEST_CASE("Test Repo Key Attribute Verify ", "[TestFFR3]") {
   LogTestController::getInstance().setDebug<core::repository::FileSystemRepository>();
   LogTestController::getInstance().setDebug<core::repository::FlowFileRepository>();
   TestController testController;
-  char format[] = "/var/tmp/testRepo.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
   std::shared_ptr<core::repository::FlowFileRepository> repository = std::make_shared<core::repository::FlowFileRepository>("ff", REPOTEST_FLOWFILE_CHECKPOINT_DIR, dir, 0, 0, 1);
 
   repository->initialize(std::make_shared<org::apache::nifi::minifi::Configure>());
@@ -147,12 +144,12 @@ TEST_CASE("Test Repo Key Attribute Verify ", "[TestFFR3]") {
 
 TEST_CASE("Test Delete Content ", "[TestFFR4]") {
   TestController testController;
-  char format[] = "/var/tmp/testRepo.XXXXXX";
+
   LogTestController::getInstance().setDebug<core::ContentRepository>();
   LogTestController::getInstance().setDebug<core::repository::FileSystemRepository>();
   LogTestController::getInstance().setDebug<core::repository::FlowFileRepository>();
 
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   std::shared_ptr<core::repository::FlowFileRepository> repository = std::make_shared<core::repository::FlowFileRepository>("ff", REPOTEST_FLOWFILE_CHECKPOINT_DIR, dir, 0, 0, 1);
 
@@ -200,13 +197,13 @@ TEST_CASE("Test Delete Content ", "[TestFFR4]") {
 TEST_CASE("Test Validate Checkpoint ", "[TestFFR5]") {
   TestController testController;
   utils::file::FileUtils::delete_dir(REPOTEST_FLOWFILE_CHECKPOINT_DIR, true);
-  char format[] = "/var/tmp/testRepo.XXXXXX";
+
   LogTestController::getInstance().setDebug<core::ContentRepository>();
   LogTestController::getInstance().setTrace<core::repository::FileSystemRepository>();
   LogTestController::getInstance().setTrace<minifi::ResourceClaim>();
   LogTestController::getInstance().setTrace<minifi::FlowFileRecord>();
 
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   std::shared_ptr<core::repository::FlowFileRepository> repository = std::make_shared<core::repository::FlowFileRepository>("ff", REPOTEST_FLOWFILE_CHECKPOINT_DIR, dir, 0, 0, 1);
 
@@ -268,8 +265,7 @@ TEST_CASE("Test FlowFile Restore", "[TestFFR6]") {
   LogTestController::getInstance().setTrace<minifi::FlowFileRecord>();
   LogTestController::getInstance().setTrace<minifi::core::repository::FlowFileRepository>();
 
-  char format[] = "/var/tmp/testRepo.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   auto config = std::make_shared<minifi::Configure>();
   config->set(minifi::Configure::nifi_dbcontent_repository_directory_default, utils::file::FileUtils::concat_path(dir, "content_repository"));
@@ -365,8 +361,7 @@ TEST_CASE("Flush deleted flowfiles before shutdown", "[TestFFR7]") {
   };
 
   TestController testController;
-  char format[] = "/var/tmp/testRepo.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   auto config = std::make_shared<minifi::Configure>();
   config->set(minifi::Configure::nifi_flowfile_repository_directory_default, utils::file::FileUtils::concat_path(dir, "flowfile_repository"));

--- a/libminifi/test/rocksdb-tests/RocksDBStreamTests.cpp
+++ b/libminifi/test/rocksdb-tests/RocksDBStreamTests.cpp
@@ -24,8 +24,7 @@
 class RocksDBStreamTest : TestController {
  public:
   RocksDBStreamTest() {
-    char format[] = "/var/tmp/testdb.XXXXXX";
-    dbPath = createTempDirectory(format);
+    dbPath = createTempDirectory();
     auto set_db_opts = [] (minifi::internal::Writable<rocksdb::DBOptions>& db_opts) {
       db_opts.set(&rocksdb::DBOptions::create_if_missing, true);
       db_opts.set(&rocksdb::DBOptions::use_direct_io_for_flush_and_compaction, true);

--- a/libminifi/test/rocksdb-tests/RocksDBTests.cpp
+++ b/libminifi/test/rocksdb-tests/RocksDBTests.cpp
@@ -37,8 +37,7 @@ struct RocksDBTest : TestController {
     LogTestController::getInstance().setTrace<minifi::internal::RocksDatabase>();
     LogTestController::getInstance().setTrace<minifi::internal::RocksDbInstance>();
     LogTestController::getInstance().setTrace<minifi::internal::ColumnHandle>();
-    char format[] = "/var/tmp/db.XXXXXX";
-    db_dir = createTempDirectory(format);
+    db_dir = createTempDirectory();
   }
 
   OpenDatabase openDB(const std::vector<std::string>& cf_names) const {
@@ -220,7 +219,7 @@ void withDefaultEnv(minifi::internal::Writable<rocksdb::DBOptions>& db_opts) {
 }
 
 TEST_CASE_METHOD(RocksDBTest, "Error is logged if different encryption keys are used", "[rocksDBTest10]") {
-  utils::Path home_dir = createTempDirectory("/var/tmp/test.XXXXXX");
+  utils::Path home_dir{createTempDirectory()};
   utils::file::FileUtils::create_dir((home_dir / "conf").str());
   std::ofstream{(home_dir / "conf" / "bootstrap.conf").str()}
     << "encryption.key.one=" << "805D7B95EF44DC27C87FFBC4DFDE376DAE604D55DB2C5496DEEF5236362DE62E" << "\n"

--- a/libminifi/test/script-tests/TestExecuteScriptProcessorWithLuaScript.cpp
+++ b/libminifi/test/script-tests/TestExecuteScriptProcessorWithLuaScript.cpp
@@ -52,8 +52,7 @@ TEST_CASE("Lua: Test Log", "[executescriptLuaLog]") { // NOLINT
     end
   )");
 
-  char getFileDirFmt[] = "/tmp/ft.XXXXXX";
-  auto getFileDir = testController.createTempDirectory(getFileDirFmt);
+  auto getFileDir = testController.createTempDirectory();
   plan->setProperty(getFile, processors::GetFile::Directory.getName(), getFileDir);
 
   std::fstream file;
@@ -114,12 +113,10 @@ TEST_CASE("Lua: Test Read File", "[executescriptLuaRead]") { // NOLINT
     end
   )");
 
-  char getFileDirFmt[] = "/tmp/ft.XXXXXX";
-  auto getFileDir = testController.createTempDirectory(getFileDirFmt);
+  auto getFileDir = testController.createTempDirectory();
   plan->setProperty(getFile, processors::GetFile::Directory.getName(), getFileDir);
 
-  char putFileDirFmt[] = "/tmp/ft.XXXXXX";
-  char *putFileDir = testController.createTempDirectory(putFileDirFmt);
+  auto putFileDir = testController.createTempDirectory();
   plan->setProperty(putFile, processors::PutFile::Directory.getName(), putFileDir);
 
   testController.runSession(plan, false);
@@ -204,12 +201,10 @@ TEST_CASE("Lua: Test Write File", "[executescriptLuaWrite]") { // NOLINT
     end
   )");
 
-  char getFileDirFmt[] = "/tmp/ft.XXXXXX";
-  auto getFileDir = testController.createTempDirectory(getFileDirFmt);
+  auto getFileDir = testController.createTempDirectory();
   plan->setProperty(getFile, processors::GetFile::Directory.getName(), getFileDir);
 
-  char putFileDirFmt[] = "/tmp/ft.XXXXXX";
-  char *putFileDir = testController.createTempDirectory(putFileDirFmt);
+  auto putFileDir = testController.createTempDirectory();
   plan->setProperty(putFile, processors::PutFile::Directory.getName(), putFileDir);
 
   testController.runSession(plan, false);
@@ -286,8 +281,7 @@ TEST_CASE("Lua: Test Update Attribute", "[executescriptLuaUpdateAttribute]") { /
     end
   )");
 
-  char getFileDirFmt[] = "/tmp/ft.XXXXXX";
-  auto getFileDir = testController.createTempDirectory(getFileDirFmt);
+  auto getFileDir = testController.createTempDirectory();
   plan->setProperty(getFile, processors::GetFile::Directory.getName(), getFileDir);
 
   std::fstream file;

--- a/libminifi/test/script-tests/TestExecuteScriptProcessorWithPythonScript.cpp
+++ b/libminifi/test/script-tests/TestExecuteScriptProcessorWithPythonScript.cpp
@@ -67,12 +67,10 @@ TEST_CASE("Python: Test Read File", "[executescriptPythonRead]") { // NOLINT
         session.transfer(flow_file, REL_SUCCESS)
   )");
 
-  char getFileDirFmt[] = "/tmp/ft.XXXXXX";
-  auto getFileDir = testController.createTempDirectory(getFileDirFmt);
+  auto getFileDir = testController.createTempDirectory();
   plan->setProperty(getFile, processors::GetFile::Directory.getName(), getFileDir);
 
-  char putFileDirFmt[] = "/tmp/ft.XXXXXX";
-  auto putFileDir = testController.createTempDirectory(putFileDirFmt);
+  auto putFileDir = testController.createTempDirectory();
   plan->setProperty(putFile, processors::PutFile::Directory.getName(), putFileDir);
 
   testController.runSession(plan, false);
@@ -151,12 +149,10 @@ TEST_CASE("Python: Test Write File", "[executescriptPythonWrite]") { // NOLINT
         session.transfer(flow_file, REL_SUCCESS)
   )");
 
-  char getFileDirFmt[] = "/tmp/ft.XXXXXX";
-  auto getFileDir = testController.createTempDirectory(getFileDirFmt);
+  auto getFileDir = testController.createTempDirectory();
   plan->setProperty(getFile, processors::GetFile::Directory.getName(), getFileDir);
 
-  char putFileDirFmt[] = "/tmp/ft.XXXXXX";
-  auto putFileDir = testController.createTempDirectory(putFileDirFmt);
+  auto putFileDir = testController.createTempDirectory();
   plan->setProperty(putFile, processors::PutFile::Directory.getName(), putFileDir);
 
   testController.runSession(plan, false);
@@ -260,8 +256,7 @@ TEST_CASE("Python: Test Update Attribute", "[executescriptPythonUpdateAttribute]
         session.transfer(flow_file, REL_SUCCESS)
   )");
 
-  char getFileDirFmt[] = "/tmp/ft.XXXXXX";
-  auto getFileDir = testController.createTempDirectory(getFileDirFmt);
+  auto getFileDir = testController.createTempDirectory();
   plan->setProperty(getFile, processors::GetFile::Directory.getName(), getFileDir);
 
   std::fstream file;
@@ -306,8 +301,7 @@ TEST_CASE("Python: Test Get Context Property", "[executescriptPythonGetContextPr
       log.info('got Script Engine property: %s' % script_engine)
   )");
 
-  char getFileDirFmt[] = "/tmp/ft.XXXXXX";
-  auto getFileDir = testController.createTempDirectory(getFileDirFmt);
+  auto getFileDir = testController.createTempDirectory();
   plan->setProperty(getFile, processors::GetFile::Directory.getName(), getFileDir);
 
   std::fstream file;

--- a/libminifi/test/sensors-tests/SensorTests.cpp
+++ b/libminifi/test/sensors-tests/SensorTests.cpp
@@ -47,8 +47,7 @@
 class PcapTestHarness : public IntegrationBase {
  public:
   PcapTestHarness() {
-    char format[] = "/tmp/ssth.XXXXXX";
-    dir = testController.createTempDirectory(format);
+    dir = testController.createTempDirectory();
   }
 
   void testSetup() override {

--- a/libminifi/test/sql-tests/SQLTestController.h
+++ b/libminifi/test/sql-tests/SQLTestController.h
@@ -57,8 +57,7 @@ class SQLTestController : public TestController {
     LogTestController::getInstance().setTrace<processors::ExecuteSQL>();
     LogTestController::getInstance().setTrace<processors::QueryDatabaseTable>();
 
-    char format[] = "/var/tmp/gt.XXXXXX";
-    test_dir_ = createTempDirectory(format);
+    test_dir_ = createTempDirectory();
     database_ = test_dir_ / "test.db";
     connection_str_ = "Driver=" + DRIVER + ";Database=" + database_.str();
 

--- a/libminifi/test/tensorflow-tests/TensorFlowTests.cpp
+++ b/libminifi/test/tensorflow-tests/TensorFlowTests.cpp
@@ -45,8 +45,7 @@ TEST_CASE("TensorFlow: Apply Graph", "[tfApplyGraph]") { // NOLINT
   auto repo = std::make_shared<TestRepository>();
 
   // Define directory for input protocol buffers
-  char in_dir_format[] = "/tmp/gt.XXXXXX";
-  std::string in_dir = testController.createTempDirectory(in_dir_format);
+  std::string in_dir = testController.createTempDirectory();
 
   // Define input graph protocol buffer file
   std::string in_graph_file(in_dir);
@@ -57,8 +56,7 @@ TEST_CASE("TensorFlow: Apply Graph", "[tfApplyGraph]") { // NOLINT
   in_tensor_file.append("/tensor.pb");
 
   // Define directory for output protocol buffers
-  char out_dir_format[] = "/tmp/gt.XXXXXX";
-  std::string out_dir = testController.createTempDirectory(out_dir_format);
+  std::string out_dir = testController.createTempDirectory();
 
   // Define output tensor protocol buffer file
   std::string out_tensor_file(out_dir);
@@ -184,16 +182,14 @@ TEST_CASE("TensorFlow: ConvertImageToTensor", "[tfConvertImageToTensor]") { // N
   auto repo = std::make_shared<TestRepository>();
 
   // Define directory for input protocol buffers
-  char in_dir_format[] = "/tmp/gt.XXXXXX";
-  std::string in_dir = testController.createTempDirectory(in_dir_format);
+  std::string in_dir = testController.createTempDirectory();
 
   // Define input tensor protocol buffer file
   std::string in_img_file(in_dir);
   in_img_file.append("/img");
 
   // Define directory for output protocol buffers
-  char out_dir_format[] = "/tmp/gt.XXXXXX";
-  std::string out_dir = testController.createTempDirectory(out_dir_format);
+  std::string out_dir = testController.createTempDirectory();
 
   // Define output tensor protocol buffer file
   std::string out_tensor_file(out_dir);
@@ -312,8 +308,7 @@ TEST_CASE("TensorFlow: Extract Top Labels", "[tfExtractTopLabels]") { // NOLINT
   auto repo = std::make_shared<TestRepository>();
 
   // Define directory for input protocol buffers
-  char in_dir_format[] = "/tmp/gt.XXXXXX";
-  std::string in_dir = testController.createTempDirectory(in_dir_format);
+  std::string in_dir = testController.createTempDirectory();
 
   // Define input labels file
   std::string in_labels_file(in_dir);

--- a/libminifi/test/unit/ChecksumCalculatorTests.cpp
+++ b/libminifi/test/unit/ChecksumCalculatorTests.cpp
@@ -28,7 +28,7 @@ namespace {
 
 TEST_CASE("ChecksumCalculator can calculate the checksum, which is equal to sha256sum", "[ChecksumCalculator]") {
   TestController test_controller;
-  std::string test_dir = utils::createTempDir(&test_controller);
+  std::string test_dir = test_controller.createTempDirectory();
   std::string file_location = utils::putFileToDir(test_dir, "simple.txt", "one line of text\n");
 
   REQUIRE(std::string{utils::ChecksumCalculator::CHECKSUM_TYPE} == std::string{"SHA256"});
@@ -42,7 +42,7 @@ TEST_CASE("ChecksumCalculator can calculate the checksum, which is equal to sha2
 
 TEST_CASE("On Windows text files, the checksum calculated is also the same as sha256sum", "[ChecksumCalculator]") {
   TestController test_controller;
-  std::string test_dir = utils::createTempDir(&test_controller);
+  std::string test_dir = test_controller.createTempDirectory();
   std::string file_location = utils::putFileToDir(test_dir, "simple.txt", "one line of text\r\n");
 
   utils::ChecksumCalculator checksum_calculator;
@@ -52,7 +52,7 @@ TEST_CASE("On Windows text files, the checksum calculated is also the same as sh
 
 TEST_CASE("The checksum can be reset and recomputed", "[ChecksumCalculator]") {
   TestController test_controller;
-  std::string test_dir = utils::createTempDir(&test_controller);
+  std::string test_dir = test_controller.createTempDirectory();
   std::string file_location = utils::putFileToDir(test_dir, "simple.txt", "one line of text\n");
 
   utils::ChecksumCalculator checksum_calculator;
@@ -71,7 +71,7 @@ TEST_CASE("The checksum can be reset and recomputed", "[ChecksumCalculator]") {
 
 TEST_CASE("If the file location is updated, the checksum will be recomputed", "[ChecksumCalculator]") {
   TestController test_controller;
-  std::string test_dir = utils::createTempDir(&test_controller);
+  std::string test_dir = test_controller.createTempDirectory();
   std::string file_location = utils::putFileToDir(test_dir, "simple.txt", "one line of text\n");
 
   utils::ChecksumCalculator checksum_calculator;
@@ -85,7 +85,7 @@ TEST_CASE("If the file location is updated, the checksum will be recomputed", "[
 
 TEST_CASE("Checksums can be computed for binary (eg. encrypted) files, too", "[ChecksumCalculator]") {
   TestController test_controller;
-  std::string test_dir = utils::createTempDir(&test_controller);
+  std::string test_dir = test_controller.createTempDirectory();
   std::string binary_data(size_t{256}, '\0');
   std::iota(binary_data.begin(), binary_data.end(), 'x');
   std::string file_location = utils::putFileToDir(test_dir, "simple.txt", binary_data);
@@ -97,7 +97,7 @@ TEST_CASE("Checksums can be computed for binary (eg. encrypted) files, too", "[C
 
 TEST_CASE("The agent identifier is excluded from the checksum", "[ChecksumCalculator]") {
   TestController test_controller;
-  std::string test_dir = utils::createTempDir(&test_controller);
+  std::string test_dir = test_controller.createTempDirectory();
   std::string file_location_1 = utils::putFileToDir(test_dir, "agent_one.txt",
       "nifi.c2.agent.class=Test\n"
       "nifi.c2.agent.identifier=Test-111\n"

--- a/libminifi/test/unit/ConfigurationChecksumsTests.cpp
+++ b/libminifi/test/unit/ConfigurationChecksumsTests.cpp
@@ -34,7 +34,7 @@ TEST_CASE("If no checksum calculators are added, we get an empty node", "[Config
 
 TEST_CASE("If one checksum calculator is added, we get a node with one child", "[ConfigurationChecksums]") {
   TestController test_controller;
-  std::string test_dir = utils::createTempDir(&test_controller);
+  std::string test_dir = test_controller.createTempDirectory();
   std::string file_location = utils::putFileToDir(test_dir, "simple.txt", "one line of text\n");
 
   utils::ChecksumCalculator checksum_calculator;
@@ -56,7 +56,7 @@ TEST_CASE("If one checksum calculator is added, we get a node with one child", "
 
 TEST_CASE("If two checksum calculators are added, we get a node with two children", "[ConfigurationChecksums]") {
   TestController test_controller;
-  std::string test_dir = utils::createTempDir(&test_controller);
+  std::string test_dir = test_controller.createTempDirectory();
   std::string file_location_1 = utils::putFileToDir(test_dir, "first.txt", "this is the first file\n");
   std::string file_location_2 = utils::putFileToDir(test_dir, "second.txt", "this is the second file\n");
 

--- a/libminifi/test/unit/EnvironmentUtilsTests.cpp
+++ b/libminifi/test/unit/EnvironmentUtilsTests.cpp
@@ -145,8 +145,7 @@ TEST_CASE("getcwd", "[getcwd]") {
 TEST_CASE("setcwd", "[setcwd]") {
   TestController testController;
   const std::string cwd = utils::Environment::getCurrentWorkingDirectory();
-  char format[] = "/tmp/envtest.XXXXXX";
-  const std::string tempDir = utils::file::getFullPath(testController.createTempDirectory(format));
+  const std::string tempDir = utils::file::getFullPath(testController.createTempDirectory());
   REQUIRE(true == utils::Environment::setCurrentWorkingDirectory(tempDir.c_str()));
   REQUIRE(tempDir == utils::Environment::getCurrentWorkingDirectory());
   REQUIRE(true == utils::Environment::setCurrentWorkingDirectory(cwd.c_str()));

--- a/libminifi/test/unit/FileStreamTests.cpp
+++ b/libminifi/test/unit/FileStreamTests.cpp
@@ -32,8 +32,7 @@
 
 TEST_CASE("TestFileOverWrite", "[TestFiles]") {
   TestController testController;
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   std::fstream file;
   std::stringstream ss;
@@ -70,8 +69,7 @@ TEST_CASE("TestFileOverWrite", "[TestFiles]") {
 
 TEST_CASE("TestFileBadArgumentNoChange", "[TestLoader]") {
   TestController testController;
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   std::fstream file;
   std::stringstream ss;
@@ -108,8 +106,7 @@ TEST_CASE("TestFileBadArgumentNoChange", "[TestLoader]") {
 
 TEST_CASE("TestFileBadArgumentNoChange2", "[TestLoader]") {
   TestController testController;
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   std::fstream file;
   std::stringstream ss;
@@ -146,8 +143,7 @@ TEST_CASE("TestFileBadArgumentNoChange2", "[TestLoader]") {
 
 TEST_CASE("TestFileBadArgumentNoChange3", "[TestLoader]") {
   TestController testController;
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   std::fstream file;
   std::stringstream ss;
@@ -184,8 +180,7 @@ TEST_CASE("TestFileBadArgumentNoChange3", "[TestLoader]") {
 
 TEST_CASE("TestFileBeyondEnd3", "[TestLoader]") {
   TestController testController;
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   std::fstream file;
   std::stringstream ss;
@@ -218,8 +213,7 @@ TEST_CASE("TestFileBeyondEnd3", "[TestLoader]") {
 
 TEST_CASE("TestFileExceedSize", "[TestLoader]") {
   TestController testController;
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   std::fstream file;
   std::stringstream ss;
@@ -253,24 +247,21 @@ TEST_CASE("TestFileExceedSize", "[TestLoader]") {
 
 TEST_CASE("Write zero bytes") {
   TestController testController;
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
   minifi::io::FileStream stream(utils::file::concat_path(dir, "test.txt"), 0, true);
   REQUIRE(stream.write(nullptr, 0) == 0);
 }
 
 TEST_CASE("Read zero bytes") {
   TestController testController;
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
   minifi::io::FileStream stream(utils::file::concat_path(dir, "test.txt"), 0, true);
   REQUIRE(stream.read(nullptr, 0) == 0);
 }
 
 TEST_CASE("Non-existing file read/write test") {
   TestController test_controller;
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = test_controller.createTempDirectory(format);
+  auto dir = test_controller.createTempDirectory();
   minifi::io::FileStream stream(utils::file::concat_path(dir, "non_existing_file.txt"), 0, true);
   REQUIRE(test_controller.getLog().getInstance().contains("Error opening file", std::chrono::seconds(0)));
   REQUIRE(test_controller.getLog().getInstance().contains("No such file or directory", std::chrono::seconds(0)));
@@ -284,8 +275,7 @@ TEST_CASE("Non-existing file read/write test") {
 
 TEST_CASE("Existing file read/write test") {
   TestController test_controller;
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = test_controller.createTempDirectory(format);
+  auto dir = test_controller.createTempDirectory();
   std::string path_to_existing_file(utils::file::concat_path(dir, "existing_file.txt"));
   {
     std::ofstream outfile(path_to_existing_file);
@@ -309,8 +299,7 @@ TEST_CASE("Existing file read/write test") {
 // This could be simplified with C++17 std::filesystem
 TEST_CASE("Opening file without permission creates error logs") {
   TestController test_controller;
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = test_controller.createTempDirectory(format);
+  auto dir = test_controller.createTempDirectory();
   std::string path_to_permissionless_file(utils::file::concat_path(dir, "permissionless_file.txt"));
   {
     std::ofstream outfile(path_to_permissionless_file);
@@ -330,8 +319,7 @@ TEST_CASE("Opening file without permission creates error logs") {
 
 TEST_CASE("Readonly filestream write test") {
   TestController test_controller;
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = test_controller.createTempDirectory(format);
+  auto dir = test_controller.createTempDirectory();
   std::string path_to_file(utils::file::concat_path(dir, "file_to_seek_in.txt"));
   {
     std::ofstream outfile(path_to_file);

--- a/libminifi/test/unit/FileSystemTests.cpp
+++ b/libminifi/test/unit/FileSystemTests.cpp
@@ -30,8 +30,7 @@ utils::crypto::Bytes encryption_key = utils::crypto::stringToBytes(utils::String
 
 struct FileSystemTest : TestController {
   FileSystemTest() {
-    char format[] = "/var/tmp/fs.XXXXXX";
-    dir = createTempDirectory(format);
+    dir = createTempDirectory();
     encrypted_file = utils::file::FileUtils::concat_path(dir, "encrypted.txt");
     raw_file = utils::file::FileUtils::concat_path(dir, "raw.txt");
     new_file = utils::file::FileUtils::concat_path(dir, "new.txt");

--- a/libminifi/test/unit/FileTriggerTests.cpp
+++ b/libminifi/test/unit/FileTriggerTests.cpp
@@ -48,8 +48,7 @@ TEST_CASE("invalidfile file", "[t2]") {
 TEST_CASE("test valid  file no update", "[t3]") {
   TestController testController;
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   std::fstream file;
   std::stringstream ss;
@@ -71,8 +70,7 @@ TEST_CASE("test valid  file no update", "[t3]") {
 TEST_CASE("test valid file update", "[t4]") {
   TestController testController;
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   std::fstream file;
   std::stringstream ss;

--- a/libminifi/test/unit/FileUtilsTests.cpp
+++ b/libminifi/test/unit/FileUtilsTests.cpp
@@ -141,8 +141,7 @@ TEST_CASE("TestFileUtils::get_executable_dir", "[TestGetExecutableDir]") {
 TEST_CASE("TestFileUtils::create_dir", "[TestCreateDir]") {
   TestController testController;
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   std::string test_dir_path = std::string(dir) + FileUtils::get_separator() + "random_dir";
 
@@ -158,8 +157,7 @@ TEST_CASE("TestFileUtils::create_dir", "[TestCreateDir]") {
 TEST_CASE("TestFileUtils::create_dir recursively", "[TestCreateDir]") {
   TestController testController;
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
 
   std::string test_dir_path = std::string(dir) + FileUtils::get_separator() + "random_dir" + FileUtils::get_separator() +
     "random_dir2" + FileUtils::get_separator() + "random_dir3";
@@ -174,8 +172,7 @@ TEST_CASE("TestFileUtils::create_dir recursively", "[TestCreateDir]") {
 TEST_CASE("TestFileUtils::getFullPath", "[TestGetFullPath]") {
   TestController testController;
 
-  char format[] = "/tmp/gt.XXXXXX";
-  const std::string tempDir = utils::file::getFullPath(testController.createTempDirectory(format));
+  const std::string tempDir = utils::file::getFullPath(testController.createTempDirectory());
 
   const std::string cwd = utils::Environment::getCurrentWorkingDirectory();
 
@@ -209,8 +206,7 @@ TEST_CASE("FileUtils::last_write_time and last_write_time_point work", "[last_wr
 
   TestController testController;
 
-  char format[] = "/tmp/gt.XXXXXX";
-  std::string dir = testController.createTempDirectory(format);
+  std::string dir = testController.createTempDirectory();
 
   std::string test_file = dir + FileUtils::get_separator() + "test.txt";
   REQUIRE(FileUtils::last_write_time(test_file) == 0);
@@ -264,8 +260,7 @@ TEST_CASE("FileUtils::last_write_time and last_write_time_point work", "[last_wr
 TEST_CASE("FileUtils::file_size works", "[file_size]") {
   TestController testController;
 
-  char format[] = "/tmp/gt.XXXXXX";
-  std::string dir = testController.createTempDirectory(format);
+  std::string dir = testController.createTempDirectory();
 
   std::string test_file = dir + FileUtils::get_separator() + "test.txt";
   REQUIRE(FileUtils::file_size(test_file) == 0);
@@ -293,8 +288,7 @@ TEST_CASE("FileUtils::computeChecksum works", "[computeChecksum]") {
 
   TestController testController;
 
-  char format[] = "/tmp/gt.XXXXXX";
-  std::string dir = testController.createTempDirectory(format);
+  std::string dir = testController.createTempDirectory();
 
   std::string test_file = dir + FileUtils::get_separator() + "test.txt";
   REQUIRE(FileUtils::computeChecksum(test_file, 0) == CHECKSUM_OF_0_BYTES);
@@ -338,8 +332,7 @@ TEST_CASE("FileUtils::computeChecksum with large files", "[computeChecksum]") {
 
   TestController testController;
 
-  char format[] = "/tmp/gt.XXXXXX";
-  std::string dir = testController.createTempDirectory(format);
+  std::string dir = testController.createTempDirectory();
 
   std::string test_file = dir + FileUtils::get_separator() + "test.txt";
   REQUIRE(FileUtils::computeChecksum(test_file, 0) == CHECKSUM_OF_0_BYTES);
@@ -383,8 +376,7 @@ TEST_CASE("FileUtils::computeChecksum with large files", "[computeChecksum]") {
 TEST_CASE("FileUtils::set_permissions", "[TestSetPermissions]") {
   TestController testController;
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
   auto path = dir + FileUtils::get_separator() + "test_file.txt";
   std::ofstream outfile(path, std::ios::out | std::ios::binary);
 
@@ -398,8 +390,7 @@ TEST_CASE("FileUtils::set_permissions", "[TestSetPermissions]") {
 TEST_CASE("FileUtils::exists", "[TestExists]") {
   TestController testController;
 
-  char format[] = "/tmp/gt.XXXXXX";
-  auto dir = testController.createTempDirectory(format);
+  auto dir = testController.createTempDirectory();
   auto path = dir + FileUtils::get_separator() + "test_file.txt";
   std::ofstream outfile(path, std::ios::out | std::ios::binary);
   auto invalid_path = dir + FileUtils::get_separator() + "test_file2.txt";

--- a/nanofi/tests/CAPITests.cpp
+++ b/nanofi/tests/CAPITests.cpp
@@ -134,10 +134,8 @@ TEST_CASE("Set valid and invalid properties", "[setProcesssorProperties]") {
 TEST_CASE("get file and put file", "[getAndPutFile]") {
   TestController testController;
 
-  char src_format[] = "/tmp/gt.XXXXXX";
-  char put_format[] = "/tmp/pt.XXXXXX";
-  auto sourcedir = testController.createTempDirectory(src_format);
-  auto putfiledir = testController.createTempDirectory(put_format);
+  auto sourcedir = testController.createTempDirectory();
+  auto putfiledir = testController.createTempDirectory();
   auto instance = create_instance_obj();
   REQUIRE(instance != nullptr);
   flow *test_flow = create_new_flow(instance);
@@ -183,8 +181,7 @@ TEST_CASE("get file and put file", "[getAndPutFile]") {
 TEST_CASE("Test manipulation of attributes", "[testAttributes]") {
   TestController testController;
 
-  char src_format[] = "/tmp/gt.XXXXXX";
-  auto sourcedir = testController.createTempDirectory(src_format);
+  auto sourcedir = testController.createTempDirectory();
 
   create_testfile_for_getfile(sourcedir.c_str());
 
@@ -259,8 +256,7 @@ TEST_CASE("Test manipulation of attributes", "[testAttributes]") {
 
 TEST_CASE("Test error handling callback", "[errorHandling]") {
   TestController testController;
-  char src_format[] = "/tmp/gt.XXXXXX";
-  auto sourcedir = testController.createTempDirectory(src_format);
+  auto sourcedir = testController.createTempDirectory();
 
   auto instance = create_instance_obj();
   REQUIRE(instance != nullptr);
@@ -305,8 +301,7 @@ TEST_CASE("Test error handling callback", "[errorHandling]") {
 TEST_CASE("Test standalone processors", "[testStandalone]") {
   TestController testController;
 
-  char src_format[] = "/tmp/gt.XXXXXX";
-  auto sourcedir = testController.createTempDirectory(src_format);
+  auto sourcedir = testController.createTempDirectory();
 
   create_testfile_for_getfile(sourcedir.c_str());
 
@@ -353,10 +348,8 @@ TEST_CASE("Test standalone processors", "[testStandalone]") {
 TEST_CASE("Test interaction of flow and standlone processors", "[testStandaloneWithFlow]") {
   TestController testController;
 
-  char src_format[] = "/tmp/gt.XXXXXX";
-  char put_format[] = "/tmp/pt.XXXXXX";
-  auto sourcedir = testController.createTempDirectory(src_format);
-  auto putfiledir = testController.createTempDirectory(put_format);
+  auto sourcedir = testController.createTempDirectory();
+  auto putfiledir = testController.createTempDirectory();
 
   create_testfile_for_getfile(sourcedir.c_str());
 
@@ -398,8 +391,7 @@ TEST_CASE("Test standalone processors with file input", "[testStandaloneWithFile
   TestController testController;
 
   enable_logging();
-  char src_format[] = "/tmp/gt.XXXXXX";
-  auto sourcedir = testController.createTempDirectory(src_format);
+  auto sourcedir = testController.createTempDirectory();
   std::string path = create_testfile_for_getfile(sourcedir.c_str());
 
   standalone_processor* extract_test = create_processor("ExtractText", NULL);
@@ -424,8 +416,7 @@ TEST_CASE("Test standalone processors with file input", "[testStandaloneWithFile
 TEST_CASE("Test custom processor", "[TestCutomProcessor]") {
   TestController testController;
 
-  char src_format[] = "/tmp/gt.XXXXXX";
-  auto sourcedir = testController.createTempDirectory(src_format);
+  auto sourcedir = testController.createTempDirectory();
 
   create_testfile_for_getfile(sourcedir.c_str());
 

--- a/nanofi/tests/CTestsBase.h
+++ b/nanofi/tests/CTestsBase.h
@@ -128,8 +128,7 @@ class TestControllerWithTemporaryWorkingDirectory {
 public:
   TestControllerWithTemporaryWorkingDirectory()
     : old_cwd_(get_current_working_directory()) {
-    char format[] = "/tmp/ctest_temp_dir.XXXXXX";
-    std::string temp_dir = test_controller_.createTempDirectory(format);
+    std::string temp_dir = test_controller_.createTempDirectory();
     int result = change_current_working_directory(temp_dir.c_str());
     if (result != 0) {
       throw std::runtime_error("Could not change to temporary directory " + temp_dir);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-1600

Remove all variants of `createTempDir`/`createTempDirectory` except one, and use that one in every test.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
