### PR TITLE
MINIFICPP-1914 Do not use clcache in the Windows CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,21 +45,11 @@ jobs:
     name: "windows-2019"
     runs-on: windows-2019
     timeout-minutes: 180
-    env:
-      CLCACHE_DIR: ${{ GITHUB.WORKSPACE }}\clcache
     steps:
       - name: Support longpaths
         run: git config --system core.longpaths true
       - id: checkout
         uses: actions/checkout@v2
-      - id: cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.CLCACHE_DIR }}
-          key: windows-2019-clcache-${{github.ref}}-${{github.sha}}
-          restore-keys: |
-            windows-2019-clcache-${{github.ref}}-
-            windows-2019-clcache-refs/heads/main-
       - name: Setup PATH
         uses: microsoft/setup-msbuild@v1.0.2
       - id: install-sqliteodbc-driver
@@ -67,16 +57,6 @@ jobs:
           Invoke-WebRequest -Uri "http://www.ch-werner.de/sqliteodbc/sqliteodbc_w64.exe" -OutFile "sqliteodbc_w64.exe"
           ./sqliteodbc_w64.exe /S
         shell: powershell
-      - name: Setup clcache
-        run: |
-          (New-Object System.Net.WebClient).DownloadFile('https://github.com/frerich/clcache/releases/download/v4.2.0/clcache-4.2.0.zip', "$pwd\clcache.zip")
-          $cl_exe_dir = Split-Path -parent $(vswhere -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find VC\Tools\MSVC\**\bin\Hostx64\x64\cl.exe | select-object -last 1)
-          Expand-Archive -Force -Path clcache.zip -DestinationPath "$cl_exe_dir";
-          move "$cl_exe_dir\cl.exe" "$cl_exe_dir\cl_original.exe"
-          move "$cl_exe_dir\cl.exe.config" "$cl_exe_dir\cl_original.exe.config"
-          move "$cl_exe_dir\clcache.exe" "$cl_exe_dir\cl.exe"
-          echo "CLCACHE_CL=$cl_exe_dir\cl_original.exe" >> $env:GITHUB_ENV
-          echo "CLCACHE_NODIRECT=1" >> $env:GITHUB_ENV
       - name: build
         run: |
           PATH %PATH%;C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64


### PR DESCRIPTION
Do not use clcache in the Windows CI job, as it causes the build to fail with mysterious errors.  After a successful build on main, we may be able to put it back.

https://issues.apache.org/jira/browse/MINIFICPP-1914

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
