### PR TITLE
MINIFICPP-1896 Change C2 component-level start/stop commands to use UUID

### DIFF
--- a/extensions/http-curl/tests/C2ClearCoreComponentStateTest.cpp
+++ b/extensions/http-curl/tests/C2ClearCoreComponentStateTest.cpp
@@ -58,8 +58,8 @@ class VerifyC2ClearCoreComponentState : public VerifyC2Base {
  protected:
   void updateProperties(minifi::FlowController& flow_controller) override {
     auto setFileName = [] (const std::string& fileName, minifi::state::StateController& component){
-      auto* processor = dynamic_cast<minifi::state::ProcessorController&>(component).getProcessor();
-      processor->setProperty(minifi::processors::TailFile::FileName, fileName);
+      auto& processor = dynamic_cast<minifi::state::ProcessorController&>(component).getProcessor();
+      processor.setProperty(minifi::processors::TailFile::FileName, fileName);
     };
 
     flow_controller.executeOnComponent("TailFile1",

--- a/extensions/http-curl/tests/C2DescribeCoreComponentStateTest.cpp
+++ b/extensions/http-curl/tests/C2DescribeCoreComponentStateTest.cpp
@@ -45,8 +45,8 @@ class VerifyC2DescribeCoreComponentState : public VerifyC2Describe {
  protected:
   void updateProperties(minifi::FlowController& flow_controller) override {
     auto setFileName = [] (const std::string& fileName, minifi::state::StateController& component){
-      auto* processor = dynamic_cast<minifi::state::ProcessorController&>(component).getProcessor();
-      processor->setProperty(minifi::processors::TailFile::FileName, fileName);
+      auto& processor = dynamic_cast<minifi::state::ProcessorController&>(component).getProcessor();
+      processor.setProperty(minifi::processors::TailFile::FileName, fileName);
     };
 
     flow_controller.executeOnComponent("TailFile1",

--- a/extensions/http-curl/tests/C2DescribeManifestTest.cpp
+++ b/extensions/http-curl/tests/C2DescribeManifestTest.cpp
@@ -18,12 +18,15 @@
 
 #undef NDEBUG
 #include <string>
-#include "TestBase.h"
 #include "Catch.h"
 #include "HTTPIntegrationBase.h"
 #include "HTTPHandlers.h"
 #include "properties/Configuration.h"
 #include "ConfigTestAccessor.h"
+
+// from TestHTTPGet.yml
+constexpr auto invokehttp_uuid = "2438e3c8-015a-1000-79ca-83af40ec1991";
+constexpr auto logattribute_uuid = "2438e3c8-015a-1000-79ca-83af40ec1992";
 
 class DescribeManifestHandler: public HeartbeatHandler {
  public:
@@ -37,7 +40,7 @@ class DescribeManifestHandler: public HeartbeatHandler {
   }
 
   void handleAcknowledge(const rapidjson::Document& root) override {
-    verifyJsonHasAgentManifest(root, {"InvokeHTTP", "LogAttribute"}, {"nifi.extension.path", "nifi.python.processor.dir"});
+    verifyJsonHasAgentManifest(root, {invokehttp_uuid, logattribute_uuid}, {"nifi.extension.path", "nifi.python.processor.dir"});
     verified_ = true;
   }
 

--- a/extensions/http-curl/tests/C2VerifyHeartbeatAndStop.cpp
+++ b/extensions/http-curl/tests/C2VerifyHeartbeatAndStop.cpp
@@ -42,7 +42,7 @@ class VerifyC2Heartbeat : public VerifyC2Base {
     using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
     assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_),
         "Received Ack from Server",
-        "C2Agent] [debug] Stopping component invoke",
+        "C2Agent] [debug] Stopping component 2438e3c8-015a-1000-79ca-83af40ec1991",
         "C2Agent] [debug] Stopping component FlowController"));
   }
 

--- a/extensions/http-curl/tests/C2VerifyLightweightHeartbeatAndStop.cpp
+++ b/extensions/http-curl/tests/C2VerifyLightweightHeartbeatAndStop.cpp
@@ -66,7 +66,7 @@ class VerifyLightWeightC2Heartbeat : public VerifyC2Base {
     using org::apache::nifi::minifi::utils::verifyLogLinePresenceInPollTime;
     assert(verifyLogLinePresenceInPollTime(std::chrono::milliseconds(wait_time_),
         "Received Ack from Server",
-        "C2Agent] [debug] Stopping component invoke",
+        "C2Agent] [debug] Stopping component 2438e3c8-015a-1000-79ca-83af40ec1991",
         "C2Agent] [debug] Stopping component FlowController"));
   }
 

--- a/extensions/http-curl/tests/HTTPHandlers.h
+++ b/extensions/http-curl/tests/HTTPHandlers.h
@@ -590,7 +590,7 @@ class HeartbeatHandler : public ServerAwareHandler {
       case minifi::c2::Operation::STOP: {
         auto operands = getOperandsOfProperties(operation_node);
         assert(operands.find("c2") != operands.end());
-        assert(operands.find("FlowController") != operands.end());
+        // FlowController is also present, but this handler has no way of knowing its UUID to test it
         for (const auto& component : verify_components) {
           assert(operands.find(component) != operands.end());
         }

--- a/extensions/http-curl/tests/HTTPHandlers.h
+++ b/extensions/http-curl/tests/HTTPHandlers.h
@@ -630,7 +630,7 @@ class StoppingHeartbeatHandler : public HeartbeatHandler {
 
  private:
   static void sendStopOperation(struct mg_connection *conn) {
-    std::string resp = "{\"operation\" : \"heartbeat\", \"requested_operations\" : [{ \"operationid\" : 41, \"operation\" : \"stop\", \"operand\" : \"invoke\"  }, "
+    std::string resp = "{\"operation\" : \"heartbeat\", \"requested_operations\" : [{ \"operationid\" : 41, \"operation\" : \"stop\", \"operand\" : \"2438e3c8-015a-1000-79ca-83af40ec1991\"  }, "
         "{ \"operationid\" : 42, \"operation\" : \"stop\", \"operand\" : \"FlowController\"  } ]}";
     mg_printf(conn, "HTTP/1.1 200 OK\r\nContent-Type: "
               "text/plain\r\nContent-Length: %lu\r\nConnection: close\r\n\r\n",

--- a/extensions/http-curl/tests/VerifyInvokeHTTP.h
+++ b/extensions/http-curl/tests/VerifyInvokeHTTP.h
@@ -70,8 +70,8 @@ class VerifyInvokeHTTP : public HTTPIntegrationBase {
     flowController_->executeOnComponent("InvokeHTTP", [&](minifi::state::StateController& component) {
       const auto processorController = dynamic_cast<minifi::state::ProcessorController*>(&component);
       assert(processorController);
-      auto proc = processorController->getProcessor();
-      proc->setProperty(property, value);
+      auto& proc = processorController->getProcessor();
+      proc.setProperty(property, value);
       executed = true;
     });
 

--- a/extensions/standard-processors/tests/integration/TailFileTest.cpp
+++ b/extensions/standard-processors/tests/integration/TailFileTest.cpp
@@ -78,8 +78,8 @@ class TailFileTestHarness : public IntegrationBase {
     fc.executeOnComponent("tf", [this] (minifi::state::StateController& component) {
       auto proc = dynamic_cast<minifi::state::ProcessorController*>(&component);
       if (nullptr != proc) {
-        proc->getProcessor()->setProperty(minifi::processors::TailFile::FileName, ss.str());
-        proc->getProcessor()->setProperty(minifi::processors::TailFile::StateFile, statefile);
+        proc->getProcessor().setProperty(minifi::processors::TailFile::FileName, ss.str());
+        proc->getProcessor().setProperty(minifi::processors::TailFile::StateFile, statefile);
       }
     });
   }

--- a/libminifi/include/FlowController.h
+++ b/libminifi/include/FlowController.h
@@ -241,7 +241,7 @@ class FlowController : public core::controller::ForwardingControllerServiceProvi
   state::StateController* getComponent(const std::string& id_or_name);
 
   state::StateController* getProcessorController(const std::string& id_or_name,
-                                                 const std::function<std::unique_ptr<state::ProcessorController>(core::Processor&)>& controllerFactory);
+      const std::function<gsl::not_null<std::unique_ptr<state::ProcessorController>>(core::Processor&)>& controllerFactory);
 
   std::vector<state::StateController*> getAllProcessorControllers(
           const std::function<gsl::not_null<std::unique_ptr<state::ProcessorController>>(core::Processor&)>& controllerFactory);

--- a/libminifi/include/FlowController.h
+++ b/libminifi/include/FlowController.h
@@ -115,7 +115,7 @@ class FlowController : public core::controller::ForwardingControllerServiceProvi
     return -1;
   }
 
-  void executeOnComponent(const std::string &name, std::function<void(state::StateController&)> func) override;
+  void executeOnComponent(const std::string& id_or_name, std::function<void(state::StateController&)> func) override;
   void executeOnAllComponents(std::function<void(state::StateController&)> func) override;
 
   int16_t clearConnection(const std::string &connection) override;
@@ -238,15 +238,15 @@ class FlowController : public core::controller::ForwardingControllerServiceProvi
  private:
   std::vector<state::StateController*> getAllComponents();
 
-  state::StateController* getComponent(const std::string &name);
+  state::StateController* getComponent(const std::string& id_or_name);
 
-  state::StateController* getProcessorController(const std::string& name,
+  state::StateController* getProcessorController(const std::string& id_or_name,
                                                  const std::function<std::unique_ptr<state::ProcessorController>(core::Processor&)>& controllerFactory);
 
   std::vector<state::StateController*> getAllProcessorControllers(
-          const std::function<std::unique_ptr<state::ProcessorController>(core::Processor&)>& controllerFactory);
+          const std::function<gsl::not_null<std::unique_ptr<state::ProcessorController>>(core::Processor&)>& controllerFactory);
 
-  std::unique_ptr<state::ProcessorController> createController(core::Processor& processor);
+  gsl::not_null<std::unique_ptr<state::ProcessorController>> createController(core::Processor& processor);
 
   std::chrono::milliseconds shutdown_check_interval_{1000};
   std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<FlowController>::getLogger();

--- a/libminifi/include/core/Scheduling.h
+++ b/libminifi/include/core/Scheduling.h
@@ -43,15 +43,9 @@ enum ScheduledState {
   RUNNING
 };
 
-/*
- * Scheduling Strategy
- */
 enum SchedulingStrategy {
-  // Event driven
   EVENT_DRIVEN,
-  // Timer driven
   TIMER_DRIVEN,
-  // Cron Driven
   CRON_DRIVEN
 };
 

--- a/libminifi/include/core/state/ProcessorController.h
+++ b/libminifi/include/core/state/ProcessorController.h
@@ -1,5 +1,4 @@
 /**
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -15,8 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef LIBMINIFI_INCLUDE_CORE_STATE_PROCESSORCONTROLLER_H_
-#define LIBMINIFI_INCLUDE_CORE_STATE_PROCESSORCONTROLLER_H_
+#pragma once
 
 #include <string>
 #include <memory>
@@ -24,11 +22,7 @@
 #include "SchedulingAgent.h"
 #include "UpdateController.h"
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
-namespace state {
+namespace org::apache::nifi::minifi::state {
 
 /**
  * Purpose, Justification, & Design: ProcessController is the state control mechanism for processors.
@@ -38,20 +32,20 @@ namespace state {
  */
 class ProcessorController : public StateController {
  public:
-  ProcessorController(core::Processor* processor, const std::shared_ptr<SchedulingAgent> &scheduler);
+  ProcessorController(core::Processor& processor, std::shared_ptr<SchedulingAgent> scheduler);
 
   ~ProcessorController() override;
 
-  std::string getComponentName() const override {
+  [[nodiscard]] std::string getComponentName() const override {
     return processor_->getName();
   }
 
-  utils::Identifier getComponentUUID() const override {
+  [[nodiscard]] utils::Identifier getComponentUUID() const override {
     return processor_->getUUID();
   }
 
-  core::Processor* getProcessor() {
-    return processor_;
+  core::Processor& getProcessor() {
+    return *processor_;
   }
   /**
    * Start the client
@@ -69,15 +63,8 @@ class ProcessorController : public StateController {
   int16_t resume() override;
 
  protected:
-  core::Processor* processor_;
+  gsl::not_null<core::Processor*> processor_;
   std::shared_ptr<SchedulingAgent> scheduler_;
 };
 
-}  // namespace state
-}  // namespace minifi
-}  // namespace nifi
-}  // namespace apache
-}  // namespace org
-
-#endif  // LIBMINIFI_INCLUDE_CORE_STATE_PROCESSORCONTROLLER_H_
-
+}  // namespace org::apache::nifi::minifi::state

--- a/libminifi/include/core/state/UpdateController.h
+++ b/libminifi/include/core/state/UpdateController.h
@@ -114,11 +114,11 @@ class Pausable {
 
 class StateController : public Pausable {
  public:
-  virtual ~StateController() = default;
+  ~StateController() override = default;
 
-  virtual std::string getComponentName() const = 0;
+  [[nodiscard]] virtual std::string getComponentName() const = 0;
 
-  virtual utils::Identifier getComponentUUID() const = 0;
+  [[nodiscard]] virtual utils::Identifier getComponentUUID() const = 0;
   /**
    * Start the client
    */
@@ -141,8 +141,8 @@ class StateMonitor : public StateController {
  public:
   ~StateMonitor() override = default;
 
-  // Execute callback func on the named component. Thread safe, locking mutex_, preventing concurrent flow update
-  virtual void executeOnComponent(const std::string &name, std::function<void(state::StateController&)> func) = 0;
+  // Execute callback func on the component. Thread safe, locking mutex_, preventing concurrent flow update
+  virtual void executeOnComponent(const std::string &id_or_name, std::function<void(state::StateController&)> func) = 0;
 
   // Execute callback func on the all components. Thread safe, locking mutex_, preventing concurrent flow update
   virtual void executeOnAllComponents(std::function<void(state::StateController&)> func) = 0;

--- a/libminifi/src/FlowController.cpp
+++ b/libminifi/src/FlowController.cpp
@@ -552,7 +552,8 @@ std::vector<state::StateController*> FlowController::getAllProcessorControllers(
   return controllerVec;
 }
 
-state::StateController* FlowController::getProcessorController(const std::string& id_or_name, const std::function<std::unique_ptr<state::ProcessorController>(core::Processor&)>& controllerFactory) {
+state::StateController* FlowController::getProcessorController(const std::string& id_or_name,
+    const std::function<gsl::not_null<std::unique_ptr<state::ProcessorController>>(core::Processor&)>& controllerFactory) {
   return utils::Identifier::parse(id_or_name)
       | utils::flatMap([this](utils::Identifier id) { return utils::optional_from_ptr(root_->findProcessorById(id)); })
       | utils::orElse([this, &id_or_name] { return utils::optional_from_ptr(root_->findProcessorByName(id_or_name)); })

--- a/libminifi/src/FlowController.cpp
+++ b/libminifi/src/FlowController.cpp
@@ -462,52 +462,46 @@ void FlowController::executeOnAllComponents(std::function<void(state::StateContr
   }
 }
 
-void FlowController::executeOnComponent(const std::string &name, std::function<void(state::StateController&)> func) {
+void FlowController::executeOnComponent(const std::string &id_or_name, std::function<void(state::StateController&)> func) {
   if (updating_) {
     return;
   }
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  if (auto* component = getComponent(name); component != nullptr) {
+  if (auto* component = getComponent(id_or_name); component != nullptr) {
     func(*component);
   } else {
-    logger_->log_error("Could not get execute requested callback for component \"%s\", because component was not found", name);
+    logger_->log_error("Could not get execute requested callback for component \"%s\", because component was not found", id_or_name);
   }
 }
 
 std::vector<state::StateController*> FlowController::getAllComponents() {
   if (root_) {
-    auto controllerFactory = [this] (core::Processor& p) {
-      return createController(p);
-    };
-    return getAllProcessorControllers(controllerFactory);
+    return getAllProcessorControllers([this](core::Processor& p) { return createController(p); });
   }
 
   return {this};
 }
 
-state::StateController* FlowController::getComponent(const std::string& name) {
-  if (name == "FlowController") {
+state::StateController* FlowController::getComponent(const std::string& id_or_name) {
+  if (id_or_name == getUUIDStr() || id_or_name == "FlowController") {
     return this;
   } else if (root_) {
-    auto controllerFactory = [this] (core::Processor& p) {
-      return createController(p);
-    };
-    return getProcessorController(name, controllerFactory);
+    return getProcessorController(id_or_name, [this](core::Processor& p) { return createController(p); });
   }
 
   return nullptr;
 }
 
-std::unique_ptr<state::ProcessorController> FlowController::createController(core::Processor& processor) {
-  switch (processor.getSchedulingStrategy()) {
-    case core::SchedulingStrategy::TIMER_DRIVEN:
-      return std::make_unique<state::ProcessorController>(&processor, timer_scheduler_);
-    case core::SchedulingStrategy::EVENT_DRIVEN:
-      return std::make_unique<state::ProcessorController>(&processor, event_scheduler_);
-    case core::SchedulingStrategy::CRON_DRIVEN:
-      return std::make_unique<state::ProcessorController>(&processor, cron_scheduler_);
-  }
-  return {};
+gsl::not_null<std::unique_ptr<state::ProcessorController>> FlowController::createController(core::Processor& processor) {
+  const auto scheduler = [this, &processor]() -> std::shared_ptr<SchedulingAgent> {
+    switch (processor.getSchedulingStrategy()) {
+      case core::SchedulingStrategy::TIMER_DRIVEN: return timer_scheduler_;
+      case core::SchedulingStrategy::EVENT_DRIVEN: return event_scheduler_;
+      case core::SchedulingStrategy::CRON_DRIVEN: return cron_scheduler_;
+    }
+    gsl_Assert(false);
+  };
+  return gsl::make_not_null(std::make_unique<state::ProcessorController>(processor, scheduler()));
 }
 
 uint64_t FlowController::getUptime() {
@@ -541,7 +535,7 @@ std::map<std::string, std::unique_ptr<io::InputStream>> FlowController::getDebug
 }
 
 std::vector<state::StateController*> FlowController::getAllProcessorControllers(
-        const std::function<std::unique_ptr<state::ProcessorController>(core::Processor&)>& controllerFactory) {
+        const std::function<gsl::not_null<std::unique_ptr<state::ProcessorController>>(core::Processor&)>& controllerFactory) {
   std::vector<state::StateController*> controllerVec{this};
   std::vector<core::Processor*> processorVec;
   root_->getAllProcessors(processorVec);
@@ -558,19 +552,20 @@ std::vector<state::StateController*> FlowController::getAllProcessorControllers(
   return controllerVec;
 }
 
-state::StateController* FlowController::getProcessorController(const std::string& name, const std::function<std::unique_ptr<state::ProcessorController>(core::Processor&)>& controllerFactory) {
-  auto* processor = root_->findProcessorByName(name);
-  if (processor == nullptr) {
-    logger_->log_error("Could not get processor controller for requested name \"%s\", because processor was not found either", name);
-    return nullptr;
-  }
-
-  // reference to the existing or newly created controller
-  auto& foundController = processor_to_controller_[processor->getUUID()];
-  if (!foundController) {
-    foundController = controllerFactory(*processor);
-  }
-  return foundController.get();
+state::StateController* FlowController::getProcessorController(const std::string& id_or_name, const std::function<std::unique_ptr<state::ProcessorController>(core::Processor&)>& controllerFactory) {
+  return utils::Identifier::parse(id_or_name)
+      | utils::flatMap([this](utils::Identifier id) { return utils::optional_from_ptr(root_->findProcessorById(id)); })
+      | utils::orElse([this, &id_or_name] { return utils::optional_from_ptr(root_->findProcessorByName(id_or_name)); })
+      | utils::map([this, &controllerFactory](gsl::not_null<core::Processor*> proc) -> gsl::not_null<state::ProcessorController*> {
+        return utils::optional_from_ptr(processor_to_controller_[proc->getUUID()].get())
+            | utils::valueOrElse([this, proc, &controllerFactory] {
+              return gsl::make_not_null((processor_to_controller_[proc->getUUID()] = controllerFactory(*proc)).get());
+            });
+      })
+      | utils::valueOrElse([this, &id_or_name]() -> state::ProcessorController* {
+        logger_->log_error("Could not get processor controller for requested id/name \"%s\", because the processor was not found", id_or_name);
+        return nullptr;
+      });
 }
 
 void FlowController::loadMetricsPublisher() {

--- a/libminifi/src/c2/C2Agent.cpp
+++ b/libminifi/src/c2/C2Agent.cpp
@@ -358,7 +358,7 @@ void C2Agent::handle_c2_server_response(const C2ContentResponse &resp) {
 
       // stop all referenced components.
       update_sink_->executeOnComponent(resp.name, [this, &resp] (state::StateController& component) {
-        logger_->log_debug("Stopping component %s", component.getComponentName());
+        logger_->log_debug("Stopping component %s", resp.name);
         if (resp.op == Operation::STOP) {
           component.stop();
         } else {

--- a/libminifi/src/core/state/ProcessorController.cpp
+++ b/libminifi/src/core/state/ProcessorController.cpp
@@ -18,16 +18,13 @@
 
 #include "core/state/ProcessorController.h"
 #include <memory>
+#include <utility>
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
-namespace state {
+namespace org::apache::nifi::minifi::state {
 
-ProcessorController::ProcessorController(core::Processor* processor, const std::shared_ptr<SchedulingAgent> &scheduler)
-    : processor_(processor),
-      scheduler_(scheduler) {
+ProcessorController::ProcessorController(core::Processor& processor, std::shared_ptr<SchedulingAgent> scheduler)
+    : processor_(&processor),
+      scheduler_(std::move(scheduler)) {
 }
 
 ProcessorController::~ProcessorController() = default;
@@ -59,8 +56,4 @@ int16_t ProcessorController::resume() {
   return start();
 }
 
-} /* namespace state */
-} /* namespace minifi */
-} /* namespace nifi */
-} /* namespace apache */
-} /* namespace org */
+}  // namespace org::apache::nifi::minifi::state

--- a/libminifi/src/core/state/nodes/SupportedOperations.cpp
+++ b/libminifi/src/core/state/nodes/SupportedOperations.cpp
@@ -112,7 +112,7 @@ void SupportedOperations::fillProperties(SerializedResponseNode& properties, min
       addProperty(properties, "c2");
       if (monitor_) {
         monitor_->executeOnAllComponents([&properties](StateController& component){
-          addProperty(properties, component.getComponentName());
+          addProperty(properties, component.getComponentUUID().to_string());
         });
       }
       break;

--- a/libminifi/test/integration/OnScheduleErrorHandlingTests.cpp
+++ b/libminifi/test/integration/OnScheduleErrorHandlingTests.cpp
@@ -93,7 +93,7 @@ class EventDriverScheduleErrorHandlingTests: public IntegrationBase {
         auto process_controller = dynamic_cast<org::apache::nifi::minifi::state::ProcessorController*>(&component);
         assert(process_controller != nullptr);
 
-        process_controller->getProcessor()->setSchedulingStrategy(org::apache::nifi::minifi::core::SchedulingStrategy::EVENT_DRIVEN);
+        process_controller->getProcessor().setSchedulingStrategy(org::apache::nifi::minifi::core::SchedulingStrategy::EVENT_DRIVEN);
       }
 
       ++controllerVecIdx;

--- a/libminifi/test/integration/StateTransactionalityTests.cpp
+++ b/libminifi/test/integration/StateTransactionalityTests.cpp
@@ -72,8 +72,7 @@ class StatefulIntegrationTest : public IntegrationBase {
         // set hooks
         const auto processController = dynamic_cast<ProcessorController*>(&component);
         assert(processController != nullptr);
-        stateful_processor_ = dynamic_cast<StatefulProcessor*>(processController->getProcessor());
-        assert(stateful_processor_ != nullptr);
+        stateful_processor_ = dynamic_cast<StatefulProcessor*>(&processController->getProcessor());
         stateful_processor_->setHooks(on_schedule_hook_, on_trigger_hooks_);
       }
 

--- a/libminifi/test/integration/StateTransactionalityTests.cpp
+++ b/libminifi/test/integration/StateTransactionalityTests.cpp
@@ -73,6 +73,7 @@ class StatefulIntegrationTest : public IntegrationBase {
         const auto processController = dynamic_cast<ProcessorController*>(&component);
         assert(processController != nullptr);
         stateful_processor_ = dynamic_cast<StatefulProcessor*>(&processController->getProcessor());
+        assert(stateful_processor_);
         stateful_processor_->setHooks(on_schedule_hook_, on_trigger_hooks_);
       }
 


### PR DESCRIPTION
Because the C2 server has no way of communicating which component to start/stop in case of duplicate names. It also changes the manifest JSON schema based on whether a name is unique or duplicate. This makes JSON parsing harder on the server side.

https://issues.apache.org/jira/browse/MINIFICPP-1896

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
