### PR TITLE
MINIFICPP-1813 Stabilize AbsoluteTimeoutTest in CI on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           win_build_vs.bat ..\b /64 /CI /S /A /PDH /SPLUNK /GCP /K /L /R /Z /N /RO
         shell: cmd
       - name: test
-        run: cd ..\b && ctest --timeout 300 --parallel 8 -C Release --output-on-failure
+        run: cd ..\b && ctest --timeout 300 --parallel %NUMBER_OF_PROCESSORS% -C Release --output-on-failure
         shell: cmd
       - name: linter
         run: cd ..\b && msbuild -maxCpuCount linter.vcxproj

--- a/extensions/http-curl/tests/AbsoluteTimeoutTest.cpp
+++ b/extensions/http-curl/tests/AbsoluteTimeoutTest.cpp
@@ -22,20 +22,14 @@
 #include "tests/TestServer.h"
 #include "HTTPHandlers.h"
 
+using namespace std::literals::chrono_literals;
+
 int main() {
   TestController controller;
 
   std::string port = "12324";
   std::string rootURI =  "/";
-  TimeoutingHTTPHandler handler({
-    std::chrono::milliseconds(500),
-    std::chrono::milliseconds(500),
-    std::chrono::milliseconds(500),
-    std::chrono::milliseconds(500),
-    std::chrono::milliseconds(500),
-    std::chrono::milliseconds(500),
-    std::chrono::milliseconds(500)
-  });
+  TimeoutingHTTPHandler handler({35, 100ms});
 
   TestServer server(port, rootURI, &handler);
 

--- a/extensions/http-curl/tests/AbsoluteTimeoutTest.cpp
+++ b/extensions/http-curl/tests/AbsoluteTimeoutTest.cpp
@@ -29,7 +29,7 @@ int main() {
 
   std::string port = "12324";
   std::string rootURI =  "/";
-  TimeoutingHTTPHandler handler({35, 100ms});
+  TimeoutingHTTPHandler handler(std::vector<std::chrono::milliseconds>(35, 100ms));
 
   TestServer server(port, rootURI, &handler);
 


### PR DESCRIPTION
Due to scheduling issues when too many tests are run parallel the read timeout limit can be reached before we reach the absolute timeout (3 times the read timeout).

https://issues.apache.org/jira/browse/MINIFICPP-1813

------------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
