### PR TITLE
MINIFICPP-1627 Do not build OpenCV in the Windows CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
   windows_VS2019:
     name: "windows-vs2019"
     runs-on: windows-2019
-    timeout-minutes: 120
+    timeout-minutes: 180
     env:
       CLCACHE_DIR: ${{ GITHUB.WORKSPACE }}\clcache
     steps:
@@ -81,7 +81,7 @@ jobs:
         run: |
           PATH %PATH%;C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64
           PATH %PATH%;C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Roslyn
-          win_build_vs.bat build /64 /CI /S /A /PDH /K /L /R /Z /N /O /RO
+          win_build_vs.bat build /64 /CI /S /A /PDH /K /L /R /Z /N /RO
         shell: cmd
       - name: test
         run: cd build && ctest --timeout 300 --parallel 8 -C Release --output-on-failure


### PR DESCRIPTION
As @adamdebreceni measured, out of the ~ 2 hour duration of the Windows CI job, ~ 30 minutes are spent compiling the OpenCV dependency.  Since this extension is not vital, and it may not be in good shape as there are no tests for it, we don't want to spend so much time every time a change is pushed.

Also: increase the timeout from 2 to 3 hours.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
