### PR TITLE
MINIFICPP-1662 fix gsl include

### DIFF
--- a/encrypt-config/tests/ConfigFileTests.cpp
+++ b/encrypt-config/tests/ConfigFileTests.cpp
@@ -21,7 +21,7 @@
 
 #include "ConfigFile.h"
 
-#include "gsl/gsl-lite.hpp"
+#include "utils/gsl.h"
 
 #include "TestBase.h"
 #include "utils/file/FileUtils.h"
@@ -185,7 +185,7 @@ TEST_CASE("ConfigFile can write to a new file", "[encrypt-config][writeTo]") {
 
   TestController test_controller;
   std::string temp_dir = test_controller.createTempDirectory();
-  auto remove_directory = gsl::finally([&temp_dir]() { utils::file::delete_dir(temp_dir); });
+  auto remove_directory = minifi::gsl::finally([&temp_dir]() { utils::file::delete_dir(temp_dir); });
   std::string file_path = utils::file::concat_path(temp_dir, "minifi.properties");
 
   test_file.writeTo(file_path);


### PR DESCRIPTION
gsl-lite recommends that libraries use it through the ::gsl_lite namespace, possibly by a namespace alias in their own namespace. source and rationale: https://github.com/gsl-lite/gsl-lite#using-gsl-lite-in-libraries
utils/gsl.h introduces such namespace alias:
::org::apache::nifi::minifi::gsl -> ::gsl_lite
We should try to use this header and alias instead of the gsl headers
and namespaces directly. Unfortunately we have no automated checks for
this in place.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
