### PR TITLE
MINIFICPP-1785 Fix CWEL attributes to be valid in HTTP requests

### DIFF
--- a/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
@@ -712,8 +712,8 @@ void ConsumeWindowsEventLog::putEventRenderFlowFileToSession(const EventRender& 
       session.write(flowFile, &wc);
     }
     session.putAttribute(flowFile, core::SpecialFlowAttribute::MIME_TYPE, mimeType);
-    session.putAttribute(flowFile, "Timezone name", timezone_name_);
-    session.putAttribute(flowFile, "Timezone offset", timezone_offset_);
+    session.putAttribute(flowFile, "timezone.name", timezone_name_);
+    session.putAttribute(flowFile, "timezone.offset", timezone_offset_);
     session.getProvenanceReporter()->receive(flowFile, provenanceUri_, getUUIDStr(), "Consume windows event logs", 0ms);
     session.transfer(flowFile, Success);
   };

--- a/extensions/windows-event-log/tests/ConsumeWindowsEventLogTests.cpp
+++ b/extensions/windows-event-log/tests/ConsumeWindowsEventLogTests.cpp
@@ -159,8 +159,8 @@ TEST_CASE("ConsumeWindowsEventLog can consume new events", "[onTrigger]") {
     REQUIRE(LogTestController::getInstance().contains("<EventData><Data>Event one</Data></EventData>"));
 
     // make sure timezone attributes are present
-    REQUIRE(LogTestController::getInstance().contains("key:Timezone offset value:"));
-    REQUIRE(LogTestController::getInstance().contains("key:Timezone name value:"));
+    REQUIRE(LogTestController::getInstance().contains("key:timezone.offset value:"));
+    REQUIRE(LogTestController::getInstance().contains("key:timezone.name value:"));
   }
 
   SECTION("Read two events") {


### PR DESCRIPTION
When ConsumeWindowsEventLogs processor creates a flowfile and that is forwarded by the InvokeHTTP processor the attributes are written as HTTP header. HTTP headers do not allow spaces in the header names, so due to the `Timezone name` and `Timezone offset` attributes the requests would always result in code 400. These attributes are changed to avoid this issue.

https://issues.apache.org/jira/browse/MINIFICPP-1785

-------------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
