### PR TITLE
MINIFICPP-1749 Validate C2 property update values

### DIFF
--- a/extensions/standard-processors/tests/unit/ConfigurationTests.cpp
+++ b/extensions/standard-processors/tests/unit/ConfigurationTests.cpp
@@ -22,6 +22,8 @@
 
 using org::apache::nifi::minifi::Configuration;
 
+namespace org::apache::nifi::minifi::test {
+
 TEST_CASE("Configuration can merge lists of property names", "[mergeProperties]") {
   using vector = std::vector<std::string>;
 
@@ -45,3 +47,12 @@ TEST_CASE("Configuration can merge lists of property names", "[mergeProperties]"
   REQUIRE(Configuration::mergeProperties(vector{"a", "b"}, vector{"a", "c\r\n"}) == (vector{"a", "b", "c"}));
   REQUIRE(Configuration::mergeProperties(vector{"a", "b"}, vector{"b\n", "\t c"}) == (vector{"a", "b", "c"}));
 }
+
+TEST_CASE("Configuration can validate values to be assigned to specific properties", "[validatePropertyValue]") {
+  REQUIRE(Configuration::validatePropertyValue(Configuration::nifi_server_name, "anything is valid"));
+  REQUIRE_FALSE(Configuration::validatePropertyValue(Configuration::nifi_flow_configuration_encrypt, "invalid.value"));
+  REQUIRE(Configuration::validatePropertyValue(Configuration::nifi_flow_configuration_encrypt, "true"));
+  REQUIRE(Configuration::validatePropertyValue("random.property", "random_value"));
+}
+
+}  // namespace org::apache::nifi::minifi::test

--- a/libminifi/include/properties/Configuration.h
+++ b/libminifi/include/properties/Configuration.h
@@ -24,10 +24,7 @@
 #include "utils/OptionalUtils.h"
 #include "utils/Export.h"
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
+namespace org::apache::nifi::minifi {
 
 namespace core {
   struct ConfigurationProperty;
@@ -162,9 +159,7 @@ class Configuration : public Properties {
   static std::vector<std::string> mergeProperties(std::vector<std::string> properties,
                                                   const std::vector<std::string>& additional_properties);
   static std::vector<std::string> getSensitiveProperties(std::function<std::optional<std::string>(const std::string&)> reader);
+  static bool validatePropertyValue(const std::string& property_name, const std::string& property_value);
 };
 
-}  // namespace minifi
-}  // namespace nifi
-}  // namespace apache
-}  // namespace org
+}  // namespace org::apache::nifi::minifi

--- a/libminifi/src/Configuration.cpp
+++ b/libminifi/src/Configuration.cpp
@@ -155,4 +155,13 @@ std::vector<std::string> Configuration::getSensitiveProperties(std::function<std
   return sensitive_properties;
 }
 
+bool Configuration::validatePropertyValue(const std::string& property_name, const std::string& property_value) {
+  for (const auto& config_property: Configuration::CONFIGURATION_PROPERTIES) {
+    if (config_property.name == property_name) {
+      return config_property.validator->validate(property_name, property_value).valid();
+    }
+  }
+  return true;
+}
+
 }  // namespace org::apache::nifi::minifi

--- a/libminifi/src/c2/C2Agent.cpp
+++ b/libminifi/src/c2/C2Agent.cpp
@@ -611,9 +611,10 @@ void C2Agent::handlePropertyUpdate(const C2ContentResponse &resp) {
       if (update_result == UpdateResult::UPDATE_SUCCESSFUL) {
         result = state::UpdateState::FULLY_APPLIED;
       } else if (update_result == UpdateResult::UPDATE_FAILED) {
-        result = state::UpdateState::PARTIALLY_APPLIED;
+        result = state::UpdateState::NOT_APPLIED;
       }
-    } else if (result == state::UpdateState::FULLY_APPLIED && update_result == UpdateResult::UPDATE_FAILED) {
+    } else if ((result == state::UpdateState::FULLY_APPLIED && update_result == UpdateResult::UPDATE_FAILED) ||
+               (result == state::UpdateState::NOT_APPLIED && update_result == UpdateResult::UPDATE_SUCCESSFUL)) {
       result = state::UpdateState::PARTIALLY_APPLIED;
     }
   };
@@ -627,19 +628,21 @@ void C2Agent::handlePropertyUpdate(const C2ContentResponse &resp) {
     changeUpdateState(update_property(entry.first, entry.second.to_string(), lifetime));
   }
   // apply changes and persist properties requested to be persisted
-  if (result != state::UpdateState::NO_OPERATION && !configuration_->commitChanges()) {
+  auto propertyWasUpdated = [&](){ return result == state::UpdateState::FULLY_APPLIED || result == state::UpdateState::PARTIALLY_APPLIED; };
+  if (propertyWasUpdated() && !configuration_->commitChanges()) {
     result = state::UpdateState::PARTIALLY_APPLIED;
   }
   C2Payload response(Operation::ACKNOWLEDGE, result, resp.ident, true);
   enqueue_c2_response(std::move(response));
-  if (result != state::UpdateState::NO_OPERATION) { restart_needed_ = true; }
+  if (propertyWasUpdated()) { restart_needed_ = true; }
 }
 
 /**
  * Updates a property
  */
 C2Agent::UpdateResult C2Agent::update_property(const std::string &property_name, const std::string &property_value, PropertyChangeLifetime lifetime) {
-  if (update_service_ && !update_service_->canUpdate(property_name)) {
+  if (!Configuration::validatePropertyValue(property_name, property_value) ||
+      (update_service_ && !update_service_->canUpdate(property_name))) {
     return UpdateResult::UPDATE_FAILED;
   }
 

--- a/libminifi/src/c2/C2Agent.cpp
+++ b/libminifi/src/c2/C2Agent.cpp
@@ -628,13 +628,13 @@ void C2Agent::handlePropertyUpdate(const C2ContentResponse &resp) {
     changeUpdateState(update_property(entry.first, entry.second.to_string(), lifetime));
   }
   // apply changes and persist properties requested to be persisted
-  auto propertyWasUpdated = [&](){ return result == state::UpdateState::FULLY_APPLIED || result == state::UpdateState::PARTIALLY_APPLIED; };
-  if (propertyWasUpdated() && !configuration_->commitChanges()) {
+  const bool propertyWasUpdated = result == state::UpdateState::FULLY_APPLIED || result == state::UpdateState::PARTIALLY_APPLIED;
+  if (propertyWasUpdated && !configuration_->commitChanges()) {
     result = state::UpdateState::PARTIALLY_APPLIED;
   }
   C2Payload response(Operation::ACKNOWLEDGE, result, resp.ident, true);
   enqueue_c2_response(std::move(response));
-  if (propertyWasUpdated()) { restart_needed_ = true; }
+  if (propertyWasUpdated) { restart_needed_ = true; }
 }
 
 /**


### PR DESCRIPTION
Added verification of C2 property values while updating them, also changed the C2 response value in case no value could be updated due to validation failure or if the update is denied by the UpdatePolicyController to NOT_APPLIED instead of PARTIALLY_APPLIED. The PARTIALLY_APPLIED response is still sent if any of the requested updates could be finished.

https://issues.apache.org/jira/browse/MINIFICPP-1749

------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
