### PR TITLE
MINIFICPP-1645 Only include each processor or controller service in the heartbeat once

### DIFF
--- a/extensions/http-curl/tests/C2LogHeartbeatTest.cpp
+++ b/extensions/http-curl/tests/C2LogHeartbeatTest.cpp
@@ -26,7 +26,12 @@
 #include "protocols/RESTSender.h"
 #include "HTTPIntegrationBase.h"
 #include "HTTPHandlers.h"
-#include "range/v3/all.hpp"
+#include "range/v3/action/sort.hpp"
+#include "range/v3/action/unique.hpp"
+#include "range/v3/range/conversion.hpp"
+#include "range/v3/view/filter.hpp"
+#include "range/v3/view/split.hpp"
+#include "range/v3/view/transform.hpp"
 #include "utils/IntegrationTestUtils.h"
 #include "utils/StringUtils.h"
 

--- a/extensions/http-curl/tests/C2LogHeartbeatTest.cpp
+++ b/extensions/http-curl/tests/C2LogHeartbeatTest.cpp
@@ -17,14 +17,18 @@
  */
 
 #undef NDEBUG
+
 #include "TestBase.h"
+
 #include "c2/C2Agent.h"
+#include "c2/HeartbeatLogger.h"
 #include "protocols/RESTProtocol.h"
 #include "protocols/RESTSender.h"
 #include "HTTPIntegrationBase.h"
 #include "HTTPHandlers.h"
+#include "range/v3/all.hpp"
 #include "utils/IntegrationTestUtils.h"
-#include "c2/HeartbeatLogger.h"
+#include "utils/StringUtils.h"
 
 class VerifyLogC2Heartbeat : public VerifyC2Base {
  public:
@@ -42,6 +46,16 @@ class VerifyLogC2Heartbeat : public VerifyC2Base {
     assert(verifyLogLinePresenceInPollTime(
         std::chrono::milliseconds(wait_time_),
         "\"operation\": \"heartbeat\""));
+
+    const auto log = LogTestController::getInstance().log_output.str();
+    auto types_in_heartbeat = log | ranges::views::split('\n')
+        | ranges::views::transform([](auto&& rng) { return rng | ranges::to<std::string>; })
+        | ranges::views::filter([](auto&& line) { return utils::StringUtils::startsWith(line, "                                \"type\":"); })
+        | ranges::to<std::vector<std::string>>;
+    const auto num_types = types_in_heartbeat.size();
+    types_in_heartbeat |= ranges::actions::sort | ranges::actions::unique;
+    const auto num_distinct_types = types_in_heartbeat.size();
+    assert(num_types == num_distinct_types);
   }
 
   void configureC2() override {

--- a/libminifi/include/core/ClassLoader.h
+++ b/libminifi/include/core/ClassLoader.h
@@ -27,7 +27,8 @@
 
 #include "core/Core.h"
 #include "ObjectFactory.h"
-#include "range/v3/all.hpp"
+#include "range/v3/action/sort.hpp"
+#include "range/v3/action/unique.hpp"
 
 namespace org {
 namespace apache {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-1645

`RocksDbPersistableKeyValueStoreService` is registered in the class loader under two different names, so we can refer to it from `minifi.properties` using different capitalization: eg. "RocksDBPersistableKeyValueStoreService" is accepted, too.  This is nice, but a side effect is that it used to be included in the heartbeat manifest twice.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
