### PR TITLE
MINIFICPP-1683 Revert github actions caching changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: macos-xcode12.0-ccache-${{github.ref}}
+          key: macos-xcode12.0-ccache-${{github.ref}}-${{github.sha}}
           restore-keys: |
-            macos-xcode12.0-ccache-
+            macos-xcode12.0-ccache-${{github.ref}}-
+            macos-xcode12.0-ccache-refs/heads/main-
       - id: install_dependencies
         run: |
           brew update
@@ -54,9 +55,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.CLCACHE_DIR }}
-          key: windows-vs2019-clcache-${{github.ref}}
+          key: windows-vs2019-clcache-${{github.ref}}-${{github.sha}}
           restore-keys: |
-            windows-vs2019-clcache-
+            windows-vs2019-clcache-${{github.ref}}-
+            windows-vs2019-clcache-refs/heads/main-
       - name: Setup PATH
         uses: microsoft/setup-msbuild@v1.0.2
       - id: install-sqliteodbc-driver
@@ -97,9 +99,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.ccache
-          key: ubuntu-20.04-ccache-${{github.ref}}
+          key: ubuntu-20.04-ccache-${{github.ref}}-${{github.sha}}
           restore-keys: |
-            ubuntu-20.04-ccache-
+            ubuntu-20.04-ccache-${{github.ref}}-
+            ubuntu-20.04-ccache-refs/heads/main-
       - id: install_deps
         run: |
           sudo apt update
@@ -136,9 +139,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.ccache
-          key: ubuntu-20.04-all-clang-ccache-${{github.ref}}
+          key: ubuntu-20.04-all-clang-ccache-${{github.ref}}-${{github.sha}}
           restore-keys: |
-            ubuntu-20.04-all-clang-ccache-
+            ubuntu-20.04-all-clang-ccache-${{github.ref}}-
+            ubuntu-20.04-all-clang-ccache-refs/heads/main-
       - id: install_deps
         run: |
           sudo apt update
@@ -166,9 +170,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.ccache
-          key: debian-ccache-${{github.ref}}
+          key: debian-ccache-${{github.ref}}-${{github.sha}}
           restore-keys: |
-            debian-ccache-
+            debian-ccache-${{github.ref}}-
+            debian-ccache-refs/heads/main-
       - id: install_deps
         run: |
           sudo apt update
@@ -187,9 +192,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.ccache
-          key: centos-ccache-${{github.ref}}
+          key: centos-ccache-${{github.ref}}-${{github.sha}}
           restore-keys: |
-            centos-ccache-
+            centos-ccache-${{github.ref}}-
+            centos-ccache-refs/heads/main-
       - id: install_deps
         run: |
           sudo apt update
@@ -208,9 +214,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.ccache
-          key: fedora-ccache-${{github.ref}}
+          key: fedora-ccache-${{github.ref}}-${{github.sha}}
           restore-keys: |
-            fedora-ccache-
+            fedora-ccache-${{github.ref}}-
+            fedora-ccache-refs/heads/main-
       - id: install_deps
         run: |
           sudo apt update
@@ -229,9 +236,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.ccache
-          key: ubuntu-18.04-ccache-${{github.ref}}
+          key: ubuntu-18.04-ccache-${{github.ref}}-${{github.sha}}
           restore-keys: |
-            ubuntu-18.04-ccache-
+            ubuntu-18.04-ccache-${{github.ref}}-
+            ubuntu-18.04-ccache-refs/heads/main
       - id: install_deps
         run: |
           sudo apt update
@@ -257,9 +265,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.ccache
-          key: docker-ccache-${{github.ref}}
+          key: docker-ccache-${{github.ref}}-${{github.sha}}
           restore-keys: |
-            docker-ccache-
+            docker-ccache-${{github.ref}}-
+            docker-ccache-refs/heads/main
       - id: build
         run: |
           if [ -d ~/.ccache ]; then mv ~/.ccache .; fi


### PR DESCRIPTION
Recently caching was changed to only keep a single cache key for each branch and update the cache content for that key in every CI build. This was done to save space so it would take longer for the older branch caches (especially main) to be evicted due to the 5GB cache space per repository. Unfortunately github cache actions does not support updating the cache content for a key because caches are immutable:
- https://github.com/actions/cache/issues/171
- https://github.com/actions/cache/issues/109

https://issues.apache.org/jira/browse/MINIFICPP-1683

------------------------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
