### PR TITLE
MINIFICPP-1806 - Use boyer_moore for extension verification

### DIFF
--- a/libminifi/src/utils/file/FileUtils.cpp
+++ b/libminifi/src/utils/file/FileUtils.cpp
@@ -21,35 +21,9 @@
 
 #include <algorithm>
 #include <iostream>
-#include <version>
 
 #include "utils/Literals.h"
-
-#ifdef _LIBCPP_VERSION
-
-template<typename ...Args>
-static auto make_searcher(Args&& ...args) {
-  return std::default_searcher(std::forward<Args>(args)...);
-}
-
-#elif __cpp_lib_boyer_moore_searcher < 201603L
-#include <experimental/functional>
-
-template<typename ...Args>
-static auto make_searcher(Args&& ...args) {
-  return std::experimental::boyer_moore_searcher(std::forward<Args>(args)...);
-}
-
-#else
-#include <functional>
-
-template<typename ...Args>
-static auto make_searcher(Args&& ...args) {
-  return std::boyer_moore_searcher(std::forward<Args>(args)...);
-}
-
-#endif
-
+#include "utils/Searcher.h"
 
 namespace org {
 namespace apache {
@@ -82,7 +56,7 @@ bool contains(const std::filesystem::path& file_path, std::string_view text_to_s
   gsl_ExpectsAudit(std::filesystem::exists(file_path));
   std::array<char, 16_KiB> buf{};
 
-  auto searcher = make_searcher(text_to_search.begin(), text_to_search.end());
+  Searcher searcher(text_to_search.begin(), text_to_search.end());
 
   std::ifstream ifs{file_path, std::ios::binary};
   do {

--- a/libminifi/src/utils/file/FileUtils.cpp
+++ b/libminifi/src/utils/file/FileUtils.cpp
@@ -26,12 +26,10 @@
 
 #if __cpp_lib_boyer_moore_searcher < 201603L
 #include <experimental/functional>
-template<typename It, typename Hash, typename Eq>
-using boyer_moore_searcher = std::experimental::boyer_moore_searcher<It, Hash, Eq>;
+using std::experimental::boyer_moore_searcher;
 #else
 #include <functional>
-template<typename It, typename Hash, typename Eq>
-using boyer_moore_searcher = std::boyer_moore_searcher<It, Hash, Eq>;
+using std::boyer_moore_searcher;
 #endif
 
 namespace org {
@@ -65,7 +63,7 @@ bool contains(const std::filesystem::path& file_path, std::string_view text_to_s
   gsl_ExpectsAudit(std::filesystem::exists(file_path));
   std::array<char, 16_KiB> buf{};
 
-  boyer_moore_searcher<const char*, std::hash<char>, std::equal_to<char>> searcher(text_to_search.begin(), text_to_search.end());
+  boyer_moore_searcher searcher(text_to_search.begin(), text_to_search.end());
 
   std::ifstream ifs{file_path, std::ios::binary};
   do {


### PR DESCRIPTION
For a debug build the extension verification for `libcore-minifi.so` took ~1400 ms (which together with other dynamic libraries adds seconds to the startup time during development), with this change it takes ~100 ms.

Alternatives considered:
- boyer_moore + custom span concat: ~150 ms
- boyer_moore + ranges::concat: ~1700 ms
- boyer_moore + mmap: ~100 ms (the mmap wrapper would add significant complexity)

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
