### PR TITLE
MINIFICPP-1635 Fix missing Python package issue in MacOS builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,7 @@ jobs:
             macos-xcode12.0-ccache-refs/heads/main-
       - id: install_dependencies
         run: |
-          brew update
-          brew install ossp-uuid boost flex lua@5.3 ccache sqliteodbc automake autoconf
+          brew install ossp-uuid boost flex lua@5.3 ccache sqliteodbc automake autoconf python
       - id: setup_env
         name: setup enviroment
         run: |


### PR DESCRIPTION
Issues started appearing since latest python package upgrade on Github Actions MacOS hosts.  (Unnecessary) `brew update` had to be removed due to issue https://github.com/actions/virtual-environments/issues/4020

https://issues.apache.org/jira/browse/MINIFICPP-1635

-----------------------------------------------------------------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
