### PR TITLE
MINIFICPP-1766 ProcessSession::read can't read zero length flowfiles …

### DIFF
--- a/extensions/rocksdb-repos/RocksDbStream.cpp
+++ b/extensions/rocksdb-repos/RocksDbStream.cpp
@@ -56,8 +56,7 @@ size_t RocksDbStream::tell() const {
 
 size_t RocksDbStream::write(const uint8_t *value, size_t size) {
   if (!write_enable_) return STREAM_ERROR;
-  if (size == 0) return 0;
-  if (IsNullOrEmpty(value)) return STREAM_ERROR;
+  if (size != 0 && IsNullOrEmpty(value)) return STREAM_ERROR;
   auto opendb = db_->open();
   if (!opendb) {
     return STREAM_ERROR;

--- a/libminifi/test/rocksdb-tests/DBContentRepositoryTests.cpp
+++ b/libminifi/test/rocksdb-tests/DBContentRepositoryTests.cpp
@@ -228,13 +228,17 @@ TEST_CASE("Delete Remove Count Claim", "[TestDBCR5]") {
   REQUIRE(readstr == "well hello there");
 }
 
-TEST_CASE("ProcessSession::read reads the flowfile from offset to size", "[readoffsetsize]") {
+TEST_CASE("ProcessSession::read reads the flowfile from offset to size (RocksDB)", "[readoffsetsize]") {
   ContentRepositoryDependentTests::testReadOnSmallerClonedFlowFiles(std::make_shared<core::repository::DatabaseContentRepository>());
 }
 
 
-TEST_CASE("ProcessSession::append should append to the flowfile and set its size correctly" "[appendsetsize]") {
+TEST_CASE("ProcessSession::append should append to the flowfile and set its size correctly (RocksDB)" "[appendsetsize]") {
   ContentRepositoryDependentTests::testAppendToUnmanagedFlowFile(std::make_shared<core::repository::DatabaseContentRepository>());
 
   ContentRepositoryDependentTests::testAppendToManagedFlowFile(std::make_shared<core::repository::DatabaseContentRepository>());
+}
+
+TEST_CASE("ProcessSession::read can read zero length flowfiles without crash (RocksDB)", "[zerolengthread]") {
+  ContentRepositoryDependentTests::testReadFromZeroLengthFlowFile(std::make_shared<core::repository::DatabaseContentRepository>());
 }

--- a/libminifi/test/unit/ContentRepositoryDependentTests.h
+++ b/libminifi/test/unit/ContentRepositoryDependentTests.h
@@ -177,4 +177,17 @@ void testAppendToManagedFlowFile(std::shared_ptr<core::ContentRepository> conten
   CHECK(to_string(read_result) == "myfoobar");
   CHECK(read_until_it_can_callback.value_ == "myfoobar");
 }
+
+void testReadFromZeroLengthFlowFile(std::shared_ptr<core::ContentRepository> content_repo) {
+  Fixture fixture = Fixture(content_repo);
+  core::ProcessSession& process_session = fixture.processSession();
+  const auto flow_file = process_session.create();
+  REQUIRE(flow_file);
+  fixture.transferAndCommit(flow_file);
+
+  CHECK(flow_file->getSize() == 0);
+  REQUIRE_NOTHROW(process_session.readBuffer(flow_file));
+  ReadUntilItCan read_until_it_can_callback;
+  REQUIRE_NOTHROW(process_session.read(flow_file, &read_until_it_can_callback));
+}
 }  // namespace ContentRepositoryDependentTests

--- a/libminifi/test/unit/ProcessSessionTests.cpp
+++ b/libminifi/test/unit/ProcessSessionTests.cpp
@@ -110,3 +110,8 @@ TEST_CASE("ProcessSession::append should append to the flowfile and set its size
   ContentRepositoryDependentTests::testAppendToManagedFlowFile(std::make_shared<minifi::core::repository::VolatileContentRepository>());
   ContentRepositoryDependentTests::testAppendToManagedFlowFile(std::make_shared<minifi::core::repository::FileSystemRepository>());
 }
+
+TEST_CASE("ProcessSession::read can read zero length flowfiles without crash", "[zerolengthread]") {
+  ContentRepositoryDependentTests::testReadFromZeroLengthFlowFile(std::make_shared<core::repository::VolatileContentRepository>());
+  ContentRepositoryDependentTests::testReadFromZeroLengthFlowFile(std::make_shared<core::repository::FileSystemRepository>());
+}


### PR DESCRIPTION
…(DatabaseContentRepository)

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
