### PR TITLE
MINIFICPP-1931 Stabilize ResourceQueueTests

### DIFF
--- a/libminifi/test/unit/ResourceQueueTests.cpp
+++ b/libminifi/test/unit/ResourceQueueTests.cpp
@@ -32,11 +32,13 @@ TEST_CASE("maximum_number_of_creatable_resources", "[utils::ResourceQueue]") {
   std::shared_ptr<core::logging::Logger> logger_{core::logging::LoggerFactory<ResourceQueue<int>>::getLogger()};
   LogTestController::getInstance().setTrace<ResourceQueue<int>>();
 
+  std::mutex resources_created_mutex;
   std::set<int> resources_created;
 
   auto worker = [&](int value, const std::shared_ptr<ResourceQueue<int>>& resource_queue) {
     auto resource = resource_queue->getResource([value]{return std::make_unique<int>(value);});
     std::this_thread::sleep_for(10ms);
+    std::lock_guard<std::mutex> lock(resources_created_mutex);
     resources_created.emplace(*resource);
   };
 

--- a/libminifi/test/unit/ResourceQueueTests.cpp
+++ b/libminifi/test/unit/ResourceQueueTests.cpp
@@ -62,13 +62,13 @@ TEST_CASE("Resource limitation is not set to the resource queue", "[utils::Resou
   auto resource_queue = ResourceQueue<int>::create(std::nullopt, logger_);
   std::set<int> resources_created;
 
-  auto resource_one = resource_queue->getResource([]{return std::make_unique<int>(1);});
-  auto resource_two = resource_queue->getResource([]{return std::make_unique<int>(2);});
-  auto resource_three = resource_queue->getResource([]{return std::make_unique<int>(3);});
+  auto resource_wrapper_one = resource_queue->getResource([]{return std::make_unique<int>(1);});
+  auto resource_wrapper_two = resource_queue->getResource([]{return std::make_unique<int>(2);});
+  auto resource_wrapper_three = resource_queue->getResource([]{return std::make_unique<int>(3);});
 
-  resources_created.emplace(*resource_one);
-  resources_created.emplace(*resource_two);
-  resources_created.emplace(*resource_three);
+  resources_created.emplace(*resource_wrapper_one);
+  resources_created.emplace(*resource_wrapper_two);
+  resources_created.emplace(*resource_wrapper_three);
 
   CHECK(!LogTestController::getInstance().contains("Waiting for resource", 0ms));
   CHECK(LogTestController::getInstance().contains("Number of instances: 3", 0ms));


### PR DESCRIPTION
Due to `std::set` not being thread safe, manipulating it in the test from multiple threads could leave it in an inconsistent state. In some cases this resulted in a state where the set contained the 2 correct members, but the `size()` call returned 3.

https://issues.apache.org/jira/browse/MINIFICPP-1931

-----------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
