### PR TITLE
MINIFICPP-1685 reduce CI usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,31 +151,10 @@ jobs:
           cd build
           export CC=clang
           export CXX=clang++
-          cmake -DUSE_SHARED_LIBS= -DCMAKE_BUILD_TYPE=Release -DENABLE_NANOFI=ON -DENABLE_JNI=ON -DENABLE_SENSORS=ON -DENABLE_OPENWSMAN=ON -DENABLE_OPENCV=ON -DENABLE_MQTT=ON -DENABLE_GPS=ON -DENABLE_USB_CAMERA=ON -DENABLE_LIBRDKAFKA=ON -DENABLE_OPC=ON -DENABLE_SFTP=ON -DENABLE_COAP=ON -DENABLE_PYTHON=ON -DENABLE_SQL=ON -DENABLE_AWS=ON -DENABLE_AZURE=ON -DSTRICT_GSL_CHECKS=AUDIT -DFAIL_ON_WARNINGS=ON ..
+          cmake -DUSE_SHARED_LIBS= -DCMAKE_BUILD_TYPE=Release -DENABLE_MQTT=ON -DENABLE_LIBRDKAFKA=ON -DENABLE_AWS=ON -DENABLE_AZURE=ON -DFAIL_ON_WARNINGS=ON ..
           cmake --build . --parallel $(nproc)
       - name: test
         run: cd build && make test ARGS="--timeout 300 -j8 --output-on-failure"
-  debian:
-    name: "debian"
-    runs-on: ubuntu-20.04
-    timeout-minutes: 60
-    steps:
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.ccache
-          key: debian-ccache-${{github.ref}}
-          restore-keys: |
-            debian-ccache-
-      - id: install_deps
-        run: |
-          sudo apt update
-          sudo apt install -y ccache
-          echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
-      - id: build
-        run: mkdir build && cd build && cmake -DSTRICT_GSL_CHECKS=AUDIT .. && make debian
   centos:
     name: "centos"
     runs-on: ubuntu-20.04
@@ -197,55 +176,6 @@ jobs:
           echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
         run: mkdir build && cd build && cmake -DSTRICT_GSL_CHECKS=AUDIT .. && make centos
-  fedora:
-    name: "fedora"
-    runs-on: ubuntu-20.04
-    timeout-minutes: 60
-    steps:
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.ccache
-          key: fedora-ccache-${{github.ref}}
-          restore-keys: |
-            fedora-ccache-
-      - id: install_deps
-        run: |
-          sudo apt update
-          sudo apt install -y ccache
-          echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
-      - id: build
-        run: mkdir build && cd build && cmake -DSTRICT_GSL_CHECKS=AUDIT .. && make fedora
-  ubuntu_18_04:
-    name: "ubuntu-18.04"
-    runs-on: ubuntu-18.04
-    timeout-minutes: 60
-    steps:
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.ccache
-          key: ubuntu-18.04-ccache-${{github.ref}}
-          restore-keys: |
-            ubuntu-18.04-ccache-
-      - id: install_deps
-        run: |
-          sudo apt update
-          sudo apt install -y ccache
-          echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
-          echo -e "127.0.0.1\t$HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
-      - id: build
-        run: |
-          ./bootstrap.sh -e -t
-          cd build
-          export CC=gcc-11
-          export CXX=g++-11
-          cmake -DSTRICT_GSL_CHECKS=AUDIT ..
-          make u18
   docker_integration_tests:
     name: "Docker integration tests"
     runs-on: ubuntu-20.04


### PR DESCRIPTION
remove ubuntu 18.04
reduce ubuntu 20.04 clang scope
remove fedora and debian docker builds

https://issues.apache.org/jira/browse/MINIFICPP-1685
MiNiFi C++ uses quite a lot of github actions time for its builds and tests on various platforms. We can reduce the number of platform by relying on results from similar ones, e.g. remove fedora and keep centos only, or reduce ubuntu-clang scope and rely on mac os x clang builds.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
