### PR TITLE
MINIFICPP-1952 Reset the callback when no longer needed

### DIFF
--- a/extensions/http-curl/processors/InvokeHTTP.cpp
+++ b/extensions/http-curl/processors/InvokeHTTP.cpp
@@ -334,6 +334,10 @@ void InvokeHTTP::onTriggerWithClient(const std::shared_ptr<core::ProcessContext>
 
   logger_->log_debug("onTrigger InvokeHTTP with %s to %s", client.getRequestMethod(), client.getURL());
 
+  const auto remove_callback_from_client_at_exit = gsl::finally([&client] {
+    client.setUploadCallback({});
+  });
+
   std::string transaction_id = utils::IdGenerator::getIdGenerator()->generate().to_string();
 
   if (shouldEmitFlowFile(client)) {


### PR DESCRIPTION
Without this, the callback would remain in the `HTTPClient` stored in the `ResourceQueue` in the `InvokeHTTP` processor, but the stream inside the callback would be pointing to a flow file resource claim which no longer exists.

This went mostly unnoticed, except in two of the test cases (`HTTPTestsResponseBodyinAttribute` and `HTTPTestsResponseBody`) in the MacOS CI job, which got stuck in the `InvokeHTTP` destructor.  Thanks, AppleClang!

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
