### PR TITLE
MINIFICPP-1674 fix azure-sdk target name, use install dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,13 @@ jobs:
         run: |
           PATH %PATH%;C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64
           PATH %PATH%;C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Roslyn
-          win_build_vs.bat build /64 /CI /S /A /PDH /K /L /R /Z /N /RO
+          win_build_vs.bat ..\b /64 /CI /S /A /PDH /K /L /R /Z /N /RO
         shell: cmd
       - name: test
-        run: cd build && ctest --timeout 300 --parallel 8 -C Release --output-on-failure
+        run: cd ..\b && ctest --timeout 300 --parallel 8 -C Release --output-on-failure
         shell: cmd
       - name: linter
-        run: cd build && msbuild linter.vcxproj
+        run: cd ..\b && msbuild linter.vcxproj
         shell: cmd
   ubuntu_20_04:
     name: "ubuntu-20.04"

--- a/cmake/BundledAzureSdkCpp.cmake
+++ b/cmake/BundledAzureSdkCpp.cmake
@@ -61,12 +61,10 @@ function(use_bundled_libazure SOURCE_DIR BINARY_DIR)
             azure-sdk-cpp-external
             URL https://github.com/Azure/azure-sdk-for-cpp/archive/refs/tags/azure-storage-files-datalake_12.2.0.tar.gz
             URL_HASH "SHA256=d4e80ea5e786dc689ddd04825d97ab91f5e1ef2787fa88a3d5ee00f0b820433f"
-            BUILD_IN_SOURCE true
             SOURCE_DIR "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src"
             INSTALL_DIR "${BINARY_DIR}/thirdparty/azure-sdk-cpp-install"
             BUILD_BYPRODUCTS "${AZURESDK_LIBRARIES_LIST}"
             EXCLUDE_FROM_ALL TRUE
-            STEP_TARGETS build
             CMAKE_ARGS ${AZURE_SDK_CMAKE_ARGS}
             LIST_SEPARATOR % # This is needed for passing semicolon-separated lists
             PATCH_COMMAND ${PC}

--- a/cmake/BundledAzureSdkCpp.cmake
+++ b/cmake/BundledAzureSdkCpp.cmake
@@ -20,22 +20,28 @@ function(use_bundled_libazure SOURCE_DIR BINARY_DIR)
     set(PC ${Bash_EXECUTABLE} -c "set -x && \
             (\"${Patch_EXECUTABLE}\" -p1 -R -s -f --dry-run -i \"${PATCH_FILE}\" || \"${Patch_EXECUTABLE}\" -p1 -N -i \"${PATCH_FILE}\")")
     # Define byproducts
+    set(INSTALL_DIR "${BINARY_DIR}/thirdparty/azure-sdk-cpp-install")
+    if (WIN32)
+        set(CMAKE_INSTALL_LIBDIR "lib")
+    else()
+        include(GNUInstallDirs)
+    endif()
     if (WIN32)
         set(SUFFIX "lib")
         set(PREFIX "")
-        set(AZURE_CORE_LIB "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src/sdk/core/azure-core/${CMAKE_BUILD_TYPE}/${PREFIX}azure-core.${SUFFIX}")
-        set(AZURE_STORAGE_COMMON_LIB "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src/sdk/storage/azure-storage-common/${CMAKE_BUILD_TYPE}/${PREFIX}azure-storage-common.${SUFFIX}")
-        set(AZURE_STORAGE_BLOBS_LIB "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src/sdk/storage/azure-storage-blobs/${CMAKE_BUILD_TYPE}/${PREFIX}azure-storage-blobs.${SUFFIX}")
-        set(AZURE_IDENTITY_LIB "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src/sdk/identity/azure-identity/${CMAKE_BUILD_TYPE}/${PREFIX}azure-identity.${SUFFIX}")
-        set(AZURE_STORAGE_FILES_DATALAKE_LIB "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src/sdk/storage/azure-storage-files-datalake/${CMAKE_BUILD_TYPE}/${PREFIX}azure-storage-files-datalake.${SUFFIX}")
+        set(AZURE_CORE_LIB "${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/${PREFIX}azure-core.${SUFFIX}")
+        set(AZURE_STORAGE_COMMON_LIB "${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/${PREFIX}azure-storage-common.${SUFFIX}")
+        set(AZURE_STORAGE_BLOBS_LIB "${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/${PREFIX}azure-storage-blobs.${SUFFIX}")
+        set(AZURE_IDENTITY_LIB "${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/${PREFIX}azure-identity.${SUFFIX}")
+        set(AZURE_STORAGE_FILES_DATALAKE_LIB "${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/${PREFIX}azure-storage-files-datalake.${SUFFIX}")
     else()
         set(SUFFIX "a")
         set(PREFIX "lib")
-        set(AZURE_CORE_LIB "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src/sdk/core/azure-core/${PREFIX}azure-core.${SUFFIX}")
-        set(AZURE_STORAGE_COMMON_LIB "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src/sdk/storage/azure-storage-common/${PREFIX}azure-storage-common.${SUFFIX}")
-        set(AZURE_STORAGE_BLOBS_LIB "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src/sdk/storage/azure-storage-blobs/${PREFIX}azure-storage-blobs.${SUFFIX}")
-        set(AZURE_IDENTITY_LIB "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src/sdk/identity/azure-identity/${PREFIX}azure-identity.${SUFFIX}")
-        set(AZURE_STORAGE_FILES_DATALAKE_LIB "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src/sdk/storage/azure-storage-files-datalake/${PREFIX}azure-storage-files-datalake.${SUFFIX}")
+        set(AZURE_CORE_LIB "${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/${PREFIX}azure-core.${SUFFIX}")
+        set(AZURE_STORAGE_COMMON_LIB "${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/${PREFIX}azure-storage-common.${SUFFIX}")
+        set(AZURE_STORAGE_BLOBS_LIB "${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/${PREFIX}azure-storage-blobs.${SUFFIX}")
+        set(AZURE_IDENTITY_LIB "${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/${PREFIX}azure-identity.${SUFFIX}")
+        set(AZURE_STORAGE_FILES_DATALAKE_LIB "${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/${PREFIX}azure-storage-files-datalake.${SUFFIX}")
     endif()
 
     set(AZURESDK_LIBRARIES_LIST
@@ -46,7 +52,8 @@ function(use_bundled_libazure SOURCE_DIR BINARY_DIR)
             "${AZURE_STORAGE_FILES_DATALAKE_LIB}")
 
     set(AZURE_SDK_CMAKE_ARGS ${PASSTHROUGH_CMAKE_ARGS}
-        -DWARNINGS_AS_ERRORS=OFF)
+        -DWARNINGS_AS_ERRORS=OFF
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR})
     append_third_party_passthrough_args(AZURE_SDK_CMAKE_ARGS "${AZURE_SDK_CMAKE_ARGS}")
 
     # Build project
@@ -56,6 +63,7 @@ function(use_bundled_libazure SOURCE_DIR BINARY_DIR)
             URL_HASH "SHA256=d4e80ea5e786dc689ddd04825d97ab91f5e1ef2787fa88a3d5ee00f0b820433f"
             BUILD_IN_SOURCE true
             SOURCE_DIR "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src"
+            INSTALL_DIR "${BINARY_DIR}/thirdparty/azure-sdk-cpp-install"
             BUILD_BYPRODUCTS "${AZURESDK_LIBRARIES_LIST}"
             EXCLUDE_FROM_ALL TRUE
             STEP_TARGETS build
@@ -65,17 +73,11 @@ function(use_bundled_libazure SOURCE_DIR BINARY_DIR)
     )
 
     # Set dependencies
-    add_dependencies(azure-sdk-cpp-external-build CURL::libcurl LibXml2::LibXml2 OpenSSL::Crypto OpenSSL::SSL)
+    add_dependencies(azure-sdk-cpp-external CURL::libcurl LibXml2::LibXml2 OpenSSL::Crypto OpenSSL::SSL)
 
     # Set variables
     set(LIBAZURE_FOUND "YES" CACHE STRING "" FORCE)
-    set(LIBAZURE_INCLUDE_DIRS
-            "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src/sdk/core/azure-core/inc/"
-            "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src/sdk/storage/azure-storage-blobs/inc/"
-            "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src/sdk/storage/azure-storage-common/inc/"
-            "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src/sdk/identity/azure-identity/inc/"
-            "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src/sdk/storage/azure-storage-files-datalake/inc/"
-            CACHE STRING "" FORCE)
+    set(LIBAZURE_INCLUDE_DIRS "${INSTALL_DIR}/include" CACHE STRING "" FORCE)
     set(LIBAZURE_LIBRARIES ${AZURESDK_LIBRARIES_LIST} CACHE STRING "" FORCE)
 
     # Create imported targets
@@ -85,7 +87,7 @@ function(use_bundled_libazure SOURCE_DIR BINARY_DIR)
 
     add_library(AZURE::azure-core STATIC IMPORTED)
     set_target_properties(AZURE::azure-core PROPERTIES IMPORTED_LOCATION "${AZURE_CORE_LIB}")
-    add_dependencies(AZURE::azure-core azure-sdk-cpp-external-build)
+    add_dependencies(AZURE::azure-core azure-sdk-cpp-external)
     target_include_directories(AZURE::azure-core INTERFACE ${LIBAZURE_INCLUDE_DIRS})
     target_link_libraries(AZURE::azure-core INTERFACE CURL::libcurl OpenSSL::Crypto OpenSSL::SSL)
     if (WIN32)
@@ -94,22 +96,22 @@ function(use_bundled_libazure SOURCE_DIR BINARY_DIR)
 
     add_library(AZURE::azure-identity STATIC IMPORTED)
     set_target_properties(AZURE::azure-identity PROPERTIES IMPORTED_LOCATION "${AZURE_IDENTITY_LIB}")
-    add_dependencies(AZURE::azure-identity azure-sdk-cpp-external-build)
+    add_dependencies(AZURE::azure-identity azure-sdk-cpp-external)
     target_include_directories(AZURE::azure-identity INTERFACE ${LIBAZURE_INCLUDE_DIRS})
 
     add_library(AZURE::azure-storage-common STATIC IMPORTED)
     set_target_properties(AZURE::azure-storage-common PROPERTIES IMPORTED_LOCATION "${AZURE_STORAGE_COMMON_LIB}")
-    add_dependencies(AZURE::azure-storage-common azure-sdk-cpp-external-build)
+    add_dependencies(AZURE::azure-storage-common azure-sdk-cpp-external)
     target_include_directories(AZURE::azure-storage-common INTERFACE ${LIBAZURE_INCLUDE_DIRS})
     target_link_libraries(AZURE::azure-storage-common INTERFACE LibXml2::LibXml2)
 
     add_library(AZURE::azure-storage-blobs STATIC IMPORTED)
     set_target_properties(AZURE::azure-storage-blobs PROPERTIES IMPORTED_LOCATION "${AZURE_STORAGE_BLOBS_LIB}")
-    add_dependencies(AZURE::azure-storage-blobs azure-sdk-cpp-external-build)
+    add_dependencies(AZURE::azure-storage-blobs azure-sdk-cpp-external)
     target_include_directories(AZURE::azure-storage-blobs INTERFACE ${LIBAZURE_INCLUDE_DIRS})
 
     add_library(AZURE::azure-storage-files-datalake STATIC IMPORTED)
     set_target_properties(AZURE::azure-storage-files-datalake PROPERTIES IMPORTED_LOCATION "${AZURE_STORAGE_FILES_DATALAKE_LIB}")
-    add_dependencies(AZURE::azure-storage-files-datalake azure-sdk-cpp-external-build)
+    add_dependencies(AZURE::azure-storage-files-datalake azure-sdk-cpp-external)
     target_include_directories(AZURE::azure-storage-files-datalake INTERFACE ${LIBAZURE_INCLUDE_DIRS})
 endfunction(use_bundled_libazure)

--- a/cmake/BundledAzureSdkCpp.cmake
+++ b/cmake/BundledAzureSdkCpp.cmake
@@ -58,7 +58,7 @@ function(use_bundled_libazure SOURCE_DIR BINARY_DIR)
 
     # Build project
     ExternalProject_Add(
-            azure-sdk-cpp-external
+            asdkext  # short for azure-sdk-cpp-external due to windows MAX_PATH limitations
             URL https://github.com/Azure/azure-sdk-for-cpp/archive/refs/tags/azure-storage-files-datalake_12.2.0.tar.gz
             URL_HASH "SHA256=d4e80ea5e786dc689ddd04825d97ab91f5e1ef2787fa88a3d5ee00f0b820433f"
             SOURCE_DIR "${BINARY_DIR}/thirdparty/azure-sdk-cpp-src"
@@ -71,7 +71,7 @@ function(use_bundled_libazure SOURCE_DIR BINARY_DIR)
     )
 
     # Set dependencies
-    add_dependencies(azure-sdk-cpp-external CURL::libcurl LibXml2::LibXml2 OpenSSL::Crypto OpenSSL::SSL)
+    add_dependencies(asdkext CURL::libcurl LibXml2::LibXml2 OpenSSL::Crypto OpenSSL::SSL)
 
     # Set variables
     set(LIBAZURE_FOUND "YES" CACHE STRING "" FORCE)
@@ -85,7 +85,7 @@ function(use_bundled_libazure SOURCE_DIR BINARY_DIR)
 
     add_library(AZURE::azure-core STATIC IMPORTED)
     set_target_properties(AZURE::azure-core PROPERTIES IMPORTED_LOCATION "${AZURE_CORE_LIB}")
-    add_dependencies(AZURE::azure-core azure-sdk-cpp-external)
+    add_dependencies(AZURE::azure-core asdkext)
     target_include_directories(AZURE::azure-core INTERFACE ${LIBAZURE_INCLUDE_DIRS})
     target_link_libraries(AZURE::azure-core INTERFACE CURL::libcurl OpenSSL::Crypto OpenSSL::SSL)
     if (WIN32)
@@ -94,22 +94,22 @@ function(use_bundled_libazure SOURCE_DIR BINARY_DIR)
 
     add_library(AZURE::azure-identity STATIC IMPORTED)
     set_target_properties(AZURE::azure-identity PROPERTIES IMPORTED_LOCATION "${AZURE_IDENTITY_LIB}")
-    add_dependencies(AZURE::azure-identity azure-sdk-cpp-external)
+    add_dependencies(AZURE::azure-identity asdkext)
     target_include_directories(AZURE::azure-identity INTERFACE ${LIBAZURE_INCLUDE_DIRS})
 
     add_library(AZURE::azure-storage-common STATIC IMPORTED)
     set_target_properties(AZURE::azure-storage-common PROPERTIES IMPORTED_LOCATION "${AZURE_STORAGE_COMMON_LIB}")
-    add_dependencies(AZURE::azure-storage-common azure-sdk-cpp-external)
+    add_dependencies(AZURE::azure-storage-common asdkext)
     target_include_directories(AZURE::azure-storage-common INTERFACE ${LIBAZURE_INCLUDE_DIRS})
     target_link_libraries(AZURE::azure-storage-common INTERFACE LibXml2::LibXml2)
 
     add_library(AZURE::azure-storage-blobs STATIC IMPORTED)
     set_target_properties(AZURE::azure-storage-blobs PROPERTIES IMPORTED_LOCATION "${AZURE_STORAGE_BLOBS_LIB}")
-    add_dependencies(AZURE::azure-storage-blobs azure-sdk-cpp-external)
+    add_dependencies(AZURE::azure-storage-blobs asdkext)
     target_include_directories(AZURE::azure-storage-blobs INTERFACE ${LIBAZURE_INCLUDE_DIRS})
 
     add_library(AZURE::azure-storage-files-datalake STATIC IMPORTED)
     set_target_properties(AZURE::azure-storage-files-datalake PROPERTIES IMPORTED_LOCATION "${AZURE_STORAGE_FILES_DATALAKE_LIB}")
-    add_dependencies(AZURE::azure-storage-files-datalake azure-sdk-cpp-external)
+    add_dependencies(AZURE::azure-storage-files-datalake asdkext)
     target_include_directories(AZURE::azure-storage-files-datalake INTERFACE ${LIBAZURE_INCLUDE_DIRS})
 endfunction(use_bundled_libazure)

--- a/win_build_vs.bat
+++ b/win_build_vs.bat
@@ -20,6 +20,7 @@ TITLE Apache NiFi MiNiFi C++ Windows Build Helper
 if [%1]==[] goto usage
 
 set builddir=%1
+set scriptdir=%~dp0
 set skiptests=OFF
 set skiptestrun=OFF
 set cmake_build_type=Release
@@ -72,7 +73,7 @@ for %%x in (%*) do (
 mkdir %builddir%
 pushd %builddir%\
 
-cmake -G %generator% -A %build_platform% -DINSTALLER_MERGE_MODULES=%installer_merge_modules% -DTEST_CUSTOM_WEL_PROVIDER=%test_custom_wel_provider% -DENABLE_SQL=%build_SQL% -DUSE_REAL_ODBC_TEST_DRIVER=%real_odbc% -DCMAKE_BUILD_TYPE_INIT=%cmake_build_type% -DCMAKE_BUILD_TYPE=%cmake_build_type% -DWIN32=WIN32 -DENABLE_LIBRDKAFKA=%build_kafka% -DENABLE_JNI=%build_jni% -DOPENSSL_OFF=OFF -DENABLE_COAP=%build_coap% -DENABLE_AWS=%build_AWS% -DENABLE_PDH=%build_PDH% -DENABLE_AZURE=%build_azure% -DENABLE_SFTP=%build_SFTP% -DENABLE_NANOFI=%build_nanofi% -DENABLE_OPENCV=%build_opencv% -DUSE_SHARED_LIBS=OFF -DDISABLE_CONTROLLER=ON  -DBUILD_ROCKSDB=ON -DFORCE_WINDOWS=ON -DUSE_SYSTEM_UUID=OFF -DDISABLE_LIBARCHIVE=OFF -DENABLE_SCRIPTING=OFF -DEXCLUDE_BOOST=ON -DENABLE_WEL=ON -DFAIL_ON_WARNINGS=OFF -DSKIP_TESTS=%skiptests% %strict_gsl_checks% %redist% -DENABLE_LINTER=%build_linter% .. && msbuild /m nifi-minifi-cpp.sln /property:Configuration=%cmake_build_type% /property:Platform=%build_platform% && copy bin\%cmake_build_type%\minifi.exe main\
+cmake -G %generator% -A %build_platform% -DINSTALLER_MERGE_MODULES=%installer_merge_modules% -DTEST_CUSTOM_WEL_PROVIDER=%test_custom_wel_provider% -DENABLE_SQL=%build_SQL% -DUSE_REAL_ODBC_TEST_DRIVER=%real_odbc% -DCMAKE_BUILD_TYPE_INIT=%cmake_build_type% -DCMAKE_BUILD_TYPE=%cmake_build_type% -DWIN32=WIN32 -DENABLE_LIBRDKAFKA=%build_kafka% -DENABLE_JNI=%build_jni% -DOPENSSL_OFF=OFF -DENABLE_COAP=%build_coap% -DENABLE_AWS=%build_AWS% -DENABLE_PDH=%build_PDH% -DENABLE_AZURE=%build_azure% -DENABLE_SFTP=%build_SFTP% -DENABLE_NANOFI=%build_nanofi% -DENABLE_OPENCV=%build_opencv% -DUSE_SHARED_LIBS=OFF -DDISABLE_CONTROLLER=ON  -DBUILD_ROCKSDB=ON -DFORCE_WINDOWS=ON -DUSE_SYSTEM_UUID=OFF -DDISABLE_LIBARCHIVE=OFF -DENABLE_SCRIPTING=OFF -DEXCLUDE_BOOST=ON -DENABLE_WEL=ON -DFAIL_ON_WARNINGS=OFF -DSKIP_TESTS=%skiptests% %strict_gsl_checks% %redist% -DENABLE_LINTER=%build_linter% "%scriptdir%" && msbuild /m nifi-minifi-cpp.sln /property:Configuration=%cmake_build_type% /property:Platform=%build_platform% && copy bin\%cmake_build_type%\minifi.exe main\
 IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%
 if [%cpack%] EQU [ON] (
     cpack -C %cmake_build_type%


### PR DESCRIPTION
Azure-sdk dependencies were not respected, because of a mismatch between
cmake target names (-external vs -external-build). After fixing this
issue, the build failed, because the azure-sdk cmake scripts tried to
install stuff to /usr/local, which they thankfully couldn't.

Apparently the azure sdk third party was used directly from its
source/build directory, so it had no install dir and defaulted to
/usr/local. I adapted it to look like other third parties, with an
install directory under our build/thirdparty dir, where the package can
install and we can consume its artifacts.

https://issues.apache.org/jira/browse/MINIFICPP-1674

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
