### PR TITLE
MINIFICPP-1668 Remove request parameters from Azure primary uri

### DIFF
--- a/extensions/azure/storage/AzureBlobStorage.cpp
+++ b/extensions/azure/storage/AzureBlobStorage.cpp
@@ -48,7 +48,11 @@ std::optional<UploadBlobResult> AzureBlobStorage::uploadBlob(const PutAzureBlobS
     auto response = blob_storage_client_->uploadBlob(params, buffer);
 
     UploadBlobResult result;
-    result.primary_uri = blob_storage_client_->getUrl(params);
+    auto upload_url = blob_storage_client_->getUrl(params);
+    if (auto query_string_pos = upload_url.find('?'); query_string_pos != std::string::npos) {
+      upload_url = upload_url.substr(0, query_string_pos);
+    }
+    result.primary_uri = upload_url;
     if (response.ETag.HasValue()) {
       result.etag = response.ETag.ToString();
     }

--- a/libminifi/test/azure-tests/PutAzureBlobStorageTests.cpp
+++ b/libminifi/test/azure-tests/PutAzureBlobStorageTests.cpp
@@ -43,7 +43,7 @@ const std::string GET_FILE_NAME = "input_data.log";
 class MockBlobStorage : public minifi::azure::storage::BlobStorageClient {
  public:
   const std::string ETAG = "test-etag";
-  const std::string PRIMARY_URI = "test-uri";
+  const std::string PRIMARY_URI = "http://test-uri/file";
   const std::string TEST_TIMESTAMP = "Sun, 21 Oct 2018 12:16:24 GMT";
 
   bool createContainerIfNotExists(const minifi::azure::storage::PutAzureBlobStorageParameters& params) override {
@@ -68,7 +68,7 @@ class MockBlobStorage : public minifi::azure::storage::BlobStorageClient {
 
   std::string getUrl(const minifi::azure::storage::PutAzureBlobStorageParameters& params) override {
     params_ = params;
-    return PRIMARY_URI;
+    return RETURNED_PRIMARY_URI;
   }
 
   minifi::azure::storage::PutAzureBlobStorageParameters getPassedParams() const {
@@ -88,6 +88,7 @@ class MockBlobStorage : public minifi::azure::storage::BlobStorageClient {
   }
 
  private:
+  const std::string RETURNED_PRIMARY_URI = "http://test-uri/file?secret-sas";
   minifi::azure::storage::PutAzureBlobStorageParameters params_;
   bool container_created_ = false;
   bool upload_fails_ = false;
@@ -372,7 +373,7 @@ TEST_CASE_METHOD(PutAzureBlobStorageTestsFixture, "Test Azure blob upload", "[az
   test_controller.runSession(plan, true);
   CHECK(LogTestController::getInstance().contains("key:azure.container value:" + CONTAINER_NAME));
   CHECK(LogTestController::getInstance().contains("key:azure.blobname value:" + GET_FILE_NAME));
-  CHECK(LogTestController::getInstance().contains("key:azure.primaryUri value:" + mock_blob_storage_ptr->PRIMARY_URI));
+  CHECK(LogTestController::getInstance().contains("key:azure.primaryUri value:" + mock_blob_storage_ptr->PRIMARY_URI + "\n"));
   CHECK(LogTestController::getInstance().contains("key:azure.etag value:" + mock_blob_storage_ptr->ETAG));
   CHECK(LogTestController::getInstance().contains("key:azure.length value:" + std::to_string(TEST_DATA.size())));
   CHECK(LogTestController::getInstance().contains("key:azure.timestamp value:" + mock_blob_storage_ptr->TEST_TIMESTAMP));
@@ -393,7 +394,7 @@ TEST_CASE_METHOD(PutAzureBlobStorageTestsFixture, "Test Azure blob upload with c
   test_controller.runSession(plan, true);
   CHECK(LogTestController::getInstance().contains("key:azure.container value:" + CONTAINER_NAME));
   CHECK(LogTestController::getInstance().contains("key:azure.blobname value:" + BLOB_NAME));
-  CHECK(LogTestController::getInstance().contains("key:azure.primaryUri value:" + mock_blob_storage_ptr->PRIMARY_URI));
+  CHECK(LogTestController::getInstance().contains("key:azure.primaryUri value:" + mock_blob_storage_ptr->PRIMARY_URI + "\n"));
   CHECK(LogTestController::getInstance().contains("key:azure.etag value:" + mock_blob_storage_ptr->ETAG));
   CHECK(LogTestController::getInstance().contains("key:azure.length value:" + std::to_string(TEST_DATA.size())));
   CHECK(LogTestController::getInstance().contains("key:azure.timestamp value:" + mock_blob_storage_ptr->TEST_TIMESTAMP));


### PR DESCRIPTION
PutAzureBlobStorage returned the azure.primaryUri by getting the blob URI as is, which could contain sensitive information like an SAS token in it. These request parameters are removed from the URL.

https://issues.apache.org/jira/browse/MINIFICPP-1668

---------------------------------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
