### PR TITLE
MINIFICPP-1710,MINIFICPP-1714 Stabilize docker tests

### DIFF
--- a/docker/test/integration/features/s3.feature
+++ b/docker/test/integration/features/s3.feature
@@ -155,12 +155,14 @@ Feature: Sending data from MiNiFi-C++ to an AWS server
     And no errors were generated on the http-proxy regarding "http://s3-server:9090/test_bucket/test_object_key"
 
   Scenario: A MiNiFi instance can list an S3 bucket directly
-    Given a TailFile processor with the "File to Tail" property set to "/tmp/input/test_file.log"
-    And the "Input Delimiter" property of the TailFile processor is set to "%"
-    And a file with filename "test_file.log" and content "test_data%" is present in "/tmp/input"
+    Given a GetFile processor with the "Input Directory" property set to "/tmp/input"
+    And the "Batch Size" property of the GetFile processor is set to "1"
+    And the scheduling period of the GetFile processor is set to "5 sec"
+    And a file with filename "test_file_1.log" and content "test_data1" is present in "/tmp/input"
+    And a file with filename "test_file_2.log" and content "test_data2" is present in "/tmp/input"
     And a PutS3Object processor set up to communicate with an s3 server
     And the "Object Key" property of the PutS3Object processor is set to "${filename}"
-    And the "success" relationship of the TailFile processor is connected to the PutS3Object
+    And the "success" relationship of the GetFile processor is connected to the PutS3Object
 
     Given a ListS3 processor in the "secondary" flow
     And a PutFile processor with the "Directory" property set to "/tmp/output"
@@ -169,9 +171,8 @@ Feature: Sending data from MiNiFi-C++ to an AWS server
     And a s3 server is set up in correspondence with the PutS3Object
 
     When all instances start up
-    And content "test_data2%" is added to file "test_file.log" present in directory "/tmp/input" 5 seconds later
 
-    Then 2 flowfiles are placed in the monitored directory in 60 seconds
+    Then 2 flowfiles are placed in the monitored directory in 120 seconds
 
   Scenario: A MiNiFi instance can list an S3 bucket objects via a http-proxy
     Given a GetFile processor with the "Input Directory" property set to "/tmp/input"

--- a/docker/test/integration/minifi/core/FileSystemObserver.py
+++ b/docker/test/integration/minifi/core/FileSystemObserver.py
@@ -38,7 +38,7 @@ class FileSystemObserver(object):
             if max_files <= self.event_handler.get_num_files_created():
                 return False
             wait_start_time = time.perf_counter()
-            for _ in range(0, max_files):
+            while True:
                 # Note: The timing on Event.wait() is inaccurate
                 self.done_event.wait(timeout_seconds - time.perf_counter() + wait_start_time)
                 if self.done_event.isSet():
@@ -49,8 +49,7 @@ class FileSystemObserver(object):
                     if output_validator.validate():
                         return True
                 if timeout_seconds < (time.perf_counter() - wait_start_time):
-                    break
-            return False
+                    return False
         finally:
             self.observer.stop()
             self.observer.join()

--- a/docker/test/integration/minifi/core/OutputEventHandler.py
+++ b/docker/test/integration/minifi/core/OutputEventHandler.py
@@ -1,6 +1,7 @@
 import logging
 import threading
 import os
+from .utils import is_temporary_output_file
 
 from watchdog.events import FileSystemEventHandler
 
@@ -9,26 +10,48 @@ class OutputEventHandler(FileSystemEventHandler):
     def __init__(self, done_event):
         self.done_event = done_event
         self.files_created_lock = threading.Lock()
-        self.files_created = 0
+        self.files_created = set()
 
     def get_num_files_created(self):
         with self.files_created_lock:
-            return self.files_created
+            logging.info("file count created: %d", len(self.files_created))
+            return len(self.files_created)
 
     def on_created(self, event):
-        if os.path.isfile(event.src_path):
-            logging.info("Output file created: " + event.src_path)
+        if os.path.isfile(event.src_path) and not is_temporary_output_file(event.src_path):
+            logging.info("Output file created: %s", event.src_path)
             with open(os.path.abspath(event.src_path), "r") as out_file:
                 logging.info("Contents: %s", out_file.read())
             with self.files_created_lock:
-                self.files_created += 1
-        self.done_event.set()
+                self.files_created.add(event.src_path)
+            self.done_event.set()
 
     def on_modified(self, event):
-        if os.path.isfile(event.src_path):
-            logging.info("Output file modified: " + event.src_path)
+        if os.path.isfile(event.src_path) and not is_temporary_output_file(event.src_path):
+            logging.info("Output file modified: %s", event.src_path)
             with open(os.path.abspath(event.src_path), "r") as out_file:
                 logging.info("Contents: %s", out_file.read())
+            with self.files_created_lock:
+                self.files_created.add(event.src_path)
+            self.done_event.set()
+
+    def on_moved(self, event):
+        if os.path.isfile(event.dest_path):
+            logging.info("Output file moved from: %s to: %s", event.src_path, event.dest_path)
+            file_count_modified = False
+            if event.src_path in self.files_created:
+                self.files_created.remove(event.src_path)
+                file_count_modified = True
+
+            if not is_temporary_output_file(event.dest_path):
+                with open(os.path.abspath(event.dest_path), "r") as out_file:
+                    logging.info("Contents: %s", out_file.read())
+                with self.files_created_lock:
+                    self.files_created.add(event.dest_path)
+                file_count_modified = True
+
+            if file_count_modified:
+                self.done_event.set()
 
     def on_deleted(self, event):
         logging.info("Output file deleted: " + event.src_path)

--- a/docker/test/integration/minifi/core/utils.py
+++ b/docker/test/integration/minifi/core/utils.py
@@ -1,5 +1,6 @@
 import time
 import functools
+import os
 
 
 def retry_check(max_tries=5, retry_interval=1):
@@ -36,3 +37,7 @@ def decode_escaped_str(str):
     if escaped:
         result += "\\"
     return result
+
+
+def is_temporary_output_file(filepath):
+    return filepath.split(os.path.sep)[-1][0] == '.'

--- a/docker/test/integration/minifi/processors/ListS3.py
+++ b/docker/test/integration/minifi/processors/ListS3.py
@@ -18,5 +18,5 @@ class ListS3(Processor):
                                          'Proxy Username': proxy_username,
                                          'Proxy Password': proxy_password,
                                      },
-                                     schedule={'scheduling period': '3 sec'},
+                                     schedule={'scheduling period': '2 sec'},
                                      auto_terminate=['success'])

--- a/docker/test/integration/minifi/validators/FileOutputValidator.py
+++ b/docker/test/integration/minifi/validators/FileOutputValidator.py
@@ -3,6 +3,7 @@ import os
 
 from os import listdir
 from os.path import join
+from ..core.utils import is_temporary_output_file
 
 from .OutputValidator import OutputValidator
 
@@ -19,7 +20,7 @@ class FileOutputValidator(OutputValidator):
         files_of_matching_content_found = 0
         for file_name in listing:
             full_path = join(dir_path, file_name)
-            if not os.path.isfile(full_path):
+            if not os.path.isfile(full_path) or is_temporary_output_file(full_path):
                 continue
             with open(full_path, 'r') as out_file:
                 contents = out_file.read()
@@ -38,7 +39,7 @@ class FileOutputValidator(OutputValidator):
         files_found = 0
         for file_name in listing:
             full_path = join(dir_path, file_name)
-            if os.path.isfile(full_path):
+            if os.path.isfile(full_path) and not is_temporary_output_file(full_path):
                 logging.info("Found output file in %s: %s", dir_path, file_name)
                 files_found += 1
         return files_found

--- a/docker/test/integration/minifi/validators/MultiFileOutputValidator.py
+++ b/docker/test/integration/minifi/validators/MultiFileOutputValidator.py
@@ -3,6 +3,7 @@ import os
 
 from os import listdir
 from os.path import join
+from ..core.utils import is_temporary_output_file
 
 from .FileOutputValidator import FileOutputValidator
 
@@ -13,7 +14,6 @@ class MultiFileOutputValidator(FileOutputValidator):
     """
 
     def __init__(self, expected_file_count, expected_content=[]):
-        self.valid = False
         self.expected_file_count = expected_file_count
         self.file_timestamps = dict()
         self.expected_content = expected_content
@@ -29,37 +29,34 @@ class MultiFileOutputValidator(FileOutputValidator):
         return True
 
     def validate(self):
-        self.valid = False
         full_dir = os.path.join(self.output_dir)
         logging.info("Output folder: %s", full_dir)
 
         if not os.path.isdir(full_dir):
-            return self.valid
+            return False
 
         listing = listdir(full_dir)
         if not listing:
-            return self.valid
+            return False
 
         for out_file_name in listing:
             logging.info("name:: %s", out_file_name)
 
             full_path = join(full_dir, out_file_name)
-            if not os.path.isfile(full_path):
-                return self.valid
+            if not os.path.isfile(full_path) or is_temporary_output_file(full_path):
+                return False
 
             logging.info("dir %s -- name %s", full_dir, out_file_name)
             logging.info("expected file count %d -- current file count %d", self.expected_file_count, len(self.file_timestamps))
 
             if full_path in self.file_timestamps and self.file_timestamps[full_path] != os.path.getmtime(full_path):
                 logging.error("Last modified timestamp changed for %s", full_path)
-                self.valid = False
-                return self.valid
+                return False
 
             self.file_timestamps[full_path] = os.path.getmtime(full_path)
             logging.info("New file added %s", full_path)
 
             if len(self.file_timestamps) == self.expected_file_count:
-                self.valid = self.check_expected_content(full_dir)
-                return self.valid
+                return self.check_expected_content(full_dir)
 
-        return self.valid
+        return False

--- a/docker/test/integration/minifi/validators/SingleJSONFileOutputValidator.py
+++ b/docker/test/integration/minifi/validators/SingleJSONFileOutputValidator.py
@@ -3,6 +3,7 @@ import os
 import json
 
 from .FileOutputValidator import FileOutputValidator
+from ..core.utils import is_temporary_output_file
 
 
 class SingleJSONFileOutputValidator(FileOutputValidator):
@@ -19,7 +20,7 @@ class SingleJSONFileOutputValidator(FileOutputValidator):
             return 0
         for file_name in listing:
             full_path = os.path.join(dir_path, file_name)
-            if not os.path.isfile(full_path):
+            if not os.path.isfile(full_path) or is_temporary_output_file(full_path):
                 continue
             with open(full_path, 'r') as out_file:
                 file_json_content = json.loads(out_file.read())


### PR DESCRIPTION
Recently some docker tests were failing randomly in the CI in the OPC and Kafka test suites. The root cause for both suite failures was the same that NiFi's and MiNiFi's PutFile processor creates a hidden temporary file before renaming it to the final version when all content has been written. The scheduling of the threads can cause that the temp file can be non-existent anymore when it is read or causes a premature notification of the file output creation. These files should be ignored in the notification and the output verification process.

This fix also revealed a flakiness of the ListS3 test due to a timing issue of the creation and the listing of S3 objects. The test was changed to be more stable.

https://issues.apache.org/jira/browse/MINIFICPP-1710
https://issues.apache.org/jira/browse/MINIFICPP-1714

------------------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
