### PR TITLE
MINIFICPP-1858 Quick fixes to the clang-tidy CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
   ubuntu_20_04_clang:
     name: "ubuntu-20.04-clang"
     runs-on: ubuntu-20.04
-    timeout-minutes: 120
+    timeout-minutes: 180
     steps:
       - id: checkout
         uses: actions/checkout@v2

--- a/run_clang_tidy.sh
+++ b/run_clang_tidy.sh
@@ -5,7 +5,14 @@ set -uo pipefail
 exit_code=0
 FILES=$1
 
+EXCLUDED_EXTENSIONS=("pdh" "windows-event-log" "tensorflow")
+
 for changed_file in ${FILES}; do
+  for extension in "${EXCLUDED_EXTENSIONS[@]}"; do
+    if [[ "${changed_file}" =~ extensions/${extension}/ ]]; then
+      continue 2
+    fi
+  done
   if [[ "${changed_file}" == *.cpp ]]; then
     clang-tidy-14 -warnings-as-errors=* -quiet -p build "${changed_file}"
     exit_code=$(( $? | exit_code ))


### PR DESCRIPTION
* If you modify any cpp files in extensions not enabled in the `ubuntu-20.04-clang` CI job, the clang-tidy check will fail, as it is not able to compile these files.  As a quick workaround, I have disabled clang-tidy on these extensions.  A better fix would be to detect which extensions are enabled, and only run clang-tidy on those.

* The clang-tidy check is very slow, and it can exceed the 2 hour timeout we have set.  As a quick workaround, I have increased the timeout to 3 hours.  A better fix would be to parallelize the clang-tidy checks.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
