### PR TITLE
MINIFICPP-1658 Fix handling OS signals when running in container

### DIFF
--- a/bin/minifi.sh
+++ b/bin/minifi.sh
@@ -212,7 +212,7 @@ case "\$1" in
         fi
       fi
       echo running
-      \${minifi_executable}
+      exec \${minifi_executable}
       ;;
     status)
         # interpret status as per LSB specifications
@@ -339,7 +339,7 @@ case "$1" in
             exit 0;
         fi
       fi
-      ${minifi_executable}
+      exec ${minifi_executable}
       ;;
     status)
       if [ "${saved_pid}" -gt 0 ]; then


### PR DESCRIPTION
If Minifi runs in a docker container signals are not handled properly because the starter shell script does not forward the signals to the spawned process. This could cause problems like being unable to stop a running container with SIGTERM signal, for example when shutting down a pod in Kubernetes environment, resulting in always waiting for the grace period to end, or locally with CTRL+C combination's SIGINT signal.

Instead of spawning a new process replacing the shell script with the Minifi process when starting it solves the issue.

https://issues.apache.org/jira/browse/MINIFICPP-1658

----------------------------------------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
