### PR TITLE
MINIFICPP-1815 - PersistenceTests transiently fails

### DIFF
--- a/libminifi/include/core/ThreadedRepository.h
+++ b/libminifi/include/core/ThreadedRepository.h
@@ -51,8 +51,10 @@ class ThreadedRepository : public core::Repository, public core::TraceableResour
       running_state_.store(RunningState::Running);
       return true;
     }
-    getThread() = std::thread(&ThreadedRepository::run, this);
+
+    // must set Running state before calling run(), as run() might check state
     running_state_.store(RunningState::Running);
+    getThread() = std::thread(&ThreadedRepository::run, this);
 
     logger_->log_debug("%s ThreadedRepository monitor thread start", name_);
     return true;


### PR DESCRIPTION
`FlowFileRepository::run` is called on an own thread from `ThreadedRepository::start`. With bad luck in scheduling, it could be called earlier than Running state was set, resulting in not calling `FlowFileRepository::prune_stored_flowfiles`, and not restoring stored Flow Files.

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
