### PR TITLE
MINIFICPP-2003 Fix PutTCPTests platform dependent message check

### DIFF
--- a/extensions/standard-processors/tests/unit/PutTCPTests.cpp
+++ b/extensions/standard-processors/tests/unit/PutTCPTests.cpp
@@ -414,7 +414,8 @@ TEST_CASE("PutTCP test non-routable server", "[PutTCP]") {
 
   CHECK((LogTestController::getInstance().contains("Connection timed out", 0ms)
       || LogTestController::getInstance().contains("Operation timed out", 0ms)
-      || LogTestController::getInstance().contains("host has failed to respond", 0ms)));
+      || LogTestController::getInstance().contains("host has failed to respond", 0ms)
+      || LogTestController::getInstance().contains("No route to host", 0ms)));
 }
 
 TEST_CASE("PutTCP test invalid server cert", "[PutTCP]") {


### PR DESCRIPTION
Added "No route to host" for ubuntu 22.04

https://issues.apache.org/jira/browse/MINIFICPP-2003

-------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
