### PR TITLE
MINIFICPP-1864 Fix Splunk tests with newer container image

### DIFF
--- a/docker/test/integration/minifi/core/DockerTestCluster.py
+++ b/docker/test/integration/minifi/core/DockerTestCluster.py
@@ -202,7 +202,10 @@ class DockerTestCluster(SingleNodeDockerCluster):
         result_str = output.decode("utf-8")
         result_lines = result_str.splitlines()
         for result_line in result_lines:
-            result_line_json = json.loads(result_line)
+            try:
+                result_line_json = json.loads(result_line)
+            except json.decoder.JSONDecodeError:
+                continue
             if "result" not in result_line_json:
                 continue
             if "host" in attributes:

--- a/docker/test/integration/resources/splunk-hec/Dockerfile
+++ b/docker/test/integration/resources/splunk-hec/Dockerfile
@@ -1,2 +1,2 @@
-FROM splunk/splunk:latest
+FROM splunk/splunk:9.0
 ADD conf/default.yml /tmp/defaults/default.yml


### PR DESCRIPTION
Splunk version 9.0 was released which had some additional warnings that were not handled by our event parser. Splunk Dockerfile was updated to use fix version number and updated the parser to handle additional messages of the query output.

https://issues.apache.org/jira/browse/MINIFICPP-1864

-----------------------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
