### PR TITLE
Fix corrupted clcache in windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: linter
         run: cd build && make -j4 linter
   windows_VS2019:
-    name: "windows-2019"
+    name: "windows-vs2019"
     runs-on: windows-2019
     timeout-minutes: 180
     env:
@@ -56,10 +56,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.CLCACHE_DIR }}
-          key: windows-2019-clcache-${{github.ref}}-${{github.sha}}
+          key: windows-vs2019-clcache-${{github.ref}}-${{github.sha}}
           restore-keys: |
-            windows-2019-clcache-${{github.ref}}-
-            windows-2019-clcache-refs/heads/main-
+            windows-vs2019-clcache-${{github.ref}}-
+            windows-vs2019-clcache-refs/heads/main-
       - name: Setup PATH
         uses: microsoft/setup-msbuild@v1.0.2
       - id: install-sqliteodbc-driver


### PR DESCRIPTION
Windows build became corrupted in https://github.com/apache/nifi-minifi-cpp/runs/7108938306 due to missing cache object. Cache key is updated in this change.

https://issues.apache.org/jira/browse/MINIFICPP-1877

-----------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
