### PR TITLE
MINIFICPP-1500 Fix multiple archive tests running in parallel

### DIFF
--- a/libminifi/include/utils/Id.h
+++ b/libminifi/include/utils/Id.h
@@ -126,12 +126,12 @@ class NonRepeatingStringGenerator {
   std::string generate() {
     return prefix_ + std::to_string(incrementor_++);
   }
-    uint64_t generateId() {
-      return incrementor_++;
-    }
+  uint64_t generateId() {
+    return incrementor_++;
+  }
  private:
   std::atomic<uint64_t> incrementor_{0};
-  std::string prefix_{std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count()) + "-"};
+  std::string prefix_{IdGenerator::getIdGenerator()->generate().to_string() + "-"};
 };
 
 }  // namespace org::apache::nifi::minifi::utils


### PR DESCRIPTION
The `NonRepeatingStringGenerator` only generated an initial prefix from the current timestamp's millisecond count. Because of this if multiple ArchiveTests (FocusArchiveTests and ManipulateArchiveTests) were run in parallel it could occur, that they generated the same temp filename due to the same timestamp. This caused failures as the different test suites manipulated each other's test files.

https://issues.apache.org/jira/browse/MINIFICPP-1500

----------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
