### PR TITLE
MINIFICPP-1892 Remove automatic CI triggers, manually trigger GH actions CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: "MiNiFi-CPP CI"
-on: [push, pull_request, workflow_dispatch]
+on: [workflow_dispatch]
 jobs:
   macos_xcode:
     name: "macos-xcode"


### PR DESCRIPTION
This would significantly reduce our Github actions machine time usage. All ASF projects are sharing a certain amount of resources, so frivolous usage is not good practice.

Related thread: https://lists.apache.org/thread/7t55prtzcmk10pho8xfdjhbvhvkg48vv

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
