### PR TITLE
MINIFICPP-1906 Restore original timeout for CivetServer

### DIFF
--- a/cmake/CivetWeb.cmake
+++ b/cmake/CivetWeb.cmake
@@ -35,6 +35,7 @@ FetchContent_MakeAvailable(civetweb)
 add_dependencies(civetweb-c-library OpenSSL::Crypto OpenSSL::SSL)
 add_dependencies(civetweb-cpp OpenSSL::Crypto OpenSSL::SSL)
 
+target_compile_definitions(civetweb-c-library PRIVATE SOCKET_TIMEOUT_QUANTUM=200)
 if (NOT WIN32)
   target_compile_options(civetweb-c-library PRIVATE -Wno-error)
   target_compile_options(civetweb-cpp PRIVATE -Wno-error)


### PR DESCRIPTION
There was a change in `CivetWeb` (commit hash: `a7361235`) where a previously used `poll` function with constant timeout of 200 ms was replaced with the `mg_poll` function. This function uses the SOCKET_TIMEOUT_QUANTUM constant for the timeout value of a single poll call. The default value of this constant is 2000 ms and due to this the shutdown of the `CivetServer` had to wait 10 times more for the ongoing poll to finish in every single test case, which increased the runtime of the test cases. The SOCKET_TIMEOUT_QUANTUM is changed back to 200 ms in this PR.

https://issues.apache.org/jira/browse/MINIFICPP-1906

--------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
