### PR TITLE
MINIFICPP-1949 ConsumeWindowsEventLog precompiled regex

### DIFF
--- a/extensions/windows-event-log/Bookmark.cpp
+++ b/extensions/windows-event-log/Bookmark.cpp
@@ -139,7 +139,7 @@ bool Bookmark::saveBookmark(EVT_HANDLE event_handle) {
 
 nonstd::expected<std::wstring, std::string> Bookmark::getNewBookmarkXml(EVT_HANDLE hEvent) {
   if (!EvtUpdateBookmark(hBookmark_.get(), hEvent)) {
-    return nonstd::make_unexpected(std::format("EvtUpdateBookmark failed due to %s", utils::OsUtils::getWindowsErrorAsString(GetLastError())));
+    return nonstd::make_unexpected(fmt::format("EvtUpdateBookmark failed due to %s", utils::OsUtils::windowsErrorToErrorCode(GetLastError()).message()));
   }
   // Render the bookmark as an XML string that can be persisted.
   logger_->log_trace("Rendering new bookmark");
@@ -152,13 +152,13 @@ nonstd::expected<std::wstring, std::string> Bookmark::getNewBookmarkXml(EVT_HAND
 
   auto last_error = GetLastError();
   if (last_error != ERROR_INSUFFICIENT_BUFFER)
-    return nonstd::make_unexpected(std::format("EvtRender failed due to %s", utils::OsUtils::getWindowsErrorAsString(last_error)));
+    return nonstd::make_unexpected(fmt::format("EvtRender failed due to %s", utils::OsUtils::windowsErrorToErrorCode(last_error).message()));
 
   bufferSize = bufferUsed;
   std::vector<wchar_t> buf(bufferSize / 2 + 1);
 
   if (!EvtRender(nullptr, hBookmark_.get(), EvtRenderBookmark, bufferSize, buf.data(), &bufferUsed, &propertyCount)) {
-    return nonstd::make_unexpected(std::format("EvtRender failed due to %s", utils::OsUtils::getWindowsErrorAsString(GetLastError())));
+    return nonstd::make_unexpected(fmt::format("EvtRender failed due to %s", utils::OsUtils::windowsErrorToErrorCode(GetLastError()).message()));
   }
 
   return std::wstring(buf.data());

--- a/extensions/windows-event-log/Bookmark.cpp
+++ b/extensions/windows-event-log/Bookmark.cpp
@@ -18,7 +18,6 @@
 
 #include "Bookmark.h"
 
-#include <direct.h>
 #include <vector>
 #include <unordered_map>
 #include <utility>
@@ -26,12 +25,9 @@
 
 #include "wel/UnicodeConversion.h"
 #include "utils/file/FileUtils.h"
+#include "utils/OsUtils.h"
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
-namespace processors {
+namespace org::apache::nifi::minifi::processors {
 static const std::string BOOKMARK_KEY = "bookmark";
 
 Bookmark::Bookmark(const std::wstring& channel,
@@ -65,7 +61,8 @@ Bookmark::Bookmark(const std::wstring& channel,
   }
 
   if (!bookmarkXml_.empty()) {
-    if (hBookmark_ = unique_evt_handle{ EvtCreateBookmark(bookmarkXml_.c_str()) }) {
+    hBookmark_ = unique_evt_handle{EvtCreateBookmark(bookmarkXml_.c_str())};
+    if (hBookmark_) {
       ok_ = true;
       return;
     }
@@ -77,18 +74,19 @@ Bookmark::Bookmark(const std::wstring& channel,
     state_manager_->set(state_map);
   }
 
-  if (!(hBookmark_ = unique_evt_handle{ EvtCreateBookmark(0) })) {
+  hBookmark_ = unique_evt_handle{EvtCreateBookmark(nullptr)};
+  if (!hBookmark_) {
     LOG_LAST_ERROR(EvtCreateBookmark);
     return;
   }
 
-  const auto hEventResults = unique_evt_handle{ EvtQuery(0, channel.c_str(), query.c_str(), EvtQueryChannelPath) };
+  const auto hEventResults = unique_evt_handle{ EvtQuery(nullptr, channel.c_str(), query.c_str(), EvtQueryChannelPath) };
   if (!hEventResults) {
     LOG_LAST_ERROR(EvtQuery);
     return;
   }
 
-  if (!EvtSeek(hEventResults.get(), 0, 0, 0, processOldEvents? EvtSeekRelativeToFirst : EvtSeekRelativeToLast)) {
+  if (!EvtSeek(hEventResults.get(), 0, nullptr, 0, processOldEvents? EvtSeekRelativeToFirst : EvtSeekRelativeToLast)) {
     LOG_LAST_ERROR(EvtSeek);
     return;
   }
@@ -129,48 +127,41 @@ bool Bookmark::saveBookmarkXml(const std::wstring& bookmarkXml) {
   return state_manager_->set(state_map);
 }
 
-bool Bookmark::saveBookmark(EVT_HANDLE hEvent) {
-  std::wstring bookmarkXml;
-  if (!getNewBookmarkXml(hEvent, bookmarkXml)) {
+bool Bookmark::saveBookmark(EVT_HANDLE event_handle) {
+  auto bookmark_xml = getNewBookmarkXml(event_handle);
+  if (!bookmark_xml) {
+    logger_->log_error("%s", bookmark_xml.error());
     return false;
   }
 
-  return saveBookmarkXml(bookmarkXml);
+  return saveBookmarkXml(*bookmark_xml);
 }
 
-bool Bookmark::getNewBookmarkXml(EVT_HANDLE hEvent, std::wstring& bookmarkXml) {
+nonstd::expected<std::wstring, std::string> Bookmark::getNewBookmarkXml(EVT_HANDLE hEvent) {
   if (!EvtUpdateBookmark(hBookmark_.get(), hEvent)) {
-    LOG_LAST_ERROR(EvtUpdateBookmark);
-    return false;
+    return nonstd::make_unexpected(std::format("EvtUpdateBookmark failed due to %s", utils::OsUtils::getWindowsErrorAsString(GetLastError())));
   }
   // Render the bookmark as an XML string that can be persisted.
   logger_->log_trace("Rendering new bookmark");
   DWORD bufferSize{};
   DWORD bufferUsed{};
   DWORD propertyCount{};
-  if (!EvtRender(nullptr, hBookmark_.get(), EvtRenderBookmark, bufferSize, nullptr, &bufferUsed, &propertyCount)) {
-    DWORD status = ERROR_SUCCESS;
-    if (ERROR_INSUFFICIENT_BUFFER == (status = GetLastError())) {
-      bufferSize = bufferUsed;
+  bool event_render_succeeded_without_buffer = EvtRender(nullptr, hBookmark_.get(), EvtRenderBookmark, bufferSize, nullptr, &bufferUsed, &propertyCount);
+  if (event_render_succeeded_without_buffer)
+    return nonstd::make_unexpected("EvtRender failed to determine the required buffer size.");
 
-      std::vector<wchar_t> buf(bufferSize / 2 + 1);
+  auto last_error = GetLastError();
+  if (last_error != ERROR_INSUFFICIENT_BUFFER)
+    return nonstd::make_unexpected(std::format("EvtRender failed due to %s", utils::OsUtils::getWindowsErrorAsString(last_error)));
 
-      if (!EvtRender(nullptr, hBookmark_.get(), EvtRenderBookmark, bufferSize, &buf[0], &bufferUsed, &propertyCount)) {
-        LOG_LAST_ERROR(EvtRender);
-        return false;
-      }
+  bufferSize = bufferUsed;
+  std::vector<wchar_t> buf(bufferSize / 2 + 1);
 
-      bookmarkXml = buf.data();
-
-      return true;
-    }
-    if (ERROR_SUCCESS != (status = GetLastError())) {
-      LOG_LAST_ERROR(EvtRender);
-      return false;
-    }
+  if (!EvtRender(nullptr, hBookmark_.get(), EvtRenderBookmark, bufferSize, buf.data(), &bufferUsed, &propertyCount)) {
+    return nonstd::make_unexpected(std::format("EvtRender failed due to %s", utils::OsUtils::getWindowsErrorAsString(GetLastError())));
   }
 
-  return false;
+  return std::wstring(buf.data());
 }
 
 bool Bookmark::getBookmarkXmlFromFile(std::wstring& bookmarkXml) {
@@ -212,8 +203,4 @@ bool Bookmark::getBookmarkXmlFromFile(std::wstring& bookmarkXml) {
   return true;
 }
 
-} /* namespace processors */
-} /* namespace minifi */
-} /* namespace nifi */
-} /* namespace apache */
-} /* namespace org */
+}  // namespace org::apache::nifi::minifi::processors

--- a/extensions/windows-event-log/Bookmark.h
+++ b/extensions/windows-event-log/Bookmark.h
@@ -28,12 +28,9 @@
 #include "core/ProcessSession.h"
 #include "wel/UniqueEvtHandle.h"
 #include "logging/Logger.h"
+#include "utils/expected.h"
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
-namespace processors {
+namespace org::apache::nifi::minifi::processors {
 
 #define LOG_LAST_ERROR(func) logger_->log_error("!"#func" error %x", GetLastError())
 
@@ -50,7 +47,7 @@ class Bookmark {
   explicit operator bool() const noexcept;
 
   /* non-owning */ EVT_HANDLE getBookmarkHandleFromXML();
-  bool getNewBookmarkXml(EVT_HANDLE hEvent, std::wstring& bookmarkXml);
+  nonstd::expected<std::wstring, std::string> getNewBookmarkXml(EVT_HANDLE hEvent);
   bool saveBookmarkXml(const std::wstring& bookmarkXml);
 
  private:
@@ -67,8 +64,4 @@ class Bookmark {
   std::wstring bookmarkXml_;
 };
 
-} /* namespace processors */
-} /* namespace minifi */
-} /* namespace nifi */
-} /* namespace apache */
-} /* namespace org */
+}  // namespace org::apache::nifi::minifi::processors

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "ConsumeWindowsEventLog.h"
-#include <stdio.h>
+#include <cstdio>
 #include <vector>
 #include <tuple>
 #include <utility>
@@ -44,21 +44,19 @@
 #include "core/PropertyBuilder.h"
 #include "core/Resource.h"
 #include "Bookmark.h"
+#include "wel/UniqueEvtHandle.h"
 #include "utils/Deleters.h"
 #include "logging/LoggerConfiguration.h"
 
 #include "utils/gsl.h"
+#include "utils/OsUtils.h"
 
 #pragma comment(lib, "wevtapi.lib")
 #pragma comment(lib, "ole32.lib")
 
 using namespace std::literals::chrono_literals;
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
-namespace processors {
+namespace org::apache::nifi::minifi::processors {
 
 const int EVT_NEXT_TIMEOUT_MS = 500;
 
@@ -214,7 +212,7 @@ void ConsumeWindowsEventLog::initialize() {
   setSupportedRelationships(relationships());
 }
 
-bool ConsumeWindowsEventLog::insertHeaderName(wel::METADATA_NAMES &header, const std::string &key, const std::string & value) const {
+bool ConsumeWindowsEventLog::insertHeaderName(wel::METADATA_NAMES &header, const std::string &key, const std::string & value) {
   wel::METADATA name = wel::WindowsEventLogMetadata::getMetadataFromString(key);
 
   if (name != wel::METADATA::UNKNOWN) {
@@ -224,7 +222,7 @@ bool ConsumeWindowsEventLog::insertHeaderName(wel::METADATA_NAMES &header, const
   return false;
 }
 
-void ConsumeWindowsEventLog::onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) {
+void ConsumeWindowsEventLog::onSchedule(const std::shared_ptr<core::ProcessContext>& context, const std::shared_ptr<core::ProcessSessionFactory>&) {
   state_manager_ = context->getStateManager();
   if (state_manager_ == nullptr) {
     throw Exception(PROCESSOR_EXCEPTION, "Failed to get StateManager");
@@ -233,7 +231,7 @@ void ConsumeWindowsEventLog::onSchedule(const std::shared_ptr<core::ProcessConte
   context->getProperty(IdentifierMatcher.getName(), regex_);
   context->getProperty(ResolveAsAttributes.getName(), resolve_as_attributes_);
   context->getProperty(IdentifierFunction.getName(), apply_identifier_function_);
-  context->getProperty(EventHeaderDelimiter.getName(), header_delimiter_);
+  header_delimiter_ = context->getProperty(EventHeaderDelimiter);
   context->getProperty(BatchCommitSize.getName(), batch_commit_size_);
 
   header_names_.clear();
@@ -254,6 +252,11 @@ void ConsumeWindowsEventLog::onSchedule(const std::shared_ptr<core::ProcessConte
         }
       }
     }
+  }
+
+  regex_.reset();
+  if (auto identifier_matcher = context->getProperty(IdentifierMatcher); identifier_matcher && !identifier_matcher->empty()) {
+    regex_.emplace(*identifier_matcher);
   }
 
   std::string mode;
@@ -319,8 +322,8 @@ void ConsumeWindowsEventLog::onSchedule(const std::shared_ptr<core::ProcessConte
     }
   }
 
-  context->getProperty(MaxBufferSize.getName(), maxBufferSize_);
-  logger_->log_debug("ConsumeWindowsEventLog: MaxBufferSize %" PRIu64, maxBufferSize_);
+  context->getProperty(MaxBufferSize.getName(), max_buffer_size_);
+  logger_->log_debug("ConsumeWindowsEventLog: MaxBufferSize %" PRIu64, max_buffer_size_);
 
   provenanceUri_ = "winlog://" + computerName_ + "/" + channel_ + "?" + query;
   logger_->log_trace("Successfully configured CWEL");
@@ -346,7 +349,7 @@ bool ConsumeWindowsEventLog::commitAndSaveBookmark(const std::wstring &bookmark_
   return true;
 }
 
-std::tuple<size_t, std::wstring> ConsumeWindowsEventLog::processEventLogs(const std::shared_ptr<core::ProcessContext> &context,
+std::tuple<size_t, std::wstring> ConsumeWindowsEventLog::processEventLogs(const std::shared_ptr<core::ProcessContext>&,
     const std::shared_ptr<core::ProcessSession> &session, const EVT_HANDLE& event_query_results) {
   size_t processed_event_count = 0;
   std::wstring bookmark_xml;
@@ -367,13 +370,19 @@ std::tuple<size_t, std::wstring> ConsumeWindowsEventLog::processEventLogs(const 
 
     const auto guard_next_event = gsl::finally([next_event]() { EvtClose(next_event); });
     logger_->log_trace("Succesfully got the next event, performing event rendering");
-    EventRender event_render;
-    std::wstring new_bookmark_xml;
-    if (createEventRender(next_event, event_render) && bookmark_->getNewBookmarkXml(next_event, new_bookmark_xml)) {
-      bookmark_xml = std::move(new_bookmark_xml);
-      processed_event_count++;
-      putEventRenderFlowFileToSession(event_render, *session);
+    auto event_render = createEventRender(next_event);
+    if (!event_render) {
+      logger_->log_error("%s", event_render.error());
+      continue;
     }
+    auto new_bookmark_xml = bookmark_->getNewBookmarkXml(next_event);
+    if (!new_bookmark_xml) {
+      logger_->log_error("%s", new_bookmark_xml.error());
+      continue;
+    }
+    bookmark_xml = std::move(*new_bookmark_xml);
+    processed_event_count++;
+    putEventRenderFlowFileToSession(*event_render, *session);
   }
   logger_->log_trace("Finished enumerating events.");
   return std::make_tuple(processed_event_count, bookmark_xml);
@@ -400,13 +409,12 @@ void ConsumeWindowsEventLog::onTrigger(const std::shared_ptr<core::ProcessContex
     logger_->log_debug("processed %zu Events in %"  PRId64 " ms", processed_event_count, time_diff());
   });
 
-  const auto event_query_results = EvtQuery(0, wstrChannel_.c_str(), wstrQuery_.c_str(), EvtQueryChannelPath);
+  wel::unique_evt_handle event_query_results{EvtQuery(nullptr, wstrChannel_.c_str(), wstrQuery_.c_str(), EvtQueryChannelPath)};
   if (!event_query_results) {
     LOG_LAST_ERROR(EvtQuery);
     context->yield();
     return;
   }
-  const auto guard_event_query_results = gsl::finally([event_query_results]() { EvtClose(event_query_results); });
 
   logger_->log_trace("Retrieved results in Channel: %ls with Query: %ls", wstrChannel_.c_str(), wstrQuery_.c_str());
 
@@ -418,7 +426,7 @@ void ConsumeWindowsEventLog::onTrigger(const std::shared_ptr<core::ProcessContex
     return;
   }
 
-  if (!EvtSeek(event_query_results, 1, bookmark_handle, 0, EvtSeekRelativeToBookmark)) {
+  if (!EvtSeek(event_query_results.get(), 1, bookmark_handle, 0, EvtSeekRelativeToBookmark)) {
     LOG_LAST_ERROR(EvtSeek);
     context->yield();
     return;
@@ -427,7 +435,7 @@ void ConsumeWindowsEventLog::onTrigger(const std::shared_ptr<core::ProcessContex
   refreshTimeZoneData();
 
   std::wstring bookmark_xml;
-  std::tie(processed_event_count, bookmark_xml) = processEventLogs(context, session, event_query_results);
+  std::tie(processed_event_count, bookmark_xml) = processEventLogs(context, session, event_query_results.get());
 
   if (processed_event_count == 0 || !commitAndSaveBookmark(bookmark_xml, context, session)) {
     context->yield();
@@ -446,7 +454,10 @@ wel::WindowsEventLogHandler& ConsumeWindowsEventLog::getEventLogHandler(const st
   std::wstring temp_wstring = std::wstring(name.begin(), name.end());
   LPCWSTR widechar = temp_wstring.c_str();
 
-  providers_[name] = wel::WindowsEventLogHandler(EvtOpenPublisherMetadata(NULL, widechar, NULL, 0, 0));
+  auto opened_publisher_metadata_provider = EvtOpenPublisherMetadata(nullptr, widechar, nullptr, 0, 0);
+  if (!opened_publisher_metadata_provider)
+    logger_->log_warn("EvtOpenPublisherMetadata failed due to %s", utils::OsUtils::getWindowsErrorAsString(GetLastError()));
+  providers_[name] = wel::WindowsEventLogHandler(opened_publisher_metadata_provider);
   logger_->log_info("Handler not found for %s, creating. Number of cached handlers: %zu", name, providers_.size());
   return providers_[name];
 }
@@ -478,11 +489,11 @@ void ConsumeWindowsEventLog::substituteXMLPercentageItems(pugi::xml_document& do
       for (size_t numberPos = 0; std::string::npos != (numberPos = nodeText.find(percentages, numberPos));) {
         numberPos += percentages.size();
 
-        auto number = 0u;
+        uint64_t number{};
         try {
           // Assumption - first character is not '0', otherwise not all digits will be replaced by 'value'.
           number = std::stoul(&nodeText[numberPos]);
-        } catch (const std::invalid_argument &) {
+        } catch (const std::invalid_argument&) {
           continue;
         }
 
@@ -497,7 +508,7 @@ void ConsumeWindowsEventLog::substituteXMLPercentageItems(pugi::xml_document& do
                             number,
                             MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
                             (LPTSTR)&pBuffer,
-                            1024, 0)) {
+                            1024, nullptr)) {
             value = pBuffer;
             LocalFree(pBuffer);
 
@@ -537,79 +548,71 @@ void ConsumeWindowsEventLog::substituteXMLPercentageItems(pugi::xml_document& do
   doc.traverse(treeWalker);
 }
 
-bool ConsumeWindowsEventLog::createEventRender(EVT_HANDLE hEvent, EventRender& eventRender) {
+nonstd::expected<std::string, std::string> ConsumeWindowsEventLog::renderEventAsXml(EVT_HANDLE event_handle) {
   logger_->log_trace("Rendering an event");
   WCHAR stackBuffer[4096];
   DWORD size = sizeof(stackBuffer);
   using Deleter = utils::StackAwareDeleter<WCHAR, utils::FreeDeleter>;
-  std::unique_ptr<WCHAR, Deleter> buf{stackBuffer, Deleter{ stackBuffer }};
+  std::unique_ptr<WCHAR, Deleter> buf{stackBuffer, Deleter{stackBuffer}};
 
   DWORD used = 0;
   DWORD propertyCount = 0;
-  if (!EvtRender(NULL, hEvent, EvtRenderEventXml, size, buf.get(), &used, &propertyCount)) {
-    if (ERROR_INSUFFICIENT_BUFFER != GetLastError()) {
-      LOG_LAST_ERROR(EvtRender);
-      return false;
+  if (!EvtRender(nullptr, event_handle, EvtRenderEventXml, size, buf.get(), &used, &propertyCount)) {
+    DWORD last_error = GetLastError();
+    if (ERROR_INSUFFICIENT_BUFFER != last_error) {
+      std::string error_message = std::format("EvtRender failed due to %s", utils::OsUtils::getWindowsErrorAsString(last_error));
+      return nonstd::make_unexpected(error_message);
     }
-    if (used > maxBufferSize_) {
-      logger_->log_error("Dropping event because it couldn't be rendered within %" PRIu64 " bytes.", maxBufferSize_);
-      return false;
+    if (used > max_buffer_size_) {
+      std::string error_message = std::format("Dropping event because it couldn't be rendered within %" PRIu64 " bytes.", max_buffer_size_);
+      return nonstd::make_unexpected(error_message);
     }
     size = used;
-    buf.reset((LPWSTR)malloc(size));
-    if (!buf) {
-      return false;
-    }
-    if (!EvtRender(NULL, hEvent, EvtRenderEventXml, size, buf.get(), &used, &propertyCount)) {
-      LOG_LAST_ERROR(EvtRender);
-      return false;
+    buf.reset((LPWSTR) malloc(size));
+    if (!EvtRender(nullptr, event_handle, EvtRenderEventXml, size, buf.get(), &used, &propertyCount)) {
+      std::string error_message = std::format("EvtRender failed due to %s", utils::OsUtils::getWindowsErrorAsString(GetLastError()));
+      return nonstd::make_unexpected(error_message);
     }
   }
+  logger_->log_trace("Event rendered with size %" PRIu32, used);
+  return wel::to_string(buf.get());
+}
 
-  logger_->log_debug("Event rendered with size %" PRIu32 ". Performing doc traversing...", used);
-
-  std::string xml = wel::to_string(buf.get());
+nonstd::expected<EventRender, std::string> ConsumeWindowsEventLog::createEventRender(EVT_HANDLE hEvent) {
+  auto event_as_xml = renderEventAsXml(hEvent);
+  if (!event_as_xml)
+    return nonstd::make_unexpected(event_as_xml.error());
 
   pugi::xml_document doc;
-  pugi::xml_parse_result result = doc.load_string(xml.c_str());
+  if (!doc.load_string(event_as_xml->c_str()))
+    return nonstd::make_unexpected("Invalid XML produced");
 
-  if (!result) {
-    logger_->log_error("Invalid XML produced");
-    return false;
-  }
+  EventRender result;
 
   // this is a well known path.
-  std::string providerName = doc.child("Event").child("System").child("Provider").attribute("Name").value();
-  wel::WindowsEventLogMetadataImpl metadata{getEventLogHandler(providerName).getMetadata(), hEvent};
+  std::string provider_name = doc.child("Event").child("System").child("Provider").attribute("Name").value();
+  wel::WindowsEventLogMetadataImpl metadata{getEventLogHandler(provider_name).getMetadata(), hEvent};
   wel::MetadataWalker walker{metadata, channel_, !resolve_as_attributes_, apply_identifier_function_, regex_};
 
   // resolve the event metadata
   doc.traverse(walker);
 
-  logger_->log_debug("Finish doc traversing, performing writing...");
+  logger_->log_trace("Finish doc traversing, performing writing...");
 
   if (output_.plaintext) {
     logger_->log_trace("Writing event in plain text");
 
-    auto& handler = getEventLogHandler(providerName);
-    auto message = handler.getEventMessage(hEvent);
+    auto& handler = getEventLogHandler(provider_name);
+    auto event_message = handler.getEventMessage(hEvent);
 
-    if (!message.empty()) {
-      for (const auto &mapEntry : walker.getIdentifiers()) {
-        // replace the identifiers with their translated strings.
-        if (mapEntry.first.empty() || mapEntry.second.empty()) {
-          continue;  // This is most probably a result of a failed ID resolution
-        }
-        utils::StringUtils::replaceAll(message, mapEntry.first, mapEntry.second);
-      }
-      wel::WindowsEventLogHeader log_header(header_names_);
-      // set the delimiter
-      log_header.setDelimiter(header_delimiter_);
-      // render the header.
-      eventRender.plaintext = log_header.getEventHeader([&walker](wel::METADATA metadata) { return walker.getMetadata(metadata); });
-      eventRender.plaintext += "Message" + header_delimiter_ + " ";
-      eventRender.plaintext += message;
-    }
+    std::string_view payload_name = event_message ? "Message" : "Error";
+
+    wel::WindowsEventLogHeader log_header(header_names_, header_delimiter_, payload_name.size());
+    result.plaintext = log_header.getEventHeader([&walker](wel::METADATA metadata) { return walker.getMetadata(metadata); });
+    result.plaintext += payload_name;
+    result.plaintext += log_header.getDelimiterFor(payload_name.size());
+    result.plaintext += event_message.has_value() ? *event_message : utils::OsUtils::getWindowsErrorAsString(event_message.error());
+
     logger_->log_trace("Finish writing in plain text");
   }
 
@@ -618,7 +621,7 @@ bool ConsumeWindowsEventLog::createEventRender(EVT_HANDLE hEvent, EventRender& e
     logger_->log_trace("Finish substituting %% in XML");
 
     if (resolve_as_attributes_) {
-      eventRender.matched_fields = walker.getFieldValues();
+      result.matched_fields = walker.getFieldValues();
     }
   }
 
@@ -627,27 +630,27 @@ bool ConsumeWindowsEventLog::createEventRender(EVT_HANDLE hEvent, EventRender& e
 
     wel::XmlString writer;
     doc.print(writer, "", pugi::format_raw);  // no indentation or formatting
-    xml = writer.xml_;
+    event_as_xml = writer.xml_;
 
-    eventRender.xml = std::move(xml);
+    result.xml = std::move(*event_as_xml);
     logger_->log_trace("Finish writing in XML");
   }
 
   if (output_.json.type == JSONType::Raw) {
     logger_->log_trace("Writing event in raw JSON");
-    eventRender.json = wel::jsonToString(wel::toRawJSON(doc));
+    result.json = wel::jsonToString(wel::toRawJSON(doc));
     logger_->log_trace("Finish writing in raw JSON");
   } else if (output_.json.type == JSONType::Simple) {
     logger_->log_trace("Writing event in simple JSON");
-    eventRender.json = wel::jsonToString(wel::toSimpleJSON(doc));
+    result.json = wel::jsonToString(wel::toSimpleJSON(doc));
     logger_->log_trace("Finish writing in simple JSON");
   } else if (output_.json.type == JSONType::Flattened) {
     logger_->log_trace("Writing event in flattened JSON");
-    eventRender.json = wel::jsonToString(wel::toFlattenedJSON(doc));
+    result.json = wel::jsonToString(wel::toFlattenedJSON(doc));
     logger_->log_trace("Finish writing in flattened JSON");
   }
 
-  return true;
+  return result;
 }
 
 void ConsumeWindowsEventLog::refreshTimeZoneData() {
@@ -725,18 +728,18 @@ void ConsumeWindowsEventLog::putEventRenderFlowFileToSession(const EventRender& 
   }
 }
 
-void ConsumeWindowsEventLog::LogWindowsError(std::string error) const {
+void ConsumeWindowsEventLog::LogWindowsError(const std::string& error) const {
   auto error_id = GetLastError();
   LPVOID lpMsg;
 
   FormatMessage(
     FORMAT_MESSAGE_ALLOCATE_BUFFER |
     FORMAT_MESSAGE_FROM_SYSTEM,
-    NULL,
+    nullptr,
     error_id,
     MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
     (LPTSTR)&lpMsg,
-    0, NULL);
+    0, nullptr);
 
   logger_->log_error((error + " %x: %s\n").c_str(), static_cast<int>(error_id), reinterpret_cast<char *>(lpMsg));
 
@@ -745,8 +748,4 @@ void ConsumeWindowsEventLog::LogWindowsError(std::string error) const {
 
 REGISTER_RESOURCE(ConsumeWindowsEventLog, Processor);
 
-}  // namespace processors
-}  // namespace minifi
-}  // namespace nifi
-}  // namespace apache
-}  // namespace org
+}  // namespace org::apache::nifi::minifi::processors

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.h
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.h
@@ -43,12 +43,9 @@
 #include "concurrentqueue.h"
 #include "pugixml.hpp"
 #include "utils/Export.h"
+#include "utils/RegexUtils.h"
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
-namespace processors {
+namespace org::apache::nifi::minifi::processors {
 
 struct EventRender {
   std::map<std::string, std::string> matched_fields;
@@ -63,7 +60,7 @@ class ConsumeWindowsEventLog : public core::Processor {
  public:
   explicit ConsumeWindowsEventLog(const std::string& name, const utils::Identifier& uuid = {});
 
-  virtual ~ConsumeWindowsEventLog();
+  ~ConsumeWindowsEventLog() override;
 
   EXTENSIONAPI static constexpr const char* Description = "Windows Event Log Subscribe Callback to receive FlowFiles from Events on Windows.";
 
@@ -83,20 +80,20 @@ class ConsumeWindowsEventLog : public core::Processor {
   EXTENSIONAPI static const core::Property ProcessOldEvents;
   static auto properties() {
     return std::array{
-      Channel,
-      Query,
-      MaxBufferSize,
-      InactiveDurationToReconnect,
-      IdentifierMatcher,
-      IdentifierFunction,
-      ResolveAsAttributes,
-      EventHeaderDelimiter,
-      EventHeader,
-      OutputFormat,
-      JSONFormat,
-      BatchCommitSize,
-      BookmarkRootDirectory,
-      ProcessOldEvents
+        Channel,
+        Query,
+        MaxBufferSize,
+        InactiveDurationToReconnect,
+        IdentifierMatcher,
+        IdentifierFunction,
+        ResolveAsAttributes,
+        EventHeaderDelimiter,
+        EventHeader,
+        OutputFormat,
+        JSONFormat,
+        BatchCommitSize,
+        BookmarkRootDirectory,
+        ProcessOldEvents
     };
   }
 
@@ -112,17 +109,19 @@ class ConsumeWindowsEventLog : public core::Processor {
 
   void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
   void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
-  void initialize(void) override;
+  void initialize() override;
   void notifyStop() override;
 
  protected:
   void refreshTimeZoneData();
   void putEventRenderFlowFileToSession(const EventRender& eventRender, core::ProcessSession& session) const;
-  wel::WindowsEventLogHandler& getEventLogHandler(const std::string & name);
-  bool insertHeaderName(wel::METADATA_NAMES &header, const std::string &key, const std::string &value) const;
-  void LogWindowsError(std::string error = "Error") const;
-  bool createEventRender(EVT_HANDLE eventHandle, EventRender& eventRender);
+  wel::WindowsEventLogHandler& getEventLogHandler(const std::string& name);
+  static bool insertHeaderName(wel::METADATA_NAMES& header, const std::string& key, const std::string& value);
+  void LogWindowsError(const std::string& error = "Error") const;
+  nonstd::expected<EventRender, std::string> createEventRender(EVT_HANDLE eventHandle);
   void substituteXMLPercentageItems(pugi::xml_document& doc);
+
+  nonstd::expected<std::string, std::string> renderEventAsXml(EVT_HANDLE event_handle);
 
   static constexpr const char* XML = "XML";
   static constexpr const char* Both = "Both";
@@ -140,29 +139,29 @@ class ConsumeWindowsEventLog : public core::Processor {
     const decltype(std::chrono::steady_clock::now()) time_ = std::chrono::steady_clock::now();
   };
 
-  bool commitAndSaveBookmark(const std::wstring &bookmarkXml, const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session);
+  bool commitAndSaveBookmark(const std::wstring& bookmarkXml, const std::shared_ptr<core::ProcessContext>& context, const std::shared_ptr<core::ProcessSession>& session);
 
-  std::tuple<size_t, std::wstring> processEventLogs(const std::shared_ptr<core::ProcessContext> &context,
-    const std::shared_ptr<core::ProcessSession> &session, const EVT_HANDLE& event_query_results);
+  std::tuple<size_t, std::wstring> processEventLogs(const std::shared_ptr<core::ProcessContext>& context,
+                                                    const std::shared_ptr<core::ProcessSession>& session,
+                                                    const EVT_HANDLE& event_query_results);
 
   std::shared_ptr<core::logging::Logger> logger_;
-  core::CoreComponentStateManager* state_manager_;
+  core::CoreComponentStateManager* state_manager_{nullptr};
   wel::METADATA_NAMES header_names_;
-  std::string header_delimiter_;
+  std::optional<std::string> header_delimiter_;
   std::string channel_;
   std::wstring wstrChannel_;
   std::wstring wstrQuery_;
-  std::string regex_;
+  std::optional<utils::Regex> regex_;
   bool resolve_as_attributes_{false};
   bool apply_identifier_function_{false};
   std::string provenanceUri_;
   std::string computerName_;
-  uint64_t maxBufferSize_{};
-  DWORD lastActivityTimestamp_{};
-  std::map<std::string, wel::WindowsEventLogHandler > providers_;
+  uint64_t max_buffer_size_{};
+  std::map<std::string, wel::WindowsEventLogHandler> providers_;
   uint64_t batch_commit_size_{};
 
-  enum class JSONType {None, Raw, Simple, Flattened};
+  enum class JSONType { None, Raw, Simple, Flattened };
 
   struct OutputFormat {
     bool xml{false};
@@ -185,8 +184,4 @@ class ConsumeWindowsEventLog : public core::Processor {
   std::string timezone_offset_;  // Represented as UTC offset in (+|-)HH:MM format, like +02:00
 };
 
-}  // namespace processors
-}  // namespace minifi
-}  // namespace nifi
-}  // namespace apache
-}  // namespace org
+}  // namespace org::apache::nifi::minifi::processors

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.h
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.h
@@ -112,7 +112,7 @@ class ConsumeWindowsEventLog : public core::Processor {
   void initialize() override;
   void notifyStop() override;
 
- protected:
+ private:
   void refreshTimeZoneData();
   void putEventRenderFlowFileToSession(const EventRender& eventRender, core::ProcessSession& session) const;
   wel::WindowsEventLogHandler& getEventLogHandler(const std::string& name);

--- a/extensions/windows-event-log/tests/BookmarkTests.cpp
+++ b/extensions/windows-event-log/tests/BookmarkTests.cpp
@@ -217,10 +217,10 @@ TEST_CASE("Bookmark::getNewBookmarkXml() updates the bookmark", "[add_event]") {
   unique_evt_handle results = queryEvents();
   unique_evt_handle event = getFirstEventFromResults(results);
 
-  std::wstring bookmark_xml_after;
-  REQUIRE(bookmark->getNewBookmarkXml(event.get(), bookmark_xml_after));
+  auto bookmark_xml_after = bookmark->getNewBookmarkXml(event.get());
 
-  REQUIRE(bookmark_xml_before != bookmark_xml_after);
+  REQUIRE(bookmark_xml_after);
+  CHECK(bookmark_xml_before != *bookmark_xml_after);
 }
 
 TEST_CASE("Bookmark::saveBookmarkXml() updates the bookmark and saves it to the state manager", "[save_bookmark][state]") {

--- a/extensions/windows-event-log/tests/CWELTestUtils.h
+++ b/extensions/windows-event-log/tests/CWELTestUtils.h
@@ -45,7 +45,7 @@ class OutputFormatTestController : public TestController {
       json_format_(std::move(json_format)) {}
 
   std::string run() {
-    LogTestController::getInstance().setDebug<ConsumeWindowsEventLog>();
+    LogTestController::getInstance().setTrace<ConsumeWindowsEventLog>();
     LogTestController::getInstance().setDebug<PutFile>();
     std::shared_ptr<TestPlan> test_plan = createPlan();
 
@@ -69,7 +69,7 @@ class OutputFormatTestController : public TestController {
     }
 
     test_plan->reset();
-    LogTestController::getInstance().resetStream(LogTestController::getInstance().log_output);
+    LogTestController::resetStream(LogTestController::getInstance().log_output);
 
 
     {

--- a/extensions/windows-event-log/tests/MetadataWalkerTests.cpp
+++ b/extensions/windows-event-log/tests/MetadataWalkerTests.cpp
@@ -34,7 +34,7 @@ using XmlString = org::apache::nifi::minifi::wel::XmlString;
 
 namespace {
 
-std::string updateXmlMetadata(const std::string &xml, EVT_HANDLE metadata_ptr, EVT_HANDLE event_ptr, bool update_xml, bool resolve, std::optional<utils::Regex> regex = std::nullopt) {
+std::string updateXmlMetadata(const std::string &xml, EVT_HANDLE metadata_ptr, EVT_HANDLE event_ptr, bool update_xml, bool resolve, utils::Regex const* regex = nullptr) {
   WindowsEventLogMetadataImpl metadata{metadata_ptr, event_ptr};
   MetadataWalker walker(metadata, "", update_xml, resolve, regex);
 
@@ -89,8 +89,8 @@ TEST_CASE("MetadataWalker updates the Sid in the XML if both update_xml and reso
 
   SECTION("Resolve nobody") {
     std::string nobody = readFile("resources/withsids.xml");
-    std::optional<utils::Regex> regex = utils::Regex(".*Sid");
-    REQUIRE(updateXmlMetadata(xml, nullptr, nullptr, true, true, regex) == formatXml(nobody));
+    auto regex = utils::Regex(".*Sid");
+    REQUIRE(updateXmlMetadata(xml, nullptr, nullptr, true, true, &regex) == formatXml(nobody));
   }
 }
 
@@ -111,8 +111,8 @@ TEST_CASE("MetadataWalker will leave a Sid unchanged if it doesn't correspond to
 
   REQUIRE(updateXmlMetadata(xml, nullptr, nullptr, false, true) == formatXml(xml));
   REQUIRE(updateXmlMetadata(xml, nullptr, nullptr, true, true) == formatXml(xml));
-  std::optional<utils::Regex> regex = utils::Regex(".*Sid");
-  REQUIRE(updateXmlMetadata(xml, nullptr, nullptr, true, true, regex) == formatXml(xml));
+  auto regex = utils::Regex(".*Sid");
+  REQUIRE(updateXmlMetadata(xml, nullptr, nullptr, true, true, &regex) == formatXml(xml));
 }
 
 TEST_CASE("MetadataWalker can replace multiple Sids", "[updateXmlMetadata]") {
@@ -152,8 +152,8 @@ void extractMappingsTestHelper(const std::string &file_name,
   pugi::xml_parse_result result = doc.load_string(input_xml.c_str());
   CHECK(result);
 
-  std::optional<utils::Regex> regex = utils::Regex(".*Sid");
-  MetadataWalker walker(FakeWindowsEventLogMetadata{}, METADATA_WALKER_TESTS_LOG_NAME, update_xml, resolve, regex);
+  auto regex = utils::Regex(".*Sid");
+  MetadataWalker walker(FakeWindowsEventLogMetadata{}, METADATA_WALKER_TESTS_LOG_NAME, update_xml, resolve, &regex);
   doc.traverse(walker);
 
   CHECK(walker.getIdentifiers() == expected_identifiers);

--- a/extensions/windows-event-log/wel/MetadataWalker.h
+++ b/extensions/windows-event-log/wel/MetadataWalker.h
@@ -50,7 +50,7 @@ namespace org::apache::nifi::minifi::wel {
  */
 class MetadataWalker : public pugi::xml_tree_walker {
  public:
-  MetadataWalker(const WindowsEventLogMetadata& windows_event_log_metadata, std::string log_name, bool update_xml, bool resolve, const std::optional<utils::Regex>& regex)
+  MetadataWalker(const WindowsEventLogMetadata& windows_event_log_metadata, std::string log_name, bool update_xml, bool resolve, utils::Regex const* regex)
       : windows_event_log_metadata_(windows_event_log_metadata),
         log_name_(std::move(log_name)),
         regex_(regex),
@@ -89,10 +89,10 @@ class MetadataWalker : public pugi::xml_tree_walker {
   void updateText(pugi::xml_node &node, const std::string &field_name, std::function<std::string(const std::string &)> &&fn);
 
   const WindowsEventLogMetadata& windows_event_log_metadata_;
-  std::string log_name_;
-  const std::optional<utils::Regex>& regex_;
-  bool update_xml_;
-  bool resolve_;
+  const std::string log_name_;
+  utils::Regex const * const regex_;
+  const bool update_xml_;
+  const bool resolve_;
   std::map<std::string, std::string> metadata_;
   std::map<std::string, std::string> fields_values_;
   std::map<std::string, std::string> replaced_identifiers_;

--- a/extensions/windows-event-log/wel/WindowsEventLog.cpp
+++ b/extensions/windows-event-log/wel/WindowsEventLog.cpp
@@ -25,49 +25,17 @@
 #include "UnicodeConversion.h"
 #include "utils/Deleters.h"
 #include "utils/gsl.h"
+#include "UniqueEvtHandle.h"
 
 namespace org::apache::nifi::minifi::wel {
 
-void WindowsEventLogMetadataImpl::renderMetadata() {
-  DWORD status = ERROR_SUCCESS;
-  EVT_VARIANT stackBuffer[4096];
-  DWORD dwBufferSize = sizeof(stackBuffer);
-  using Deleter = utils::StackAwareDeleter<EVT_VARIANT, utils::FreeDeleter>;
-  std::unique_ptr<EVT_VARIANT, Deleter> rendered_values{ stackBuffer, Deleter{stackBuffer} };
-  DWORD dwBufferUsed = 0;
-  DWORD dwPropertyCount = 0;
-
-  auto context = EvtCreateRenderContext(0, NULL, EvtRenderContextSystem);
-  if (context == NULL) {
-    return;
-  }
-  const auto contextGuard = gsl::finally([&context](){
-    EvtClose(context);
-  });
-  if (!EvtRender(context, event_ptr_, EvtRenderEventValues, dwBufferSize, rendered_values.get(), &dwBufferUsed, &dwPropertyCount)) {
-    if (ERROR_INSUFFICIENT_BUFFER != (status = GetLastError())) {
-      return;
-    }
-
-    dwBufferSize = dwBufferUsed;
-    rendered_values.reset((PEVT_VARIANT)(malloc(dwBufferSize)));
-    if (!rendered_values) {
-      return;
-    }
-
-    EvtRender(context, event_ptr_, EvtRenderEventValues, dwBufferSize, rendered_values.get(), &dwBufferUsed, &dwPropertyCount);
-    if (ERROR_SUCCESS != (status = GetLastError())) {
-      return;
-    }
-  }
-
-  event_timestamp_ = static_cast<PEVT_VARIANT>(rendered_values.get())[EvtSystemTimeCreated].FileTimeVal;
-
+namespace {
+std::string GetEventTimestampStr(uint64_t event_timestamp) {
   SYSTEMTIME st;
   FILETIME ft;
 
-  ft.dwHighDateTime = (DWORD)((event_timestamp_ >> 32) & 0xFFFFFFFF);
-  ft.dwLowDateTime = (DWORD)(event_timestamp_ & 0xFFFFFFFF);
+  ft.dwHighDateTime = (DWORD)((event_timestamp >> 32) & 0xFFFFFFFF);
+  ft.dwLowDateTime = (DWORD)(event_timestamp & 0xFFFFFFFF);
 
   FileTimeToSystemTime(&ft, &st);
   std::stringstream datestr;
@@ -82,7 +50,42 @@ void WindowsEventLogMetadataImpl::renderMetadata() {
     hour = 12;
   datestr << st.wMonth << "/" << st.wDay << "/" << st.wYear << " " << std::setfill('0') << std::setw(2) << hour << ":" << std::setfill('0')
           << std::setw(2) << st.wMinute << ":" << std::setfill('0') << std::setw(2) << st.wSecond << " " << period;
-  event_timestamp_str_ = datestr.str();
+  return datestr.str();
+}
+}  // namespace
+
+void WindowsEventLogMetadataImpl::renderMetadata() {
+  DWORD status = ERROR_SUCCESS;
+  EVT_VARIANT stackBuffer[4096];
+  DWORD dwBufferSize = sizeof(stackBuffer);
+  using Deleter = utils::StackAwareDeleter<EVT_VARIANT, utils::FreeDeleter>;
+  std::unique_ptr<EVT_VARIANT, Deleter> rendered_values{stackBuffer, Deleter{stackBuffer}};
+  DWORD dwBufferUsed = 0;
+  DWORD dwPropertyCount = 0;
+
+  unique_evt_handle context{EvtCreateRenderContext(0, nullptr, EvtRenderContextSystem)};
+  if (!context)
+    return;
+
+  if (!EvtRender(context.get(), event_ptr_, EvtRenderEventValues, dwBufferSize, rendered_values.get(), &dwBufferUsed, &dwPropertyCount)) {
+    if (ERROR_INSUFFICIENT_BUFFER != (status = GetLastError())) {
+      return;
+    }
+
+    dwBufferSize = dwBufferUsed;
+    rendered_values.reset((PEVT_VARIANT) (malloc(dwBufferSize)));
+    if (!rendered_values) {
+      return;
+    }
+
+    EvtRender(context.get(), event_ptr_, EvtRenderEventValues, dwBufferSize, rendered_values.get(), &dwBufferUsed, &dwPropertyCount);
+    if (ERROR_SUCCESS != (status = GetLastError())) {
+      return;
+    }
+  }
+
+  event_timestamp_str_ = GetEventTimestampStr(static_cast<PEVT_VARIANT>(rendered_values.get())[EvtSystemTimeCreated].FileTimeVal);
+
   auto level = static_cast<PEVT_VARIANT>(rendered_values.get())[EvtSystemLevel];
   auto keyword = static_cast<PEVT_VARIANT>(rendered_values.get())[EvtSystemKeywords];
   if (level.Type == EvtVarTypeByte) {
@@ -121,20 +124,18 @@ std::string WindowsEventLogMetadataImpl::getEventData(EVT_FORMAT_MESSAGE_FLAGS f
   WCHAR stack_buffer[4096];
   DWORD num_chars_in_buffer = sizeof(stack_buffer) / sizeof(stack_buffer[0]);
   using Deleter = utils::StackAwareDeleter<WCHAR, utils::FreeDeleter>;
-  std::unique_ptr<WCHAR, Deleter> buffer{ stack_buffer, Deleter{stack_buffer} };
+  std::unique_ptr<WCHAR, Deleter> buffer{stack_buffer, Deleter{stack_buffer}};
   DWORD num_chars_used = 0;
-  DWORD result = 0;
 
   std::string event_data;
 
-  if (metadata_ptr_ == NULL || event_ptr_ == NULL) {
+  if (!metadata_ptr_ || !event_ptr_) {
     return event_data;
   }
 
-
-  if (!EvtFormatMessage(metadata_ptr_, event_ptr_, 0, 0, NULL, flags, num_chars_in_buffer, buffer.get(), &num_chars_used)) {
-    result = GetLastError();
-    if (ERROR_INSUFFICIENT_BUFFER == result) {
+  if (!EvtFormatMessage(metadata_ptr_, event_ptr_, 0, 0, nullptr, flags, num_chars_in_buffer, buffer.get(), &num_chars_used)) {
+    auto last_error = GetLastError();
+    if (ERROR_INSUFFICIENT_BUFFER == last_error) {
       num_chars_in_buffer = num_chars_used;
 
       buffer.reset((LPWSTR) malloc(num_chars_in_buffer * sizeof(WCHAR)));
@@ -142,7 +143,7 @@ std::string WindowsEventLogMetadataImpl::getEventData(EVT_FORMAT_MESSAGE_FLAGS f
         return event_data;
       }
 
-      EvtFormatMessage(metadata_ptr_, event_ptr_, 0, 0, NULL, flags, num_chars_in_buffer, buffer.get(), &num_chars_used);
+      EvtFormatMessage(metadata_ptr_, event_ptr_, 0, 0, nullptr, flags, num_chars_in_buffer, buffer.get(), &num_chars_used);
     }
   }
 
@@ -158,51 +159,57 @@ std::string WindowsEventLogMetadataImpl::getEventData(EVT_FORMAT_MESSAGE_FLAGS f
   return event_data;
 }
 
-std::string WindowsEventLogHandler::getEventMessage(EVT_HANDLE eventHandle) const {
+nonstd::expected<std::string, DWORD> WindowsEventLogHandler::getEventMessage(EVT_HANDLE eventHandle) const {
   std::string returnValue;
   WCHAR stack_buffer[4096];
   DWORD num_chars_in_buffer = sizeof(stack_buffer) / sizeof(stack_buffer[0]);
   using Deleter = utils::StackAwareDeleter<WCHAR, utils::FreeDeleter>;
-  std::unique_ptr<WCHAR, Deleter> buffer{ stack_buffer, Deleter{stack_buffer} };
+  std::unique_ptr<WCHAR, Deleter> buffer{stack_buffer, Deleter{stack_buffer}};
   DWORD num_chars_used = 0;
-  DWORD status = 0;
 
-  EvtFormatMessage(metadata_provider_.get(), eventHandle, 0, 0, NULL, EvtFormatMessageEvent, num_chars_in_buffer, buffer.get(), &num_chars_used);
-  if (num_chars_used == 0) {
-    return returnValue;
-  }
+  bool evt_format_succeeded = EvtFormatMessage(metadata_provider_.get(), eventHandle, 0, 0, nullptr, EvtFormatMessageEvent, num_chars_in_buffer, buffer.get(), &num_chars_used);
+  if (evt_format_succeeded)
+    return to_string(buffer.get());
 
-  //  we need to get the size of the buffer
-  status = GetLastError();
-  if (ERROR_INSUFFICIENT_BUFFER == status) {
-    num_chars_in_buffer = num_chars_used;
+  DWORD status = GetLastError();
 
-    /* All C++ examples use malloc and even HeapAlloc in some cases. To avoid any problems ( with EvtFormatMessage calling
-      free for example ) we will continue to use malloc and use a custom deleter with unique_ptr.
-    '*/
-    buffer.reset((LPWSTR)malloc(num_chars_in_buffer * sizeof(WCHAR)));
-    if (!buffer) {
-      return returnValue;
-    }
+  if (status != ERROR_INSUFFICIENT_BUFFER)
+    return nonstd::make_unexpected(status);
 
-    EvtFormatMessage(metadata_provider_.get(), eventHandle, 0, 0, NULL, EvtFormatMessageEvent, num_chars_in_buffer, buffer.get(), &num_chars_used);
-  }
-
-  if (ERROR_EVT_MESSAGE_NOT_FOUND == status || ERROR_EVT_MESSAGE_ID_NOT_FOUND == status) {
-    return returnValue;
-  }
-
-  // convert wstring to std::string
-  return to_string(buffer.get());
+  num_chars_in_buffer = num_chars_used;
+  buffer.reset((LPWSTR) malloc(num_chars_in_buffer * sizeof(WCHAR)));
+  if (EvtFormatMessage(metadata_provider_.get(), eventHandle, 0, 0, nullptr,
+                       EvtFormatMessageEvent, num_chars_in_buffer,
+                       buffer.get(), &num_chars_used))
+    return to_string(buffer.get());
+  return nonstd::make_unexpected(GetLastError());
 }
 
-void WindowsEventLogHeader::setDelimiter(const std::string &delim) {
-  delimiter_ = delim;
+namespace {
+size_t findLongestHeaderNameSize(const METADATA_NAMES& header_names, const size_t minimum_size) {
+  size_t max = minimum_size;
+  for (const auto& option : header_names) {
+    max = (std::max(max, option.second.size()));
+  }
+  return ++max;
+}
+}  // namespace
+
+WindowsEventLogHeader::WindowsEventLogHeader(const METADATA_NAMES& header_names, const std::optional<std::string>& custom_delimiter, const size_t minimum_size)
+    : header_names_(header_names),
+      custom_delimiter_(custom_delimiter),
+      longest_header_name_(findLongestHeaderNameSize(header_names, minimum_size)) {
 }
 
-std::string WindowsEventLogHeader::createDefaultDelimiter(size_t max, size_t length) const {
-  if (max > length) {
-    return ":" + std::string(max - length, ' ');
+std::string WindowsEventLogHeader::getDelimiterFor(size_t length) const {
+  if (custom_delimiter_)
+    return *custom_delimiter_;
+  return createDefaultDelimiter(length);
+}
+
+std::string WindowsEventLogHeader::createDefaultDelimiter(size_t length) const {
+  if (longest_header_name_ > length) {
+    return ":" + std::string(longest_header_name_ - length, ' ');
   } else {
     return ": ";
   }

--- a/extensions/windows-event-log/wel/WindowsEventLog.cpp
+++ b/extensions/windows-event-log/wel/WindowsEventLog.cpp
@@ -34,8 +34,8 @@ std::string GetEventTimestampStr(uint64_t event_timestamp) {
   SYSTEMTIME st;
   FILETIME ft;
 
-  ft.dwHighDateTime = (DWORD)((event_timestamp >> 32) & 0xFFFFFFFF);
-  ft.dwLowDateTime = (DWORD)(event_timestamp & 0xFFFFFFFF);
+  ft.dwHighDateTime = (DWORD)((event_timestamp >> 32) & 0xFF'FF'FF'FF);
+  ft.dwLowDateTime = (DWORD)(event_timestamp & 0xFF'FF'FF'FF);
 
   FileTimeToSystemTime(&ft, &st);
   std::stringstream datestr;
@@ -178,6 +178,8 @@ nonstd::expected<std::string, DWORD> WindowsEventLogHandler::getEventMessage(EVT
 
   num_chars_in_buffer = num_chars_used;
   buffer.reset((LPWSTR) malloc(num_chars_in_buffer * sizeof(WCHAR)));
+  if (!buffer)
+    return nonstd::make_unexpected(ERROR_OUTOFMEMORY);
   if (EvtFormatMessage(metadata_provider_.get(), eventHandle, 0, 0, nullptr,
                        EvtFormatMessageEvent, num_chars_in_buffer,
                        buffer.get(), &num_chars_used))

--- a/extensions/windows-event-log/wel/WindowsEventLog.h
+++ b/extensions/windows-event-log/wel/WindowsEventLog.h
@@ -72,7 +72,7 @@ class WindowsEventLogHandler {
   explicit WindowsEventLogHandler(EVT_HANDLE metadataProvider) : metadata_provider_(metadataProvider) {
   }
 
-  nonstd::expected<std::string, DWORD> getEventMessage(EVT_HANDLE eventHandle) const;
+  nonstd::expected<std::string, std::error_code> getEventMessage(EVT_HANDLE eventHandle) const;
 
   [[nodiscard]] EVT_HANDLE getMetadata() const;
 

--- a/extensions/windows-event-log/wel/WindowsEventLog.h
+++ b/extensions/windows-event-log/wel/WindowsEventLog.h
@@ -39,6 +39,7 @@
 #include "UniqueEvtHandle.h"
 
 #include "pugixml.hpp"
+#include "utils/expected.h"
 
 namespace org::apache::nifi::minifi::wel {
 
@@ -59,9 +60,9 @@ enum METADATA {
 };
 
 
-// this is a continuous enum so we can rely on the array
+// this is a continuous enum, so we can rely on the array
 
-typedef std::vector<std::pair<METADATA, std::string>> METADATA_NAMES;
+using METADATA_NAMES = std::vector<std::pair<METADATA, std::string>>;
 
 class WindowsEventLogHandler {
  public:
@@ -71,9 +72,9 @@ class WindowsEventLogHandler {
   explicit WindowsEventLogHandler(EVT_HANDLE metadataProvider) : metadata_provider_(metadataProvider) {
   }
 
-  std::string getEventMessage(EVT_HANDLE eventHandle) const;
+  nonstd::expected<std::string, DWORD> getEventMessage(EVT_HANDLE eventHandle) const;
 
-  EVT_HANDLE getMetadata() const;
+  [[nodiscard]] EVT_HANDLE getMetadata() const;
 
  private:
   unique_evt_handle metadata_provider_;
@@ -82,8 +83,8 @@ class WindowsEventLogHandler {
 class WindowsEventLogMetadata {
  public:
   virtual ~WindowsEventLogMetadata() = default;
-  virtual std::string getEventData(EVT_FORMAT_MESSAGE_FLAGS flags) const = 0;
-  virtual std::string getEventTimestamp() const = 0;
+  [[nodiscard]] virtual std::string getEventData(EVT_FORMAT_MESSAGE_FLAGS flags) const = 0;
+  [[nodiscard]] virtual std::string getEventTimestamp() const = 0;
   virtual short getEventTypeIndex() const = 0;  // NOLINT short comes from WINDOWS API
 
   static std::string getMetadataString(METADATA val) {
@@ -146,20 +147,19 @@ class WindowsEventLogMetadata {
 
 class WindowsEventLogMetadataImpl : public WindowsEventLogMetadata {
  public:
-  WindowsEventLogMetadataImpl(EVT_HANDLE metadataProvider, EVT_HANDLE event_ptr) : metadata_ptr_(metadataProvider), event_timestamp_(0), event_ptr_(event_ptr) {
+  WindowsEventLogMetadataImpl(EVT_HANDLE metadataProvider, EVT_HANDLE event_ptr) : metadata_ptr_(metadataProvider), event_ptr_(event_ptr) {
     renderMetadata();
   }
 
-  std::string getEventData(EVT_FORMAT_MESSAGE_FLAGS flags) const override;
+  [[nodiscard]] std::string getEventData(EVT_FORMAT_MESSAGE_FLAGS flags) const override;
 
-  std::string getEventTimestamp() const override { return event_timestamp_str_; }
+  [[nodiscard]] std::string getEventTimestamp() const override { return event_timestamp_str_; }
 
   short getEventTypeIndex() const override { return event_type_index_; }  // NOLINT short comes from WINDOWS API
 
  private:
   void renderMetadata();
 
-  uint64_t event_timestamp_;
   std::string event_type_;
   short event_type_index_;  // NOLINT short comes from WINDOWS API
   std::string event_timestamp_str_;
@@ -169,33 +169,31 @@ class WindowsEventLogMetadataImpl : public WindowsEventLogMetadata {
 
 class WindowsEventLogHeader {
  public:
-  explicit WindowsEventLogHeader(METADATA_NAMES header_names) : header_names_(header_names) {}
-
-  void setDelimiter(const std::string& delim);
+  explicit WindowsEventLogHeader(const METADATA_NAMES& header_names, const std::optional<std::string>& custom_delimiter, size_t minimum_size);
 
   template<typename MetadataCollection>
   std::string getEventHeader(const MetadataCollection& metadata_collection) const;
 
+  [[nodiscard]] std::string getDelimiterFor(size_t length) const;
  private:
-  std::string createDefaultDelimiter(size_t max, size_t length) const;
+  [[nodiscard]] std::string createDefaultDelimiter(size_t length) const;
 
-  std::string delimiter_;
-  METADATA_NAMES header_names_;
+  const METADATA_NAMES& header_names_;
+  const std::optional<std::string>& custom_delimiter_;
+  const size_t longest_header_name_;
 };
 
 template<typename MetadataCollection>
 std::string WindowsEventLogHeader::getEventHeader(const MetadataCollection& metadata_collection) const {
   std::stringstream eventHeader;
-  size_t max = 1;
-  for (const auto& option : header_names_) {
-    max = (std::max(max, option.second.size()));
-  }
-  ++max;  // increment by one to get space.
+
   for (const auto& option : header_names_) {
     auto name = option.second;
-    if (!name.empty()) {
-      eventHeader << name << (delimiter_.empty() ? createDefaultDelimiter(max, name.size()) : delimiter_);
-    }
+    eventHeader << name;
+    if (custom_delimiter_)
+      eventHeader << *custom_delimiter_;
+    else
+      eventHeader << createDefaultDelimiter(name.size());
     eventHeader << utils::StringUtils::trim(metadata_collection(option.first)) << std::endl;
   }
 

--- a/extensions/windows-event-log/wel/WindowsEventLog.h
+++ b/extensions/windows-event-log/wel/WindowsEventLog.h
@@ -161,7 +161,7 @@ class WindowsEventLogMetadataImpl : public WindowsEventLogMetadata {
   void renderMetadata();
 
   std::string event_type_;
-  short event_type_index_;  // NOLINT short comes from WINDOWS API
+  short event_type_index_ = 0;  // NOLINT short comes from WINDOWS API
   std::string event_timestamp_str_;
   EVT_HANDLE event_ptr_;
   EVT_HANDLE metadata_ptr_;

--- a/libminifi/include/utils/OsUtils.h
+++ b/libminifi/include/utils/OsUtils.h
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <optional>
+#include <system_error>
 
 struct sockaddr;
 
@@ -39,7 +40,7 @@ int64_t getSystemTotalPhysicalMemory();
 /// Returns the total paging file size in bytes
 int64_t getTotalPagingFileSize();
 
-std::string getWindowsErrorAsString(unsigned long error_code);  // NOLINT [runtime/int]
+std::error_code windowsErrorToErrorCode(unsigned long error_code);  // NOLINT [runtime/int]
 #endif
 
 /// Returns the host architecture (e.g. x32, arm64)

--- a/libminifi/include/utils/OsUtils.h
+++ b/libminifi/include/utils/OsUtils.h
@@ -38,6 +38,8 @@ int64_t getSystemTotalPhysicalMemory();
 #ifdef WIN32
 /// Returns the total paging file size in bytes
 int64_t getTotalPagingFileSize();
+
+std::string getWindowsErrorAsString(unsigned long error_code);  // NOLINT [runtime/int]
 #endif
 
 /// Returns the host architecture (e.g. x32, arm64)

--- a/libminifi/src/utils/OsUtils.cpp
+++ b/libminifi/src/utils/OsUtils.cpp
@@ -285,20 +285,8 @@ int64_t OsUtils::getTotalPagingFileSize() {
   return total_paging_file_size;
 }
 
-std::string OsUtils::getWindowsErrorAsString(DWORD error_code) {
-  if (error_code == 0)
-    return "";
-
-  LPSTR message_buffer = nullptr;
-
-  size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                               nullptr, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                               (LPSTR)&message_buffer, 0, nullptr);
-
-  std::string message(message_buffer, size);
-
-  LocalFree(message_buffer);
-  return message;
+std::error_code OsUtils::windowsErrorToErrorCode(DWORD error_code) {
+  return {gsl::narrow_cast<int>(error_code), std::system_category()};
 }
 #endif
 

--- a/libminifi/src/utils/OsUtils.cpp
+++ b/libminifi/src/utils/OsUtils.cpp
@@ -284,6 +284,22 @@ int64_t OsUtils::getTotalPagingFileSize() {
   DWORDLONG total_paging_file_size = memory_info.ullTotalPageFile;
   return total_paging_file_size;
 }
+
+std::string OsUtils::getWindowsErrorAsString(DWORD error_code) {
+  if (error_code == 0)
+    return "";
+
+  LPSTR message_buffer = nullptr;
+
+  size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                               nullptr, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                               (LPSTR)&message_buffer, 0, nullptr);
+
+  std::string message(message_buffer, size);
+
+  LocalFree(message_buffer);
+  return message;
+}
 #endif
 
 std::string OsUtils::getMachineArchitecture() {


### PR DESCRIPTION
MINIFICPP-1956 ConsumeWindowsEventLog plaintext out should contain the EvtFormatMessage errors

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
