### PR TITLE
MINIFICPP-1734 Tell kubernetes to run minifi as root instead of modifying the image

### DIFF
--- a/docker/test/integration/minifi/core/ImageStore.py
+++ b/docker/test/integration/minifi/core/ImageStore.py
@@ -45,8 +45,6 @@ class ImageStore:
 
         if container_engine == "minifi-cpp" or container_engine == "transient-minifi":
             image = self.__build_minifi_cpp_image()
-        elif container_engine == "minifi-cpp-in-kubernetes":
-            image = self.__build_simple_minifi_cpp_image_with_root()
         elif container_engine == "http-proxy":
             image = self.__build_http_proxy_image()
         elif container_engine == "nifi":
@@ -99,15 +97,6 @@ class ImageStore:
                 USER minificpp
                 """.format(base_image='apacheminificpp:' + MinifiContainer.MINIFI_VERSION,
                            minifi_root=MinifiContainer.MINIFI_ROOT))
-
-        return self.__build_image(dockerfile)
-
-    def __build_simple_minifi_cpp_image_with_root(self):
-        dockerfile = dedent(r"""\
-                FROM {base_image}
-                USER root
-                CMD ["/bin/sh", "-c", "cp /tmp/minifi_config/config.yml /tmp/minifi_config/minifi-log.properties ./conf/ && ./bin/minifi.sh run"]
-                """.format(base_image='apacheminificpp:' + MinifiContainer.MINIFI_VERSION))
 
         return self.__build_image(dockerfile)
 

--- a/docker/test/integration/minifi/core/KindProxy.py
+++ b/docker/test/integration/minifi/core/KindProxy.py
@@ -24,12 +24,9 @@ from textwrap import dedent
 
 
 class KindProxy:
-    def __init__(self, temp_directory, resources_directory, image_name, image_repository, image_tag):
+    def __init__(self, temp_directory, resources_directory):
         self.temp_directory = temp_directory
         self.resources_directory = resources_directory
-        self.image_name = image_name
-        self.image_repository = image_repository
-        self.image_tag = image_tag
 
         self.kind_binary_path = os.path.join(self.temp_directory, 'kind')
         self.kind_config_path = os.path.join(self.temp_directory, 'kind-config.yml')
@@ -67,12 +64,9 @@ class KindProxy:
         if subprocess.run([self.kind_binary_path, 'create', 'cluster', '--config=' + self.kind_config_path]).returncode != 0:
             raise Exception("Could not start the kind cluster")
 
-    def load_docker_image(self, image_store):
-        image = image_store.get_image(self.image_name)
-        image.tag(repository=self.image_repository, tag=self.image_tag)
-
-        if subprocess.run([self.kind_binary_path, 'load', 'docker-image', self.image_repository + ':' + self.image_tag]).returncode != 0:
-            raise Exception("Could not load the %s docker image (%s:%s) into the kind cluster" % (self.image_name, self.image_repository, self.image_tag))
+    def load_docker_image(self, image_name, image_tag):
+        if subprocess.run([self.kind_binary_path, 'load', 'docker-image', image_name + ':' + image_tag]).returncode != 0:
+            raise Exception("Could not load the %s docker image into the kind cluster" % image_name)
 
     def create_objects(self):
         self.__wait_for_default_service_account('default')

--- a/docker/test/integration/resources/kubernetes/pods-etc/log-collector.pod.yml
+++ b/docker/test/integration/resources/kubernetes/pods-etc/log-collector.pod.yml
@@ -4,16 +4,20 @@ metadata:
   namespace: daemon
   name: log-collector
 spec:
+  securityContext:
+    runAsUser: 0
   containers:
   - name: minifi
-    image: minifi-kubernetes-test:v1
+    image: apacheminificpp:docker_test
     imagePullPolicy: Never
+    securityContext:
+      allowPrivilegeEscalation: false
     volumeMounts:
     - name: var-log-pods
       mountPath: /var/log/pods
       readOnly: true
     - name: tmp-minifi-config
-      mountPath: /tmp/minifi_config
+      mountPath: /opt/minifi/minifi-current/conf
       readOnly: true
     - name: tmp-output
       mountPath: /tmp/output


### PR DESCRIPTION
This is a small improvement of #1270.  We need minifi to run as root in the Kubernetes log collection use case, because the `/var/log/pods` directory is only readable by root.  Previously, we built a custom image to change the USER from minificpp to root; now we add `runAsUser: 0` to the pod definition.

This makes the test slightly cleaner.  More importantly, these Kubernetes yaml files also serve as documentation of how to use this feature, so it's good to show that one can use the released apacheminificpp docker image directly, without building a new image.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
