### PR TITLE
MINIFICPP-1924 Upgrade range lib version and fetch source archive

### DIFF
--- a/cmake/RangeV3.cmake
+++ b/cmake/RangeV3.cmake
@@ -18,8 +18,8 @@
 include(FetchContent)
 
 FetchContent_Declare(range-v3_src
-    GIT_REPOSITORY https://github.com/ericniebler/range-v3.git
-    GIT_TAG 0487cca29e352e8f16bbd91fda38e76e39a0ed28
+    URL      https://github.com/ericniebler/range-v3/archive/refs/tags/0.12.0.tar.gz
+    URL_HASH SHA256=015adb2300a98edfceaf0725beec3337f542af4915cec4d0b89fa0886f4ba9cb
 )
 FetchContent_MakeAvailable(range-v3_src)
 


### PR DESCRIPTION
Upgrading to the latest release version of the range-v3 library (v0.12.0) and using tar.gz archive to fetch source instead of fetching the git repository as it was much slower and caused problems by hanging and making CI jobs fail: https://github.com/apache/nifi-minifi-cpp/runs/8011417864?check_suite_focus=true

https://issues.apache.org/jira/browse/MINIFICPP-1924

--------------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
