### PR TITLE
MINIFICPP-1621 fix docker focal build

### DIFF
--- a/docker/bionic/Dockerfile
+++ b/docker/bionic/Dockerfile
@@ -28,21 +28,21 @@ ENV MINIFI_BASE_DIR /opt/minifi
 ENV MINIFI_HOME $MINIFI_BASE_DIR/nifi-minifi-cpp-$MINIFI_VERSION
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 
-RUN apt-get update && apt-get install -y openjdk-8-jdk openjdk-8-source sudo git maven autogen autoconf automake
-
-RUN mkdir -p $MINIFI_BASE_DIR
+RUN apt-get update \
+    && DEBIAN_FRONTEND="noninteractive" apt-get install -y openjdk-8-jdk openjdk-8-source sudo git maven autogen autoconf automake \
+    && mkdir -p $MINIFI_BASE_DIR
 COPY . ${MINIFI_BASE_DIR}
 
 
 FROM build_deps AS release
 ARG ENABLE_JNI
-# Run bootstrap
-RUN cd $MINIFI_BASE_DIR && ./bootstrap.sh -t
 
 ENV CC gcc-11
 ENV CXX g++-11
 
-# Build
-RUN cd $MINIFI_BASE_DIR/build \
+# Run bootstrap and build
+RUN cd $MINIFI_BASE_DIR \
+    && ./bootstrap.sh -t \
+    && cd $MINIFI_BASE_DIR/build \
 	&& cmake -DUSE_SHARED_LIBS= -DENABLE_MQTT=ON -DENABLE_LIBRDKAFKA=ON -DPORTABLE=ON -DENABLE_COAP=ON -DCMAKE_BUILD_TYPE=Release -DSKIP_TESTS=true -DENABLE_JNI=$ENABLE_JNI .. \
 	&& make -j$(nproc) package

--- a/docker/focal/Dockerfile
+++ b/docker/focal/Dockerfile
@@ -28,23 +28,22 @@ ENV MINIFI_BASE_DIR /opt/minifi
 ENV MINIFI_HOME $MINIFI_BASE_DIR/nifi-minifi-cpp-$MINIFI_VERSION
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 
-RUN apt update
-RUN DEBIAN_FRONTEND="noninteractive" apt install -y openjdk-8-jdk openjdk-8-source python3.9-dev sudo git maven autogen autoconf automake cmake software-properties-common
+RUN apt update \
+    && DEBIAN_FRONTEND="noninteractive" apt install -y openjdk-8-jdk openjdk-8-source python3.9-dev sudo git maven autogen autoconf automake cmake software-properties-common \
+    && mkdir -p "${MINIFI_BASE_DIR}"
 
-RUN mkdir -p $MINIFI_BASE_DIR
 COPY . ${MINIFI_BASE_DIR}
 
 
 FROM build_deps AS release
 ARG ENABLE_JNI
 
-# Run bootstrap
-RUN cd $MINIFI_BASE_DIR && ./bootstrap.sh -t
-
 ENV CC gcc-11
 ENV CXX g++-11
 
-# Build
-RUN cd $MINIFI_BASE_DIR/build \
-       && cmake -DUSE_SHARED_LIBS= -DENABLE_MQTT=ON -DENABLE_LIBRDKAFKA=ON -DPORTABLE=ON -DENABLE_COAP=ON -DCMAKE_BUILD_TYPE=Release -DSKIP_TESTS=true -DENABLE_JNI=$ENABLE_JNI .. \
-       && make -j$(nproc) package
+# Run bootstrap and build
+RUN cd $MINIFI_BASE_DIR \
+    && ./bootstrap.sh -t \
+    && cd $MINIFI_BASE_DIR/build \
+    && cmake -DUSE_SHARED_LIBS= -DENABLE_MQTT=ON -DENABLE_LIBRDKAFKA=ON -DPORTABLE=ON -DENABLE_COAP=ON -DCMAKE_BUILD_TYPE=Release -DSKIP_TESTS=true -DENABLE_JNI=$ENABLE_JNI .. \
+    && make -j$(nproc) package

--- a/docker/focal/Dockerfile
+++ b/docker/focal/Dockerfile
@@ -29,7 +29,7 @@ ENV MINIFI_HOME $MINIFI_BASE_DIR/nifi-minifi-cpp-$MINIFI_VERSION
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 
 RUN apt update
-RUN DEBIAN_FRONTEND="noninteractive" apt install -y openjdk-8-jdk openjdk-8-source python3.9-dev sudo git maven autogen autoconf automake cmake
+RUN DEBIAN_FRONTEND="noninteractive" apt install -y openjdk-8-jdk openjdk-8-source python3.9-dev sudo git maven autogen autoconf automake cmake software-properties-common
 
 RUN mkdir -p $MINIFI_BASE_DIR
 COPY . ${MINIFI_BASE_DIR}
@@ -37,11 +37,14 @@ COPY . ${MINIFI_BASE_DIR}
 
 FROM build_deps AS release
 ARG ENABLE_JNI
-# Perform the build
-RUN cd $MINIFI_BASE_DIR \
-	&& ./bootstrap.sh -e -t \
-	&& rm -rf build \
-	&& mkdir build \
-	&& cd build \
-	&& cmake -DUSE_SHARED_LIBS=  -DENABLE_MQTT=ON -DENABLE_LIBRDKAFKA=ON -DPORTABLE=ON -DENABLE_COAP=ON -DCMAKE_BUILD_TYPE=Release -DSKIP_TESTS=true -DENABLE_JNI=$ENABLE_JNI .. \
-	&& make -j$(nproc) package
+
+# Run bootstrap
+RUN cd $MINIFI_BASE_DIR && ./bootstrap.sh -t
+
+ENV CC gcc-11
+ENV CXX g++-11
+
+# Build
+RUN cd $MINIFI_BASE_DIR/build \
+       && cmake -DUSE_SHARED_LIBS= -DENABLE_MQTT=ON -DENABLE_LIBRDKAFKA=ON -DPORTABLE=ON -DENABLE_COAP=ON -DCMAKE_BUILD_TYPE=Release -DSKIP_TESTS=true -DENABLE_JNI=$ENABLE_JNI .. \
+       && make -j$(nproc) package


### PR DESCRIPTION
When upgrading compilers, I broke make u20. Since now we rely on the ubuntu toolchain ppa, we need the add-apt-repository command, and it's not available in ubuntu docker images. We need to install it before calling the bootstrap script in docker.

I also forgot to adapt it like I did with the other docker jobs, due to it not showing up in the CI.

---
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
