### PR TITLE
MINIFICPP-1889 fix ListenHTTP yield, add reg test

### DIFF
--- a/extensions/civetweb/processors/ListenHTTP.h
+++ b/extensions/civetweb/processors/ListenHTTP.h
@@ -185,8 +185,8 @@ class ListenHTTP : public core::Processor {
  private:
   static const uint64_t DEFAULT_BUFFER_SIZE;
 
-  void processIncomingFlowFile(core::ProcessSession *session);
-  void processRequestBuffer(core::ProcessSession *session);
+  bool processIncomingFlowFile(core::ProcessSession &session);
+  bool processRequestBuffer(core::ProcessSession &session);
 
   std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ListenHTTP>::getLogger();
   CivetCallbacks callbacks_;


### PR DESCRIPTION
[MINIFICPP-1889 ListenHTTP doesn't bored yield](https://issues.apache.org/jira/browse/MINIFICPP-1889)

Steps to reproduce:
1. Create a ListenHTTP processor with no connections, and a scheduling period of 0
2. Run the flow

Observed: High minifi agent CPU usage

Expected: Negligible CPU usage, ListenHTTP should yield if there is nothing to do

fix: Add yield is neither incoming flow files, nor incoming requests are produced. Add regression test

------

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
