### PR TITLE
MINIFICPP-1977 Upgrade pybind11 to support Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Set up Lua
         uses: xpol/setup-lua@v0.3
       - id: install-sqliteodbc-driver

--- a/cmake/Pybind11.cmake
+++ b/cmake/Pybind11.cmake
@@ -18,8 +18,8 @@
 include(FetchContent)
 
 FetchContent_Declare(pybind11_src
-    URL      https://github.com/pybind/pybind11/archive/refs/tags/v2.7.0.tar.gz
-    URL_HASH SHA256=6cd73b3d0bf3daf415b5f9b87ca8817cc2e2b64c275d65f9500250f9fee1677e
+    URL      https://github.com/pybind/pybind11/archive/refs/tags/v2.10.1.tar.gz
+    URL_HASH SHA256=111014b516b625083bef701df7880f78c2243835abdb263065b6b59b960b6bad
 )
 FetchContent_GetProperties(pybind11_src)
 if (NOT pybind11_src_POPULATED)

--- a/extensions/script/CMakeLists.txt
+++ b/extensions/script/CMakeLists.txt
@@ -32,10 +32,7 @@ add_library(minifi-script-extensions SHARED ${SOURCES})
 target_link_libraries(minifi-script-extensions ${LIBMINIFI} Threads::Threads)
 
 if (NOT DISABLE_PYTHON_SCRIPTING)
-    find_package(PythonLibs 3.5)
-    if (NOT PYTHONLIBS_FOUND)
-        find_package(PythonLibs 3.0 REQUIRED)
-    endif()
+    find_package(PythonLibs 3.6 REQUIRED)
 
     include(Pybind11)
     add_definitions(-DPYTHON_SUPPORT)

--- a/extensions/script/tests/CMakeLists.txt
+++ b/extensions/script/tests/CMakeLists.txt
@@ -21,11 +21,7 @@ if (NOT DISABLE_PYTHON_SCRIPTING)
     file(GLOB EXECUTESCRIPT_PYTHON_TESTS  "TestExecuteScriptProcessorWithPythonScript.cpp" "PythonScriptEngineTests.cpp" "PythonManifestTests.cpp")
     file(GLOB EXECUTEPYTHONPROCESSOR_UNIT_TESTS  "ExecutePythonProcessorTests.cpp")
     file(GLOB PY_SOURCES  "python/*.cpp")
-    find_package(PythonLibs 3.5)
-    if (NOT PYTHONLIBS_FOUND)
-        find_package(PythonLibs 3.0 REQUIRED)
-    endif()
-    file(COPY "${CMAKE_SOURCE_DIR}/extensions/script/tests/test_python_scripts" DESTINATION "${CMAKE_BINARY_DIR}/bin/")
+    find_package(PythonLibs 3.6 REQUIRED)
 endif()
 
 if (ENABLE_LUA_SCRIPTING)
@@ -49,6 +45,17 @@ FOREACH(testfile ${EXECUTESCRIPT_PYTHON_TESTS})
     createTests("${testfilename}")
     MATH(EXPR EXTENSIONS_TEST_COUNT "${EXTENSIONS_TEST_COUNT}+1")
     add_test(NAME "${testfilename}" COMMAND "${testfilename}" WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+    if(EXTENSIONS_TEST_COUNT EQUAL 1)
+        # Copy test resources
+        add_custom_command(
+            TARGET "${testfilename}"
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+                    "${CMAKE_SOURCE_DIR}/extensions/script/tests/test_python_scripts"
+                    "$<TARGET_FILE_DIR:${testfilename}>/test_python_scripts"
+            )
+    endif()
 ENDFOREACH()
 
 FOREACH(testfile ${EXECUTEPYTHONPROCESSOR_UNIT_TESTS})
@@ -73,6 +80,17 @@ FOREACH(testfile ${EXECUTEPYTHONPROCESSOR_UNIT_TESTS})
     createTests("${testfilename}")
     add_test(NAME "${testfilename}" COMMAND "${testfilename}"  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     MATH(EXPR EXTENSIONS_TEST_COUNT "${EXTENSIONS_TEST_COUNT}+1")
+
+    if(EXTENSIONS_TEST_COUNT EQUAL 1)
+        # Copy test resources
+        add_custom_command(
+            TARGET "${testfilename}"
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+                    "${CMAKE_SOURCE_DIR}/extensions/script/tests/test_python_scripts"
+                    "$<TARGET_FILE_DIR:${testfilename}>/test_python_scripts"
+            )
+    endif()
 ENDFOREACH()
 
 FOREACH(testfile ${EXECUTESCRIPT_LUA_TESTS})

--- a/extensions/script/tests/CMakeLists.txt
+++ b/extensions/script/tests/CMakeLists.txt
@@ -46,8 +46,8 @@ FOREACH(testfile ${EXECUTESCRIPT_PYTHON_TESTS})
     MATH(EXPR EXTENSIONS_TEST_COUNT "${EXTENSIONS_TEST_COUNT}+1")
     add_test(NAME "${testfilename}" COMMAND "${testfilename}" WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
+    # Copy test resources only once after the first build to be available for all test cases
     if(EXTENSIONS_TEST_COUNT EQUAL 1)
-        # Copy test resources
         add_custom_command(
             TARGET "${testfilename}"
             POST_BUILD
@@ -81,8 +81,8 @@ FOREACH(testfile ${EXECUTEPYTHONPROCESSOR_UNIT_TESTS})
     add_test(NAME "${testfilename}" COMMAND "${testfilename}"  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     MATH(EXPR EXTENSIONS_TEST_COUNT "${EXTENSIONS_TEST_COUNT}+1")
 
+    # Copy test resources only once after the first build to be available for all test cases
     if(EXTENSIONS_TEST_COUNT EQUAL 1)
-        # Copy test resources
         add_custom_command(
             TARGET "${testfilename}"
             POST_BUILD

--- a/extensions/script/tests/ExecutePythonProcessorTests.cpp
+++ b/extensions/script/tests/ExecutePythonProcessorTests.cpp
@@ -47,7 +47,7 @@ class ExecutePythonProcessorTestBase {
     std::string path;
     std::string filename;
     getFileNameAndPath(__FILE__, path, filename);
-    SCRIPT_FILES_DIRECTORY = getFullPath(concat_path(path, "test_python_scripts"));
+    SCRIPT_FILES_DIRECTORY = getFullPath(concat_path(minifi::utils::file::FileUtils::get_executable_dir(), "test_python_scripts"));
     reInitialize();
   }
   virtual ~ExecutePythonProcessorTestBase() {

--- a/extensions/script/tests/TestExecuteScriptProcessorWithPythonScript.cpp
+++ b/extensions/script/tests/TestExecuteScriptProcessorWithPythonScript.cpp
@@ -358,11 +358,7 @@ TEST_CASE("Python: Test Module Directory property", "[executescriptPythonModuleD
   logTestController.setDebug<TestPlan>();
   logTestController.setDebug<minifi::processors::ExecuteScript>();
 
-  std::string path;
-  std::string filename;
-  minifi::utils::file::getFileNameAndPath(__FILE__, path, filename);
-  const std::string SCRIPT_FILES_DIRECTORY = minifi::utils::file::getFullPath(concat_path(path, "test_python_scripts"));
-
+  const std::string SCRIPT_FILES_DIRECTORY = minifi::utils::file::getFullPath(concat_path(minifi::utils::file::FileUtils::get_executable_dir(), "test_python_scripts"));
   auto getScriptFullPath = [&SCRIPT_FILES_DIRECTORY](const std::string& script_file_name) {
     return concat_path(SCRIPT_FILES_DIRECTORY, script_file_name);
   };

--- a/extensions/standard-processors/tests/CMakeLists.txt
+++ b/extensions/standard-processors/tests/CMakeLists.txt
@@ -48,14 +48,16 @@ FOREACH(testfile ${PROCESSOR_UNIT_TESTS})
 
     MATH(EXPR PROCESSOR_INT_TEST_COUNT "${PROCESSOR_INT_TEST_COUNT}+1")
 
-    # Copy test resources
-    add_custom_command(
-        TARGET "${testfilename}"
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-                "${CMAKE_SOURCE_DIR}/extensions/standard-processors/tests/unit/resources"
-                "$<TARGET_FILE_DIR:${testfilename}>/resources"
-        )
+    if(PROCESSOR_INT_TEST_COUNT EQUAL 1)
+        # Copy test resources
+        add_custom_command(
+            TARGET "${testfilename}"
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+                    "${CMAKE_SOURCE_DIR}/extensions/standard-processors/tests/unit/resources"
+                    "$<TARGET_FILE_DIR:${testfilename}>/resources"
+            )
+    endif()
 ENDFOREACH()
 
 message("-- Finished building ${PROCESSOR_INT_TEST_COUNT} processor unit test file(s)...")

--- a/extensions/standard-processors/tests/CMakeLists.txt
+++ b/extensions/standard-processors/tests/CMakeLists.txt
@@ -48,8 +48,8 @@ FOREACH(testfile ${PROCESSOR_UNIT_TESTS})
 
     MATH(EXPR PROCESSOR_INT_TEST_COUNT "${PROCESSOR_INT_TEST_COUNT}+1")
 
+    # Copy test resources only once after the first build to be available for all test cases
     if(PROCESSOR_INT_TEST_COUNT EQUAL 1)
-        # Copy test resources
         add_custom_command(
             TARGET "${testfilename}"
             POST_BUILD

--- a/win_build_vs.bat
+++ b/win_build_vs.bat
@@ -107,11 +107,13 @@ pushd %builddir%\
 
 if [%generator%] EQU ["Ninja"] (
     set "buildcmd=ninja && copy bin\minifi.exe minifi_main\"
+    set "build_platform_cmd="
 ) else (
     set "buildcmd=msbuild /m nifi-minifi-cpp.sln /property:Configuration=%cmake_build_type% /property:Platform=%build_platform% && copy bin\%cmake_build_type%\minifi.exe minifi_main\"
+    set "build_platform_cmd=-A %build_platform%"
 )
 echo on
-cmake -G %generator% -A %build_platform% -DINSTALLER_MERGE_MODULES=%installer_merge_modules% -DTEST_CUSTOM_WEL_PROVIDER=%test_custom_wel_provider% -DENABLE_SQL=%build_SQL% -DUSE_REAL_ODBC_TEST_DRIVER=%real_odbc% ^
+cmake -G %generator% %build_platform_cmd% -DINSTALLER_MERGE_MODULES=%installer_merge_modules% -DTEST_CUSTOM_WEL_PROVIDER=%test_custom_wel_provider% -DENABLE_SQL=%build_SQL% -DUSE_REAL_ODBC_TEST_DRIVER=%real_odbc% ^
         -DCMAKE_BUILD_TYPE_INIT=%cmake_build_type% -DCMAKE_BUILD_TYPE=%cmake_build_type% -DWIN32=WIN32 -DENABLE_LIBRDKAFKA=%build_kafka% -DENABLE_JNI=%build_jni% -DOPENSSL_OFF=OFF ^
         -DENABLE_COAP=%build_coap% -DENABLE_AWS=%build_AWS% -DENABLE_PDH=%build_PDH% -DENABLE_AZURE=%build_azure% -DENABLE_SFTP=%build_SFTP% -DENABLE_SPLUNK=%build_SPLUNK% -DENABLE_GCP=%build_GCP% ^
         -DENABLE_NANOFI=%build_nanofi% -DENABLE_OPENCV=%build_opencv% -DENABLE_PROMETHEUS=%build_prometheus% -DENABLE_ELASTICSEARCH=%build_ELASTIC% -DUSE_SHARED_LIBS=OFF -DDISABLE_CONTROLLER=ON  ^


### PR DESCRIPTION
Pybind11 implemented support for Python 3.11 in version 2.10.1: https://pybind11.readthedocs.io/en/stable/changelog.html#version-2-10-1-oct-31-2022

Upgraded to this version to avoid CI and other build failures using Python 3.11 libs.

https://issues.apache.org/jira/browse/MINIFICPP-1977

-----------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
