### PR TITLE
MINIFICPP-1737 Fix ConsumeKafka test transient failures

### DIFF
--- a/docker/test/integration/minifi/validators/MultiFileOutputValidator.py
+++ b/docker/test/integration/minifi/validators/MultiFileOutputValidator.py
@@ -10,7 +10,7 @@ from .FileOutputValidator import FileOutputValidator
 
 class MultiFileOutputValidator(FileOutputValidator):
     """
-    Validates the content of multiple files in the given directory, also verifying that the old files are not rewritten.
+    Validates the number of files created and/or the content of multiple files in the given directory, also verifying that the old files are not rewritten.
     """
 
     def __init__(self, expected_file_count, expected_content=[]):

--- a/docker/test/integration/minifi/validators/MultiFileOutputValidator.py
+++ b/docker/test/integration/minifi/validators/MultiFileOutputValidator.py
@@ -56,7 +56,10 @@ class MultiFileOutputValidator(FileOutputValidator):
             self.file_timestamps[full_path] = os.path.getmtime(full_path)
             logging.info("New file added %s", full_path)
 
-            if len(self.file_timestamps) == self.expected_file_count:
-                return self.check_expected_content(full_dir)
+        if self.expected_file_count != 0 and len(self.file_timestamps) != self.expected_file_count:
+            return False
+
+        if len(self.file_timestamps) >= len(self.expected_content):
+            return self.check_expected_content(full_dir)
 
         return False

--- a/docker/test/integration/steps/steps.py
+++ b/docker/test/integration/steps/steps.py
@@ -561,7 +561,7 @@ def step_impl(context, content_1, content_2, duration):
 @then("flowfiles with these contents are placed in the monitored directory in less than {duration}: \"{contents}\"")
 def step_impl(context, duration, contents):
     contents_arr = contents.split(",")
-    context.test.check_for_multiple_files_generated(len(contents_arr), timeparse(duration), contents_arr)
+    context.test.check_for_multiple_files_generated(0, timeparse(duration), contents_arr)
 
 
 @then("after a wait of {duration}, at least {lower_bound:d} and at most {upper_bound:d} flowfiles are produced and placed in the monitored directory")


### PR DESCRIPTION
The test case `Messages are separated into multiple flowfiles if the message demarcator is present in the message` was failing due to some rare glitches with the kafka broker, when empty or duplicated messages arrived. The verification is changed to only check if all the expected messages arrived in the designated time period.

https://issues.apache.org/jira/browse/MINIFICPP-1737

-----------------------------------------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
