### PR TITLE
MINIFICPP-1656 Load the extensions before generating the agent docs

### DIFF
--- a/main/MiNiFiMain.cpp
+++ b/main/MiNiFiMain.cpp
@@ -53,6 +53,7 @@
 #include "core/FlowConfiguration.h"
 #include "core/ConfigurationFactory.h"
 #include "core/RepositoryFactory.h"
+#include "core/extension/ExtensionManager.h"
 #include "DiskSpaceWatchdog.h"
 #include "properties/Decryptor.h"
 #include "utils/file/PathUtils.h"
@@ -222,6 +223,8 @@ int main(int argc, char **argv) {
       std::cerr << "Working directory doesn't exist and cannot be created: " << argv[2] << std::endl;
       exit(1);
     }
+
+    minifi::core::extension::ExtensionManager::get().initialize(configure);
 
     std::cerr << "Dumping docs to " << argv[2] << std::endl;
     if (argc == 4) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-1656

Now that extensions are shared libraries, we need to explicitly load them.  In the normal use case, this happens in `core::createFlowConfiguration()` [-> `YamlConfiguration` c'tor -> `FlowConfiguration` c'tor], but in the "docs" use case, we need to do it manually.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
