### PR TITLE
MINIFICPP-1622 Fix filename update of CompressContent in case of tar.gz

### DIFF
--- a/extensions/libarchive/CompressContent.h
+++ b/extensions/libarchive/CompressContent.h
@@ -75,6 +75,8 @@ class CompressContent : public core::Processor {
   static core::Relationship Failure;
   static core::Relationship Success;
 
+  static const std::string TAR_EXT;
+
   SMART_ENUM(CompressionMode,
     (Compress, "compress"),
     (Decompress, "decompress")


### PR DESCRIPTION
In case the "Encapsulate in TAR" and "Update Filename" properties were set the filename property was only updated with the added ".gz" extension. Updated to add ".tar.gz" extension instead and to expect ".tar.gz" extension to be removed in case of decompression with the same properties set.

https://issues.apache.org/jira/browse/MINIFICPP-1622

---------------------------------------------------------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
