### PR TITLE
MINIFICPP-1911 Make concat_path variadic

### DIFF
--- a/extensions/aws/s3/S3Wrapper.cpp
+++ b/extensions/aws/s3/S3Wrapper.cpp
@@ -33,7 +33,7 @@ namespace org::apache::nifi::minifi::aws::s3 {
 
 void HeadObjectResult::setFilePaths(const std::string& key) {
   absolute_path = key;
-  std::tie(path, filename) = minifi::utils::file::split_path(key, true /*force_posix*/);
+  std::tie(path, filename) = minifi::utils::file::split_path(key);
 }
 
 S3Wrapper::S3Wrapper() : request_sender_(std::make_unique<S3ClientRequestSender>()) {
@@ -74,7 +74,7 @@ std::string S3Wrapper::getEncryptionString(Aws::S3::Model::ServerSideEncryption 
   return "";
 }
 
-std::optional<PutObjectResult> S3Wrapper::putObject(const PutObjectRequestParameters& put_object_params, std::shared_ptr<Aws::IOStream> data_stream) {
+std::optional<PutObjectResult> S3Wrapper::putObject(const PutObjectRequestParameters& put_object_params, const std::shared_ptr<Aws::IOStream>& data_stream) {
   Aws::S3::Model::PutObjectRequest request;
   request.SetBucket(put_object_params.bucket);
   request.SetKey(put_object_params.object_key);

--- a/extensions/aws/s3/S3Wrapper.h
+++ b/extensions/aws/s3/S3Wrapper.h
@@ -200,7 +200,7 @@ class S3Wrapper {
   S3Wrapper();
   explicit S3Wrapper(std::unique_ptr<S3RequestSender>&& request_sender);
 
-  std::optional<PutObjectResult> putObject(const PutObjectRequestParameters& put_object_params, std::shared_ptr<Aws::IOStream> data_stream);
+  std::optional<PutObjectResult> putObject(const PutObjectRequestParameters& put_object_params, const std::shared_ptr<Aws::IOStream>& data_stream);
   bool deleteObject(const DeleteObjectRequestParameters& params);
   std::optional<GetObjectResult> getObject(const GetObjectRequestParameters& get_object_params, io::BaseStream& out_body);
   std::optional<std::vector<ListedObjectAttributes>> listBucket(const ListRequestParameters& params);
@@ -213,7 +213,7 @@ class S3Wrapper {
   static Expiration getExpiration(const std::string& expiration);
 
   void setCannedAcl(Aws::S3::Model::PutObjectRequest& request, const std::string& canned_acl) const;
-  static int64_t writeFetchedBody(Aws::IOStream& source, const int64_t data_size, io::BaseStream& output);
+  static int64_t writeFetchedBody(Aws::IOStream& source, int64_t data_size, io::BaseStream& output);
   static std::string getEncryptionString(Aws::S3::Model::ServerSideEncryption encryption);
 
   std::optional<std::vector<ListedObjectAttributes>> listVersions(const ListRequestParameters& params);

--- a/extensions/azure/storage/AzureDataLakeStorage.cpp
+++ b/extensions/azure/storage/AzureDataLakeStorage.cpp
@@ -112,7 +112,7 @@ std::optional<ListDataLakeStorageResult> AzureDataLakeStorage::listDirectory(con
         continue;
       }
       ListDataLakeStorageElement element;
-      auto [directory, filename] = minifi::utils::file::FileUtils::split_path(azure_element.Name, true /*force_posix*/);
+      auto [directory, filename] = minifi::utils::file::FileUtils::split_path(azure_element.Name);
       if (!directory.empty()) {
         directory = directory.substr(0, directory.size() - 1);  // Remove ending '/' character
       }

--- a/extensions/civetweb/tests/ListenHTTPTests.cpp
+++ b/extensions/civetweb/tests/ListenHTTPTests.cpp
@@ -468,8 +468,8 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS without client cert", "[basic][h
 }
 
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert from good CA", "[https]") {
-  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
-  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
+  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
+  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
   plan->setProperty(listen_http, "SSL Verify Peer", "yes");
 
   create_ssl_context_service("goodCA.crt", "goodCA_goodClient.pem");
@@ -491,8 +491,8 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert from good CA", 
 }
 
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with PKCS12 client cert from good CA", "[https]") {
-  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
-  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
+  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
+  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
   plan->setProperty(listen_http, "SSL Verify Peer", "yes");
 
   create_ssl_context_service("goodCA.crt", "goodCA_goodClient.p12");
@@ -514,8 +514,8 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with PKCS12 client cert from goo
 }
 
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert from bad CA", "[https]") {
-  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
-  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
+  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
+  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
 
   bool should_succeed = false;
   int64_t response_code = 0;
@@ -560,8 +560,8 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert from bad CA", "
 }
 
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert with matching DN", "[https][DN]") {
-  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
-  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
+  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
+  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
   plan->setProperty(listen_http, "Authorized DN Pattern", ".*/CN=good\\..*");
   plan->setProperty(listen_http, "SSL Verify Peer", "yes");
 
@@ -584,8 +584,8 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert with matching D
 }
 
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert with non-matching DN", "[https][DN]") {
-  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
-  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
+  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
+  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
   plan->setProperty(listen_http, "Authorized DN Pattern", ".*/CN=good\\..*");
 
   int64_t response_code = 0;
@@ -630,8 +630,8 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert with non-matchi
 
 #if CURL_AT_LEAST_VERSION(7, 54, 0)
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS minimum SSL version", "[https]") {
-  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
-  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
+  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
+  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
 
   SECTION("GET") {
     method = "GET";

--- a/extensions/civetweb/tests/ListenHTTPTests.cpp
+++ b/extensions/civetweb/tests/ListenHTTPTests.cpp
@@ -70,7 +70,7 @@ class ListenHTTPTestsFixture {
     REQUIRE(!tmp_dir.empty());
 
     // Define test input file
-    std::string test_input_file = minifi::utils::file::FileUtils::concat_path(tmp_dir, "test");
+    std::string test_input_file = minifi::utils::file::concat_path(tmp_dir, "test");
     {
       std::ofstream os(test_input_file);
       os << "Hello response body";
@@ -425,7 +425,7 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTP Batch tests", "[batch]") {
 
 #ifdef OPENSSL_SUPPORT
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS without CA", "[basic][https]") {
-  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::FileUtils::concat_path(minifi::utils::file::FileUtils::get_executable_dir(), "resources/server.pem"));
+  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
 
   create_ssl_context_service("goodCA.crt", nullptr);
 
@@ -446,8 +446,8 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS without CA", "[basic][https]") {
 }
 
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS without client cert", "[basic][https]") {
-  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::FileUtils::concat_path(minifi::utils::file::FileUtils::get_executable_dir(), "resources/server.pem"));
-  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::FileUtils::concat_path(minifi::utils::file::FileUtils::get_executable_dir(), "resources/goodCA.crt"));
+  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
+  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
 
   create_ssl_context_service("goodCA.crt", nullptr);
 
@@ -468,8 +468,8 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS without client cert", "[basic][h
 }
 
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert from good CA", "[https]") {
-  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::FileUtils::concat_path(minifi::utils::file::FileUtils::get_executable_dir(), "resources/server.pem"));
-  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::FileUtils::concat_path(minifi::utils::file::FileUtils::get_executable_dir(), "resources/goodCA.crt"));
+  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
+  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
   plan->setProperty(listen_http, "SSL Verify Peer", "yes");
 
   create_ssl_context_service("goodCA.crt", "goodCA_goodClient.pem");
@@ -491,8 +491,8 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert from good CA", 
 }
 
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with PKCS12 client cert from good CA", "[https]") {
-  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::FileUtils::concat_path(minifi::utils::file::FileUtils::get_executable_dir(), "resources/server.pem"));
-  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::FileUtils::concat_path(minifi::utils::file::FileUtils::get_executable_dir(), "resources/goodCA.crt"));
+  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
+  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
   plan->setProperty(listen_http, "SSL Verify Peer", "yes");
 
   create_ssl_context_service("goodCA.crt", "goodCA_goodClient.p12");
@@ -514,8 +514,8 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with PKCS12 client cert from goo
 }
 
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert from bad CA", "[https]") {
-  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::FileUtils::concat_path(minifi::utils::file::FileUtils::get_executable_dir(), "resources/server.pem"));
-  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::FileUtils::concat_path(minifi::utils::file::FileUtils::get_executable_dir(), "resources/goodCA.crt"));
+  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
+  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
 
   bool should_succeed = false;
   int64_t response_code = 0;
@@ -560,8 +560,8 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert from bad CA", "
 }
 
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert with matching DN", "[https][DN]") {
-  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::FileUtils::concat_path(minifi::utils::file::FileUtils::get_executable_dir(), "resources/server.pem"));
-  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::FileUtils::concat_path(minifi::utils::file::FileUtils::get_executable_dir(), "resources/goodCA.crt"));
+  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
+  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
   plan->setProperty(listen_http, "Authorized DN Pattern", ".*/CN=good\\..*");
   plan->setProperty(listen_http, "SSL Verify Peer", "yes");
 
@@ -584,8 +584,8 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert with matching D
 }
 
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert with non-matching DN", "[https][DN]") {
-  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::FileUtils::concat_path(minifi::utils::file::FileUtils::get_executable_dir(), "resources/server.pem"));
-  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::FileUtils::concat_path(minifi::utils::file::FileUtils::get_executable_dir(), "resources/goodCA.crt"));
+  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
+  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
   plan->setProperty(listen_http, "Authorized DN Pattern", ".*/CN=good\\..*");
 
   int64_t response_code = 0;
@@ -630,8 +630,8 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert with non-matchi
 
 #if CURL_AT_LEAST_VERSION(7, 54, 0)
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS minimum SSL version", "[https]") {
-  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::FileUtils::concat_path(minifi::utils::file::FileUtils::get_executable_dir(), "resources/server.pem"));
-  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::FileUtils::concat_path(minifi::utils::file::FileUtils::get_executable_dir(), "resources/goodCA.crt"));
+  plan->setProperty(listen_http, "SSL Certificate", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "server.pem"));
+  plan->setProperty(listen_http, "SSL Certificate Authority", minifi::utils::file::concat_path (minifi::utils::file::get_executable_dir(), "resources", "goodCA.crt"));
 
   SECTION("GET") {
     method = "GET";

--- a/extensions/http-curl/tests/HTTPSiteToSiteTests.cpp
+++ b/extensions/http-curl/tests/HTTPSiteToSiteTests.cpp
@@ -56,8 +56,7 @@ class SiteToSiteTestHarness : public HTTPIntegrationBase {
     LogTestController::getInstance().setTrace<minifi::extensions::curl::HttpStreamingCallback>();
 
     std::fstream file;
-    ss << dir << utils::file::get_separator() << "tstFile.ext";
-    file.open(ss.str(), std::ios::out);
+    file.open(utils::file::concat_path(dir, "tstFile.ext"), std::ios::out);
     file << "tempFile";
     file.close();
 
@@ -72,7 +71,6 @@ class SiteToSiteTestHarness : public HTTPIntegrationBase {
  protected:
   bool isSecure;
   std::string dir;
-  std::stringstream ss;
   TestController testController;
 };
 

--- a/extensions/http-curl/tests/TimeoutHTTPSiteToSiteTests.cpp
+++ b/extensions/http-curl/tests/TimeoutHTTPSiteToSiteTests.cpp
@@ -58,8 +58,7 @@ class SiteToSiteTestHarness : public HTTPIntegrationBase {
     LogTestController::getInstance().setTrace<minifi::extensions::curl::HttpStreamingCallback>();
 
     std::fstream file;
-    ss << dir << utils::file::FileUtils::get_separator() << "tstFile.ext";
-    file.open(ss.str(), std::ios::out);
+    file.open(utils::file::concat_path(dir, "tstFile.ext"), std::ios::out);
     file << "tempFile";
     file.close();
 
@@ -74,7 +73,6 @@ class SiteToSiteTestHarness : public HTTPIntegrationBase {
  protected:
   bool isSecure;
   std::string dir;
-  std::stringstream ss;
   TestController testController;
 };
 

--- a/extensions/script/tests/ExecutePythonProcessorTests.cpp
+++ b/extensions/script/tests/ExecutePythonProcessorTests.cpp
@@ -107,7 +107,7 @@ class SimplePythonFlowFileTransferTest : public ExecutePythonProcessorTestBase {
     REQUIRE_NOTHROW(plan_->runNextProcessor());  // ExecutePythonProcessor
     plan_->runNextProcessor();  // PutFile
 
-    const std::string output_file_path = output_dir + utils::file::FileUtils::get_separator() +  TEST_FILE_NAME;
+    const std::string output_file_path = utils::file::concat_path(output_dir, TEST_FILE_NAME);
 
     if (Expectation::OUTPUT_FILE_MATCHES_INPUT == expectation) {
       const std::string output_file_content{ getFileContent(output_file_path) };
@@ -195,7 +195,7 @@ class SimplePythonFlowFileTransferTest : public ExecutePythonProcessorTestBase {
     std::vector<std::string> file_contents;
 
     auto lambda = [&file_contents](const std::string& path, const std::string& filename) -> bool {
-      std::ifstream is(path + utils::file::FileUtils::get_separator() + filename, std::ifstream::binary);
+      std::ifstream is(utils::file::concat_path(path, filename), std::ifstream::binary);
       file_contents.push_back(std::string((std::istreambuf_iterator<char>(is)), std::istreambuf_iterator<char>()));
       return true;
     };
@@ -303,7 +303,7 @@ TEST_CASE_METHOD(SimplePythonFlowFileTransferTest, "Test module load of processo
   std::vector<std::string> file_contents;
 
   auto lambda = [&file_contents](const std::string& path, const std::string& filename) -> bool {
-    std::ifstream is(path + utils::file::FileUtils::get_separator() + filename, std::ifstream::binary);
+    std::ifstream is(utils::file::concat_path(path, filename), std::ifstream::binary);
     file_contents.push_back(std::string((std::istreambuf_iterator<char>(is)), std::istreambuf_iterator<char>()));
     return true;
   };

--- a/extensions/script/tests/TestExecuteScriptProcessorWithLuaScript.cpp
+++ b/extensions/script/tests/TestExecuteScriptProcessorWithLuaScript.cpp
@@ -162,10 +162,9 @@ TEST_CASE("Lua: Test Read File", "[executescriptLuaRead]") {
   REQUIRE(record == nullptr);
   REQUIRE(records.empty());
 
+  std::string file_name = utils::file::concat_path(getFileDir, "tstFile.ext");
   std::fstream file;
-  std::stringstream ss;
-  ss << getFileDir << "/" << "tstFile.ext";
-  file.open(ss.str(), std::ios::out);
+  file.open(file_name, std::ios::out);
   file << "tempFile";
   file.close();
   plan->reset();
@@ -178,17 +177,16 @@ TEST_CASE("Lua: Test Read File", "[executescriptLuaRead]") {
   record = plan->getCurrentFlowFile();
   testController.runSession(plan, false);
 
-  unlink(ss.str().c_str());
+  std::filesystem::remove(file_name);
 
   REQUIRE(logTestController.contains("[info] file content: tempFile"));
 
   // Verify that file content was preserved
-  REQUIRE(!std::ifstream(ss.str()).good());
-  std::stringstream movedFile;
-  movedFile << putFileDir << "/" << "tstFile.ext";
-  REQUIRE(std::ifstream(movedFile.str()).good());
+  REQUIRE(!std::ifstream(file_name).good());
+  std::string moved_file_name = utils::file::concat_path(putFileDir, "tstFile.ext");
+  REQUIRE(std::ifstream(moved_file_name).good());
 
-  file.open(movedFile.str(), std::ios::in);
+  file.open(moved_file_name, std::ios::in);
   std::string contents((std::istreambuf_iterator<char>(file)),
                        std::istreambuf_iterator<char>());
   REQUIRE("tempFile" == contents);
@@ -250,10 +248,9 @@ TEST_CASE("Lua: Test Write File", "[executescriptLuaWrite]") {
   REQUIRE(record == nullptr);
   REQUIRE(records.empty());
 
+  std::string file_name = utils::file::concat_path(getFileDir, "tstFile.ext");
   std::fstream file;
-  std::stringstream ss;
-  ss << getFileDir << "/" << "tstFile.ext";
-  file.open(ss.str(), std::ios::out);
+  file.open(file_name, std::ios::out);
   file << "tempFile";
   file.close();
   plan->reset();
@@ -266,15 +263,14 @@ TEST_CASE("Lua: Test Write File", "[executescriptLuaWrite]") {
   record = plan->getCurrentFlowFile();
   testController.runSession(plan, false);
 
-  unlink(ss.str().c_str());
+  std::filesystem::remove(file_name);
 
   // Verify new content was written
-  REQUIRE(!std::ifstream(ss.str()).good());
-  std::stringstream movedFile;
-  movedFile << putFileDir << "/" << "tstFile.ext";
-  REQUIRE(std::ifstream(movedFile.str()).good());
+  REQUIRE(!std::ifstream(file_name).good());
+  std::string moved_file_name = utils::file::concat_path(putFileDir, "tstFile.ext");
+  REQUIRE(std::ifstream(moved_file_name).good());
 
-  file.open(movedFile.str(), std::ios::in);
+  file.open(moved_file_name, std::ios::in);
   std::string contents((std::istreambuf_iterator<char>(file)),
                        std::istreambuf_iterator<char>());
   REQUIRE("hello 2" == contents);

--- a/extensions/script/tests/TestExecuteScriptProcessorWithPythonScript.cpp
+++ b/extensions/script/tests/TestExecuteScriptProcessorWithPythonScript.cpp
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <set>
@@ -121,10 +122,9 @@ TEST_CASE("Python: Test Read File", "[executescriptPythonRead]") {
   REQUIRE(record == nullptr);
   REQUIRE(records.empty());
 
+  std::string file_name = utils::file::concat_path(getFileDir, "tstFile.ext");
   std::fstream file;
-  std::stringstream ss;
-  ss << getFileDir << "/" << "tstFile.ext";
-  file.open(ss.str(), std::ios::out);
+  file.open(file_name, std::ios::out);
   file << "tempFile";
   file.close();
   plan->reset();
@@ -137,17 +137,16 @@ TEST_CASE("Python: Test Read File", "[executescriptPythonRead]") {
   record = plan->getCurrentFlowFile();
   testController.runSession(plan, false);
 
-  unlink(ss.str().c_str());
+  std::filesystem::remove(file_name);
 
   REQUIRE(logTestController.contains("[info] file content: tempFile"));
 
   // Verify that file content was preserved
-  REQUIRE(!std::ifstream(ss.str()).good());
-  std::stringstream movedFile;
-  movedFile << putFileDir << "/" << "tstFile.ext";
-  REQUIRE(std::ifstream(movedFile.str()).good());
+  REQUIRE(!std::ifstream(file_name).good());
+  std::string moved_file_name = utils::file::concat_path(putFileDir, "tstFile.ext");
+  REQUIRE(std::ifstream(moved_file_name).good());
 
-  file.open(movedFile.str(), std::ios::in);
+  file.open(moved_file_name, std::ios::in);
   std::string contents((std::istreambuf_iterator<char>(file)),
                        std::istreambuf_iterator<char>());
   REQUIRE("tempFile" == contents);
@@ -203,10 +202,9 @@ TEST_CASE("Python: Test Write File", "[executescriptPythonWrite]") {
   REQUIRE(record == nullptr);
   REQUIRE(records.empty());
 
+  std::string file_name = utils::file::concat_path(getFileDir, "tstFile.ext");
   std::fstream file;
-  std::stringstream ss;
-  ss << getFileDir << "/" << "tstFile.ext";
-  file.open(ss.str(), std::ios::out);
+  file.open(file_name, std::ios::out);
   file << "tempFile";
   file.close();
   plan->reset();
@@ -219,15 +217,14 @@ TEST_CASE("Python: Test Write File", "[executescriptPythonWrite]") {
   record = plan->getCurrentFlowFile();
   testController.runSession(plan, false);
 
-  unlink(ss.str().c_str());
+  std::filesystem::remove(file_name);
 
   // Verify new content was written
-  REQUIRE(!std::ifstream(ss.str()).good());
-  std::stringstream movedFile;
-  movedFile << putFileDir << "/" << "tstFile.ext";
-  REQUIRE(std::ifstream(movedFile.str()).good());
+  REQUIRE(!std::ifstream(file_name).good());
+  std::string moved_file_name = utils::file::concat_path(putFileDir, "tstFile.ext");;
+  REQUIRE(std::ifstream(moved_file_name).good());
 
-  file.open(movedFile.str(), std::ios::in);
+  file.open(moved_file_name, std::ios::in);
   std::string contents((std::istreambuf_iterator<char>(file)),
                        std::istreambuf_iterator<char>());
   REQUIRE("hello 2" == contents);

--- a/extensions/sftp/processors/FetchSFTP.cpp
+++ b/extensions/sftp/processors/FetchSFTP.cpp
@@ -152,7 +152,7 @@ void FetchSFTP::onTrigger(const std::shared_ptr<core::ProcessContext> &context, 
   /* Set attributes */
   std::string parent_path;
   std::string child_path;
-  std::tie(parent_path, child_path) = utils::file::split_path(remote_file, true /*force_posix*/);
+  std::tie(parent_path, child_path) = utils::file::split_path(remote_file);
 
   session->putAttribute(flow_file, ATTRIBUTE_SFTP_REMOTE_HOST, common_properties.hostname);
   session->putAttribute(flow_file, ATTRIBUTE_SFTP_REMOTE_PORT, std::to_string(common_properties.port));

--- a/extensions/sftp/processors/ListSFTP.cpp
+++ b/extensions/sftp/processors/ListSFTP.cpp
@@ -186,7 +186,7 @@ ListSFTP::Child::Child(const std::string& parent_path_, std::tuple<std::string /
 }
 
 std::string ListSFTP::Child::getPath() const {
-  return utils::file::FileUtils::concat_path(parent_path, filename, true /*force_posix*/);
+  return utils::StringUtils::join_pack(parent_path, "/", filename);
 }
 
 bool ListSFTP::filter(const std::string& parent_path, const std::tuple<std::string /* filename */, std::string /* longentry */, LIBSSH2_SFTP_ATTRIBUTES /* attrs */>& sftp_child) {
@@ -290,7 +290,7 @@ bool ListSFTP::filterDirectory(const std::string& parent_path, const std::string
 
   /* Path Filter Regex */
   if (compiled_path_filter_regex_) {
-    std::string dir_path = utils::file::FileUtils::concat_path(parent_path, filename, true /*force_posix*/);
+    std::string dir_path = utils::StringUtils::join_pack(parent_path, "/", filename);
     bool match = false;
     match = utils::regexMatch(dir_path, *compiled_path_filter_regex_);
     if (!match) {
@@ -890,7 +890,7 @@ void ListSFTP::onTrigger(const std::shared_ptr<core::ProcessContext> &context, c
 
   /* Add initial directory */
   Child root;
-  std::tie(root.parent_path, root.filename) = utils::file::FileUtils::split_path(remote_path, true /*force_posix*/);
+  std::tie(root.parent_path, root.filename) = utils::file::FileUtils::split_path(remote_path);
   root.directory = true;
   directories.emplace_back(std::move(root));
 

--- a/extensions/sftp/processors/PutSFTP.cpp
+++ b/extensions/sftp/processors/PutSFTP.cpp
@@ -190,7 +190,7 @@ bool PutSFTP::processOne(const std::shared_ptr<core::ProcessContext> &context, c
   /* Try to detect conflicts if needed */
   std::string resolved_filename = filename;
   if (conflict_resolution_ != CONFLICT_RESOLUTION_NONE) {
-    std::string target_path = utils::file::concat_path(remote_path, filename, true /*force_posix*/);
+    std::string target_path = utils::StringUtils::join_pack(remote_path, "/", filename);
     LIBSSH2_SFTP_ATTRIBUTES attrs;
     if (!client->stat(target_path, true /*follow_symlinks*/, attrs)) {
       if (client->getLastError() != utils::SFTPError::FileDoesNotExist) {
@@ -228,7 +228,7 @@ bool PutSFTP::processOne(const std::shared_ptr<core::ProcessContext> &context, c
           std::stringstream possible_resolved_filename_ss;
           possible_resolved_filename_ss << i << "." << filename;
           possible_resolved_filename = possible_resolved_filename_ss.str();
-          std::string possible_resolved_path = utils::file::concat_path(remote_path, possible_resolved_filename, true /*force_posix*/);
+          std::string possible_resolved_path = utils::StringUtils::join_pack(remote_path, "/", possible_resolved_filename);
           if (!client->stat(possible_resolved_path, true /*follow_symlinks*/, attrs)) {
             if (client->getLastError() == utils::SFTPError::FileDoesNotExist) {
               unique_name_generated = true;
@@ -286,7 +286,7 @@ bool PutSFTP::processOne(const std::shared_ptr<core::ProcessContext> &context, c
     target_path_ss << resolved_filename;
   }
   auto target_path = target_path_ss.str();
-  std::string final_target_path = utils::file::concat_path(remote_path, resolved_filename, true /*force_posix*/);
+  std::string final_target_path = utils::StringUtils::join_pack(remote_path, "/", resolved_filename);
   logger_->log_debug("The target path is %s, final target path is %s", target_path.c_str(), final_target_path.c_str());
 
   try {

--- a/extensions/sftp/tests/FetchSFTPTests.cpp
+++ b/extensions/sftp/tests/FetchSFTPTests.cpp
@@ -217,7 +217,7 @@ TEST_CASE_METHOD(FetchSFTPTestsFixture, "FetchSFTP fetch one file", "[FetchSFTP]
 
 TEST_CASE_METHOD(FetchSFTPTestsFixture, "FetchSFTP public key authentication", "[FetchSFTP][basic]") {
   plan->setProperty(fetch_sftp, "Remote File", "nifi_test/tstFile.ext");
-  plan->setProperty(fetch_sftp, "Private Key Path", utils::file::concat_path(get_sftp_test_dir(), "resources/id_rsa"));
+  plan->setProperty(fetch_sftp, "Private Key Path", utils::file::concat_path(get_sftp_test_dir(), "resources", "id_rsa"));
   plan->setProperty(fetch_sftp, "Private Key Passphrase", "privatekeypassword");
 
   createFile("nifi_test/tstFile.ext", "Test content 1");
@@ -385,7 +385,7 @@ TEST_CASE_METHOD(FetchSFTPTestsFixture, "FetchSFTP expression language test", "[
   plan->setProperty(update_attribute, "attr_Username", "nifiuser", true /*dynamic*/);
   plan->setProperty(update_attribute, "attr_Password", "nifipassword", true /*dynamic*/);
   plan->setProperty(update_attribute, "attr_Private Key Path",
-    utils::file::concat_path(get_sftp_test_dir(), "resources/id_rsa"), true /*dynamic*/);
+    utils::file::concat_path(get_sftp_test_dir(), "resources", "id_rsa"), true /*dynamic*/);
   plan->setProperty(update_attribute, "attr_Private Key Passphrase", "privatekeypassword", true /*dynamic*/);
   plan->setProperty(update_attribute, "attr_Remote File", "nifi_test/tstFile.ext", true /*dynamic*/);
   plan->setProperty(update_attribute, "attr_Move Destination Directory", "nifi_done/", true /*dynamic*/);

--- a/extensions/sftp/tests/FetchSFTPTests.cpp
+++ b/extensions/sftp/tests/FetchSFTPTests.cpp
@@ -16,44 +16,22 @@
  * limitations under the License.
  */
 
-#include <sys/stat.h>
-#undef NDEBUG
-#include <cassert>
-#include <cstring>
-#include <utility>
-#include <chrono>
-#include <fstream>
 #include <memory>
 #include <string>
 #include <thread>
 #include <type_traits>
 #include <vector>
 #include <iostream>
-#include <sstream>
-#include <algorithm>
-#include <functional>
 #include <iterator>
-#include <random>
-#ifndef WIN32
-#include <unistd.h>
-#endif
 
 #include "TestBase.h"
 #include "Catch.h"
-#include "utils/StringUtils.h"
 #include "utils/file/FileUtils.h"
-#include "core/Core.h"
-#include "core/logging/Logger.h"
 #include "core/ProcessGroup.h"
-#include "core/yaml/YamlConfiguration.h"
 #include "FlowController.h"
-#include "properties/Configure.h"
-#include "unit/ProvenanceTestHelper.h"
-#include "io/StreamFactory.h"
 #include "processors/FetchSFTP.h"
 #include "processors/GenerateFlowFile.h"
 #include "processors/LogAttribute.h"
-#include "processors/UpdateAttribute.h"
 #include "processors/PutFile.h"
 #include "tools/SFTPTestServer.h"
 
@@ -78,7 +56,7 @@ class FetchSFTPTestsFixture {
     REQUIRE(plan);
 
     // Start SFTP server
-    sftp_server = std::make_unique<SFTPTestServer>(src_dir);
+    sftp_server = std::make_unique<SFTPTestServer>(src_dir.string());
     REQUIRE(true == sftp_server->start());
 
     // Build MiNiFi processing graph
@@ -122,7 +100,7 @@ class FetchSFTPTestsFixture {
     plan->setProperty(fetch_sftp, "Use Compression", "false");
 
     // Configure PutFile processor
-    plan->setProperty(put_file, "Directory", dst_dir + "/${path}");
+    plan->setProperty(put_file, "Directory", (dst_dir / "${path}").string());
     plan->setProperty(put_file, "Conflict Resolution Strategy", minifi::processors::PutFile::CONFLICT_RESOLUTION_STRATEGY_FAIL);
     plan->setProperty(put_file, "Create Missing Directories", "true");
   }
@@ -133,11 +111,11 @@ class FetchSFTPTestsFixture {
 
   // Create source file
   void createFile(const std::string& relative_path, const std::string& content) {
+    const auto file_path = src_dir / "vfs" / relative_path;
+    std::filesystem::create_directories(file_path.parent_path());
+
     std::fstream file;
-    std::stringstream ss;
-    ss << src_dir << "/vfs/" << relative_path;
-    utils::file::create_dir(utils::file::get_parent_path(ss.str()));
-    file.open(ss.str(), std::ios::out);
+    file.open(file_path, std::ios::out);
     file << content;
     file.close();
   }
@@ -148,17 +126,17 @@ class FetchSFTPTestsFixture {
   };
 
   void testFile(TestWhere where, const std::string& relative_path, const std::string& expected_content) {
-    std::stringstream resultFile;
+    std::filesystem::path result_file;
     if (where == IN_DESTINATION) {
-      resultFile << dst_dir << "/" << relative_path;
+      result_file = dst_dir / relative_path;
     } else {
-      resultFile << src_dir << "/vfs/" << relative_path;
+      result_file = src_dir / "vfs" / relative_path;
 #ifndef WIN32
       /* Workaround for mina-sshd setting the read file's permissions to 0000 */
-      REQUIRE(0 == chmod(resultFile.str().c_str(), 0644));
+      REQUIRE(0 == chmod(result_file.string().c_str(), 0644));
 #endif
     }
-    std::ifstream file(resultFile.str());
+    std::ifstream file(result_file);
     REQUIRE(true == file.good());
     std::stringstream content;
     std::vector<char> buffer(1024U);
@@ -170,25 +148,25 @@ class FetchSFTPTestsFixture {
   }
 
   void testFileNotExists(TestWhere where, const std::string& relative_path) {
-    std::stringstream resultFile;
+    std::filesystem::path result_file;
     if (where == IN_DESTINATION) {
-      resultFile << dst_dir << "/" << relative_path;
+      result_file = dst_dir / relative_path;
     } else {
-      resultFile << src_dir << "/vfs/" << relative_path;
+      result_file = src_dir / "vfs" / relative_path;
 #ifndef WIN32
       /* Workaround for mina-sshd setting the read file's permissions to 0000 */
-      REQUIRE(-1 == chmod(resultFile.str().c_str(), 0644));
+      REQUIRE(-1 == chmod(result_file.string().c_str(), 0644));
 #endif
     }
-    std::ifstream file(resultFile.str());
+    std::ifstream file(result_file);
     REQUIRE(false == file.is_open());
     REQUIRE(false == file.good());
   }
 
  protected:
   TestController testController;
-  std::string src_dir = testController.createTempDirectory();
-  std::string dst_dir = testController.createTempDirectory();
+  std::filesystem::path src_dir{testController.createTempDirectory()};
+  std::filesystem::path dst_dir{testController.createTempDirectory()};
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::unique_ptr<SFTPTestServer> sftp_server;
   std::shared_ptr<core::Processor> generate_flow_file;
@@ -256,7 +234,7 @@ TEST_CASE_METHOD(FetchSFTPTestsFixture, "FetchSFTP fetch non-readable file", "[F
   plan->setProperty(fetch_sftp, "Remote File", "nifi_test/tstFile.ext");
 
   createFile("nifi_test/tstFile.ext", "Test content 1");
-  REQUIRE(0 == chmod((src_dir + "/vfs/nifi_test/tstFile.ext").c_str(), 0000));
+  REQUIRE(0 == chmod((src_dir / "vfs" / "nifi_test" / "tstFile.ext").string().c_str(), 0000));
 
   testController.runSession(plan, true);
 
@@ -311,7 +289,7 @@ TEST_CASE_METHOD(FetchSFTPTestsFixture, "FetchSFTP Completion Strategy Delete Fi
 
   createFile("nifi_test/tstFile.ext", "Test content 1");
   /* By making the parent directory non-writable we make it impossible do delete the source file */
-  REQUIRE(0 == chmod((src_dir + "/vfs/nifi_test").c_str(), 0500));
+  REQUIRE(0 == chmod((src_dir / "vfs" / "nifi_test").string().c_str(), 0500));
 
   testController.runSession(plan, true);
 
@@ -327,7 +305,7 @@ TEST_CASE_METHOD(FetchSFTPTestsFixture, "FetchSFTP Completion Strategy Delete Fi
   REQUIRE(LogTestController::getInstance().contains("key:sftp.remote.port value:" + std::to_string(sftp_server->getPort())));
   REQUIRE(LogTestController::getInstance().contains("key:path value:nifi_test/"));
   REQUIRE(LogTestController::getInstance().contains("key:filename value:tstFile.ext"));
-  REQUIRE(0 == chmod((src_dir + "/vfs/nifi_test").c_str(), 0755));
+  REQUIRE(0 == chmod((src_dir / "vfs" / "nifi_test").string().c_str(), 0755));
 }
 #endif
 

--- a/extensions/sftp/tests/ListSFTPTests.cpp
+++ b/extensions/sftp/tests/ListSFTPTests.cpp
@@ -187,7 +187,7 @@ TEST_CASE_METHOD(ListSFTPTestsFixture, "ListSFTP list one file", "[ListSFTP][bas
 
 TEST_CASE_METHOD(ListSFTPTestsFixture, "ListSFTP public key authentication", "[ListSFTP][basic]") {
   plan->setProperty(list_sftp, "Remote File", "nifi_test/tstFile.ext");
-  plan->setProperty(list_sftp, "Private Key Path", utils::file::FileUtils::concat_path(get_sftp_test_dir(), "resources/id_rsa"));
+  plan->setProperty(list_sftp, "Private Key Path", utils::file::concat_path(get_sftp_test_dir(), "resources", "id_rsa"));
   plan->setProperty(list_sftp, "Private Key Passphrase", "privatekeypassword");
 
   createFileWithModificationTimeDiff("nifi_test/tstFile.ext", "Test content 1");

--- a/extensions/sftp/tests/PutSFTPTests.cpp
+++ b/extensions/sftp/tests/PutSFTPTests.cpp
@@ -244,7 +244,7 @@ TEST_CASE_METHOD(PutSFTPTestsFixture, "PutSFTP bad password", "[PutSFTP][authent
 }
 
 TEST_CASE_METHOD(PutSFTPTestsFixture, "PutSFTP public key authentication success", "[PutSFTP][authentication]") {
-  plan->setProperty(put, "Private Key Path", utils::file::concat_path(get_sftp_test_dir(), "resources/id_rsa"));
+  plan->setProperty(put, "Private Key Path", utils::file::concat_path(get_sftp_test_dir(), "resources", "id_rsa"));
   plan->setProperty(put, "Private Key Passphrase", "privatekeypassword");
 
   createFile(src_dir, "tstFile.ext", "tempFile");
@@ -257,7 +257,7 @@ TEST_CASE_METHOD(PutSFTPTestsFixture, "PutSFTP public key authentication success
 
 TEST_CASE_METHOD(PutSFTPTestsFixture, "PutSFTP public key authentication bad passphrase", "[PutSFTP][authentication]") {
   plan->setProperty(put, "Password", "");
-  plan->setProperty(put, "Private Key Path", utils::file::concat_path(get_sftp_test_dir(), "resources/id_rsa"));
+  plan->setProperty(put, "Private Key Path", utils::file::concat_path(get_sftp_test_dir(), "resources", "id_rsa"));
   plan->setProperty(put, "Private Key Passphrase", "badpassword");
 
   createFile(src_dir, "tstFile.ext", "tempFile");
@@ -273,7 +273,7 @@ TEST_CASE_METHOD(PutSFTPTestsFixture, "PutSFTP public key authentication bad pas
 }
 
 TEST_CASE_METHOD(PutSFTPTestsFixture, "PutSFTP public key authentication bad passphrase fallback to password", "[PutSFTP][authentication]") {
-  plan->setProperty(put, "Private Key Path", utils::file::concat_path(get_sftp_test_dir(), "resources/id_rsa"));
+  plan->setProperty(put, "Private Key Path", utils::file::concat_path(get_sftp_test_dir(), "resources", "id_rsa"));
   plan->setProperty(put, "Private Key Passphrase", "badpassword");
 
   createFile(src_dir, "tstFile.ext", "tempFile");
@@ -286,7 +286,7 @@ TEST_CASE_METHOD(PutSFTPTestsFixture, "PutSFTP public key authentication bad pas
 }
 
 TEST_CASE_METHOD(PutSFTPTestsFixture, "PutSFTP host key checking success", "[PutSFTP][hostkey]") {
-  plan->setProperty(put, "Host Key File", utils::file::concat_path(get_sftp_test_dir(), "resources/known_hosts"));
+  plan->setProperty(put, "Host Key File", utils::file::concat_path(get_sftp_test_dir(), "resources", "known_hosts"));
   plan->setProperty(put, "Strict Host Key Checking", "true");
 
   createFile(src_dir, "tstFile.ext", "tempFile");
@@ -300,7 +300,7 @@ TEST_CASE_METHOD(PutSFTPTestsFixture, "PutSFTP host key checking success", "[Put
 TEST_CASE_METHOD(PutSFTPTestsFixture, "PutSFTP host key checking missing strict", "[PutSFTP][hostkey]") {
   plan->setProperty(put, "Hostname", "127.0.0.1");
 
-  plan->setProperty(put, "Host Key File", utils::file::concat_path(get_sftp_test_dir(), "resources/known_hosts"));
+  plan->setProperty(put, "Host Key File", utils::file::concat_path(get_sftp_test_dir(), "resources", "known_hosts"));
   plan->setProperty(put, "Strict Host Key Checking", "true");
 
   createFile(src_dir, "tstFile.ext", "tempFile");
@@ -318,7 +318,7 @@ TEST_CASE_METHOD(PutSFTPTestsFixture, "PutSFTP host key checking missing strict"
 TEST_CASE_METHOD(PutSFTPTestsFixture, "PutSFTP host key checking missing non-strict", "[PutSFTP][hostkey]") {
   plan->setProperty(put, "Hostname", "127.0.0.1");
 
-  plan->setProperty(put, "Host Key File", utils::file::concat_path(get_sftp_test_dir(), "resources/known_hosts"));
+  plan->setProperty(put, "Host Key File", utils::file::concat_path(get_sftp_test_dir(), "resources", "known_hosts"));
   plan->setProperty(put, "Strict Host Key Checking", "false");
 
   createFile(src_dir, "tstFile.ext", "tempFile");
@@ -330,7 +330,7 @@ TEST_CASE_METHOD(PutSFTPTestsFixture, "PutSFTP host key checking missing non-str
 }
 
 TEST_CASE_METHOD(PutSFTPTestsFixture, "PutSFTP host key checking mismatch strict", "[PutSFTP][hostkey]") {
-  plan->setProperty(put, "Host Key File", utils::file::concat_path(get_sftp_test_dir(), "resources/known_hosts_mismatch"));
+  plan->setProperty(put, "Host Key File", utils::file::concat_path(get_sftp_test_dir(), "resources", "known_hosts_mismatch"));
   plan->setProperty(put, "Strict Host Key Checking", "true");
 
   createFile(src_dir, "tstFile.ext", "tempFile");
@@ -847,7 +847,7 @@ TEST_CASE_METHOD(PutSFTPTestsFixture, "PutSFTP expression language test", "[PutS
   plan->setProperty(update_attribute, "attr_Username", "nifiuser", true /*dynamic*/);
   plan->setProperty(update_attribute, "attr_Password", "nifipassword", true /*dynamic*/);
   plan->setProperty(update_attribute, "attr_Private Key Path",
-      utils::file::FileUtils::concat_path(get_sftp_test_dir(), "resources/id_rsa"), true /*dynamic*/);
+      utils::file::concat_path(get_sftp_test_dir(), "resources", "id_rsa"), true /*dynamic*/);
   plan->setProperty(update_attribute, "attr_Private Key Passphrase", "privatekeypassword", true /*dynamic*/);
   plan->setProperty(update_attribute, "attr_Remote Path", "nifi_test/", true /*dynamic*/);
   plan->setProperty(update_attribute, "attr_Temporary Filename", "tempfile", true /*dynamic*/);

--- a/extensions/standard-processors/processors/FetchFile.cpp
+++ b/extensions/standard-processors/processors/FetchFile.cpp
@@ -141,7 +141,7 @@ void FetchFile::logWithLevel(LogLevelOption log_level, Args&&... args) const {
 }
 
 std::string FetchFile::getMoveAbsolutePath(const std::string& file_name) const {
-  return move_destination_directory_ + utils::file::FileUtils::get_separator() + file_name;
+  return utils::file::concat_path(move_destination_directory_, file_name);
 }
 
 bool FetchFile::moveDestinationConflicts(const std::string& file_name) const {

--- a/extensions/standard-processors/processors/GetFile.h
+++ b/extensions/standard-processors/processors/GetFile.h
@@ -170,7 +170,7 @@ class GetFile : public core::Processor, public state::response::MetricsNodeSourc
   bool isListingEmpty() const;
   void putListing(std::string fileName);
   std::queue<std::string> pollListing(uint64_t batch_size);
-  bool fileMatchesRequestCriteria(std::string fullName, std::string name, const GetFileRequest &request);
+  bool fileMatchesRequestCriteria(const std::string& fullName, const std::string& name, const GetFileRequest& request);
   void getSingleFile(core::ProcessSession& session, const std::string& file_name) const;
 
   std::shared_ptr<GetFileMetrics> metrics_;

--- a/extensions/standard-processors/processors/PutFile.cpp
+++ b/extensions/standard-processors/processors/PutFile.cpp
@@ -127,10 +127,7 @@ void PutFile::onTrigger(core::ProcessContext *context, core::ProcessSession *ses
 
   logger_->log_debug("PutFile using temporary file %s", tmpFile);
 
-  // Determine dest full file paths
-  std::stringstream destFileSs;
-  destFileSs << directory << utils::file::get_separator() << filename;
-  std::string destFile = destFileSs.str();
+  std::string destFile = utils::file::concat_path(directory, filename);
 
   logger_->log_debug("PutFile writing file %s into directory %s", filename, directory);
 
@@ -185,7 +182,7 @@ std::string PutFile::tmpWritePath(const std::string &filename, const std::string
   return tmpFile;
 }
 
-bool PutFile::putFile(core::ProcessSession *session, std::shared_ptr<core::FlowFile> flowFile, const std::string &tmpFile, const std::string &destFile, const std::string &destDir) {
+bool PutFile::putFile(core::ProcessSession *session, const std::shared_ptr<core::FlowFile>& flowFile, const std::string &tmpFile, const std::string &destFile, const std::string &destDir) {
   if (!utils::file::exists(destDir) && try_mkdirs_) {
     // Attempt to create directories in file's path
     std::stringstream dir_path_stream;

--- a/extensions/standard-processors/processors/PutFile.h
+++ b/extensions/standard-processors/processors/PutFile.h
@@ -17,8 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef EXTENSIONS_STANDARD_PROCESSORS_PROCESSORS_PUTFILE_H_
-#define EXTENSIONS_STANDARD_PROCESSORS_PROCESSORS_PUTFILE_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -32,11 +31,7 @@
 #include "utils/Id.h"
 #include "utils/Export.h"
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
-namespace processors {
+namespace org::apache::nifi::minifi::processors {
 
 class PutFile : public core::Processor {
  public:
@@ -116,7 +111,7 @@ class PutFile : public core::Processor {
   int64_t max_dest_files_ = -1;
 
   bool putFile(core::ProcessSession *session,
-               std::shared_ptr<core::FlowFile> flowFile,
+               const std::shared_ptr<core::FlowFile>& flowFile,
                const std::string &tmpFile,
                const std::string &destFile,
                const std::string &destDir);
@@ -127,8 +122,8 @@ class PutFile : public core::Processor {
   class FilePermissions {
     static const uint32_t MINIMUM_INVALID_PERMISSIONS_VALUE = 1 << 9;
    public:
-    bool valid() { return permissions_ < MINIMUM_INVALID_PERMISSIONS_VALUE; }
-    uint32_t getValue() const { return permissions_; }
+    [[nodiscard]] bool valid() const { return permissions_ < MINIMUM_INVALID_PERMISSIONS_VALUE; }
+    [[nodiscard]] uint32_t getValue() const { return permissions_; }
     void setValue(uint32_t perms) { permissions_ = perms; }
    private:
     uint32_t permissions_ = MINIMUM_INVALID_PERMISSIONS_VALUE;
@@ -140,10 +135,4 @@ class PutFile : public core::Processor {
 #endif
 };
 
-}  // namespace processors
-}  // namespace minifi
-}  // namespace nifi
-}  // namespace apache
-}  // namespace org
-
-#endif  // EXTENSIONS_STANDARD_PROCESSORS_PROCESSORS_PUTFILE_H_
+}  // namespace org::apache::nifi::minifi::processors

--- a/extensions/standard-processors/processors/TailFile.cpp
+++ b/extensions/standard-processors/processors/TailFile.cpp
@@ -623,7 +623,7 @@ std::vector<TailState> TailFile::findAllRotatedFiles(const TailState &state) con
   auto collect_matching_files = [&](const std::string &path, const std::string &file_name) -> bool {
     utils::Regex pattern_regex(pattern);
     if (file_name != state.file_name_ && utils::regexMatch(file_name, pattern_regex)) {
-      std::string full_file_name = path + utils::file::get_separator() + file_name;
+      std::string full_file_name = utils::file::concat_path(path, file_name);
       TailStateWithMtime::TimePoint mtime{utils::file::last_write_time_point(full_file_name)};
       logger_->log_debug("File %s with mtime %" PRId64 " matches rolling filename pattern %s, so we are reading it", file_name, int64_t{mtime.time_since_epoch().count()}, pattern);
       matched_files_with_mtime.emplace_back(TailState{path, file_name}, mtime);
@@ -645,7 +645,7 @@ std::vector<TailState> TailFile::findRotatedFilesAfterLastReadTime(const TailSta
   auto collect_matching_files = [&](const std::string &path, const std::string &file_name) -> bool {
     utils::Regex pattern_regex(pattern);
     if (file_name != state.file_name_ && utils::regexMatch(file_name, pattern_regex)) {
-      std::string full_file_name = path + utils::file::get_separator() + file_name;
+      std::string full_file_name = utils::file::concat_path(path, file_name);
       TailStateWithMtime::TimePoint mtime{utils::file::last_write_time_point(full_file_name)};
       logger_->log_debug("File %s with mtime %" PRId64 " matches rolling filename pattern %s", file_name, int64_t{mtime.time_since_epoch().count()}, pattern);
       if (mtime >= std::chrono::time_point_cast<std::chrono::seconds>(state.last_read_time_)) {
@@ -871,7 +871,7 @@ void TailFile::checkForRemovedFiles() {
 
 void TailFile::checkForNewFiles(core::ProcessContext& context) {
   auto add_new_files_callback = [&](const std::string &path, const std::string &file_name) -> bool {
-    std::string full_file_name = path + utils::file::get_separator() + file_name;
+    std::string full_file_name = utils::file::concat_path(path, file_name);
     utils::Regex file_to_tail_regex(file_to_tail_);
     if (!containsKey(tail_states_, full_file_name) && utils::regexMatch(file_name, file_to_tail_regex)) {
       tail_states_.emplace(full_file_name, TailState{path, file_name});

--- a/extensions/standard-processors/processors/TailFile.h
+++ b/extensions/standard-processors/processors/TailFile.h
@@ -55,7 +55,7 @@ struct TailState {
   TailState() = default;
 
   std::string fileNameWithPath() const {
-    return path_ + utils::file::get_separator() + file_name_;
+    return utils::file::concat_path(path_, file_name_);
   }
 
   int64_t lastReadTimeInMilliseconds() const {

--- a/extensions/standard-processors/tests/integration/SecureSocketGetTCPTest.cpp
+++ b/extensions/standard-processors/tests/integration/SecureSocketGetTCPTest.cpp
@@ -66,8 +66,7 @@ class SecureSocketTest : public IntegrationBase {
     LogTestController::getInstance().setTrace<minifi::io::TLSSocket>();
     LogTestController::getInstance().setTrace<minifi::processors::GetTCP>();
     std::fstream file;
-    ss << dir << utils::file::get_separator() << "tstFile.ext";
-    file.open(ss.str(), std::ios::out);
+    file.open(utils::file::concat_path(dir, "tstFile.ext"), std::ios::out);
     file << "tempFile";
     file.close();
   }
@@ -129,7 +128,6 @@ class SecureSocketTest : public IntegrationBase {
   bool isSecure;
   std::atomic<bool> isRunning_;
   std::string dir;
-  std::stringstream ss;
   TestController testController;
   std::shared_ptr<org::apache::nifi::minifi::io::TLSServerSocket> server_socket_;
 };

--- a/extensions/standard-processors/tests/integration/TailFileTest.cpp
+++ b/extensions/standard-processors/tests/integration/TailFileTest.cpp
@@ -41,11 +41,10 @@ class TailFileTestHarness : public IntegrationBase {
   TailFileTestHarness() : IntegrationBase(2s) {
     dir = testController.createTempDirectory();
 
-    statefile = dir + utils::file::get_separator();
-    statefile += "statefile";
+    statefile = utils::file::concat_path(dir, "statefile");
+    test_file = utils::file::concat_path(dir, "tstFile.ext");
     std::fstream file;
-    ss << dir << utils::file::get_separator() << "tstFile.ext";
-    file.open(ss.str(), std::ios::out);
+    file.open(test_file, std::ios::out);
     file << "Lin\\e1\nli\\nen\nli\\ne3\nli\\ne4\nli\\ne5\n";
     file.close();
   }
@@ -60,7 +59,7 @@ class TailFileTestHarness : public IntegrationBase {
   }
 
   void cleanup() override {
-    std::remove(ss.str().c_str());
+    std::remove(test_file.c_str());
     std::remove(statefile.c_str());
     IntegrationBase::cleanup();
   }
@@ -78,15 +77,15 @@ class TailFileTestHarness : public IntegrationBase {
     fc.executeOnComponent("tf", [this] (minifi::state::StateController& component) {
       auto proc = dynamic_cast<minifi::state::ProcessorController*>(&component);
       if (nullptr != proc) {
-        proc->getProcessor().setProperty(minifi::processors::TailFile::FileName, ss.str());
+        proc->getProcessor().setProperty(minifi::processors::TailFile::FileName, test_file);
         proc->getProcessor().setProperty(minifi::processors::TailFile::StateFile, statefile);
       }
     });
   }
 
   std::string statefile;
+  std::string test_file;
   std::string dir;
-  std::stringstream ss;
   TestController testController;
 };
 

--- a/extensions/standard-processors/tests/unit/AttributesToJSONTests.cpp
+++ b/extensions/standard-processors/tests/unit/AttributesToJSONTests.cpp
@@ -94,7 +94,7 @@ class AttributesToJSONTestFixture {
     std::vector<std::string> file_contents;
 
     auto callback = [&file_contents](const std::string& path, const std::string& filename) -> bool {
-      std::ifstream is(path + utils::file::FileUtils::get_separator() + filename, std::ifstream::binary);
+      std::ifstream is(utils::file::concat_path(path, filename), std::ifstream::binary);
       std::string file_content(std::istreambuf_iterator<char>{is}, std::istreambuf_iterator<char>{});
       file_contents.push_back(file_content);
       return true;
@@ -123,14 +123,14 @@ TEST_CASE_METHOD(AttributesToJSONTestFixture, "Move all attributes to a flowfile
   REQUIRE(file_contents[0] == TEST_FILE_CONTENT);
 
   const std::unordered_map<std::string, std::optional<std::string>> expected_attributes {
-    {"absolute.path", dir_ + utils::file::FileUtils::get_separator() + TEST_FILE_NAME},
+    {"absolute.path", utils::file::concat_path(dir_, TEST_FILE_NAME)},
     {"empty_attribute", ""},
     {"filename", TEST_FILE_NAME},
     {"flow.id", "test"},
     {"my_attribute", "my_value"},
     {"my_attribute_1", "my_value_1"},
     {"other_attribute", "other_value"},
-    {"path", dir_ + utils::file::FileUtils::get_separator()}
+    {"path", dir_}
   };
   assertJSONAttributesFromLog(expected_attributes);
 }
@@ -184,14 +184,14 @@ TEST_CASE_METHOD(AttributesToJSONTestFixture, "JSON attributes are written in fl
   test_controller_.runSession(plan_);
 
   const std::unordered_map<std::string, std::optional<std::string>> expected_attributes {
-    {"absolute.path", dir_ + utils::file::FileUtils::get_separator() + TEST_FILE_NAME},
+    {"absolute.path", utils::file::concat_path(dir_, TEST_FILE_NAME)},
     {"empty_attribute", ""},
     {"filename", TEST_FILE_NAME},
     {"flow.id", "test"},
     {"my_attribute", "my_value"},
     {"my_attribute_1", "my_value_1"},
     {"other_attribute", "other_value"},
-    {"path", dir_ + utils::file::FileUtils::get_separator()}
+    {"path", dir_}
   };
   assertJSONAttributesFromFile(expected_attributes);
 }
@@ -243,7 +243,7 @@ TEST_CASE_METHOD(AttributesToJSONTestFixture, "Attributes from attributes list a
     {"empty_attribute", ""},
     {"filename", TEST_FILE_NAME},
     {"my_attribute", "my_value"},
-    {"path", dir_ + utils::file::FileUtils::get_separator()}
+    {"path", dir_}
   };
   assertJSONAttributesFromLog(expected_attributes);
 }
@@ -272,7 +272,7 @@ TEST_CASE_METHOD(AttributesToJSONTestFixture, "Core attributes are written if th
 
   const std::unordered_map<std::string, std::optional<std::string>> expected_attributes {
     {"filename", TEST_FILE_NAME},
-    {"path", dir_ + utils::file::FileUtils::get_separator()},
+    {"path", dir_},
     {"my_attribute", "my_value"}
   };
   assertJSONAttributesFromLog(expected_attributes);

--- a/extensions/standard-processors/tests/unit/ExtractTextTests.cpp
+++ b/extensions/standard-processors/tests/unit/ExtractTextTests.cpp
@@ -79,9 +79,7 @@ TEST_CASE("Test usage of ExtractText", "[extracttextTest]") {
   std::shared_ptr<core::Processor> laprocessor = plan->addProcessor("LogAttribute", "outputLogAttribute", core::Relationship("success", "description"), true);
   plan->setProperty(laprocessor, org::apache::nifi::minifi::processors::LogAttribute::AttributesToLog.getName(), TEST_ATTR);
 
-  std::stringstream ss1;
-  ss1 << temp_dir << utils::file::get_separator() << TEST_FILE;
-  std::string test_file_path = ss1.str();
+  std::string test_file_path = utils::file::concat_path(temp_dir, TEST_FILE);
 
   std::ofstream test_file(test_file_path);
   if (test_file.is_open()) {
@@ -150,9 +148,7 @@ TEST_CASE("Test usage of ExtractText in regex mode", "[extracttextRegexTest]") {
   std::shared_ptr<core::Processor> laprocessor = plan->addProcessor("LogAttribute", "outputLogAttribute", core::Relationship("success", "description"), true);
   plan->setProperty(laprocessor, org::apache::nifi::minifi::processors::LogAttribute::AttributesToLog.getName(), TEST_ATTR);
 
-  std::stringstream ss;
-  ss << dir << utils::file::get_separator() << TEST_FILE;
-  std::string test_file_path = ss.str();
+  std::string test_file_path = utils::file::concat_path(dir, TEST_FILE);
 
   std::ofstream test_file(test_file_path);
   if (test_file.is_open()) {

--- a/extensions/standard-processors/tests/unit/GetFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/GetFileTests.cpp
@@ -49,7 +49,7 @@ class GetFileTestController {
  private:
   TestController test_controller_;
   std::shared_ptr<TestPlan> test_plan_;
-  std::string temp_dir_;
+  std::filesystem::path temp_dir_;
   std::string input_file_name_;
   std::string large_input_file_name_;
   std::string hidden_input_file_name_;
@@ -70,7 +70,7 @@ GetFileTestController::GetFileTestController()
 
   // Build MiNiFi processing graph
   get_file_processor_ = test_plan_->addProcessor("GetFile", "Get");
-  test_plan_->setProperty(get_file_processor_, minifi::processors::GetFile::Directory.getName(), temp_dir_);
+  test_plan_->setProperty(get_file_processor_, minifi::processors::GetFile::Directory.getName(), temp_dir_.string());
   auto log_attr = test_plan_->addProcessor("LogAttribute", "Log", core::Relationship("success", "description"), true);
   test_plan_->setProperty(log_attr, minifi::processors::LogAttribute::FlowFilesToLog.getName(), "0");
 
@@ -85,7 +85,7 @@ GetFileTestController::GetFileTestController()
 }
 
 std::string GetFileTestController::getFullPath(const std::string& filename) const {
-  return temp_dir_ + utils::file::FileUtils::get_separator() + filename;
+  return (temp_dir_ / filename).string();
 }
 
 std::string GetFileTestController::getInputFilePath() const {

--- a/extensions/standard-processors/tests/unit/ListenSyslogTests.cpp
+++ b/extensions/standard-processors/tests/unit/ListenSyslogTests.cpp
@@ -509,7 +509,8 @@ TEST_CASE("Test ListenSyslog via TCP with SSL connection", "[ListenSyslog]") {
   ssl_context_service->enable();
   controller.plan->scheduleProcessor(listen_syslog);
   REQUIRE(utils::sendMessagesViaSSL({rfc5424_logger_example_1}, endpoint, minifi::utils::file::concat_path(executable_dir, "resources/ca_cert.crt")));
-  REQUIRE(utils::sendMessagesViaSSL({invalid_syslog}, endpoint, minifi::utils::file::concat_path(executable_dir, "/resources/ca_cert.crt")));
+  REQUIRE(utils::sendMessagesViaSSL({invalid_syslog}, endpoint, minifi::utils::file::concat_path(executable_dir, "resources/ca_cert.crt")));
+
   std::unordered_map<core::Relationship, std::vector<std::shared_ptr<core::FlowFile>>> result;
   REQUIRE(controller.triggerUntil({{ListenSyslog::Success, 2}}, result, 300ms, 50ms));
   CHECK(controller.plan->getContent(result.at(ListenSyslog::Success)[0]) == rfc5424_logger_example_1);

--- a/extensions/standard-processors/tests/unit/ListenTcpTests.cpp
+++ b/extensions/standard-processors/tests/unit/ListenTcpTests.cpp
@@ -190,14 +190,14 @@ TEST_CASE("Test ListenTCP with SSL connection", "[ListenTCP]") {
     controller.plan->scheduleProcessor(listen_tcp);
 
     minifi::utils::net::SslData ssl_data;
-    ssl_data.ca_loc = minifi::utils::file::FileUtils::get_executable_dir() + "/resources/ca_cert.crt";
-    ssl_data.cert_loc = minifi::utils::file::FileUtils::get_executable_dir() + "/resources/cert_and_private_key.pem";
-    ssl_data.key_loc = minifi::utils::file::FileUtils::get_executable_dir() + "/resources/cert_and_private_key.pem";
+    ssl_data.ca_loc = minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "ca_cert.crt");
+    ssl_data.cert_loc = minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "cert_and_private_key.pem");
+    ssl_data.key_loc = minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "cert_and_private_key.pem");
     ssl_data.key_pw = "Password12";
 
     expected_successful_messages = {"test_message_1", "another_message"};
     for (const auto& message : expected_successful_messages) {
-      REQUIRE(utils::sendMessagesViaSSL({message}, endpoint, minifi::utils::file::FileUtils::get_executable_dir() + "/resources/ca_cert.crt", ssl_data));
+      REQUIRE(utils::sendMessagesViaSSL({message}, endpoint, minifi::utils::file::concat_path(minifi::utils::file::get_executable_dir(), "resources", "ca_cert.crt"), ssl_data));
     }
   }
 
@@ -214,7 +214,7 @@ TEST_CASE("Test ListenTCP with SSL connection", "[ListenTCP]") {
     ssl_context_service->enable();
     controller.plan->scheduleProcessor(listen_tcp);
 
-    REQUIRE_FALSE(utils::sendMessagesViaSSL({"test_message_1"}, endpoint, minifi::utils::file::concat_path(executable_dir, "/resources/ca_cert.crt")));
+    REQUIRE_FALSE(utils::sendMessagesViaSSL({"test_message_1"}, endpoint, minifi::utils::file::concat_path(executable_dir, "resources", "ca_cert.crt")));
   }
 
   ProcessorTriggerResult result;

--- a/extensions/windows-event-log/Bookmark.cpp
+++ b/extensions/windows-event-log/Bookmark.cpp
@@ -47,9 +47,7 @@ Bookmark::Bookmark(const std::wstring& channel,
   if (state_manager_->get(state_map) && state_map.count(BOOKMARK_KEY) == 1U) {
     bookmarkXml_ = wel::to_wstring(state_map[BOOKMARK_KEY].c_str());
   } else if (!bookmarkRootDir.empty()) {
-    filePath_ = utils::file::concat_path(
-      utils::file::concat_path(
-        utils::file::concat_path(bookmarkRootDir, "uuid"), uuid.to_string()), "Bookmark.txt");
+    filePath_ = utils::file::concat_path(bookmarkRootDir, "uuid", uuid.to_string().view(), "Bookmark.txt");
 
     std::wstring bookmarkXml;
     if (getBookmarkXmlFromFile(bookmarkXml)) {

--- a/libminifi/include/Defaults.h
+++ b/libminifi/include/Defaults.h
@@ -18,15 +18,15 @@
 #pragma once
 
 #ifdef WIN32
-#define DEFAULT_NIFI_CONFIG_YML "conf\\config.yml"
-#define DEFAULT_NIFI_PROPERTIES_FILE "conf\\minifi.properties"
-#define DEFAULT_LOG_PROPERTIES_FILE "conf\\minifi-log.properties"
-#define DEFAULT_UID_PROPERTIES_FILE "conf\\minifi-uid.properties"
-#define DEFAULT_BOOTSTRAP_FILE "conf\\bootstrap.conf"
+constexpr const char* DEFAULT_NIFI_CONFIG_YML = "conf\\config.yml";
+constexpr const char* DEFAULT_NIFI_PROPERTIES_FILE = "conf\\minifi.properties";
+constexpr const char* DEFAULT_LOG_PROPERTIES_FILE = "conf\\minifi-log.properties";
+constexpr const char* DEFAULT_UID_PROPERTIES_FILE = "conf\\minifi-uid.properties";
+constexpr const char* DEFAULT_BOOTSTRAP_FILE = "conf\\bootstrap.conf";
 #else
-#define DEFAULT_NIFI_CONFIG_YML "conf/config.yml"
-#define DEFAULT_NIFI_PROPERTIES_FILE "conf/minifi.properties"
-#define DEFAULT_LOG_PROPERTIES_FILE "conf/minifi-log.properties"
-#define DEFAULT_UID_PROPERTIES_FILE "conf/minifi-uid.properties"
-#define DEFAULT_BOOTSTRAP_FILE "conf/bootstrap.conf"
+constexpr const char* DEFAULT_NIFI_CONFIG_YML = "conf/config.yml";
+constexpr const char* DEFAULT_NIFI_PROPERTIES_FILE = "conf/minifi.properties";
+constexpr const char* DEFAULT_LOG_PROPERTIES_FILE = "conf/minifi-log.properties";
+constexpr const char* DEFAULT_UID_PROPERTIES_FILE = "conf/minifi-uid.properties";
+constexpr const char* DEFAULT_BOOTSTRAP_FILE = "conf/bootstrap.conf";
 #endif

--- a/libminifi/include/Defaults.h
+++ b/libminifi/include/Defaults.h
@@ -18,15 +18,15 @@
 #pragma once
 
 #ifdef WIN32
-#define DEFAULT_NIFI_CONFIG_YML "\\conf\\config.yml"
-#define DEFAULT_NIFI_PROPERTIES_FILE "\\conf\\minifi.properties"
-#define DEFAULT_LOG_PROPERTIES_FILE "\\conf\\minifi-log.properties"
-#define DEFAULT_UID_PROPERTIES_FILE "\\conf\\minifi-uid.properties"
-#define DEFAULT_BOOTSTRAP_FILE "\\conf\\bootstrap.conf"
+#define DEFAULT_NIFI_CONFIG_YML "conf\\config.yml"
+#define DEFAULT_NIFI_PROPERTIES_FILE "conf\\minifi.properties"
+#define DEFAULT_LOG_PROPERTIES_FILE "conf\\minifi-log.properties"
+#define DEFAULT_UID_PROPERTIES_FILE "conf\\minifi-uid.properties"
+#define DEFAULT_BOOTSTRAP_FILE "conf\\bootstrap.conf"
 #else
-#define DEFAULT_NIFI_CONFIG_YML "./conf/config.yml"
-#define DEFAULT_NIFI_PROPERTIES_FILE "./conf/minifi.properties"
-#define DEFAULT_LOG_PROPERTIES_FILE "./conf/minifi-log.properties"
-#define DEFAULT_UID_PROPERTIES_FILE "./conf/minifi-uid.properties"
-#define DEFAULT_BOOTSTRAP_FILE "./conf/bootstrap.conf"
+#define DEFAULT_NIFI_CONFIG_YML "conf/config.yml"
+#define DEFAULT_NIFI_PROPERTIES_FILE "conf/minifi.properties"
+#define DEFAULT_LOG_PROPERTIES_FILE "conf/minifi-log.properties"
+#define DEFAULT_UID_PROPERTIES_FILE "conf/minifi-uid.properties"
+#define DEFAULT_BOOTSTRAP_FILE "conf/bootstrap.conf"
 #endif

--- a/libminifi/include/core/FlowConfiguration.h
+++ b/libminifi/include/core/FlowConfiguration.h
@@ -15,8 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef LIBMINIFI_INCLUDE_CORE_FLOWCONFIGURATION_H_
-#define LIBMINIFI_INCLUDE_CORE_FLOWCONFIGURATION_H_
+#pragma once
 
 #include <memory>
 #include <optional>
@@ -42,11 +41,7 @@
 #include "utils/file/FileSystem.h"
 #include "utils/ChecksumCalculator.h"
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
-namespace core {
+namespace org::apache::nifi::minifi::core {
 
 class static_initializers {
  public:
@@ -62,21 +57,15 @@ extern static_initializers &get_static_functions();
  */
 class FlowConfiguration : public CoreComponent {
  public:
-  /**
-   * Constructor that will be used for configuring
-   * the flow controller.
-   */
-  explicit FlowConfiguration(std::shared_ptr<core::Repository> repo, std::shared_ptr<core::Repository> flow_file_repo,
+  explicit FlowConfiguration(const std::shared_ptr<core::Repository>& repo, std::shared_ptr<core::Repository> flow_file_repo,
                              std::shared_ptr<core::ContentRepository> content_repo, std::shared_ptr<io::StreamFactory> stream_factory,
                              std::shared_ptr<Configure> configuration, const std::optional<std::string>& path,
                              std::shared_ptr<utils::file::FileSystem> filesystem = std::make_shared<utils::file::FileSystem>());
 
   ~FlowConfiguration() override;
 
-  // Create Processor (Node/Input/Output Port) based on the name
   std::unique_ptr<core::Processor> createProcessor(const std::string &name, const utils::Identifier &uuid);
   std::unique_ptr<core::Processor> createProcessor(const std::string &name, const std::string &fullname, const utils::Identifier &uuid);
-  // Create Root Processor Group
 
   static std::unique_ptr<core::ProcessGroup> createRootProcessGroup(const std::string &name, const utils::Identifier &uuid, int version);
   static std::unique_ptr<core::ProcessGroup> createSimpleProcessGroup(const std::string &name, const utils::Identifier &uuid, int version);
@@ -85,12 +74,10 @@ class FlowConfiguration : public CoreComponent {
   std::shared_ptr<core::controller::ControllerServiceNode> createControllerService(const std::string &class_name, const std::string &full_class_name, const std::string &name,
       const utils::Identifier &uuid);
 
-  // Create Connection
-  std::unique_ptr<minifi::Connection> createConnection(const std::string &name, const utils::Identifier &uuid) const;
-  // Create Provenance Report Task
+  [[nodiscard]] std::unique_ptr<minifi::Connection> createConnection(const std::string &name, const utils::Identifier &uuid) const;
   std::unique_ptr<core::reporting::SiteToSiteProvenanceReportingTask> createProvenanceReportTask();
 
-  std::shared_ptr<state::response::FlowVersion> getFlowVersion() const {
+  [[nodiscard]] std::shared_ptr<state::response::FlowVersion> getFlowVersion() const {
     return flow_version_;
   }
 
@@ -100,10 +87,6 @@ class FlowConfiguration : public CoreComponent {
 
   bool persist(const std::string& configuration);
 
-  /**
-   * Returns the configuration path string
-   * @return config_path_
-   */
   const std::optional<std::string> &getConfigurationPath() {
     return config_path_;
   }
@@ -125,17 +108,11 @@ class FlowConfiguration : public CoreComponent {
   utils::ChecksumCalculator& getChecksumCalculator() { return checksum_calculator_; }
 
  protected:
-  // service provider reference.
   std::shared_ptr<core::controller::StandardControllerServiceProvider> service_provider_;
-  // based, shared controller service map.
   std::shared_ptr<core::controller::ControllerServiceMap> controller_services_;
-  // configuration path
   std::optional<std::string> config_path_;
-  // flow file repo
   std::shared_ptr<core::Repository> flow_file_repo_;
-  // content repository.
   std::shared_ptr<core::ContentRepository> content_repo_;
-  // stream factory
   std::shared_ptr<io::StreamFactory> stream_factory_;
   std::shared_ptr<Configure> configuration_;
   std::shared_ptr<state::response::FlowVersion> flow_version_;
@@ -146,11 +123,4 @@ class FlowConfiguration : public CoreComponent {
   std::shared_ptr<logging::Logger> logger_;
 };
 
-}  // namespace core
-}  // namespace minifi
-}  // namespace nifi
-}  // namespace apache
-}  // namespace org
-
-#endif  // LIBMINIFI_INCLUDE_CORE_FLOWCONFIGURATION_H_
-
+}  // namespace org::apache::nifi::minifi::core

--- a/libminifi/include/utils/TestUtils.h
+++ b/libminifi/include/utils/TestUtils.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <chrono>
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -33,14 +34,10 @@
 #include "date/tz.h"
 #endif
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
-namespace utils {
+namespace org::apache::nifi::minifi::utils {
 
-std::string putFileToDir(const std::string& dir_path, const std::string& file_name, const std::string& content) {
-  std::string file_path(file::FileUtils::concat_path(dir_path, file_name));
+inline std::string putFileToDir(const std::filesystem::path& dir_path, const std::string& file_name, const std::string& content) {
+  std::string file_path(file::concat_path(dir_path, file_name));
   std::ofstream out_file(file_path, std::ios::binary | std::ios::out);
   if (out_file.is_open()) {
     out_file << content;
@@ -48,14 +45,14 @@ std::string putFileToDir(const std::string& dir_path, const std::string& file_na
   return file_path;
 }
 
-std::string getFileContent(const std::string& file_name) {
+inline std::string getFileContent(const std::string& file_name) {
   std::ifstream file_handle(file_name, std::ios::binary | std::ios::in);
   assert(file_handle.is_open());
   std::string file_content{ (std::istreambuf_iterator<char>(file_handle)), (std::istreambuf_iterator<char>()) };
   return file_content;
 }
 
-Identifier generateUUID() {
+inline Identifier generateUUID() {
   // TODO(hunyadi): Will make the Id generator manage lifetime using a unique_ptr and return a raw ptr on access
   static std::shared_ptr<utils::IdGenerator> id_generator = utils::IdGenerator::getIdGenerator();
   return id_generator->generate();
@@ -113,8 +110,4 @@ class ManualClock : public timeutils::SteadyClock {
 void dateSetInstall(const std::string& install);
 #endif
 
-}  // namespace utils
-}  // namespace minifi
-}  // namespace nifi
-}  // namespace apache
-}  // namespace org
+}  // namespace org::apache::nifi::minifi::utils

--- a/libminifi/include/utils/file/FileUtils.h
+++ b/libminifi/include/utils/file/FileUtils.h
@@ -436,10 +436,18 @@ inline std::tuple<std::string /*parent_path*/, std::string /*child_path*/> split
   return std::make_tuple(std::move(parent), std::move(child));
 }
 
+/**
+ * Returns the directory part of the input path.
+ * Note that empty filenames are allowed, so `get_parent_path("foo/bar/") == "foo/bar"`.
+ */
 inline std::string get_parent_path(const std::string& path) {
   return std::filesystem::path{path}.parent_path().string();
 }
 
+/**
+ * Returns the filename part of the input path.
+ * Note that empty filenames are allowed, so `get_child_path("foo/bar/") == ""`.
+ */
 inline std::string get_child_path(const std::string& path) {
   return std::filesystem::path{path}.filename().string();
 }

--- a/libminifi/include/utils/file/FileUtils.h
+++ b/libminifi/include/utils/file/FileUtils.h
@@ -331,17 +331,10 @@ inline void addFilesMatchingExtension(const std::shared_ptr<core::logging::Logge
   }
 }
 
-inline std::string concat_path(const std::string& root, const std::string& child, bool force_posix = false) {
-  if (root.empty()) {
-    return child;
-  }
-  std::stringstream new_path;
-  if (root.back() == get_separator(force_posix)) {
-    new_path << root << child;
-  } else {
-    new_path << root << get_separator(force_posix) << child;
-  }
-  return new_path.str();
+template<typename ...T>
+requires (std::is_convertible_v<std::decay_t<T>, std::filesystem::path> && ...)
+inline std::string concat_path(const T&... segments) {
+  return (... / std::filesystem::path{segments}).string();
 }
 
 /**

--- a/libminifi/include/utils/file/PathUtils.h
+++ b/libminifi/include/utils/file/PathUtils.h
@@ -38,41 +38,17 @@ using path = const char*;
  * @param fileName output file name
  * @return result of the operation.
  */
-bool getFileNameAndPath(const std::string &path, std::string &filePath, std::string &fileName);
+bool getFileNameAndPath(const std::string& path_string, std::string& file_path, std::string& file_name);
 
 /**
- * Resolves the supplied path to an absolute pathname using the native OS functions
- * (realpath(3) on *nix, GetFullPathNameA on Windows)
- * @param path the name of the file
+ * Resolves the supplied path to an absolute pathname
  * @return the canonicalized absolute pathname on success, empty string on failure
  */
 std::string getFullPath(const std::string& path);
 
+std::optional<std::string> canonicalize(const std::string& path);
+
 std::string globToRegex(std::string glob);
-
-inline bool isAbsolutePath(const char* const path) noexcept {
-#ifdef _WIN32
-  return path && std::isalpha(path[0]) && path[1] == ':' && (path[2] == '\\' || path[2] == '/');
-#else
-  return path && path[0] == '/';
-#endif
-}
-
-inline std::optional<std::string> canonicalize(const std::string &path) {
-  const char *resolved = nullptr;
-#ifndef WIN32
-  char full_path[PATH_MAX];
-  resolved = realpath(path.c_str(), full_path);
-#else
-  resolved = path.c_str();
-#endif
-
-  if (resolved == nullptr) {
-    return std::nullopt;
-  }
-  return std::string(path);
-}
-
 
 /**
  * Represents filesystem space information in bytes

--- a/libminifi/src/utils/crypto/EncryptionManager.cpp
+++ b/libminifi/src/utils/crypto/EncryptionManager.cpp
@@ -25,17 +25,12 @@
 #include "utils/crypto/ciphers/Aes256Ecb.h"
 #include "core/logging/LoggerConfiguration.h"
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
-namespace utils {
-namespace crypto {
+namespace org::apache::nifi::minifi::utils::crypto {
 
 #ifdef WIN32
-constexpr const char* DEFAULT_NIFI_BOOTSTRAP_FILE = "\\conf\\bootstrap.conf";
+constexpr const char* DEFAULT_NIFI_BOOTSTRAP_FILE = "conf\\bootstrap.conf";
 #else
-constexpr const char* DEFAULT_NIFI_BOOTSTRAP_FILE = "./conf/bootstrap.conf";
+constexpr const char* DEFAULT_NIFI_BOOTSTRAP_FILE = "conf/bootstrap.conf";
 #endif  // WIN32
 
 std::shared_ptr<core::logging::Logger> EncryptionManager::logger_{core::logging::LoggerFactory<EncryptionManager>::getLogger()};
@@ -81,9 +76,4 @@ bool EncryptionManager::writeKey(const std::string &key_name, const Bytes& key) 
   return bootstrap_conf.commitChanges();
 }
 
-}  // namespace crypto
-}  // namespace utils
-}  // namespace minifi
-}  // namespace nifi
-}  // namespace apache
-}  // namespace org
+}  // namespace org::apache::nifi::minifi::utils::crypto

--- a/libminifi/src/utils/file/PathUtils.cpp
+++ b/libminifi/src/utils/file/PathUtils.cpp
@@ -26,59 +26,33 @@
 #include <cstdlib>
 #endif
 
-#include <iostream>
+#include <filesystem>
 #include "utils/file/FileUtils.h"
 #include "utils/gsl.h"
 
 namespace org::apache::nifi::minifi::utils::file {
 
-bool getFileNameAndPath(const std::string &path, std::string &filePath, std::string &fileName) {
-  const std::size_t found = path.find_last_of(FileUtils::get_separator());
-  /**
-   * Don't make an assumption about about the path, return false for this case.
-   * Could make the assumption that the path is just the file name but with the function named
-   * getFileNameAndPath we expect both to be there ( a fully qualified path ).
-   *
-   */
-  if (found == std::string::npos || found == path.length() - 1) {
+bool getFileNameAndPath(const std::string& path_string, std::string& file_path, std::string& file_name) {
+  const std::filesystem::path path{path_string};
+  if (path.has_parent_path() && path.has_filename()) {
+    file_path = path.parent_path().string();
+    file_name = path.filename().string();
+    return true;
+  } else {
     return false;
   }
-  if (found == 0) {
-    filePath = "";  // don't assume that path is not empty
-    filePath += FileUtils::get_separator();
-    fileName = path.substr(found + 1);
-    return true;
-  }
-  filePath = path.substr(0, found);
-  fileName = path.substr(found + 1);
-  return true;
 }
 
 std::string getFullPath(const std::string& path) {
-#ifdef WIN32
-  std::vector<char> buffer(MAX_PATH);
-  uint32_t len = 0U;
-  while (true) {
-    len = GetFullPathNameA(path.c_str(), gsl::narrow<DWORD>(buffer.size()), buffer.data(), nullptr /*lpFilePart*/);
-    if (len < buffer.size()) {
-      break;
-    }
-    buffer.resize(len);
-  }
-  if (len > 0U) {
-    return std::string(buffer.data(), len);
-  } else {
-    return "";
-  }
-#else
-  std::vector<char> buffer(PATH_MAX);
-  char* res = realpath(path.c_str(), buffer.data());
-  if (res == nullptr) {
-    return "";
-  } else {
-    return res;
-  }
-#endif
+  std::error_code error_code;
+  const auto canonical_path = std::filesystem::canonical(path, error_code);
+  return !error_code ? canonical_path.string() : "";
+}
+
+std::optional<std::string> canonicalize(const std::string& path) {
+  std::error_code error_code;
+  const auto canonical_path = std::filesystem::canonical(path, error_code);
+  return !error_code ? std::optional{canonical_path.string()} : std::nullopt;
 }
 
 std::string globToRegex(std::string glob) {

--- a/libminifi/test/unit/FileUtilsTests.cpp
+++ b/libminifi/test/unit/FileUtilsTests.cpp
@@ -52,43 +52,43 @@ TEST_CASE("TestFileUtils::concat_path", "[TestConcatPath]") {
 
 TEST_CASE("TestFileUtils::get_parent_path", "[TestGetParentPath]") {
 #ifdef WIN32
-  REQUIRE("foo\\" == FileUtils::get_parent_path("foo\\bar"));
-  REQUIRE("foo\\" == FileUtils::get_parent_path("foo\\bar\\"));
-  REQUIRE("C:\\foo\\" == FileUtils::get_parent_path("C:\\foo\\bar"));
-  REQUIRE("C:\\foo\\" == FileUtils::get_parent_path("C:\\foo\\bar\\"));
-  REQUIRE("C:\\" == FileUtils::get_parent_path("C:\\foo"));
-  REQUIRE("C:\\" == FileUtils::get_parent_path("C:\\foo\\"));
-  REQUIRE("" == FileUtils::get_parent_path("C:\\"));  // NOLINT(readability-container-size-empty)
-  REQUIRE("" == FileUtils::get_parent_path("C:\\\\"));  // NOLINT(readability-container-size-empty)
+  CHECK("foo" == FileUtils::get_parent_path("foo\\bar"));
+  CHECK("foo\\bar" == FileUtils::get_parent_path("foo\\bar\\"));
+  CHECK("C:\\foo" == FileUtils::get_parent_path("C:\\foo\\bar"));
+  CHECK("C:\\foo\\bar" == FileUtils::get_parent_path("C:\\foo\\bar\\"));
+  CHECK("C:\\" == FileUtils::get_parent_path("C:\\foo"));
+  CHECK("C:\\foo" == FileUtils::get_parent_path("C:\\foo\\"));
+  CHECK("C:\\" == FileUtils::get_parent_path("C:\\"));
+  CHECK("C:\\\\" == FileUtils::get_parent_path("C:\\\\"));
 #else
-  REQUIRE("foo/" == FileUtils::get_parent_path("foo/bar"));
-  REQUIRE("foo/" == FileUtils::get_parent_path("foo/bar/"));
-  REQUIRE("/foo/" == FileUtils::get_parent_path("/foo/bar"));
-  REQUIRE("/foo/" == FileUtils::get_parent_path("/foo/bar/"));
-  REQUIRE("/" == FileUtils::get_parent_path("/foo"));
-  REQUIRE("/" == FileUtils::get_parent_path("/foo/"));
-  REQUIRE("" == FileUtils::get_parent_path("/"));  // NOLINT(readability-container-size-empty)
-  REQUIRE("" == FileUtils::get_parent_path("//"));  // NOLINT(readability-container-size-empty)
+  CHECK("foo" == FileUtils::get_parent_path("foo/bar"));
+  CHECK("foo/bar" == FileUtils::get_parent_path("foo/bar/"));
+  CHECK("/foo" == FileUtils::get_parent_path("/foo/bar"));
+  CHECK("/foo/bar" == FileUtils::get_parent_path("/foo/bar/"));
+  CHECK("/" == FileUtils::get_parent_path("/foo"));
+  CHECK("/foo" == FileUtils::get_parent_path("/foo/"));
+  CHECK("/" == FileUtils::get_parent_path("/"));
+  CHECK("//" == FileUtils::get_parent_path("//"));
 #endif
 }
 
 TEST_CASE("TestFileUtils::get_child_path", "[TestGetChildPath]") {
 #ifdef WIN32
   REQUIRE("bar" == FileUtils::get_child_path("foo\\bar"));
-  REQUIRE("bar\\" == FileUtils::get_child_path("foo\\bar\\"));
+  REQUIRE("" == FileUtils::get_child_path("foo\\bar\\"));  // NOLINT(readability-container-size-empty)
   REQUIRE("bar" == FileUtils::get_child_path("C:\\foo\\bar"));
-  REQUIRE("bar\\" == FileUtils::get_child_path("C:\\foo\\bar\\"));
+  REQUIRE("" == FileUtils::get_child_path("C:\\foo\\bar\\"));  // NOLINT(readability-container-size-empty)
   REQUIRE("foo" == FileUtils::get_child_path("C:\\foo"));
-  REQUIRE("foo\\" == FileUtils::get_child_path("C:\\foo\\"));
+  REQUIRE("" == FileUtils::get_child_path("C:\\foo\\"));  // NOLINT(readability-container-size-empty)
   REQUIRE("" == FileUtils::get_child_path("C:\\"));  // NOLINT(readability-container-size-empty)
   REQUIRE("" == FileUtils::get_child_path("C:\\\\"));  // NOLINT(readability-container-size-empty)
 #else
   REQUIRE("bar" == FileUtils::get_child_path("foo/bar"));
-  REQUIRE("bar/" == FileUtils::get_child_path("foo/bar/"));
+  REQUIRE("" == FileUtils::get_child_path("foo/bar/"));  // NOLINT(readability-container-size-empty)
   REQUIRE("bar" == FileUtils::get_child_path("/foo/bar"));
-  REQUIRE("bar/" == FileUtils::get_child_path("/foo/bar/"));
+  REQUIRE("" == FileUtils::get_child_path("/foo/bar/"));  // NOLINT(readability-container-size-empty)
   REQUIRE("foo" == FileUtils::get_child_path("/foo"));
-  REQUIRE("foo/" == FileUtils::get_child_path("/foo/"));
+  REQUIRE("" == FileUtils::get_child_path("/foo/"));  // NOLINT(readability-container-size-empty)
   REQUIRE("" == FileUtils::get_child_path("/"));  // NOLINT(readability-container-size-empty)
   REQUIRE("" == FileUtils::get_child_path("//"));  // NOLINT(readability-container-size-empty)
 #endif
@@ -301,18 +301,18 @@ TEST_CASE("TestFileUtils::getFullPath", "[TestGetFullPath]") {
 
   const std::string tempDir1 = utils::file::FileUtils::concat_path(tempDir, "test1");
   const std::string tempDir2 = utils::file::FileUtils::concat_path(tempDir, "test2");
-  REQUIRE(0 == utils::file::FileUtils::create_dir(tempDir1));
-  REQUIRE(0 == utils::file::FileUtils::create_dir(tempDir2));
+  CHECK(0 == utils::file::FileUtils::create_dir(tempDir1));
+  CHECK(0 == utils::file::FileUtils::create_dir(tempDir2));
 
-  REQUIRE(tempDir1 == utils::file::getFullPath(tempDir1));
-  REQUIRE(tempDir1 == utils::file::getFullPath("test1"));
-  REQUIRE(tempDir1 == utils::file::getFullPath("./test1"));
-  REQUIRE(tempDir1 == utils::file::getFullPath("././test1"));
-  REQUIRE(tempDir1 == utils::file::getFullPath("./test2/../test1"));
+  CHECK(tempDir1 == utils::file::getFullPath(tempDir1));
+  CHECK(tempDir1 == utils::file::getFullPath("test1"));
+  CHECK(tempDir1 == utils::file::getFullPath("./test1"));
+  CHECK(tempDir1 == utils::file::getFullPath("././test1"));
+  CHECK(tempDir1 == utils::file::getFullPath("./test2/../test1"));
 #ifdef WIN32
-  REQUIRE(tempDir1 == utils::file::getFullPath(".\\test1"));
-  REQUIRE(tempDir1 == utils::file::getFullPath(".\\.\\test1"));
-  REQUIRE(tempDir1 == utils::file::getFullPath(".\\test2\\..\\test1"));
+  CHECK(tempDir1 == utils::file::getFullPath(".\\test1"));
+  CHECK(tempDir1 == utils::file::getFullPath(".\\.\\test1"));
+  CHECK(tempDir1 == utils::file::getFullPath(".\\test2\\..\\test1"));
 #endif
 }
 

--- a/libminifi/test/unit/PathUtilsTests.cpp
+++ b/libminifi/test/unit/PathUtilsTests.cpp
@@ -30,21 +30,3 @@ TEST_CASE("file::globToRegex works", "[globToRegex]") {
   REQUIRE(fs::globToRegex("Replace*Multiple*Asterisks") == "Replace.*Multiple.*Asterisks");
   REQUIRE(fs::globToRegex("ReplaceQuestionMark?.txt") == "ReplaceQuestionMark.\\.txt");
 }
-
-TEST_CASE("path::isAbsolutePath", "[path::isAbsolutePath]") {
-#ifdef WIN32
-  REQUIRE(fs::isAbsolutePath("C:\\"));
-  REQUIRE(fs::isAbsolutePath("C:\\Program Files"));
-  REQUIRE(fs::isAbsolutePath("C:\\Program Files\\ApacheNiFiMiNiFi\\nifi-minifi-cpp\\conf\\minifi.properties"));
-  REQUIRE(fs::isAbsolutePath("C:/"));
-  REQUIRE(fs::isAbsolutePath("C:/Program Files"));
-  REQUIRE(fs::isAbsolutePath("C:/Program Files/ApacheNiFiMiNiFi/nifi-minifi-cpp/conf/minifi.properties"));
-  REQUIRE(!fs::isAbsolutePath("/"));
-#else
-  REQUIRE(fs::isAbsolutePath("/"));
-  REQUIRE(fs::isAbsolutePath("/etc"));
-  REQUIRE(fs::isAbsolutePath("/opt/minifi/conf/minifi.properties"));
-#endif /* WIN32 */
-
-  REQUIRE(!fs::isAbsolutePath("hello"));
-}

--- a/minifi_main/MainHelper.cpp
+++ b/minifi_main/MainHelper.cpp
@@ -144,7 +144,7 @@ std::string determineMinifiHome(const std::shared_ptr<logging::Logger>& logger) 
   if (validHome(minifiHome)) {
     minifiHomeValid = true;
   } else {
-    logger->log_info("%s is not a valid " MINIFI_HOME_ENV_KEY ", because there is no " DEFAULT_NIFI_PROPERTIES_FILE " file in it.", minifiHome);
+    logger->log_info("%s is not a valid %s, because there is no %s file in it.", minifiHome, MINIFI_HOME_ENV_KEY, DEFAULT_NIFI_PROPERTIES_FILE);
 
     const std::filesystem::path path{minifiHome};
     std::string minifiHomeWithoutBin = path.parent_path().string();
@@ -155,15 +155,15 @@ std::string determineMinifiHome(const std::shared_ptr<logging::Logger>& logger) 
         minifiHomeValid = true;
         minifiHome = std::move(minifiHomeWithoutBin);
       } else {
-        logger->log_info("%s is not a valid " MINIFI_HOME_ENV_KEY ", because there is no " DEFAULT_NIFI_PROPERTIES_FILE " file in it.", minifiHomeWithoutBin);
+        logger->log_info("%s is not a valid %s, because there is no %s file in it.", minifiHomeWithoutBin, MINIFI_HOME_ENV_KEY, DEFAULT_NIFI_PROPERTIES_FILE);
       }
     }
   }
 
   /* Fail if not */
   if (!minifiHomeValid) {
-    logger->log_error("Cannot find a valid " MINIFI_HOME_ENV_KEY " containing a " DEFAULT_NIFI_PROPERTIES_FILE " file in it. "
-                      "Please set " MINIFI_HOME_ENV_KEY " or run minifi from a valid location.");
+    logger->log_error("Cannot find a valid %s containing a %s file in it. Please set %s or run minifi from a valid location.",
+        MINIFI_HOME_ENV_KEY, DEFAULT_NIFI_PROPERTIES_FILE, MINIFI_HOME_ENV_KEY);
     return "";
   }
 

--- a/minifi_main/MainHelper.cpp
+++ b/minifi_main/MainHelper.cpp
@@ -146,16 +146,16 @@ std::string determineMinifiHome(const std::shared_ptr<logging::Logger>& logger) 
   } else {
     logger->log_info("%s is not a valid %s, because there is no %s file in it.", minifiHome, MINIFI_HOME_ENV_KEY, DEFAULT_NIFI_PROPERTIES_FILE);
 
-    const std::filesystem::path path{minifiHome};
-    std::string minifiHomeWithoutBin = path.parent_path().string();
-    std::string binDir = path.filename().string();
-    if (!minifiHomeWithoutBin.empty() && (binDir == "bin" || binDir == std::string("bin") + minifi::utils::file::get_separator())) {
-      if (validHome(minifiHomeWithoutBin)) {
-        logger->log_info("%s is a valid " MINIFI_HOME_ENV_KEY ", falling back to it.", minifiHomeWithoutBin);
+    const std::filesystem::path maybe_bin_dir_under_minifi_home{minifiHome};
+    std::string maybe_minifi_home = maybe_bin_dir_under_minifi_home.parent_path().string();
+    std::string maybe_bin_dir = maybe_bin_dir_under_minifi_home.filename().string();
+    if (!maybe_minifi_home.empty() && maybe_bin_dir == "bin") {
+      if (validHome(maybe_minifi_home)) {
+        logger->log_info("%s is a valid " MINIFI_HOME_ENV_KEY ", falling back to it.", maybe_minifi_home);
         minifiHomeValid = true;
-        minifiHome = std::move(minifiHomeWithoutBin);
+        minifiHome = std::move(maybe_minifi_home);
       } else {
-        logger->log_info("%s is not a valid %s, because there is no %s file in it.", minifiHomeWithoutBin, MINIFI_HOME_ENV_KEY, DEFAULT_NIFI_PROPERTIES_FILE);
+        logger->log_info("%s is not a valid %s, because there is no %s file in it.", maybe_minifi_home, MINIFI_HOME_ENV_KEY, DEFAULT_NIFI_PROPERTIES_FILE);
       }
     }
   }

--- a/minifi_main/MainHelper.cpp
+++ b/minifi_main/MainHelper.cpp
@@ -112,9 +112,9 @@ std::string determineMinifiHome(const std::shared_ptr<logging::Logger>& logger) 
     if (executablePath.empty()) {
       logger->log_error("Failed to determine location of the minifi executable");
     } else {
-      std::string minifiPath;
-      std::string minifiFileName;
-      std::tie(minifiPath, minifiFileName) = minifi::utils::file::split_path(executablePath);
+      const std::filesystem::path path{executablePath};
+      std::string minifiPath = path.parent_path().string();
+      std::string minifiFileName = path.filename().string();
       logger->log_info("Inferred " MINIFI_HOME_ENV_KEY "=%s based on the minifi executable location %s", minifiPath, executablePath);
       return minifiPath;
     }
@@ -146,9 +146,9 @@ std::string determineMinifiHome(const std::shared_ptr<logging::Logger>& logger) 
   } else {
     logger->log_info("%s is not a valid " MINIFI_HOME_ENV_KEY ", because there is no " DEFAULT_NIFI_PROPERTIES_FILE " file in it.", minifiHome);
 
-    std::string minifiHomeWithoutBin;
-    std::string binDir;
-    std::tie(minifiHomeWithoutBin, binDir) = minifi::utils::file::split_path(minifiHome);
+    const std::filesystem::path path{minifiHome};
+    std::string minifiHomeWithoutBin = path.parent_path().string();
+    std::string binDir = path.filename().string();
     if (!minifiHomeWithoutBin.empty() && (binDir == "bin" || binDir == std::string("bin") + minifi::utils::file::get_separator())) {
       if (validHome(minifiHomeWithoutBin)) {
         logger->log_info("%s is a valid " MINIFI_HOME_ENV_KEY ", falling back to it.", minifiHomeWithoutBin);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-1911

* Make `concat_path` variadic, and use the 3-parameter version in some tests.
* Remove some manual (and OS-dependent) path manipulation and replace them with functions using the `std::filesystem` library.  I slightly regret this part, as a small change snowballed into a much bigger one, but I figured it's better to keep it than to throw it away.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
