### PR TITLE
MINIFICPP-1619 Make sure serialized records expire in DBProvenanceRepositoryTests

### DIFF
--- a/libminifi/test/rocksdb-tests/DBProvenanceRepositoryTests.cpp
+++ b/libminifi/test/rocksdb-tests/DBProvenanceRepositoryTests.cpp
@@ -102,14 +102,14 @@ TEST_CASE("Test time limit", "[timeLimitTest]") {
   /**
    * Magic: TTL-based DB cleanup only triggers when writeBuffers are serialized to storage
    * To achieve this 250 entries are put to DB with a total size that ensures at least one buffer is serialized
-   * Wait more than a sec to make sure the serialized records expire
+   * Wait 2 seconds to make sure the serialized records expire
    * Put another set of entries to trigger cleanup logic to drop the already serialized records
    * This tests relies on the default settings of Provenance repo: a size of a writeBuffer is 16 MB
    * One provisioning call here writes 25 MB to make sure serialization is triggered
    * When the 2nd 50 MB is written the records of the 1st serialization are dropped -> around 160 of them
    * That's why the final check verifies keyCount to be below 400
    */
-  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+  std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
   provisionRepo(provdb, keyCount /2, 102400);
 


### PR DESCRIPTION
DBProvenanceRepositoryTests transiently failed due to not waiting enough time to have the serialized records to expire in the test. The failure does not seem to be connected to a specific change as it seems to transiently fail with commits from a few months ago, but the failures seem to increase in the past week. Increasing the wait time from 1,5 to 2 seconds solves the issue.

https://issues.apache.org/jira/browse/MINIFICPP-1619

--------------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
