### PR TITLE
MINIFICPP-2012 - Make free unconditional

### DIFF
--- a/libminifi/src/utils/OsUtils.cpp
+++ b/libminifi/src/utils/OsUtils.cpp
@@ -147,7 +147,6 @@ std::string OsUtils::userIdToUsername(const std::string &uid) {
           }
         }
         GlobalFree(windowsAccount);
-        if (dwwindowsDomainSize > 0)
         GlobalFree(windowsDomain);
       }
     }

--- a/libminifi/test/unit/OsUtilTests.cpp
+++ b/libminifi/test/unit/OsUtilTests.cpp
@@ -25,16 +25,19 @@ namespace org::apache::nifi::minifi::test {
 
 #ifdef WIN32
 TEST_CASE("Test userIdToUsername for well-known SIDs", "[OsUtils]") {
-  CHECK("Nobody" == minifi::utils::OsUtils::userIdToUsername("S-1-0-0"));
-  CHECK("Everyone" == minifi::utils::OsUtils::userIdToUsername("S-1-1-0"));
-  CHECK("Local" == minifi::utils::OsUtils::userIdToUsername("S-1-2-0"));
-  CHECK("Console Logon" == minifi::utils::OsUtils::userIdToUsername("S-1-2-1"));
-  CHECK("Creator Owner" == minifi::utils::OsUtils::userIdToUsername("S-1-3-0"));
-  CHECK("Creator Group" == minifi::utils::OsUtils::userIdToUsername("S-1-3-1"));
-  CHECK("CREATOR OWNER SERVER" == minifi::utils::OsUtils::userIdToUsername("S-1-3-2"));
-  CHECK("CREATOR GROUP SERVER" == minifi::utils::OsUtils::userIdToUsername("S-1-3-3"));
-  CHECK("OWNER RIGHTS" == minifi::utils::OsUtils::userIdToUsername("S-1-3-4"));
-  CHECK("NT SERVICE\\ALL SERVICES" == minifi::utils::OsUtils::userIdToUsername("S-1-5-80-0"));
+  // this test also verifies the fix for a memory leak found in userIdToUsername
+  // if ran through drmemory, due to localization dependence we only check for non-emptiness
+  // and these tests should be revised in MINIFICPP-2013
+  CHECK_FALSE(minifi::utils::OsUtils::userIdToUsername("S-1-0-0").empty());
+  CHECK_FALSE(minifi::utils::OsUtils::userIdToUsername("S-1-1-0").empty());
+  CHECK_FALSE(minifi::utils::OsUtils::userIdToUsername("S-1-2-0").empty());
+  CHECK_FALSE(minifi::utils::OsUtils::userIdToUsername("S-1-2-1").empty());
+  CHECK_FALSE(minifi::utils::OsUtils::userIdToUsername("S-1-3-0").empty());
+  CHECK_FALSE(minifi::utils::OsUtils::userIdToUsername("S-1-3-1").empty());
+  CHECK_FALSE(minifi::utils::OsUtils::userIdToUsername("S-1-3-2").empty());
+  CHECK_FALSE(minifi::utils::OsUtils::userIdToUsername("S-1-3-3").empty());
+  CHECK_FALSE(minifi::utils::OsUtils::userIdToUsername("S-1-3-4").empty());
+  CHECK_FALSE(minifi::utils::OsUtils::userIdToUsername("S-1-5-80-0").empty());
 }
 #endif
 


### PR DESCRIPTION
Root cause:

We first query the size of the required buffer with
```
LookupAccountSid(NULL /** local computer **/, pSidOwner,
          windowsAccount,
          (LPDWORD)&windowsAccountNameSize,
          windowsDomain,
          (LPDWORD)&dwwindowsDomainSize,
          &sidType);
```

Then we allocate the appropriately sized buffers with `GlobalAlloc`. The size provided by `LookupAccountSid` includes
the `\0` terminator.

We then extract the account and domain into these buffers, and we also provide the size of buffers,
BUT `LookupAccountSid` again writes into the size variables, the length of the string written but this
time WITHOUT the `\0` terminator.

We then conditionally free one of the buffers:
```
 if (dwwindowsDomainSize > 0)
   GlobalFree(windowsDomain);
```

If the domain is empty, the first query returns `1`, we allocate the buffer, then the second query rewrites it to `0`, causing
the free to be skipped, leaking the buffer.

---
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
