### PR TITLE
MINIFICPP-1855 Change libwebsockets source to github

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -62,7 +62,7 @@ This software includes third party software subject to the following copyrights:
 - asio - Copyright (c) 2003-2022 Christopher M. Kohlhoff (chris at kohlhoff dot com)
 - TartanLlama/expected - public domain, thanks to Sy Brand
 - libyaml - Copyright (c) 2006-2016 Kirill Simonov, Copyright (c) 2017-2020 Ingy döt Net
-- libwebsockets - Copyright (C) 2010 - 2020 Andy Green <andy@warmcat.com>
+- libwebsockets - Copyright (C) 2010 - 2022 Andy Green <andy@warmcat.com>
 - kubernetes-client/c - Brendan Burns, Hui Yu and other contributors
 - nlohmann json - Copyright (c) 2013-2022 Niels Lohmann
 - abseil-cpp - Google Inc.

--- a/cmake/KubernetesClientC.cmake
+++ b/cmake/KubernetesClientC.cmake
@@ -36,8 +36,8 @@ set(WEBSOCKETS_PATCH_FILE "${CMAKE_SOURCE_DIR}/thirdparty/libwebsockets/fix-incl
 set(WEBSOCKETS_PC ${Bash_EXECUTABLE} -c "set -x &&\
         (${Patch_EXECUTABLE} -R -p1 -s -f --dry-run -i ${WEBSOCKETS_PATCH_FILE} || ${Patch_EXECUTABLE} -p1 -i ${WEBSOCKETS_PATCH_FILE})")
 FetchContent_Declare(websockets
-        GIT_REPOSITORY  https://libwebsockets.org/repo/libwebsockets.git
-        GIT_TAG         v4.3.1
+        GIT_REPOSITORY  https://github.com/warmcat/libwebsockets.git
+        GIT_TAG         b0a749c8e7a8294b68581ce4feac0e55045eb00b  # v4.3.2
         PATCH_COMMAND "${WEBSOCKETS_PC}"
 )
 


### PR DESCRIPTION
... and upgrade from v4.3.1 to v4.3.2.  The old source, https://libwebsockets.org, is down at the moment, and I don't know for how long.  It stops three of our CI jobs (ubuntu-20.04, ubuntu-20.04-clang, Docker integration tests) from running.  This github repo is owned by Andy Green, the developer of libwebsockets.

https://issues.apache.org/jira/browse/MINIFICPP-1855

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
