### PR TITLE
MINIFICPP-1725 Upgrade libwebsockets and remove workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
           cmake -DUSE_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DSTRICT_GSL_CHECKS=AUDIT -DFAIL_ON_WARNINGS=ON -DENABLE_AWS=ON -DENABLE_AZURE=ON -DENABLE_BUSTACHE=ON -DENABLE_COAP=ON \
               -DENABLE_ENCRYPT_CONFIG=ON -DENABLE_GPS=ON -DENABLE_JNI=ON -DENABLE_LIBRDKAFKA=ON -DENABLE_LINTER=ON -DENABLE_MQTT=ON -DENABLE_NANOFI=ON -DENABLE_OPC=ON -DENABLE_OPENCV=ON \
               -DENABLE_OPENWSMAN=ON -DENABLE_OPS=ON -DENABLE_PCAP=ON -DENABLE_PYTHON=ON -DENABLE_SENSORS=ON -DENABLE_SFTP=ON -DENABLE_SQL=ON -DENABLE_SYSTEMD=ON -DENABLE_TENSORFLOW=OFF \
-              -DENABLE_USB_CAMERA=ON -DENABLE_SCRIPTING=ON -DENABLE_LUA_SCRIPTING=ON ..
+              -DENABLE_USB_CAMERA=ON -DENABLE_SCRIPTING=ON -DENABLE_LUA_SCRIPTING=ON -DENABLE_KUBERNETES=ON ..
           make -j$(nproc) VERBOSE=1
       - name: test
         run: cd build && make test ARGS="--timeout 300 -j2 --output-on-failure"
@@ -181,7 +181,7 @@ jobs:
           sudo apt install -y ccache
           echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       - id: build
-        run: mkdir build && cd build && cmake -DSTRICT_GSL_CHECKS=AUDIT -DENABLE_KUBERNETES=ON .. && make centos
+        run: mkdir build && cd build && cmake -DSTRICT_GSL_CHECKS=AUDIT .. && make centos
   docker_integration_tests:
     name: "Docker integration tests"
     runs-on: ubuntu-20.04

--- a/cmake/BundledLibreSSL.cmake
+++ b/cmake/BundledLibreSSL.cmake
@@ -60,7 +60,6 @@ function(use_libre_ssl SOURCE_DIR BINARY_DIR)
     # Set variables
     set(OPENSSL_FOUND "YES" CACHE STRING "" FORCE)
     set(OPENSSL_INCLUDE_DIR "${LIBRESSL_BIN_DIR}/include" CACHE STRING "" FORCE)
-    set(OPENSSL_INCLUDE_DIRS "${OPENSSL_INCLUDE_DIR}" CACHE STRING "" FORCE)  # workaround for libwebsockets
     set(OPENSSL_LIBRARIES ${LIBRESSL_LIBRARIES_LIST} CACHE STRING "" FORCE)
     set(OPENSSL_CRYPTO_LIBRARY "${LIBRESSL_BIN_DIR}/lib/${BYPRODUCT_PREFIX}crypto${BYPRODUCT_SUFFIX}" CACHE STRING "" FORCE)
     set(OPENSSL_SSL_LIBRARY "${LIBRESSL_BIN_DIR}/lib/${BYPRODUCT_PREFIX}ssl${BYPRODUCT_SUFFIX}" CACHE STRING "" FORCE)
@@ -100,4 +99,4 @@ function(use_libre_ssl SOURCE_DIR BINARY_DIR)
             IMPORTED_LOCATION "${LIBRESSL_BIN_DIR}/lib/${BYPRODUCT_PREFIX}tls${BYPRODUCT_SUFFIX}")
     add_dependencies(LibreSSL::TLS libressl-portable)
     set_property(TARGET LibreSSL::TLS APPEND PROPERTY INTERFACE_LINK_LIBRARIES OpenSSL::Crypto)
-endfunction(use_libre_ssl) 
+endfunction(use_libre_ssl)

--- a/cmake/KubernetesClientC.cmake
+++ b/cmake/KubernetesClientC.cmake
@@ -31,22 +31,29 @@ set(LWS_WITHOUT_TEST_PING ON            CACHE BOOL "" FORCE)
 set(LWS_WITHOUT_TEST_CLIENT ON          CACHE BOOL "" FORCE)
 set(LWS_WITH_SHARED OFF                 CACHE BOOL "" FORCE)
 set(CMAKE_C_FLAGS "-fpic"               CACHE STRING "" FORCE)
+
+set(WEBSOCKETS_PATCH_FILE "${CMAKE_SOURCE_DIR}/thirdparty/libwebsockets/fix-include-dirs.patch")
+set(WEBSOCKETS_PC ${Bash_EXECUTABLE} -c "set -x &&\
+        (${Patch_EXECUTABLE} -R -p1 -s -f --dry-run -i ${WEBSOCKETS_PATCH_FILE} || ${Patch_EXECUTABLE} -p1 -i ${WEBSOCKETS_PATCH_FILE})")
 FetchContent_Declare(websockets
         GIT_REPOSITORY  https://libwebsockets.org/repo/libwebsockets.git
-        GIT_TAG         43a1e83394bf06689b966402e7d4378685d05fbc  # v4.2-stable
+        GIT_TAG         v4.3.1
+        PATCH_COMMAND "${WEBSOCKETS_PC}"
 )
 
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
-set(PATCH_FILE "${CMAKE_SOURCE_DIR}/thirdparty/kubernetes-client-c/remove-findpackage.patch")
-set(PC ${Bash_EXECUTABLE} -c "set -x &&\
-        (${Patch_EXECUTABLE} -R -p1 -s -f --dry-run -i ${PATCH_FILE} || ${Patch_EXECUTABLE} -p1 -i ${PATCH_FILE})")
+set(K8S_PATCH_FILE "${CMAKE_SOURCE_DIR}/thirdparty/kubernetes-client-c/remove-findpackage.patch")
+set(K8S_PC ${Bash_EXECUTABLE} -c "set -x &&\
+        (${Patch_EXECUTABLE} -R -p1 -s -f --dry-run -i ${K8S_PATCH_FILE} || ${Patch_EXECUTABLE} -p1 -i ${K8S_PATCH_FILE})")
 FetchContent_Declare(kubernetes
     GIT_REPOSITORY https://github.com/kubernetes-client/c
     GIT_TAG 9581cd9a8426a5ad7d543b146d5c5ede37cc32e0  # latest commit on master as of 2022-01-05
     SOURCE_SUBDIR kubernetes
-    PATCH_COMMAND "${PC}"
+    PATCH_COMMAND "${K8S_PC}"
 )
 
 FetchContent_MakeAvailable(yaml websockets kubernetes)
+
+set(K8S_CLIENT_DIR "${kubernetes_SOURCE_DIR}/kubernetes" CACHE STRING "" FORCE)
 
 add_dependencies(websockets CURL::libcurl OpenSSL::Crypto OpenSSL::SSL)

--- a/cmake/KubernetesClientC.cmake
+++ b/cmake/KubernetesClientC.cmake
@@ -54,6 +54,4 @@ FetchContent_Declare(kubernetes
 
 FetchContent_MakeAvailable(yaml websockets kubernetes)
 
-set(K8S_CLIENT_DIR "${kubernetes_SOURCE_DIR}/kubernetes" CACHE STRING "" FORCE)
-
 add_dependencies(websockets CURL::libcurl OpenSSL::Crypto OpenSSL::SSL)

--- a/extensions/kubernetes/CMakeLists.txt
+++ b/extensions/kubernetes/CMakeLists.txt
@@ -19,6 +19,7 @@ include(${CMAKE_SOURCE_DIR}/extensions/ExtensionHeader.txt)
 
 file(GLOB SOURCES "*.cpp" "controllerservice/*.cpp")
 add_library(minifi-kubernetes-extensions SHARED ${SOURCES})
+target_include_directories(minifi-kubernetes PRIVATE ${K8S_CLIENT_DIR})
 target_link_libraries(minifi-kubernetes-extensions ${LIBMINIFI} kubernetes CURL::libcurl)
 
 set(KUBERNETES-EXTENSIONS minifi-kubernetes-extensions PARENT_SCOPE)

--- a/extensions/kubernetes/CMakeLists.txt
+++ b/extensions/kubernetes/CMakeLists.txt
@@ -19,7 +19,6 @@ include(${CMAKE_SOURCE_DIR}/extensions/ExtensionHeader.txt)
 
 file(GLOB SOURCES "*.cpp" "controllerservice/*.cpp")
 add_library(minifi-kubernetes-extensions SHARED ${SOURCES})
-target_include_directories(minifi-kubernetes PRIVATE ${K8S_CLIENT_DIR})
 target_link_libraries(minifi-kubernetes-extensions ${LIBMINIFI} kubernetes CURL::libcurl)
 
 set(KUBERNETES-EXTENSIONS minifi-kubernetes-extensions PARENT_SCOPE)

--- a/thirdparty/libwebsockets/fix-include-dirs.patch
+++ b/thirdparty/libwebsockets/fix-include-dirs.patch
@@ -1,0 +1,22 @@
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index c55c6198..5e401726 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -170,7 +170,7 @@ if (LWS_WITH_STATIC)
+ 	)
+ 	target_include_directories(websockets PRIVATE ${LWS_LIB_BUILD_INC_PATHS})
+ 	target_compile_definitions(websockets PRIVATE LWS_BUILDING_STATIC)
+-	target_include_directories(websockets PUBLIC ${LWS_PUBLIC_INCLUDES})
++	target_include_directories(websockets PUBLIC $<BUILD_INTERFACE:${LWS_PUBLIC_INCLUDES}>)
+ 	set(LWS_PUBLIC_INCLUDES ${LWS_PUBLIC_INCLUDES} PARENT_SCOPE)
+ 
+ 	if (WIN32)
+@@ -198,7 +198,7 @@ if (LWS_WITH_SHARED)
+ 	)
+ 	target_include_directories(websockets_shared PRIVATE ${LWS_LIB_BUILD_INC_PATHS})
+ 	target_compile_definitions(websockets_shared PRIVATE LWS_BUILDING_SHARED)
+-	target_include_directories(websockets_shared PUBLIC ${LWS_PUBLIC_INCLUDES})
++	target_include_directories(websockets_shared PUBLIC $<BUILD_INTERFACE:${LWS_PUBLIC_INCLUDES}>)
+ 	set(LWS_PUBLIC_INCLUDES ${LWS_PUBLIC_INCLUDES} PARENT_SCOPE)
+ 
+ 	# We want the shared lib to be named "libwebsockets"


### PR DESCRIPTION
- Updated libwebsockets to version 4.3.1
- Removed workaround for libwebsockets 4.2
- Moved CI execution from centos to ubuntu 20.04 job (centos was not compiling the k8s extension as the centos Dockerfile arguments are fixed)
- Fixed includes of the k8s client poc build

https://issues.apache.org/jira/browse/MINIFICPP-1725

----------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
