### PR TITLE
MINIFICPP-1711 Stabilize C2 tests under load

### DIFF
--- a/extensions/http-curl/tests/C2MultipleCommandsTest.cpp
+++ b/extensions/http-curl/tests/C2MultipleCommandsTest.cpp
@@ -111,8 +111,8 @@ class VerifyC2MultipleCommands : public VerifyC2Base {
   }
 
   void runAssertions() override {
-    assert(utils::verifyEventHappenedInPollTime(3s, [&] {return ack_auditor_.isAcknowledged("889345");}));
-    assert(utils::verifyEventHappenedInPollTime(3s, [&] {return ack_auditor_.isAcknowledged("889346");}));
+    assert(utils::verifyEventHappenedInPollTime(10s, [&] {return ack_auditor_.isAcknowledged("889345");}));
+    assert(utils::verifyEventHappenedInPollTime(10s, [&] {return ack_auditor_.isAcknowledged("889346");}));
   }
 
  private:

--- a/extensions/http-curl/tests/C2PauseResumeTest.cpp
+++ b/extensions/http-curl/tests/C2PauseResumeTest.cpp
@@ -34,7 +34,13 @@
 
 class VerifyC2PauseResume : public VerifyC2Base {
  public:
-  explicit VerifyC2PauseResume(const std::atomic_bool& flow_resumed_successfully) : VerifyC2Base(), flow_resumed_successfully_(flow_resumed_successfully) {}
+  explicit VerifyC2PauseResume(const std::atomic_bool& flow_resumed_successfully) : VerifyC2Base(), flow_resumed_successfully_(flow_resumed_successfully) {
+    LogTestController::getInstance().setTrace<minifi::c2::C2Agent>();
+    LogTestController::getInstance().setDebug<minifi::c2::RESTSender>();
+    LogTestController::getInstance().setDebug<minifi::FlowController>();
+    LogTestController::getInstance().setDebug<minifi::core::ProcessContext>();
+    LogTestController::getInstance().setTrace<minifi::core::ProcessSession>();
+  }
 
   void configureC2() override {
     VerifyC2Base::configureC2();
@@ -75,7 +81,7 @@ class PauseResumeHandler: public HeartbeatHandler {
       pause_start_time_ = std::chrono::system_clock::now();
       flow_state_ = FlowState::PAUSED;
       operation = "pause";
-    } else if (get_invoke_count_ == INITIAL_GET_INVOKE_COUNT && flow_state_ == FlowState::STARTED) {
+    } else if (get_invoke_count_ >= INITIAL_GET_INVOKE_COUNT && flow_state_ == FlowState::STARTED) {
       flow_state_ = FlowState::PAUSE_INITIATED;
       operation = "pause";
     } else if (flow_state_ == FlowState::PAUSED) {

--- a/extensions/http-curl/tests/C2PropertiesUpdateTests.cpp
+++ b/extensions/http-curl/tests/C2PropertiesUpdateTests.cpp
@@ -162,13 +162,13 @@ int main() {
   // On msvc, the passed lambda can't capture a reference to the object under construction, so we need to late-init harness.
   VerifyPropertyUpdate harness;
   harness = VerifyPropertyUpdate([&] {
-    assert(utils::verifyEventHappenedInPollTime(3s, [&] {return ack_handler.isAcknowledged("79");}));
-    assert(utils::verifyEventHappenedInPollTime(3s, [&] {
+    assert(utils::verifyEventHappenedInPollTime(10s, [&] {return ack_handler.isAcknowledged("79");}));
+    assert(utils::verifyEventHappenedInPollTime(10s, [&] {
       return ack_handler.getApplyCount("FULLY_APPLIED") == 1;
     }));
 
     // Updating the same property will result in a no operation response
-    assert(utils::verifyEventHappenedInPollTime(3s, [&] {
+    assert(utils::verifyEventHappenedInPollTime(10s, [&] {
       return ack_handler.getApplyCount("NO_OPERATION") > 0;
     }));
 
@@ -176,12 +176,12 @@ int main() {
     hb_handler.setProperties({{minifi::Configuration::nifi_c2_rest_heartbeat_minimize_updates, "banana", true}, {minifi::Configuration::minifi_disk_space_watchdog_enable, "true", true}});
 
     // Due to 1 invalid value the result will be partially applied
-    assert(utils::verifyEventHappenedInPollTime(3s, [&] {
+    assert(utils::verifyEventHappenedInPollTime(10s, [&] {
       return ack_handler.getApplyCount("PARTIALLY_APPLIED") == 1;
     }));
 
     // Repeating the previous update request results in 1 no operation and 1 failure which results in not applied response
-    assert(utils::verifyEventHappenedInPollTime(3s, [&] {
+    assert(utils::verifyEventHappenedInPollTime(10s, [&] {
       return ack_handler.getApplyCount("NOT_APPLIED") > 0
         && harness.getRestartRequestedCount() == 2;
     }));

--- a/extensions/http-curl/tests/C2RequestClassTest.cpp
+++ b/extensions/http-curl/tests/C2RequestClassTest.cpp
@@ -83,7 +83,7 @@ class VerifyC2ClassRequest : public VerifyC2Base {
   }
 
   void runAssertions() override {
-    assert(utils::verifyEventHappenedInPollTime(std::chrono::seconds(3), verify_));
+    assert(utils::verifyEventHappenedInPollTime(std::chrono::seconds(10), verify_));
   }
 
  private:

--- a/extensions/http-curl/tests/C2VerifyHeartbeatAndStop.cpp
+++ b/extensions/http-curl/tests/C2VerifyHeartbeatAndStop.cpp
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
   const cmd_args args = parse_cmdline_args(argc, argv, "heartbeat");
   VerifyC2Heartbeat harness;
   harness.setKeyDir(args.key_dir);
-  HeartbeatHandler responder(harness.getConfiguration());
+  StoppingHeartbeatHandler responder(harness.getConfiguration());
   harness.setUrl(args.url, &responder);
   harness.run(args.test_file);
 

--- a/libminifi/test/integration/IntegrationBase.h
+++ b/libminifi/test/integration/IntegrationBase.h
@@ -17,7 +17,7 @@
  */
 #pragma once
 
-#define DEFAULT_WAITTIME_MSECS 3000
+#define DEFAULT_WAITTIME_MSECS 10000
 
 #include <future>
 #include <memory>


### PR DESCRIPTION
Multiple C2 tests are stabilized that failed under load due to timing, multithreading or other issues:

- Added more test states to C2ClearCoreComponentStateTest to wait for core component state to be processed before moving to the next state
- Removed polling in ACK handling to avoid overloading HTTP client and cause timeout
- Removed default STOP command sending in HeartbeatHandler which could stop the FlowController before we had the chance to retrigger the processor being tested
- Increased different timeout periods to avoid timing out under load   

https://issues.apache.org/jira/browse/MINIFICPP-1711

---------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
