### PR TITLE
MINIFICPP-1828 fix InvokeHTTP Attributes to Send

### DIFF
--- a/extensions/http-curl/client/HTTPClient.h
+++ b/extensions/http-curl/client/HTTPClient.h
@@ -55,11 +55,7 @@
 #include "core/logging/Logger.h"
 #include "core/logging/LoggerConfiguration.h"
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
-namespace utils {
+namespace org::apache::nifi::minifi::utils {
 
 /**
  * Purpose and Justification: Pull the basics for an HTTPClient into a self contained class. Simply provide
@@ -112,8 +108,6 @@ class HTTPClient : public BaseHTTPClient, public core::Connectable {
   void setSeekFunction(HTTPUploadCallback *callbackObj) override;
 
   virtual void setReadCallback(HTTPReadCallback *callbackObj);
-
-  struct curl_slist *build_header_list(std::string regex, const std::map<std::string, std::string> &attributes);
 
   void setContentType(std::string content_type) override;
 
@@ -307,11 +301,7 @@ class HTTPClient : public BaseHTTPClient, public core::Connectable {
   std::shared_ptr<core::logging::Logger> logger_{core::logging::LoggerFactory<HTTPClient>::getLogger()};
 };
 
-}  // namespace utils
-}  // namespace minifi
-}  // namespace nifi
-}  // namespace apache
-}  // namespace org
+}  // namespace org::apache::nifi::minifi::utils
 
 #ifdef WIN32
 #pragma warning(pop)

--- a/extensions/http-curl/processors/InvokeHTTP.h
+++ b/extensions/http-curl/processors/InvokeHTTP.h
@@ -33,6 +33,7 @@
 #include "../client/HTTPClient.h"
 #include "utils/Export.h"
 #include "utils/Enum.h"
+#include "utils/RegexUtils.h"
 
 namespace org::apache::nifi::minifi::processors {
 
@@ -104,13 +105,13 @@ class InvokeHTTP : public core::Processor {
   void route(const std::shared_ptr<core::FlowFile> &request, const std::shared_ptr<core::FlowFile> &response, const std::shared_ptr<core::ProcessSession> &session,
              const std::shared_ptr<core::ProcessContext> &context, bool isSuccess, int64_t statusCode);
   bool shouldEmitFlowFile() const;
-  std::optional<std::map<std::string, std::string>> validateAttributesAgainstHTTPHeaderRules(const std::map<std::string, std::string>& attributes) const;
+  [[nodiscard]] bool appendHeaders(const core::FlowFile& flow_file, /*std::invocable<std::string, std::string>*/ auto append_header);
 
   std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service_;
   std::string method_;
   std::string url_;
   bool date_header_include_{true};
-  std::string attribute_to_send_regex_;
+  std::optional<utils::Regex> attributes_to_send_;
   std::chrono::milliseconds connect_timeout_ms_{20000};
   std::chrono::milliseconds read_timeout_ms_{20000};
   // attribute in which response body will be added

--- a/extensions/http-curl/tests/unit/InvokeHTTPTests.cpp
+++ b/extensions/http-curl/tests/unit/InvokeHTTPTests.cpp
@@ -315,6 +315,7 @@ TEST_CASE("InvokeHTTP fails with when flow contains invalid attribute names in H
   invokehttp->setProperty(InvokeHTTP::Method, "GET");
   invokehttp->setProperty(InvokeHTTP::URL, TestHTTPServer::URL);
   invokehttp->setProperty(InvokeHTTP::InvalidHTTPHeaderFieldHandlingStrategy, "fail");
+  invokehttp->setProperty(InvokeHTTP::AttributesToSend, ".*");
   invokehttp->setAutoTerminatedRelationships({InvokeHTTP::RelNoRetry, InvokeHTTP::Success, InvokeHTTP::RelResponse, InvokeHTTP::RelRetry});
   test_controller.enqueueFlowFile("data", {{"invalid header", "value"}});
   const auto result = test_controller.trigger();
@@ -333,6 +334,7 @@ TEST_CASE("InvokeHTTP replaces invalid characters of attributes", "[httptest1]")
 
   invokehttp->setProperty(InvokeHTTP::Method, "GET");
   invokehttp->setProperty(InvokeHTTP::URL, TestHTTPServer::URL);
+  invokehttp->setProperty(InvokeHTTP::AttributesToSend, ".*");
   invokehttp->setAutoTerminatedRelationships({InvokeHTTP::RelNoRetry, InvokeHTTP::RelFailure, InvokeHTTP::RelResponse, InvokeHTTP::RelRetry});
   test_controller.enqueueFlowFile("data", {{"invalid header", "value"}, {"", "value2"}});
   const auto result = test_controller.trigger();
@@ -355,6 +357,7 @@ TEST_CASE("InvokeHTTP drops invalid attributes from HTTP headers", "[httptest1]"
   invokehttp->setProperty(InvokeHTTP::Method, "GET");
   invokehttp->setProperty(InvokeHTTP::URL, TestHTTPServer::URL);
   invokehttp->setProperty(InvokeHTTP::InvalidHTTPHeaderFieldHandlingStrategy, "drop");
+  invokehttp->setProperty(InvokeHTTP::AttributesToSend, ".*");
   invokehttp->setAutoTerminatedRelationships({InvokeHTTP::RelNoRetry, InvokeHTTP::RelFailure, InvokeHTTP::RelResponse, InvokeHTTP::RelRetry});
   test_controller.enqueueFlowFile("data", {{"legit-header", "value1"}, {"invalid header", "value2"}});
   const auto result = test_controller.trigger();
@@ -366,4 +369,50 @@ TEST_CASE("InvokeHTTP drops invalid attributes from HTTP headers", "[httptest1]"
   REQUIRE_FALSE(LogTestController::getInstance().contains("key:invalid", 0s));
 }
 
+TEST_CASE("InvokeHTTP empty Attributes to Send means no attributes are sent", "[httptest1]") {
+  using minifi::processors::InvokeHTTP;
+  TestHTTPServer http_server;
+
+  auto invokehttp = std::make_shared<InvokeHTTP>("InvokeHTTP");
+  test::SingleProcessorTestController test_controller{invokehttp};
+  LogTestController::getInstance().setTrace<InvokeHTTP>();
+
+  invokehttp->setProperty(InvokeHTTP::Method, "GET");
+  invokehttp->setProperty(InvokeHTTP::URL, TestHTTPServer::URL);
+  invokehttp->setProperty(InvokeHTTP::InvalidHTTPHeaderFieldHandlingStrategy, "drop");
+  invokehttp->setProperty(InvokeHTTP::AttributesToSend, "");
+  invokehttp->setAutoTerminatedRelationships({InvokeHTTP::RelNoRetry, InvokeHTTP::RelFailure, InvokeHTTP::RelResponse, InvokeHTTP::RelRetry});
+  test_controller.enqueueFlowFile("data", {{"legit-header", "value1"}, {"invalid header", "value2"}});
+  const auto result = test_controller.trigger();
+  auto file_contents = result.at(InvokeHTTP::Success);
+  REQUIRE(file_contents.size() == 1);
+  REQUIRE(test_controller.plan->getContent(file_contents[0]) == "data");
+  http_server.trigger();
+  REQUIRE_FALSE(LogTestController::getInstance().contains("key:legit-header value:value1"));
+  REQUIRE_FALSE(LogTestController::getInstance().contains("key:invalid", 0s));
+}
+
+TEST_CASE("InvokeHTTP Attributes to Send uses full string matching, not substring", "[httptest1]") {
+  using minifi::processors::InvokeHTTP;
+  TestHTTPServer http_server;
+
+  auto invokehttp = std::make_shared<InvokeHTTP>("InvokeHTTP");
+  test::SingleProcessorTestController test_controller{invokehttp};
+  LogTestController::getInstance().setTrace<InvokeHTTP>();
+
+  invokehttp->setProperty(InvokeHTTP::Method, "GET");
+  invokehttp->setProperty(InvokeHTTP::URL, TestHTTPServer::URL);
+  invokehttp->setProperty(InvokeHTTP::InvalidHTTPHeaderFieldHandlingStrategy, "drop");
+  invokehttp->setProperty(InvokeHTTP::AttributesToSend, "he.*er");
+  invokehttp->setAutoTerminatedRelationships({InvokeHTTP::RelNoRetry, InvokeHTTP::RelFailure, InvokeHTTP::RelResponse, InvokeHTTP::RelRetry});
+  test_controller.enqueueFlowFile("data", {{"header1", "value1"}, {"header", "value2"}});
+  const auto result = test_controller.trigger();
+  auto file_contents = result.at(InvokeHTTP::Success);
+  REQUIRE(file_contents.size() == 1);
+  REQUIRE(test_controller.plan->getContent(file_contents[0]) == "data");
+  http_server.trigger();
+  REQUIRE_FALSE(LogTestController::getInstance().contains("key:header1 value:value1"));
+  REQUIRE(LogTestController::getInstance().contains("key:header value:value2"));
+  REQUIRE_FALSE(LogTestController::getInstance().contains("key:invalid", 0s));
+}
 }  // namespace org::apache::nifi::minifi::test

--- a/libminifi/include/utils/OptionalUtils.h
+++ b/libminifi/include/utils/OptionalUtils.h
@@ -113,6 +113,18 @@ auto operator|(std::optional<SourceType> o, value_or_else_wrapper<F> f) noexcept
     return std::invoke(std::forward<F>(f.function));
   }
 }
+
+// filter implementation
+template<typename SourceType, typename F>
+requires std::is_convertible_v<std::invoke_result_t<F, SourceType>, bool>
+auto operator|(std::optional<SourceType> o, filter_wrapper<F> f) noexcept(noexcept(std::invoke(std::forward<F>(f.function), *o)))
+    -> std::optional<SourceType> {
+  if (o && std::invoke(std::forward<F>(f.function), *o)) {
+    return o;
+  } else {
+    return std::nullopt;
+  }
+}
 }  // namespace detail
 }  // namespace org::apache::nifi::minifi::utils
 

--- a/libminifi/include/utils/RegexUtils.h
+++ b/libminifi/include/utils/RegexUtils.h
@@ -90,11 +90,11 @@ class SMatch {
       if (match.rm_so == -1) {
         return "";
       }
-      return std::string(pattern.begin() + match.rm_so, pattern.begin() + match.rm_eo);
+      return std::string(string.begin() + match.rm_so, string.begin() + match.rm_eo);
     }
 
     regmatch_t match;
-    std::string_view pattern;
+    std::string_view string;
   };
 
   struct SuffixWrapper {
@@ -112,11 +112,11 @@ class SMatch {
   void clear();
 
   std::vector<Regmatch> matches_;
-  std::string pattern_;
+  std::string string_;
 
-  friend bool regexMatch(const std::string &pattern, SMatch& match, const Regex& regex);
-  friend bool regexSearch(const std::string &pattern, SMatch& match, const Regex& regex);
-  friend utils::SMatch getLastRegexMatch(const std::string& str, const utils::Regex& pattern);
+  friend bool regexMatch(const std::string& string, SMatch& match, const Regex& regex);
+  friend bool regexSearch(const std::string& string, SMatch& match, const Regex& regex);
+  friend utils::SMatch getLastRegexMatch(const std::string& string, const utils::Regex& pattern);
 };
 #endif
 
@@ -149,25 +149,25 @@ class Regex {
   int regex_mode_;
 #endif
 
-  friend bool regexMatch(const std::string &pattern, const Regex& regex);
-  friend bool regexMatch(const std::string &pattern, SMatch& match, const Regex& regex);
-  friend bool regexSearch(const std::string &pattern, const Regex& regex);
-  friend bool regexSearch(const std::string &pattern, SMatch& match, const Regex& regex);
-  friend SMatch getLastRegexMatch(const std::string& pattern, const utils::Regex& regex);
+  friend bool regexMatch(const std::string &string, const Regex& regex);
+  friend bool regexMatch(const std::string &string, SMatch& match, const Regex& regex);
+  friend bool regexSearch(const std::string &string, const Regex& regex);
+  friend bool regexSearch(const std::string &string, SMatch& match, const Regex& regex);
+  friend SMatch getLastRegexMatch(const std::string& string, const utils::Regex& regex);
 };
 
-bool regexMatch(const std::string &pattern, const Regex& regex);
-bool regexMatch(const std::string &pattern, SMatch& match, const Regex& regex);
+bool regexMatch(const std::string &string, const Regex& regex);
+bool regexMatch(const std::string &string, SMatch& match, const Regex& regex);
 
-bool regexSearch(const std::string &pattern, const Regex& regex);
-bool regexSearch(const std::string &pattern, SMatch& match, const Regex& regex);
+bool regexSearch(const std::string &string, const Regex& regex);
+bool regexSearch(const std::string &string, SMatch& match, const Regex& regex);
 
 /**
  * Returns the last match of a regular expression within the given string
- * @param pattern incoming string
+ * @param string incoming string
  * @param regex the regex to be matched
  * @return the last valid SMatch or a default constructed SMatch (ready() != true) if no matches have been found
  */
-SMatch getLastRegexMatch(const std::string& pattern, const utils::Regex& regex);
+SMatch getLastRegexMatch(const std::string& string, const utils::Regex& regex);
 
 }  // namespace org::apache::nifi::minifi::utils

--- a/libminifi/include/utils/detail/MonadicOperationWrappers.h
+++ b/libminifi/include/utils/detail/MonadicOperationWrappers.h
@@ -40,6 +40,10 @@ struct value_or_else_wrapper {
   T function;
 };
 
+template<typename T>
+struct filter_wrapper {
+  T function;
+};
 }  // namespace detail
 
 template<typename T>
@@ -53,4 +57,7 @@ detail::or_else_wrapper<T&&> orElse(T&& func) noexcept { return {std::forward<T>
 
 template<typename T>
 detail::value_or_else_wrapper<T&&> valueOrElse(T&& func) noexcept { return {std::forward<T>(func)}; }
+
+template<typename T>
+detail::filter_wrapper<T&&> filter(T&& func) noexcept { return {std::forward<T>(func)}; }
 }  // namespace org::apache::nifi::minifi::utils

--- a/libminifi/src/SchedulingAgent.cpp
+++ b/libminifi/src/SchedulingAgent.cpp
@@ -93,7 +93,7 @@ bool SchedulingAgent::onTrigger(core::Processor* processor, const std::shared_pt
     return true;
   }
   if (processor->isThrottledByBackpressure()) {
-    logger_->log_debug("backpressure applied because too much outgoing for %s", processor->getUUIDStr());
+    logger_->log_debug("backpressure applied because too much outgoing for %s %s", processor->getUUIDStr(), processor->getName());
     // need to apply backpressure
     return true;
   }

--- a/libminifi/test/unit/OptionalTest.cpp
+++ b/libminifi/test/unit/OptionalTest.cpp
@@ -72,3 +72,8 @@ TEST_CASE("optional valueOrElse", "[optional][valueOrElse]") {
   REQUIRE(0 == test2);
   REQUIRE_THROWS_AS(std::optional<int>{} | utils::valueOrElse([]() -> int { throw std::exception{}; }), std::exception);
 }
+
+TEST_CASE("optional filter", "[optional][filter]") {
+  REQUIRE(7 == (std::make_optional(7) | utils::filter([](int i) { return i % 2 == 1; })).value());
+  REQUIRE(std::nullopt == (std::make_optional(8) | utils::filter([](int i) { return i % 2 == 1; })));
+}


### PR DESCRIPTION
It was using subsequence matching (search) instead of full matching
(match).

Additionally, renamed "pattern" to "string" in RegexUtils, because it
was used to refer to the string in which we looked for the pattern
(regex). It was confusing.

unrelated change: added processor name to backpressure logging to help
debugging

add utils::filter to filter optional values

---
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [X] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
