### PR TITLE
MINIFICPP-1948 Add the UUID to the end of Processor and Controller Service log lines

### DIFF
--- a/conf/minifi-log.properties
+++ b/conf/minifi-log.properties
@@ -49,6 +49,9 @@ appender.rolling.max_file_size=5242880
 #appender.alert1.level=TRACE
 #appender.alert1.ssl.context.service=<Name of the SSLContextService>
 
+# Uncomment if you do not want to include the UUID of the component at the end of log lines
+#logger.include.uuid=false
+
 logger.root=INFO,rolling
 
 #Logging configurable by namespace

--- a/docker/conf/minifi-log.properties
+++ b/docker/conf/minifi-log.properties
@@ -38,6 +38,9 @@ appender.stderr=stderr
 ## The syslog appender will log using syslog(3) on *nix, and to the Windows Event Log on Windows
 #appender.syslog=syslog
 
+# Uncomment if you do not want to include the UUID of the component at the end of log lines
+#logger.include.uuid=false
+
 logger.root=INFO,stderr
 
 #Logging configurable by namespace

--- a/extensions/aws/processors/DeleteS3Object.h
+++ b/extensions/aws/processors/DeleteS3Object.h
@@ -57,7 +57,7 @@ class DeleteS3Object : public S3Processor {
   ADD_COMMON_VIRTUAL_FUNCTIONS_FOR_PROCESSORS
 
   explicit DeleteS3Object(const std::string& name, const minifi::utils::Identifier& uuid = minifi::utils::Identifier())
-    : S3Processor(name, uuid, core::logging::LoggerFactory<DeleteS3Object>::getLogger()) {
+    : S3Processor(name, uuid, core::logging::LoggerFactory<DeleteS3Object>::getLogger(uuid)) {
   }
 
   ~DeleteS3Object() override = default;
@@ -69,7 +69,7 @@ class DeleteS3Object : public S3Processor {
   friend class ::S3TestsFixture<DeleteS3Object>;
 
   explicit DeleteS3Object(std::string name, const minifi::utils::Identifier& uuid, std::unique_ptr<aws::s3::S3RequestSender> s3_request_sender)
-    : S3Processor(std::move(name), uuid, core::logging::LoggerFactory<DeleteS3Object>::getLogger(), std::move(s3_request_sender)) {
+    : S3Processor(std::move(name), uuid, core::logging::LoggerFactory<DeleteS3Object>::getLogger(uuid), std::move(s3_request_sender)) {
   }
 
   std::optional<aws::s3::DeleteObjectRequestParameters> buildDeleteS3RequestParams(

--- a/extensions/aws/processors/FetchS3Object.h
+++ b/extensions/aws/processors/FetchS3Object.h
@@ -61,7 +61,7 @@ class FetchS3Object : public S3Processor {
   ADD_COMMON_VIRTUAL_FUNCTIONS_FOR_PROCESSORS
 
   explicit FetchS3Object(std::string name, const minifi::utils::Identifier& uuid = minifi::utils::Identifier())
-    : S3Processor(std::move(name), uuid, core::logging::LoggerFactory<FetchS3Object>::getLogger()) {
+    : S3Processor(std::move(name), uuid, core::logging::LoggerFactory<FetchS3Object>::getLogger(uuid)) {
   }
 
   ~FetchS3Object() override = default;
@@ -74,7 +74,7 @@ class FetchS3Object : public S3Processor {
   friend class ::S3TestsFixture<FetchS3Object>;
 
   explicit FetchS3Object(const std::string& name, const minifi::utils::Identifier& uuid, std::unique_ptr<aws::s3::S3RequestSender> s3_request_sender)
-    : S3Processor(name, uuid, core::logging::LoggerFactory<FetchS3Object>::getLogger(), std::move(s3_request_sender)) {
+    : S3Processor(name, uuid, core::logging::LoggerFactory<FetchS3Object>::getLogger(uuid), std::move(s3_request_sender)) {
   }
 
   std::optional<aws::s3::GetObjectRequestParameters> buildFetchS3RequestParams(

--- a/extensions/aws/processors/ListS3.h
+++ b/extensions/aws/processors/ListS3.h
@@ -63,10 +63,10 @@ class ListS3 : public S3Processor {
   ADD_COMMON_VIRTUAL_FUNCTIONS_FOR_PROCESSORS
 
   explicit ListS3(std::string name, const minifi::utils::Identifier& uuid = minifi::utils::Identifier())
-    : S3Processor(std::move(name), uuid, core::logging::LoggerFactory<ListS3>::getLogger()) {
+    : S3Processor(std::move(name), uuid, core::logging::LoggerFactory<ListS3>::getLogger(uuid)) {
   }
   explicit ListS3(const std::string& name, minifi::utils::Identifier uuid, std::unique_ptr<aws::s3::S3RequestSender> s3_request_sender)
-    : S3Processor(name, uuid, core::logging::LoggerFactory<ListS3>::getLogger(), std::move(s3_request_sender)) {
+    : S3Processor(name, uuid, core::logging::LoggerFactory<ListS3>::getLogger(uuid), std::move(s3_request_sender)) {
   }
 
   ~ListS3() override = default;

--- a/extensions/aws/processors/PutS3Object.h
+++ b/extensions/aws/processors/PutS3Object.h
@@ -81,7 +81,7 @@ class PutS3Object : public S3Processor {
   ADD_COMMON_VIRTUAL_FUNCTIONS_FOR_PROCESSORS
 
   explicit PutS3Object(std::string name, const minifi::utils::Identifier& uuid = minifi::utils::Identifier())
-    : S3Processor(std::move(name), uuid, core::logging::LoggerFactory<PutS3Object>::getLogger()) {
+    : S3Processor(std::move(name), uuid, core::logging::LoggerFactory<PutS3Object>::getLogger(uuid)) {
   }
 
   ~PutS3Object() override = default;
@@ -137,7 +137,7 @@ class PutS3Object : public S3Processor {
   friend class ::S3TestsFixture<PutS3Object>;
 
   explicit PutS3Object(const std::string& name, const minifi::utils::Identifier& uuid, std::unique_ptr<aws::s3::S3RequestSender> s3_request_sender)
-    : S3Processor(name, uuid, core::logging::LoggerFactory<PutS3Object>::getLogger(), std::move(s3_request_sender)) {
+    : S3Processor(name, uuid, core::logging::LoggerFactory<PutS3Object>::getLogger(uuid), std::move(s3_request_sender)) {
   }
 
   void fillUserMetadata(const std::shared_ptr<core::ProcessContext> &context);

--- a/extensions/aws/processors/S3Processor.cpp
+++ b/extensions/aws/processors/S3Processor.cpp
@@ -18,7 +18,6 @@
 #include "S3Processor.h"
 
 #include <string>
-#include <set>
 #include <memory>
 #include <utility>
 
@@ -35,8 +34,8 @@ S3Processor::S3Processor(std::string name, const minifi::utils::Identifier& uuid
     logger_(std::move(logger)) {
 }
 
-S3Processor::S3Processor(const std::string& name, const minifi::utils::Identifier& uuid, std::shared_ptr<core::logging::Logger> logger, std::unique_ptr<aws::s3::S3RequestSender> s3_request_sender)
-  : core::Processor(name, uuid),
+S3Processor::S3Processor(std::string name, const minifi::utils::Identifier& uuid, std::shared_ptr<core::logging::Logger> logger, std::unique_ptr<aws::s3::S3RequestSender> s3_request_sender)
+  : core::Processor(std::move(name), uuid),
     logger_(std::move(logger)),
     s3_wrapper_(std::move(s3_request_sender)) {
 }

--- a/extensions/aws/processors/S3Processor.h
+++ b/extensions/aws/processors/S3Processor.h
@@ -116,7 +116,7 @@ class S3Processor : public core::Processor {
   void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
 
  protected:
-  explicit S3Processor(const std::string& name, const minifi::utils::Identifier& uuid, std::shared_ptr<core::logging::Logger> logger, std::unique_ptr<aws::s3::S3RequestSender> s3_request_sender);
+  explicit S3Processor(std::string name, const minifi::utils::Identifier& uuid, std::shared_ptr<core::logging::Logger> logger, std::unique_ptr<aws::s3::S3RequestSender> s3_request_sender);
 
   std::optional<Aws::Auth::AWSCredentials> getAWSCredentialsFromControllerService(const std::shared_ptr<core::ProcessContext> &context) const;
   std::optional<Aws::Auth::AWSCredentials> getAWSCredentials(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::FlowFile> &flow_file);

--- a/extensions/azure/controllerservices/AzureStorageCredentialsService.h
+++ b/extensions/azure/controllerservices/AzureStorageCredentialsService.h
@@ -82,7 +82,7 @@ class AzureStorageCredentialsService : public core::controller::ControllerServic
 
  private:
   storage::AzureStorageCredentials credentials_;
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<AzureStorageCredentialsService>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<AzureStorageCredentialsService>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::azure::controllers

--- a/extensions/azure/processors/AzureBlobStorageProcessorBase.h
+++ b/extensions/azure/processors/AzureBlobStorageProcessorBase.h
@@ -55,10 +55,6 @@ class AzureBlobStorageProcessorBase : public AzureStorageProcessorBase {
     });
   }
 
-  explicit AzureBlobStorageProcessorBase(std::string name, const minifi::utils::Identifier& uuid, const std::shared_ptr<core::logging::Logger>& logger)
-    : AzureBlobStorageProcessorBase(std::move(name), uuid, logger, nullptr) {
-  }
-
   void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
 
  protected:

--- a/extensions/azure/processors/AzureBlobStorageSingleBlobProcessorBase.h
+++ b/extensions/azure/processors/AzureBlobStorageSingleBlobProcessorBase.h
@@ -37,10 +37,6 @@ class AzureBlobStorageSingleBlobProcessorBase : public AzureBlobStorageProcessor
     return utils::array_cat(AzureBlobStorageProcessorBase::properties(), std::array{Blob});
   }
 
-  explicit AzureBlobStorageSingleBlobProcessorBase(std::string name, const minifi::utils::Identifier& uuid, const std::shared_ptr<core::logging::Logger>& logger)
-    : AzureBlobStorageSingleBlobProcessorBase(std::move(name), uuid, logger, nullptr) {
-  }
-
  protected:
   explicit AzureBlobStorageSingleBlobProcessorBase(
     std::string name,

--- a/extensions/azure/processors/DeleteAzureDataLakeStorage.h
+++ b/extensions/azure/processors/DeleteAzureDataLakeStorage.h
@@ -49,7 +49,7 @@ class DeleteAzureDataLakeStorage final : public AzureDataLakeStorageFileProcesso
   ADD_COMMON_VIRTUAL_FUNCTIONS_FOR_PROCESSORS
 
   explicit DeleteAzureDataLakeStorage(std::string name, const minifi::utils::Identifier& uuid = minifi::utils::Identifier())
-    : AzureDataLakeStorageFileProcessorBase(std::move(name), uuid, core::logging::LoggerFactory<DeleteAzureDataLakeStorage>::getLogger()) {
+    : AzureDataLakeStorageFileProcessorBase(std::move(name), uuid, core::logging::LoggerFactory<DeleteAzureDataLakeStorage>::getLogger(uuid)) {
   }
 
   ~DeleteAzureDataLakeStorage() override = default;

--- a/extensions/azure/processors/FetchAzureDataLakeStorage.h
+++ b/extensions/azure/processors/FetchAzureDataLakeStorage.h
@@ -57,7 +57,7 @@ class FetchAzureDataLakeStorage final : public AzureDataLakeStorageFileProcessor
   ADD_COMMON_VIRTUAL_FUNCTIONS_FOR_PROCESSORS
 
   explicit FetchAzureDataLakeStorage(std::string name, const minifi::utils::Identifier& uuid = minifi::utils::Identifier())
-    : AzureDataLakeStorageFileProcessorBase(std::move(name), uuid, core::logging::LoggerFactory<FetchAzureDataLakeStorage>::getLogger()) {
+    : AzureDataLakeStorageFileProcessorBase(std::move(name), uuid, core::logging::LoggerFactory<FetchAzureDataLakeStorage>::getLogger(uuid)) {
   }
 
   ~FetchAzureDataLakeStorage() override = default;

--- a/extensions/azure/processors/ListAzureBlobStorage.h
+++ b/extensions/azure/processors/ListAzureBlobStorage.h
@@ -65,7 +65,7 @@ class ListAzureBlobStorage final : public AzureBlobStorageProcessorBase {
   }
 
   explicit ListAzureBlobStorage(std::string name, std::unique_ptr<storage::BlobStorageClient> blob_storage_client, const minifi::utils::Identifier& uuid = minifi::utils::Identifier())
-    : AzureBlobStorageProcessorBase(std::move(name), uuid, core::logging::LoggerFactory<ListAzureBlobStorage>::getLogger(), std::move(blob_storage_client)) {
+    : AzureBlobStorageProcessorBase(std::move(name), uuid, core::logging::LoggerFactory<ListAzureBlobStorage>::getLogger(uuid), std::move(blob_storage_client)) {
   }
 
   void initialize() override;

--- a/extensions/azure/processors/ListAzureDataLakeStorage.h
+++ b/extensions/azure/processors/ListAzureDataLakeStorage.h
@@ -64,7 +64,7 @@ class ListAzureDataLakeStorage final : public AzureDataLakeStorageProcessorBase 
   ADD_COMMON_VIRTUAL_FUNCTIONS_FOR_PROCESSORS
 
   explicit ListAzureDataLakeStorage(std::string name, const minifi::utils::Identifier& uuid = minifi::utils::Identifier())
-    : AzureDataLakeStorageProcessorBase(std::move(name), uuid, core::logging::LoggerFactory<ListAzureDataLakeStorage>::getLogger()) {
+    : AzureDataLakeStorageProcessorBase(std::move(name), uuid, core::logging::LoggerFactory<ListAzureDataLakeStorage>::getLogger(uuid)) {
   }
 
   ~ListAzureDataLakeStorage() override = default;
@@ -77,7 +77,7 @@ class ListAzureDataLakeStorage final : public AzureDataLakeStorageProcessorBase 
   friend class ::ListAzureDataLakeStorageTestsFixture;
 
   explicit ListAzureDataLakeStorage(std::string name, const minifi::utils::Identifier& uuid, std::unique_ptr<storage::DataLakeStorageClient> data_lake_storage_client)
-    : AzureDataLakeStorageProcessorBase(std::move(name), uuid, core::logging::LoggerFactory<ListAzureDataLakeStorage>::getLogger(), std::move(data_lake_storage_client)) {
+    : AzureDataLakeStorageProcessorBase(std::move(name), uuid, core::logging::LoggerFactory<ListAzureDataLakeStorage>::getLogger(uuid), std::move(data_lake_storage_client)) {
   }
 
   std::optional<storage::ListAzureDataLakeStorageParameters> buildListParameters(core::ProcessContext& context);

--- a/extensions/bustache/ApplyTemplate.h
+++ b/extensions/bustache/ApplyTemplate.h
@@ -57,7 +57,7 @@ class ApplyTemplate : public core::Processor {
   void initialize() override;
 
  private:
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ApplyTemplate>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ApplyTemplate>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/civetweb/processors/ListenHTTP.h
+++ b/extensions/civetweb/processors/ListenHTTP.h
@@ -43,8 +43,7 @@ class ListenHTTP : public core::Processor {
   using FlowFileBufferPair = std::pair<std::shared_ptr<FlowFileRecord>, std::unique_ptr<io::BufferStream>>;
 
   explicit ListenHTTP(std::string name, const utils::Identifier& uuid = {})
-      : Processor(std::move(name), uuid),
-        batch_size_(0) {
+      : Processor(std::move(name), uuid) {
     callbacks_.log_message = &logMessage;
     callbacks_.log_access = &logAccess;
   }
@@ -190,12 +189,12 @@ class ListenHTTP : public core::Processor {
   bool processIncomingFlowFile(core::ProcessSession &session);
   bool processRequestBuffer(core::ProcessSession &session);
 
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ListenHTTP>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ListenHTTP>::getLogger(uuid_);
   CivetCallbacks callbacks_;
   std::unique_ptr<CivetServer> server_;
   std::unique_ptr<Handler> handler_;
   std::string listeningPort;
-  uint64_t batch_size_;
+  uint64_t batch_size_{0};
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/elasticsearch/ElasticsearchCredentialsControllerService.h
+++ b/extensions/elasticsearch/ElasticsearchCredentialsControllerService.h
@@ -68,6 +68,6 @@ class ElasticsearchCredentialsControllerService : public core::controller::Contr
  private:
   std::optional<std::pair<std::string, std::string>> username_password_;
   std::optional<std::string> api_key_;
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ElasticsearchCredentialsControllerService>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ElasticsearchCredentialsControllerService>::getLogger(uuid_);
 };
 }  //  namespace org::apache::nifi::minifi::extensions::elasticsearch

--- a/extensions/elasticsearch/PostElasticsearch.h
+++ b/extensions/elasticsearch/PostElasticsearch.h
@@ -85,7 +85,7 @@ class PostElasticsearch : public core::Processor {
   std::string host_url_;
   std::shared_ptr<ElasticsearchCredentialsControllerService> credentials_service_;
   curl::HTTPClient client_;
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<PostElasticsearch>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<PostElasticsearch>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::extensions::elasticsearch

--- a/extensions/gcp/controllerservices/GCPCredentialsControllerService.h
+++ b/extensions/gcp/controllerservices/GCPCredentialsControllerService.h
@@ -80,6 +80,6 @@ class GCPCredentialsControllerService : public core::controller::ControllerServi
 
 
   std::shared_ptr<google::cloud::storage::oauth2::Credentials> credentials_;
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<GCPCredentialsControllerService>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<GCPCredentialsControllerService>::getLogger(uuid_);
 };
 }  // namespace org::apache::nifi::minifi::extensions::gcp

--- a/extensions/gcp/processors/DeleteGCSObject.h
+++ b/extensions/gcp/processors/DeleteGCSObject.h
@@ -30,7 +30,7 @@ namespace org::apache::nifi::minifi::extensions::gcp {
 class DeleteGCSObject : public GCSProcessor {
  public:
   explicit DeleteGCSObject(std::string name, const utils::Identifier& uuid = {})
-      : GCSProcessor(std::move(name), uuid, core::logging::LoggerFactory<DeleteGCSObject>::getLogger()) {
+      : GCSProcessor(std::move(name), uuid, core::logging::LoggerFactory<DeleteGCSObject>::getLogger(uuid)) {
   }
   ~DeleteGCSObject() override = default;
 

--- a/extensions/gcp/processors/FetchGCSObject.h
+++ b/extensions/gcp/processors/FetchGCSObject.h
@@ -31,7 +31,7 @@ namespace org::apache::nifi::minifi::extensions::gcp {
 class FetchGCSObject : public GCSProcessor {
  public:
   explicit FetchGCSObject(std::string name, const utils::Identifier& uuid = {})
-      : GCSProcessor(std::move(name), uuid, core::logging::LoggerFactory<FetchGCSObject>::getLogger()) {
+      : GCSProcessor(std::move(name), uuid, core::logging::LoggerFactory<FetchGCSObject>::getLogger(uuid)) {
   }
   ~FetchGCSObject() override = default;
 

--- a/extensions/gcp/processors/ListGCSBucket.h
+++ b/extensions/gcp/processors/ListGCSBucket.h
@@ -30,7 +30,7 @@ namespace org::apache::nifi::minifi::extensions::gcp {
 class ListGCSBucket : public GCSProcessor {
  public:
   explicit ListGCSBucket(std::string name, const utils::Identifier& uuid = {})
-      : GCSProcessor(std::move(name), uuid, core::logging::LoggerFactory<ListGCSBucket>::getLogger()) {
+      : GCSProcessor(std::move(name), uuid, core::logging::LoggerFactory<ListGCSBucket>::getLogger(uuid)) {
   }
   ~ListGCSBucket() override = default;
 

--- a/extensions/gcp/processors/PutGCSObject.h
+++ b/extensions/gcp/processors/PutGCSObject.h
@@ -41,7 +41,7 @@ class PutGCSObject : public GCSProcessor {
              (PUBLIC_READ_WRITE, "publicReadWrite"));
 
   explicit PutGCSObject(std::string name, const utils::Identifier& uuid = {})
-      : GCSProcessor(std::move(name), uuid, core::logging::LoggerFactory<PutGCSObject>::getLogger()) {
+      : GCSProcessor(std::move(name), uuid, core::logging::LoggerFactory<PutGCSObject>::getLogger(uuid)) {
   }
   ~PutGCSObject() override = default;
 

--- a/extensions/gps/GetGPS.h
+++ b/extensions/gps/GetGPS.h
@@ -69,7 +69,7 @@ class GetGPS : public core::Processor {
   std::string gpsdHost_;
   std::string gpsdPort_;
   int64_t gpsdWaitTime_;
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<GetGPS>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<GetGPS>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/http-curl/processors/InvokeHTTP.h
+++ b/extensions/http-curl/processors/InvokeHTTP.h
@@ -160,7 +160,7 @@ class InvokeHTTP : public core::Processor {
 
   InvalidHTTPHeaderFieldHandlingOption invalid_http_header_field_handling_strategy_;
 
-  std::shared_ptr<core::logging::Logger> logger_{core::logging::LoggerFactory<InvokeHTTP>::getLogger()};
+  std::shared_ptr<core::logging::Logger> logger_{core::logging::LoggerFactory<InvokeHTTP>::getLogger(uuid_)};
   std::shared_ptr<utils::ResourceQueue<extensions::curl::HTTPClient>> client_queue_;
 };
 

--- a/extensions/jni/ExecuteJavaControllerService.h
+++ b/extensions/jni/ExecuteJavaControllerService.h
@@ -82,7 +82,7 @@ class ExecuteJavaControllerService : public ConfigurationContext, public std::en
 
     try {
       if (!onEnabledName.first.empty())
-        current_cs_class.callVoidMethod(env, clazzInstance, onEnabledName.first.c_str(), onEnabledName.second);
+        current_cs_class.callVoidMethod(env, clazzInstance, onEnabledName.first, onEnabledName.second);
     } catch (std::runtime_error &re) {
       // this is avoidable.
     }
@@ -133,7 +133,7 @@ class ExecuteJavaControllerService : public ConfigurationContext, public std::en
 
   std::string class_name_;
 
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ExecuteJavaControllerService>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ExecuteJavaControllerService>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::jni::controllers

--- a/extensions/jni/jvm/JavaControllerService.h
+++ b/extensions/jni/jvm/JavaControllerService.h
@@ -155,7 +155,7 @@ class JavaControllerService : public core::controller::ControllerService, public
 
   JVMLoader *loader = nullptr;
 
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<JavaControllerService>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<JavaControllerService>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::jni::controllers

--- a/extensions/kubernetes/controllerservice/KubernetesControllerService.cpp
+++ b/extensions/kubernetes/controllerservice/KubernetesControllerService.cpp
@@ -48,7 +48,7 @@ const core::Property KubernetesControllerService::ContainerNameFilter{
 
 KubernetesControllerService::KubernetesControllerService(const std::string& name, const utils::Identifier& uuid)
   : AttributeProviderService(name, uuid),
-    logger_{core::logging::LoggerFactory<KubernetesControllerService>::getLogger()} {
+    logger_{core::logging::LoggerFactory<KubernetesControllerService>::getLogger(uuid)} {
 }
 
 KubernetesControllerService::KubernetesControllerService(const std::string& name, const std::shared_ptr<Configure>& configuration)

--- a/extensions/kubernetes/processors/CollectKubernetesPodMetrics.h
+++ b/extensions/kubernetes/processors/CollectKubernetesPodMetrics.h
@@ -54,7 +54,7 @@ class CollectKubernetesPodMetrics : public core::Processor {
   void onTrigger(const std::shared_ptr<core::ProcessContext>& context, const std::shared_ptr<core::ProcessSession>& session) override;
 
  private:
-  gsl::not_null<std::shared_ptr<core::logging::Logger>> logger_ = gsl::make_not_null(core::logging::LoggerFactory<CollectKubernetesPodMetrics>::getLogger());
+  gsl::not_null<std::shared_ptr<core::logging::Logger>> logger_ = gsl::make_not_null(core::logging::LoggerFactory<CollectKubernetesPodMetrics>::getLogger(uuid_));
   std::shared_ptr<controllers::KubernetesControllerService> kubernetes_controller_service_;
 };
 

--- a/extensions/libarchive/CompressContent.h
+++ b/extensions/libarchive/CompressContent.h
@@ -47,9 +47,7 @@ namespace org::apache::nifi::minifi::processors {
 class CompressContent : public core::Processor {
  public:
   explicit CompressContent(std::string name, const utils::Identifier& uuid = {})
-    : core::Processor(std::move(name), uuid)
-    , updateFileName_(false)
-    , encapsulateInTar_(false) {
+    : core::Processor(std::move(name), uuid) {
   }
   ~CompressContent() override = default;
 
@@ -95,11 +93,10 @@ class CompressContent : public core::Processor {
     (USE_MIME_TYPE, "use mime.type attribute")
   )
 
- public:
   class GzipWriteCallback {
    public:
     GzipWriteCallback(CompressionMode compress_mode, int compress_level, std::shared_ptr<core::FlowFile> flow, std::shared_ptr<core::ProcessSession> session)
-      : compress_mode_(std::move(compress_mode))
+      : compress_mode_(compress_mode)
       , compress_level_(compress_level)
       , flow_(std::move(flow))
       , session_(std::move(session)) {
@@ -146,7 +143,6 @@ class CompressContent : public core::Processor {
     }
   };
 
- public:
   /**
    * Function that's executed when the processor is scheduled.
    * @param context process context.
@@ -167,12 +163,12 @@ class CompressContent : public core::Processor {
 
   void processFlowFile(const std::shared_ptr<core::FlowFile>& flowFile, const std::shared_ptr<core::ProcessSession>& session);
 
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<CompressContent>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<CompressContent>::getLogger(uuid_);
   int compressLevel_{};
   CompressionMode compressMode_;
   ExtendedCompressionFormat compressFormat_;
-  bool updateFileName_;
-  bool encapsulateInTar_;
+  bool updateFileName_ = false;
+  bool encapsulateInTar_ = false;
   uint32_t batchSize_{1};
   static const std::map<std::string, io::CompressionFormat> compressionFormatMimeTypeMap_;
   static const std::map<io::CompressionFormat, std::string> fileExtension_;

--- a/extensions/libarchive/FocusArchiveEntry.h
+++ b/extensions/libarchive/FocusArchiveEntry.h
@@ -76,7 +76,7 @@ class FocusArchiveEntry : public core::Processor {
   };
 
  private:
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<FocusArchiveEntry>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<FocusArchiveEntry>::getLogger(uuid_);
   static std::shared_ptr<utils::IdGenerator> id_generator_;
 };
 

--- a/extensions/libarchive/ManipulateArchive.h
+++ b/extensions/libarchive/ManipulateArchive.h
@@ -80,7 +80,7 @@ class ManipulateArchive : public core::Processor {
   void initialize() override;
 
  private:
-  std::shared_ptr<Logger> logger_ = core::logging::LoggerFactory<ManipulateArchive>::getLogger();
+  std::shared_ptr<Logger> logger_ = core::logging::LoggerFactory<ManipulateArchive>::getLogger(uuid_);
   std::string before_, after_, operation_, destination_, targetEntry_;
 };
 

--- a/extensions/libarchive/MergeContent.cpp
+++ b/extensions/libarchive/MergeContent.cpp
@@ -43,7 +43,7 @@ std::string MergeContent::readContent(const std::string& path) {
     in.seekg(0, std::ios::end);
     contents.resize(gsl::narrow<size_t>(in.tellg()));
     in.seekg(0, std::ios::beg);
-    in.read(contents.data(), contents.size());
+    in.read(contents.data(), gsl::narrow<std::streamsize>(contents.size()));
     in.close();
   }
   return (contents);
@@ -128,7 +128,7 @@ void MergeContent::validatePropertyOptions() {
   }
 }
 
-std::string MergeContent::getGroupId(core::ProcessContext*, std::shared_ptr<core::FlowFile> flow) {
+std::string MergeContent::getGroupId(core::ProcessContext*, const std::shared_ptr<core::FlowFile>& flow) {
   std::string groupId;
   std::string value;
   if (!correlationAttributeName_.empty()) {

--- a/extensions/libarchive/UnfocusArchiveEntry.h
+++ b/extensions/libarchive/UnfocusArchiveEntry.h
@@ -75,7 +75,7 @@ class UnfocusArchiveEntry : public core::Processor {
   };
 
  private:
-  std::shared_ptr<Logger> logger_ = core::logging::LoggerFactory<UnfocusArchiveEntry>::getLogger();
+  std::shared_ptr<Logger> logger_ = core::logging::LoggerFactory<UnfocusArchiveEntry>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/librdkafka/ConsumeKafka.h
+++ b/extensions/librdkafka/ConsumeKafka.h
@@ -134,7 +134,7 @@ class ConsumeKafka : public KafkaProcessorBase {
   static constexpr const std::size_t METADATA_COMMUNICATIONS_TIMEOUT_MS{ 60000 };
 
   explicit ConsumeKafka(std::string name, const utils::Identifier& uuid = utils::Identifier()) :
-      KafkaProcessorBase(std::move(name), uuid, core::logging::LoggerFactory<ConsumeKafka>::getLogger()) {}
+      KafkaProcessorBase(std::move(name), uuid, core::logging::LoggerFactory<ConsumeKafka>::getLogger(uuid)) {}
 
   ~ConsumeKafka() override = default;
 
@@ -157,11 +157,10 @@ class ConsumeKafka : public KafkaProcessorBase {
   std::optional<std::vector<std::shared_ptr<FlowFileRecord>>> transform_pending_messages_into_flowfiles(core::ProcessSession& session) const;
   void process_pending_messages(core::ProcessSession& session);
 
- private:
   std::string kafka_brokers_;
   std::vector<std::string> topic_names_;
   std::string topic_name_format_;
-  bool honor_transactions_;
+  bool honor_transactions_{};
   std::string group_id_;
   std::string offset_reset_;
   std::string key_attribute_encoding_;
@@ -169,9 +168,9 @@ class ConsumeKafka : public KafkaProcessorBase {
   std::string message_header_encoding_;
   std::string duplicate_header_handling_;
   std::vector<std::string> headers_to_add_as_attributes_;
-  std::size_t max_poll_records_;
-  std::chrono::milliseconds max_poll_time_milliseconds_;
-  std::chrono::milliseconds session_timeout_milliseconds_;
+  std::size_t max_poll_records_{};
+  std::chrono::milliseconds max_poll_time_milliseconds_{};
+  std::chrono::milliseconds session_timeout_milliseconds_{};
 
   std::unique_ptr<rd_kafka_t, utils::rd_kafka_consumer_deleter> consumer_;
   std::unique_ptr<rd_kafka_conf_t, utils::rd_kafka_conf_deleter> conf_;

--- a/extensions/librdkafka/PublishKafka.h
+++ b/extensions/librdkafka/PublishKafka.h
@@ -123,7 +123,7 @@ class PublishKafka : public KafkaProcessorBase {
   static constexpr const char* KAFKA_KEY_ATTRIBUTE = "kafka.key";
 
   explicit PublishKafka(std::string name, const utils::Identifier& uuid = {})
-      : KafkaProcessorBase(std::move(name), uuid, core::logging::LoggerFactory<PublishKafka>::getLogger()) {
+      : KafkaProcessorBase(std::move(name), uuid, core::logging::LoggerFactory<PublishKafka>::getLogger(uuid)) {
   }
 
   ~PublishKafka() override = default;

--- a/extensions/mqtt/processors/AbstractMQTTProcessor.h
+++ b/extensions/mqtt/processors/AbstractMQTTProcessor.h
@@ -206,7 +206,7 @@ class AbstractMQTTProcessor : public core::Processor {
   uint32_t last_will_qos_ = MQTT_QOS_1;
   bool last_will_retain_ = false;
 
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<AbstractMQTTProcessor>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<AbstractMQTTProcessor>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/mqtt/processors/ConsumeMQTT.h
+++ b/extensions/mqtt/processors/ConsumeMQTT.h
@@ -121,7 +121,7 @@ class ConsumeMQTT : public processors::AbstractMQTTProcessor {
 
   void checkProperties() override;
 
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ConsumeMQTT>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ConsumeMQTT>::getLogger(uuid_);
   bool cleanSession_ = true;
   uint64_t maxQueueSize_;
   moodycamel::ConcurrentQueue<std::unique_ptr<MQTTAsync_message, MQTTMessageDeleter>> queue_;

--- a/extensions/mqtt/processors/PublishMQTT.h
+++ b/extensions/mqtt/processors/PublishMQTT.h
@@ -128,7 +128,7 @@ class PublishMQTT : public processors::AbstractMQTTProcessor {
   }
 
   bool retain_ = false;
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<PublishMQTT>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<PublishMQTT>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/opc/include/fetchopc.h
+++ b/extensions/opc/include/fetchopc.h
@@ -39,8 +39,8 @@ namespace org::apache::nifi::minifi::processors {
 class FetchOPCProcessor : public BaseOPCProcessor {
  public:
   explicit FetchOPCProcessor(std::string name, const utils::Identifier& uuid = {})
-      : BaseOPCProcessor(std::move(name), uuid), nameSpaceIdx_(0), nodesFound_(0), variablesFound_(0), maxDepth_(0) {
-    logger_ = core::logging::LoggerFactory<FetchOPCProcessor>::getLogger();
+      : BaseOPCProcessor(std::move(name), uuid) {
+    logger_ = core::logging::LoggerFactory<FetchOPCProcessor>::getLogger(uuid_);
   }
 
   EXTENSIONAPI static constexpr const char* Description = "Fetches OPC-UA node";
@@ -82,12 +82,12 @@ class FetchOPCProcessor : public BaseOPCProcessor {
   void OPCData2FlowFile(const opc::NodeData& opcnode, const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session);
 
   std::string nodeID_;
-  int32_t nameSpaceIdx_;
-  opc::OPCNodeIDType idType_;
-  uint32_t nodesFound_;
-  uint32_t variablesFound_;
-  uint64_t maxDepth_;
-  bool lazy_mode_;
+  int32_t nameSpaceIdx_ = 0;
+  opc::OPCNodeIDType idType_{};
+  uint32_t nodesFound_ = 0;
+  uint32_t variablesFound_ = 0;
+  uint64_t maxDepth_ = 0;
+  bool lazy_mode_ = false;
 
  private:
   std::vector<UA_NodeId> translatedNodeIDs_;  // Only used when user provides path, path->nodeid translation is only done once

--- a/extensions/opc/include/putopc.h
+++ b/extensions/opc/include/putopc.h
@@ -72,8 +72,8 @@ class PutOPCProcessor : public BaseOPCProcessor {
   ADD_COMMON_VIRTUAL_FUNCTIONS_FOR_PROCESSORS
 
   explicit PutOPCProcessor(std::string name, const utils::Identifier& uuid = {})
-      : BaseOPCProcessor(std::move(name), uuid), nameSpaceIdx_(0), parentExists_(false) {
-    logger_ = core::logging::LoggerFactory<PutOPCProcessor>::getLogger();
+      : BaseOPCProcessor(std::move(name), uuid) {
+    logger_ = core::logging::LoggerFactory<PutOPCProcessor>::getLogger(uuid_);
   }
 
   void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &factory) override;

--- a/extensions/opencv/CaptureRTSPFrame.h
+++ b/extensions/opencv/CaptureRTSPFrame.h
@@ -81,7 +81,7 @@ class CaptureRTSPFrame : public core::Processor {
   void notifyStop() override;
 
  private:
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<CaptureRTSPFrame>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<CaptureRTSPFrame>::getLogger(uuid_);
   std::mutex mutex_;
   std::string rtsp_username_;
   std::string rtsp_password_;

--- a/extensions/opencv/MotionDetector.h
+++ b/extensions/opencv/MotionDetector.h
@@ -72,7 +72,7 @@ class MotionDetector : public core::Processor {
  private:
   bool detectAndDraw(cv::Mat &frame);
 
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<MotionDetector>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<MotionDetector>::getLogger(uuid_);
   std::mutex mutex_;
   cv::Mat background_;
   cv::Mat bg_img_;

--- a/extensions/pcap/CapturePacket.h
+++ b/extensions/pcap/CapturePacket.h
@@ -166,7 +166,7 @@ class CapturePacket : public core::Processor {
   std::unique_ptr<PacketMovers> mover;
   static std::atomic<int> num_;
   std::vector<pcpp::PcapLiveDevice*> device_list_;
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<CapturePacket>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<CapturePacket>::getLogger(uuid_);
   static std::shared_ptr<utils::IdGenerator> id_generator_;
 };
 

--- a/extensions/procfs/processors/ProcFsMonitor.h
+++ b/extensions/procfs/processors/ProcFsMonitor.h
@@ -67,7 +67,6 @@ class ProcFsMonitor : public core::Processor {
 
   ADD_COMMON_VIRTUAL_FUNCTIONS_FOR_PROCESSORS
 
- public:
   void onSchedule(const std::shared_ptr<core::ProcessContext>& context, const std::shared_ptr<core::ProcessSessionFactory>& sessionFactory) override;
 
   void onTrigger(core::ProcessContext *context, core::ProcessSession *session) override;
@@ -124,7 +123,7 @@ class ProcFsMonitor : public core::Processor {
   ResultRelativeness result_relativeness_ = ResultRelativeness::ABSOLUTE;
 
   std::optional<uint8_t> decimal_places_;
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ProcFsMonitor>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ProcFsMonitor>::getLogger(uuid_);
 
   ProcFs proc_fs_;
 

--- a/extensions/script/ExecuteScript.h
+++ b/extensions/script/ExecuteScript.h
@@ -115,7 +115,7 @@ class ExecuteScript : public core::Processor {
                  const std::shared_ptr<core::ProcessSession> &session) override;
 
  private:
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ExecuteScript>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ExecuteScript>::getLogger(uuid_);
 
   ScriptEngineOption script_engine_;
   std::string script_file_;

--- a/extensions/script/python/ExecutePythonProcessor.h
+++ b/extensions/script/python/ExecutePythonProcessor.h
@@ -115,7 +115,7 @@ class ExecutePythonProcessor : public core::Processor {
   bool processor_initialized_;
   bool python_dynamic_;
 
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ExecutePythonProcessor>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ExecutePythonProcessor>::getLogger(uuid_);
 
   std::string script_to_exec_;
   bool reload_on_script_change_;

--- a/extensions/sftp/processors/FetchSFTP.cpp
+++ b/extensions/sftp/processors/FetchSFTP.cpp
@@ -42,10 +42,8 @@ void FetchSFTP::initialize() {
 }
 
 FetchSFTP::FetchSFTP(std::string name, const utils::Identifier& uuid /*= utils::Identifier()*/)
-    : SFTPProcessorBase(std::move(name), uuid),
-      create_directory_(false),
-      disable_directory_listing_(false) {
-  logger_ = core::logging::LoggerFactory<FetchSFTP>::getLogger();
+    : SFTPProcessorBase(std::move(name), uuid) {
+  logger_ = core::logging::LoggerFactory<FetchSFTP>::getLogger(uuid_);
 }
 
 FetchSFTP::~FetchSFTP() = default;

--- a/extensions/sftp/processors/FetchSFTP.h
+++ b/extensions/sftp/processors/FetchSFTP.h
@@ -93,8 +93,8 @@ class FetchSFTP : public SFTPProcessorBase {
 
  private:
   std::string completion_strategy_;
-  bool create_directory_;
-  bool disable_directory_listing_;
+  bool create_directory_ = false;
+  bool disable_directory_listing_ = false;
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/sftp/processors/ListSFTP.h
+++ b/extensions/sftp/processors/ListSFTP.h
@@ -119,21 +119,21 @@ class ListSFTP : public SFTPProcessorBase {
   void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
 
  private:
-  core::CoreComponentStateManager* state_manager_;
+  core::CoreComponentStateManager* state_manager_{};
   std::string listing_strategy_;
-  bool search_recursively_;
-  bool follow_symlink_;
+  bool search_recursively_{};
+  bool follow_symlink_{};
   std::string file_filter_regex_;
   std::string path_filter_regex_;
   std::optional<utils::Regex> compiled_file_filter_regex_;
   std::optional<utils::Regex> compiled_path_filter_regex_;
-  bool ignore_dotted_files_;
+  bool ignore_dotted_files_{};
   std::string target_system_timestamp_precision_;
   std::string entity_tracking_initial_listing_target_;
-  std::chrono::milliseconds minimum_file_age_;
-  std::chrono::milliseconds maximum_file_age_;
-  uint64_t minimum_file_size_;
-  uint64_t maximum_file_size_;
+  std::chrono::milliseconds minimum_file_age_{};
+  std::chrono::milliseconds maximum_file_age_{};
+  uint64_t minimum_file_size_{};
+  uint64_t maximum_file_size_{};
 
   std::string last_listing_strategy_;
   std::string last_hostname_;
@@ -141,24 +141,24 @@ class ListSFTP : public SFTPProcessorBase {
   std::filesystem::path last_remote_path_;
 
   struct Child {
-    Child();
+    Child() = default;
     Child(const std::string& parent_path_, std::tuple<std::string /* filename */, std::string /* longentry */, LIBSSH2_SFTP_ATTRIBUTES /* attrs */>&& sftp_child);
     [[nodiscard]] std::string getPath() const;
 
-    bool directory;
+    bool directory{false};
     std::filesystem::path parent_path;
     std::filesystem::path filename;
-    LIBSSH2_SFTP_ATTRIBUTES attrs;
+    LIBSSH2_SFTP_ATTRIBUTES attrs{};
   };
 
-  bool already_loaded_from_cache_;
+  bool already_loaded_from_cache_{};
 
-  std::chrono::steady_clock::time_point last_run_time_;
+  std::chrono::steady_clock::time_point last_run_time_{};
   std::optional<std::chrono::system_clock::time_point> last_listed_latest_entry_timestamp_;
   std::optional<std::chrono::system_clock::time_point> last_processed_latest_entry_timestamp_;
   std::set<std::string> latest_identifiers_processed_;
 
-  bool initial_listing_complete_;
+  bool initial_listing_complete_{};
   struct ListedEntity {
     uint64_t timestamp;
     uint64_t size;

--- a/extensions/splunk/PutSplunkHTTP.h
+++ b/extensions/splunk/PutSplunkHTTP.h
@@ -73,7 +73,7 @@ class PutSplunkHTTP final : public SplunkHECProcessor {
   void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
 
  private:
-  std::shared_ptr<core::logging::Logger> logger_{core::logging::LoggerFactory<PutSplunkHTTP>::getLogger()};
+  std::shared_ptr<core::logging::Logger> logger_{core::logging::LoggerFactory<PutSplunkHTTP>::getLogger(uuid_)};
   std::shared_ptr<utils::ResourceQueue<extensions::curl::HTTPClient>> client_queue_;
 };
 

--- a/extensions/sql/processors/ExecuteSQL.cpp
+++ b/extensions/sql/processors/ExecuteSQL.cpp
@@ -18,18 +18,12 @@
 #include "ExecuteSQL.h"
 
 #include <string>
-#include <memory>
+#include <utility>
 
-#include <soci/soci.h>
-
-#include "io/BufferStream.h"
 #include "io/StreamPipe.h"
 #include "core/ProcessContext.h"
 #include "core/ProcessSession.h"
-#include "core/Resource.h"
 #include "Exception.h"
-#include "data/JSONSQLWriter.h"
-#include "data/SQLRowsetProcessor.h"
 
 namespace org::apache::nifi::minifi::processors {
 
@@ -37,7 +31,7 @@ const std::string ExecuteSQL::RESULT_ROW_COUNT = "executesql.row.count";
 const std::string ExecuteSQL::INPUT_FLOW_FILE_UUID = "input.flowfile.uuid";
 
 ExecuteSQL::ExecuteSQL(std::string name, const utils::Identifier& uuid)
-  : SQLProcessor(std::move(name), uuid, core::logging::LoggerFactory<ExecuteSQL>::getLogger()) {
+  : SQLProcessor(std::move(name), uuid, core::logging::LoggerFactory<ExecuteSQL>::getLogger(uuid)) {
 }
 
 void ExecuteSQL::initialize() {

--- a/extensions/sql/processors/PutSQL.cpp
+++ b/extensions/sql/processors/PutSQL.cpp
@@ -18,17 +18,17 @@
 #include "PutSQL.h"
 
 #include <string>
+#include <utility>
 
 #include "io/BufferStream.h"
 #include "core/ProcessContext.h"
 #include "core/ProcessSession.h"
-#include "core/Resource.h"
 #include "Exception.h"
 
 namespace org::apache::nifi::minifi::processors {
 
 PutSQL::PutSQL(std::string name, const utils::Identifier& uuid)
-  : SQLProcessor(std::move(name), uuid, core::logging::LoggerFactory<PutSQL>::getLogger()) {
+  : SQLProcessor(std::move(name), uuid, core::logging::LoggerFactory<PutSQL>::getLogger(uuid)) {
 }
 
 void PutSQL::initialize() {

--- a/extensions/sql/processors/QueryDatabaseTable.cpp
+++ b/extensions/sql/processors/QueryDatabaseTable.cpp
@@ -19,18 +19,12 @@
 
 #include <vector>
 #include <string>
-#include <memory>
 #include <algorithm>
-
-#include <soci/soci.h>
 
 #include "io/BufferStream.h"
 #include "core/ProcessContext.h"
 #include "core/ProcessSession.h"
-#include "core/Resource.h"
 #include "Exception.h"
-#include "data/JSONSQLWriter.h"
-#include "data/SQLRowsetProcessor.h"
 #include "data/MaxCollector.h"
 #include "utils/StringUtils.h"
 
@@ -45,7 +39,7 @@ const std::string QueryDatabaseTable::TABLENAME_KEY = "tablename";
 const std::string QueryDatabaseTable::MAXVALUE_KEY_PREFIX = "maxvalue.";
 
 QueryDatabaseTable::QueryDatabaseTable(std::string name, const utils::Identifier& uuid)
-  : SQLProcessor(std::move(name), uuid, core::logging::LoggerFactory<QueryDatabaseTable>::getLogger()) {
+  : SQLProcessor(std::move(name), uuid, core::logging::LoggerFactory<QueryDatabaseTable>::getLogger(uuid)) {
 }
 
 void QueryDatabaseTable::initialize() {

--- a/extensions/sql/processors/QueryDatabaseTable.h
+++ b/extensions/sql/processors/QueryDatabaseTable.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
 #include <memory>
 
 #include "core/ProcessSession.h"
@@ -82,7 +83,7 @@ class QueryDatabaseTable: public SQLProcessor, public FlowFileSource {
 
   bool saveState();
 
-  core::CoreComponentStateManager* state_manager_;
+  core::CoreComponentStateManager* state_manager_{};
   std::string table_name_;
   std::unordered_set<sql::SQLColumnIdentifier> return_columns_;
   std::string queried_columns_;

--- a/extensions/sql/services/DatabaseService.h
+++ b/extensions/sql/services/DatabaseService.h
@@ -17,7 +17,9 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "core/logging/LoggerConfiguration.h"
 #include "core/controller/ControllerService.h"
@@ -69,7 +71,6 @@ class DatabaseService : public core::controller::ControllerService {
   virtual std::unique_ptr<sql::Connection> getConnection() const = 0;
 
  protected:
-
   void initializeProperties();
 
   // initialization mutex.
@@ -80,8 +81,7 @@ class DatabaseService : public core::controller::ControllerService {
   std::string connection_string_;
 
  private:
-
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<DatabaseService>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<DatabaseService>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::sql::controllers

--- a/extensions/sql/services/ODBCConnector.h
+++ b/extensions/sql/services/ODBCConnector.h
@@ -17,6 +17,10 @@
 
 #pragma once
 
+#include <memory>
+#include <string>
+#include <utility>
+
 #include "core/logging/LoggerConfiguration.h"
 #include "core/controller/ControllerService.h"
 
@@ -51,7 +55,7 @@ class ODBCService : public DatabaseService {
   std::unique_ptr<sql::Connection> getConnection() const override;
 
  private:
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ODBCService>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ODBCService>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::sql::controllers

--- a/extensions/standard-processors/processors/AppendHostInfo.h
+++ b/extensions/standard-processors/processors/AppendHostInfo.h
@@ -17,8 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef EXTENSIONS_STANDARD_PROCESSORS_PROCESSORS_APPENDHOSTINFO_H_
-#define EXTENSIONS_STANDARD_PROCESSORS_PROCESSORS_APPENDHOSTINFO_H_
+#pragma once
 
 #include <memory>
 #include <optional>
@@ -43,8 +42,7 @@ class AppendHostInfo : public core::Processor {
   static constexpr const char* REFRESH_POLICY_ON_SCHEDULE = "On schedule";
 
   explicit AppendHostInfo(std::string name, const utils::Identifier& uuid = {})
-      : core::Processor(std::move(name), uuid),
-        refresh_on_trigger_(false) {
+      : core::Processor(std::move(name), uuid) {
   }
   ~AppendHostInfo() override = default;
 
@@ -82,16 +80,14 @@ class AppendHostInfo : public core::Processor {
 
  private:
   std::shared_mutex shared_mutex_;
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<AppendHostInfo>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<AppendHostInfo>::getLogger(uuid_);
   std::string hostname_attribute_name_;
   std::string ipaddress_attribute_name_;
   std::optional<std::regex> interface_name_filter_;
-  bool refresh_on_trigger_;
+  bool refresh_on_trigger_ = false;
 
   std::string hostname_;
   std::optional<std::string> ipaddresses_;
 };
 
 }  // namespace org::apache::nifi::minifi::processors
-
-#endif  // EXTENSIONS_STANDARD_PROCESSORS_PROCESSORS_APPENDHOSTINFO_H_

--- a/extensions/standard-processors/processors/AttributesToJSON.h
+++ b/extensions/standard-processors/processors/AttributesToJSON.h
@@ -88,7 +88,7 @@ class AttributesToJSON : public core::Processor {
   void addAttributeToJson(rapidjson::Document& document, const std::string& key, const std::optional<std::string>& value) const;
   std::string buildAttributeJsonData(const core::FlowFile::AttributeMap& flowfile_attributes);
 
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<AttributesToJSON>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<AttributesToJSON>::getLogger(uuid_);
   std::vector<std::string> attribute_list_;
   std::optional<utils::Regex> attributes_regular_expression_;
   WriteDestination write_destination_;

--- a/extensions/standard-processors/processors/DefragmentText.h
+++ b/extensions/standard-processors/processors/DefragmentText.h
@@ -123,7 +123,7 @@ class DefragmentText : public core::Processor {
   std::optional<std::chrono::milliseconds> max_age_;
   std::optional<size_t> max_size_;
 
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<DefragmentText>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<DefragmentText>::getLogger(uuid_);
   core::FlowFileStore flow_file_store_;
   std::unordered_map<FragmentSource::Id, FragmentSource, FragmentSource::Id::hash> fragment_sources_;
 

--- a/extensions/standard-processors/processors/ExecuteProcess.h
+++ b/extensions/standard-processors/processors/ExecuteProcess.h
@@ -47,9 +47,7 @@ class ExecuteProcess : public core::Processor {
  public:
   explicit ExecuteProcess(std::string name, const utils::Identifier& uuid = {})
       : Processor(std::move(name), uuid),
-        working_dir_("."),
-        redirect_error_stream_(false),
-        pid_(0) {
+        working_dir_(".") {
   }
   ~ExecuteProcess() override {
     if (pid_ > 0) {
@@ -99,15 +97,15 @@ class ExecuteProcess : public core::Processor {
   void readOutput(core::ProcessSession& session);
   bool writeToFlowFile(core::ProcessSession& session, std::shared_ptr<core::FlowFile>& flow_file, gsl::span<const char> buffer) const;
 
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ExecuteProcess>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ExecuteProcess>::getLogger(uuid_);
   std::string command_;
   std::string command_argument_;
   std::filesystem::path working_dir_;
   std::chrono::milliseconds batch_duration_  = std::chrono::milliseconds(0);
-  bool redirect_error_stream_;
+  bool redirect_error_stream_ = false;
   std::string full_command_;
   int pipefd_[2]{};
-  pid_t pid_;
+  pid_t pid_{};
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/standard-processors/processors/ExtractText.h
+++ b/extensions/standard-processors/processors/ExtractText.h
@@ -85,7 +85,7 @@ class ExtractText : public core::Processor {
   };
 
  private:
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ExtractText>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ExtractText>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/standard-processors/processors/FetchFile.h
+++ b/extensions/standard-processors/processors/FetchFile.h
@@ -117,7 +117,7 @@ class FetchFile : public core::Processor {
   MoveConflictStrategyOption move_confict_strategy_;
   LogLevelOption log_level_when_file_not_found_;
   LogLevelOption log_level_when_permission_denied_;
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<FetchFile>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<FetchFile>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/standard-processors/processors/GenerateFlowFile.h
+++ b/extensions/standard-processors/processors/GenerateFlowFile.h
@@ -74,7 +74,6 @@ class GenerateFlowFile : public core::Processor {
 
   EXTENSIONAPI static const char *DATA_FORMAT_TEXT;
 
- public:
   void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &sessionFactory) override;
   void onTrigger(core::ProcessContext *context, core::ProcessSession *session) override;
   void initialize() override;
@@ -88,7 +87,7 @@ class GenerateFlowFile : public core::Processor {
   bool textData_;
 
  private:
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<GenerateFlowFile>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<GenerateFlowFile>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/standard-processors/processors/GetFile.h
+++ b/extensions/standard-processors/processors/GetFile.h
@@ -145,7 +145,7 @@ class GetFile : public core::Processor {
   std::queue<std::filesystem::path> directory_listing_;
   mutable std::mutex directory_listing_mutex_;
   std::atomic<std::chrono::time_point<std::chrono::system_clock>> last_listing_time_{};
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<GetFile>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<GetFile>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/standard-processors/processors/HashContent.h
+++ b/extensions/standard-processors/processors/HashContent.h
@@ -57,7 +57,7 @@ namespace { // NOLINT
       ret = stream->read(buffer);
       if (ret > 0) {
         MD5_Update(&context, buffer.data(), ret);
-        ret_val.second += ret;
+        ret_val.second += gsl::narrow<int64_t>(ret);
       }
     } while (ret > 0);
 
@@ -81,7 +81,7 @@ namespace { // NOLINT
       ret = stream->read(buffer);
       if (ret > 0) {
         SHA1_Update(&context, buffer.data(), ret);
-        ret_val.second += ret;
+        ret_val.second += gsl::narrow<int64_t>(ret);
       }
     } while (ret > 0);
 
@@ -105,7 +105,7 @@ namespace { // NOLINT
       ret = stream->read(buffer);
       if (ret > 0) {
         SHA256_Update(&context, buffer.data(), ret);
-        ret_val.second += ret;
+        ret_val.second += gsl::narrow<int64_t>(ret);
       }
     } while (ret > 0);
 
@@ -160,7 +160,7 @@ class HashContent : public core::Processor {
   void initialize() override;
 
  private:
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<HashContent>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<HashContent>::getLogger(uuid_);
   std::function<HashReturnType(const std::shared_ptr<io::InputStream>&)> algorithm_ = SHA256Hash;
   std::string attrKey_;
   bool failOnEmpty_{};

--- a/extensions/standard-processors/processors/ListFile.h
+++ b/extensions/standard-processors/processors/ListFile.h
@@ -99,7 +99,7 @@ class ListFile : public core::Processor {
   bool fileMatchesFilters(const ListedFile& listed_file);
   std::shared_ptr<core::FlowFile> createFlowFile(core::ProcessSession& session, const ListedFile& listed_file);
 
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ListFile>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ListFile>::getLogger(uuid_);
   std::filesystem::path input_directory_;
   std::unique_ptr<minifi::utils::ListingStateManager> state_manager_;
   bool recurse_subdirectories_ = true;

--- a/extensions/standard-processors/processors/ListenSyslog.h
+++ b/extensions/standard-processors/processors/ListenSyslog.h
@@ -31,7 +31,7 @@ namespace org::apache::nifi::minifi::processors {
 class ListenSyslog : public NetworkListenerProcessor {
  public:
   explicit ListenSyslog(std::string name, const utils::Identifier& uuid = {})
-      : NetworkListenerProcessor(std::move(name), uuid, core::logging::LoggerFactory<ListenSyslog>::getLogger()) {
+      : NetworkListenerProcessor(std::move(name), uuid, core::logging::LoggerFactory<ListenSyslog>::getLogger(uuid)) {
   }
 
   EXTENSIONAPI static constexpr const char* Description = "Listens for Syslog messages being sent to a given port over TCP or UDP. "

--- a/extensions/standard-processors/processors/ListenTCP.h
+++ b/extensions/standard-processors/processors/ListenTCP.h
@@ -29,7 +29,7 @@ namespace org::apache::nifi::minifi::processors {
 class ListenTCP : public NetworkListenerProcessor {
  public:
   explicit ListenTCP(std::string name, const utils::Identifier& uuid = {})
-    : NetworkListenerProcessor(std::move(name), uuid, core::logging::LoggerFactory<ListenTCP>::getLogger()) {
+    : NetworkListenerProcessor(std::move(name), uuid, core::logging::LoggerFactory<ListenTCP>::getLogger(uuid)) {
   }
 
   EXTENSIONAPI static constexpr const char* Description = "Listens for incoming TCP connections and reads data from each connection using a line separator as the message demarcator. "

--- a/extensions/standard-processors/processors/ListenUDP.h
+++ b/extensions/standard-processors/processors/ListenUDP.h
@@ -27,7 +27,7 @@ namespace org::apache::nifi::minifi::processors {
 class ListenUDP : public NetworkListenerProcessor {
  public:
   explicit ListenUDP(const std::string& name, const utils::Identifier& uuid = {})
-    : NetworkListenerProcessor(name, uuid, core::logging::LoggerFactory<ListenUDP>::getLogger()) {
+    : NetworkListenerProcessor(name, uuid, core::logging::LoggerFactory<ListenUDP>::getLogger(uuid)) {
   }
 
   EXTENSIONAPI static constexpr const char* Description = "Listens for incoming UDP datagrams. For each datagram the processor produces a single FlowFile.";

--- a/extensions/standard-processors/processors/LogAttribute.h
+++ b/extensions/standard-processors/processors/LogAttribute.h
@@ -37,10 +37,7 @@ namespace org::apache::nifi::minifi::processors {
 class LogAttribute : public core::Processor {
  public:
   explicit LogAttribute(std::string name, const utils::Identifier& uuid = {})
-      : Processor(std::move(name), uuid),
-        flowfiles_to_log_(1),
-        hexencode_(false),
-        max_line_length_(80U) {
+      : Processor(std::move(name), uuid) {
   }
   ~LogAttribute() override = default;
 
@@ -84,8 +81,8 @@ class LogAttribute : public core::Processor {
     LogAttrLevelWarn,
     LogAttrLevelError
   };
-  // Convert log level from string to enum
-  bool logLevelStringToEnum(const std::string &logStr, LogAttrLevel &level) {
+
+  static bool logLevelStringToEnum(const std::string &logStr, LogAttrLevel &level) {
     if (logStr == "trace") {
       level = LogAttrLevelTrace;
       return true;
@@ -106,17 +103,15 @@ class LogAttribute : public core::Processor {
     }
   }
 
- public:
   void onSchedule(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory> &factory) override;
   void onTrigger(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) override;
   void initialize() override;
 
  private:
-  uint64_t flowfiles_to_log_;
-  bool hexencode_;
-  uint32_t max_line_length_;
-  // Logger
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<LogAttribute>::getLogger();
+  uint64_t flowfiles_to_log_{1};
+  bool hexencode_{false};
+  uint32_t max_line_length_{80};
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<LogAttribute>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/standard-processors/processors/PutFile.h
+++ b/extensions/standard-processors/processors/PutFile.h
@@ -115,15 +115,15 @@ class PutFile : public core::Processor {
                const std::filesystem::path& tmpFile,
                const std::filesystem::path& destFile,
                const std::filesystem::path& destDir);
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<PutFile>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<PutFile>::getLogger(uuid_);
   static std::shared_ptr<utils::IdGenerator> id_generator_;
 
 #ifndef WIN32
   class FilePermissions {
     static const uint32_t MINIMUM_INVALID_PERMISSIONS_VALUE = 1 << 9;
    public:
-    bool valid() { return permissions_ < MINIMUM_INVALID_PERMISSIONS_VALUE; }
-    uint32_t getValue() const { return permissions_; }
+    [[nodiscard]] bool valid() const { return permissions_ < MINIMUM_INVALID_PERMISSIONS_VALUE; }
+    [[nodiscard]] uint32_t getValue() const { return permissions_; }
     void setValue(uint32_t perms) { permissions_ = perms; }
    private:
     uint32_t permissions_ = MINIMUM_INVALID_PERMISSIONS_VALUE;

--- a/extensions/standard-processors/processors/PutTCP.h
+++ b/extensions/standard-processors/processors/PutTCP.h
@@ -123,7 +123,7 @@ class PutTCP final : public core::Processor {
   std::optional<size_t> max_size_of_socket_send_buffer_;
   std::chrono::milliseconds timeout_ = std::chrono::seconds(15);
   std::shared_ptr<controllers::SSLContextService> ssl_context_service_;
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<PutTCP>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<PutTCP>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/standard-processors/processors/PutUDP.cpp
+++ b/extensions/standard-processors/processors/PutUDP.cpp
@@ -49,7 +49,7 @@ const core::Relationship PutUDP::Success{"success", "FlowFiles that are sent to 
 const core::Relationship PutUDP::Failure{"failure", "FlowFiles that encountered IO errors are send out this relationship."};
 
 PutUDP::PutUDP(std::string name, const utils::Identifier& uuid)
-    : Processor(std::move(name), uuid), logger_{core::logging::LoggerFactory<PutUDP>::getLogger()}
+    : Processor(std::move(name), uuid), logger_{core::logging::LoggerFactory<PutUDP>::getLogger(uuid)}
 { }
 
 PutUDP::~PutUDP() = default;

--- a/extensions/standard-processors/processors/ReplaceText.cpp
+++ b/extensions/standard-processors/processors/ReplaceText.cpp
@@ -77,7 +77,7 @@ const core::Relationship ReplaceText::Failure("failure", "FlowFiles that could n
 
 ReplaceText::ReplaceText(std::string name, const utils::Identifier& uuid)
   : core::Processor(std::move(name), uuid),
-    logger_(core::logging::LoggerFactory<ReplaceText>::getLogger()) {
+    logger_(core::logging::LoggerFactory<ReplaceText>::getLogger(uuid)) {
 }
 
 void ReplaceText::initialize() {

--- a/extensions/standard-processors/processors/RetryFlowFile.h
+++ b/extensions/standard-processors/processors/RetryFlowFile.h
@@ -103,7 +103,7 @@ class RetryFlowFile : public core::Processor {
   std::string reuse_mode_;
   std::vector<core::Property> exceeded_flowfile_attribute_keys_;
 
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<RetryFlowFile>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<RetryFlowFile>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/standard-processors/processors/RouteOnAttribute.h
+++ b/extensions/standard-processors/processors/RouteOnAttribute.h
@@ -17,8 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef EXTENSIONS_STANDARD_PROCESSORS_PROCESSORS_ROUTEONATTRIBUTE_H_
-#define EXTENSIONS_STANDARD_PROCESSORS_PROCESSORS_ROUTEONATTRIBUTE_H_
+#pragma once
 
 #include <map>
 #include <memory>
@@ -59,11 +58,9 @@ class RouteOnAttribute : public core::Processor {
   void initialize() override;
 
  private:
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<RouteOnAttribute>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<RouteOnAttribute>::getLogger(uuid_);
   std::map<std::string, core::Property> route_properties_;
   std::map<std::string, core::Relationship> route_rels_;
 };
 
 }  // namespace org::apache::nifi::minifi::processors
-
-#endif  // EXTENSIONS_STANDARD_PROCESSORS_PROCESSORS_ROUTEONATTRIBUTE_H_

--- a/extensions/standard-processors/processors/RouteText.cpp
+++ b/extensions/standard-processors/processors/RouteText.cpp
@@ -105,7 +105,7 @@ const core::Relationship RouteText::Unmatched("unmatched", "Segments that do not
 const core::Relationship RouteText::Matched("matched", "Segments that satisfy the required user-defined rules will be routed to this Relationship");
 
 RouteText::RouteText(std::string name, const utils::Identifier& uuid)
-    : core::Processor(std::move(name), uuid), logger_(core::logging::LoggerFactory<RouteText>::getLogger()) {}
+    : core::Processor(std::move(name), uuid), logger_(core::logging::LoggerFactory<RouteText>::getLogger(uuid)) {}
 
 void RouteText::initialize() {
   setSupportedProperties(properties());
@@ -144,7 +144,7 @@ class RouteText::ReadCallback {
     switch (segmentation_.value()) {
       case Segmentation::FULL_TEXT: {
         fn_({content, 0});
-        return content.length();
+        return gsl::narrow<int64_t>(content.length());
       }
       case Segmentation::PER_LINE: {
         // 1-based index as in nifi
@@ -164,7 +164,7 @@ class RouteText::ReadCallback {
           curr = next_line;
           ++segment_idx;
         }
-        return content.length();
+        return gsl::narrow<int64_t>(content.length());
       }
     }
     throw Exception(PROCESSOR_EXCEPTION, "Unknown segmentation strategy");

--- a/extensions/standard-processors/processors/TailFile.h
+++ b/extensions/standard-processors/processors/TailFile.h
@@ -215,7 +215,7 @@ class TailFile : public core::Processor {
   controllers::AttributeProviderService* attribute_provider_service_ = nullptr;
   std::unordered_map<std::string, controllers::AttributeProviderService::AttributeMap> extra_attributes_;
   std::optional<uint32_t> batch_size_;
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<TailFile>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<TailFile>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/standard-processors/processors/UpdateAttribute.h
+++ b/extensions/standard-processors/processors/UpdateAttribute.h
@@ -17,8 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef EXTENSIONS_STANDARD_PROCESSORS_PROCESSORS_UPDATEATTRIBUTE_H_
-#define EXTENSIONS_STANDARD_PROCESSORS_PROCESSORS_UPDATEATTRIBUTE_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -60,10 +59,8 @@ class UpdateAttribute : public core::Processor {
   void initialize() override;
 
  private:
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<UpdateAttribute>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<UpdateAttribute>::getLogger(uuid_);
   std::vector<core::Property> attributes_;
 };
 
 }  // namespace org::apache::nifi::minifi::processors
-
-#endif  // EXTENSIONS_STANDARD_PROCESSORS_PROCESSORS_UPDATEATTRIBUTE_H_

--- a/extensions/systemd/ConsumeJournald.h
+++ b/extensions/systemd/ConsumeJournald.h
@@ -111,7 +111,7 @@ class ConsumeJournald final : public core::Processor {
   std::string getCursor() const;
 
   std::atomic<bool> running_{false};
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ConsumeJournald>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ConsumeJournald>::getLogger(uuid_);
   core::CoreComponentStateManager* state_manager_;
   std::unique_ptr<libwrapper::LibWrapper> libwrapper_;
   std::unique_ptr<utils::FifoExecutor> worker_;

--- a/extensions/tensorflow/TFApplyGraph.h
+++ b/extensions/tensorflow/TFApplyGraph.h
@@ -32,7 +32,7 @@ class TFApplyGraph : public core::Processor {
  public:
   explicit TFApplyGraph(const std::string &name, const utils::Identifier &uuid = {})
       : Processor(name, uuid),
-        logger_(logging::LoggerFactory<TFApplyGraph>::getLogger()) {
+        logger_(logging::LoggerFactory<TFApplyGraph>::getLogger(uuid_)) {
   }
 
   EXTENSIONAPI static constexpr const char* Description = "Applies a TensorFlow graph to the tensor protobuf supplied as input. The tensor is fed into the node specified by the Input Node property. "

--- a/extensions/tensorflow/TFConvertImageToTensor.h
+++ b/extensions/tensorflow/TFConvertImageToTensor.h
@@ -32,7 +32,7 @@ class TFConvertImageToTensor : public core::Processor {
  public:
   explicit TFConvertImageToTensor(const std::string &name, const utils::Identifier &uuid = {})
       : Processor(name, uuid),
-        logger_(logging::LoggerFactory<TFConvertImageToTensor>::getLogger()) {
+        logger_(logging::LoggerFactory<TFConvertImageToTensor>::getLogger(uuid_)) {
   }
 
   EXTENSIONAPI static constexpr const char* Description = "Converts the input image file into a tensor protobuf. The image will be resized to the given output tensor dimensions.";

--- a/extensions/tensorflow/TFExtractTopLabels.h
+++ b/extensions/tensorflow/TFExtractTopLabels.h
@@ -32,7 +32,7 @@ class TFExtractTopLabels : public core::Processor {
  public:
   explicit TFExtractTopLabels(const std::string &name, const utils::Identifier &uuid = {})
       : Processor(name, uuid),
-        logger_(logging::LoggerFactory<TFExtractTopLabels>::getLogger()) {
+        logger_(logging::LoggerFactory<TFExtractTopLabels>::getLogger(uuid_)) {
   }
 
   EXTENSIONAPI static constexpr const char* Description = "Extracts the top 5 labels for categorical inference models";

--- a/extensions/test-processors/KamikazeProcessor.h
+++ b/extensions/test-processors/KamikazeProcessor.h
@@ -66,7 +66,7 @@ class KamikazeProcessor : public core::Processor {
 
  private:
   bool _throwInOnTrigger = false;
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<KamikazeProcessor>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<KamikazeProcessor>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/test-processors/LogOnDestructionProcessor.h
+++ b/extensions/test-processors/LogOnDestructionProcessor.h
@@ -47,7 +47,7 @@ class LogOnDestructionProcessor : public core::Processor {
   ADD_COMMON_VIRTUAL_FUNCTIONS_FOR_PROCESSORS
 
  private:
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<LogOnDestructionProcessor>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<LogOnDestructionProcessor>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/usb-camera/GetUSBCamera.h
+++ b/extensions/usb-camera/GetUSBCamera.h
@@ -94,7 +94,7 @@ class GetUSBCamera : public core::Processor {
                  core::ProcessSession *session) override;
   void initialize() override;
 
-  typedef struct {
+  struct CallbackData {
     core::ProcessContext *context;
     core::ProcessSessionFactory *session_factory;
     std::shared_ptr<core::logging::Logger> logger;
@@ -107,7 +107,7 @@ class GetUSBCamera : public core::Processor {
     uint32_t device_fps;
     double target_fps;
     std::chrono::steady_clock::time_point last_frame_time;
-  } CallbackData;
+  };
 
   static void onFrame(uvc_frame_t *frame, void *ptr);
 
@@ -127,11 +127,11 @@ class GetUSBCamera : public core::Processor {
   };
 
  private:
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<GetUSBCamera>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<GetUSBCamera>::getLogger(uuid_);
   static std::shared_ptr<utils::IdGenerator> id_generator_;
 
   std::shared_ptr<std::thread> camera_thread_;
-  CallbackData cb_data_;
+  CallbackData cb_data_{};
 
   std::shared_ptr<std::mutex> png_write_mtx_;
   std::shared_ptr<std::recursive_mutex> dev_access_mtx_;

--- a/extensions/windows-event-log/CollectorInitiatedSubscription.cpp
+++ b/extensions/windows-event-log/CollectorInitiatedSubscription.cpp
@@ -160,7 +160,7 @@ const core::Property CollectorInitiatedSubscription::InactiveDurationToReconnect
 const core::Relationship CollectorInitiatedSubscription::Success("success", "Relationship for successfully consumed events.");
 
 CollectorInitiatedSubscription::CollectorInitiatedSubscription(const std::string& name, const utils::Identifier& uuid)
-  : core::Processor(name, uuid), logger_(core::logging::LoggerFactory<CollectorInitiatedSubscription>::getLogger()) {
+  : core::Processor(name, uuid), logger_(core::logging::LoggerFactory<CollectorInitiatedSubscription>::getLogger(uuid_)) {
   char buff[MAX_COMPUTERNAME_LENGTH + 1];
   DWORD size = sizeof(buff);
   if (GetComputerName(buff, &size)) {

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
@@ -179,7 +179,7 @@ const core::Relationship ConsumeWindowsEventLog::Success("success", "Relationshi
 
 ConsumeWindowsEventLog::ConsumeWindowsEventLog(const std::string& name, const utils::Identifier& uuid)
   : core::Processor(name, uuid),
-    logger_(core::logging::LoggerFactory<ConsumeWindowsEventLog>::getLogger()) {
+    logger_(core::logging::LoggerFactory<ConsumeWindowsEventLog>::getLogger(uuid_)) {
   char buff[MAX_COMPUTERNAME_LENGTH + 1];
   DWORD size = sizeof(buff);
   if (GetComputerName(buff, &size)) {

--- a/libminifi/include/Funnel.h
+++ b/libminifi/include/Funnel.h
@@ -26,7 +26,7 @@ namespace org::apache::nifi::minifi {
 
 class Funnel final : public ForwardingNode {
  public:
-  Funnel(std::string name, const utils::Identifier& uuid) : ForwardingNode(std::move(name), uuid, core::logging::LoggerFactory<Funnel>::getLogger()) {}
+  Funnel(std::string name, const utils::Identifier& uuid) : ForwardingNode(std::move(name), uuid, core::logging::LoggerFactory<Funnel>::getLogger(uuid)) {}
   explicit Funnel(std::string name) : ForwardingNode(std::move(name), core::logging::LoggerFactory<Funnel>::getLogger()) {}
 
   MINIFIAPI static constexpr core::annotation::Input InputRequirement = core::annotation::Input::INPUT_REQUIRED;

--- a/libminifi/include/Port.h
+++ b/libminifi/include/Port.h
@@ -31,7 +31,7 @@ enum class PortType {
 
 class Port final : public ForwardingNode {
  public:
-  Port(std::string name, const utils::Identifier& uuid, PortType port_type) : ForwardingNode(std::move(name), uuid, core::logging::LoggerFactory<Port>::getLogger()), port_type_(port_type) {}
+  Port(std::string name, const utils::Identifier& uuid, PortType port_type) : ForwardingNode(std::move(name), uuid, core::logging::LoggerFactory<Port>::getLogger(uuid)), port_type_(port_type) {}
   Port(std::string name, PortType port_type) : ForwardingNode(std::move(name), core::logging::LoggerFactory<Port>::getLogger()), port_type_(port_type) {}
   PortType getPortType() const {
     return port_type_;

--- a/libminifi/include/RemoteProcessorGroupPort.h
+++ b/libminifi/include/RemoteProcessorGroupPort.h
@@ -81,7 +81,7 @@ class RemoteProcessorGroupPort : public core::Processor {
         timeout_(0),
         bypass_rest_api_(false),
         ssl_service(nullptr),
-        logger_(core::logging::LoggerFactory<RemoteProcessorGroupPort>::getLogger()) {
+        logger_(core::logging::LoggerFactory<RemoteProcessorGroupPort>::getLogger(uuid)) {
     client_type_ = sitetosite::CLIENT_TYPE::RAW;
     stream_factory_ = stream_factory;
     protocol_uuid_ = uuid;

--- a/libminifi/include/controllers/LinuxPowerManagementService.h
+++ b/libminifi/include/controllers/LinuxPowerManagementService.h
@@ -133,7 +133,7 @@ class LinuxPowerManagerService : public ThreadManagementService {
   std::string status_keyword_;
 
  private:
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<LinuxPowerManagerService>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<LinuxPowerManagerService>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::controllers

--- a/libminifi/include/controllers/NetworkPrioritizerService.h
+++ b/libminifi/include/controllers/NetworkPrioritizerService.h
@@ -134,7 +134,7 @@ class NetworkPrioritizerService : public core::controller::ControllerService, pu
 
  private:
   std::shared_ptr<utils::timeutils::Clock> clock_;
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<NetworkPrioritizerService>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<NetworkPrioritizerService>::getLogger(uuid_);
 };
 
 }  // namespace org::apache::nifi::minifi::controllers

--- a/libminifi/include/controllers/SSLContextService.h
+++ b/libminifi/include/controllers/SSLContextService.h
@@ -82,7 +82,7 @@ class SSLContextService : public core::controller::ControllerService {
   explicit SSLContextService(std::string name, const utils::Identifier &uuid = {})
       : ControllerService(std::move(name), uuid),
         initialized_(false),
-        logger_(core::logging::LoggerFactory<SSLContextService>::getLogger()) {
+        logger_(core::logging::LoggerFactory<SSLContextService>::getLogger(uuid)) {
   }
 
   explicit SSLContextService(std::string name, const std::shared_ptr<Configure> &configuration)
@@ -256,6 +256,5 @@ class SSLContextService : public core::controller::ControllerService {
 
   std::shared_ptr<core::logging::Logger> logger_;
 };
-typedef int (SSLContextService::*ptr)(char *, int, int, void *);
 
 }  // namespace org::apache::nifi::minifi::controllers

--- a/libminifi/include/controllers/SSLContextService.h
+++ b/libminifi/include/controllers/SSLContextService.h
@@ -82,13 +82,13 @@ class SSLContextService : public core::controller::ControllerService {
   explicit SSLContextService(std::string name, const utils::Identifier &uuid = {})
       : ControllerService(std::move(name), uuid),
         initialized_(false),
-        logger_(core::logging::LoggerFactory<SSLContextService>::getLogger(uuid)) {
+        logger_(core::logging::LoggerFactory<SSLContextService>::getLogger(uuid_)) {
   }
 
   explicit SSLContextService(std::string name, const std::shared_ptr<Configure> &configuration)
       : ControllerService(std::move(name)),
         initialized_(false),
-        logger_(core::logging::LoggerFactory<SSLContextService>::getLogger()) {
+        logger_(core::logging::LoggerFactory<SSLContextService>::getLogger(uuid_)) {
     setConfiguration(configuration);
     initialize();
 

--- a/libminifi/include/core/Processor.h
+++ b/libminifi/include/core/Processor.h
@@ -247,7 +247,6 @@ class Processor : public Connectable, public ConfigurableComponent, public state
   mutable std::mutex mutex_;
   std::atomic<std::chrono::time_point<std::chrono::system_clock>> yield_expiration_{};
 
- private:
   static std::mutex& getGraphMutex() {
     static std::mutex mutex{};
     return mutex;

--- a/libminifi/include/core/logging/Logger.h
+++ b/libminifi/include/core/logging/Logger.h
@@ -15,12 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef LIBMINIFI_INCLUDE_CORE_LOGGING_LOGGER_H_
-#define LIBMINIFI_INCLUDE_CORE_LOGGING_LOGGER_H_
+#pragma once
 
 #include <string>
 #include <mutex>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <utility>
 #include <iostream>
@@ -33,14 +33,9 @@
 #include "utils/SmallString.h"
 #include "utils/meta/detected.h"
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
-namespace core {
-namespace logging {
+namespace org::apache::nifi::minifi::core::logging {
 
-#define LOG_BUFFER_SIZE 1024
+inline constexpr size_t LOG_BUFFER_SIZE = 1024;
 
 class LoggerControl {
  public:
@@ -83,29 +78,30 @@ std::string format_string(int max_size, char const* format_str, const Args& ...a
   if (result < 0) {
     return "Error while formatting log message";
   }
-  if (result <= LOG_BUFFER_SIZE) {
+  const auto buf_size = gsl::narrow<size_t>(result);
+  if (buf_size <= LOG_BUFFER_SIZE) {
     // static buffer was large enough
-    return std::string(buf, gsl::narrow<size_t>(result));
+    return {buf, buf_size};
   }
-  if (max_size >= 0 && max_size <= LOG_BUFFER_SIZE) {
+  if (max_size >= 0 && gsl::narrow<size_t>(max_size) <= LOG_BUFFER_SIZE) {
     // static buffer was already larger than allowed, use the filled buffer
-    return std::string(buf, LOG_BUFFER_SIZE);
+    return {buf, LOG_BUFFER_SIZE};
   }
   // try to use dynamic buffer
-  size_t dynamic_buffer_size = max_size < 0 ? gsl::narrow<size_t>(result) : gsl::narrow<size_t>(std::min(result, max_size));
+  size_t dynamic_buffer_size = max_size < 0 ? buf_size : gsl::narrow<size_t>(std::min(result, max_size));
   std::vector<char> buffer(dynamic_buffer_size + 1);  // extra '\0' character
   result = std::snprintf(buffer.data(), buffer.size(), format_str, conditional_convert(args)...);
   if (result < 0) {
     return "Error while formatting log message";
   }
-  return std::string(buffer.cbegin(), buffer.cend() - 1);  // -1 to not include the terminating '\0'
+  return {buffer.cbegin(), buffer.cend() - 1};  // -1 to not include the terminating '\0'
 }
 
 inline std::string format_string(int /*max_size*/, char const* format_str) {
   return format_str;
 }
 
-typedef enum {
+enum LOG_LEVEL {
   trace = 0,
   debug = 1,
   info = 2,
@@ -113,7 +109,7 @@ typedef enum {
   err = 4,
   critical = 5,
   off = 6
-} LOG_LEVEL;
+};
 
 class BaseLogger {
  public:
@@ -210,9 +206,11 @@ class Logger : public BaseLogger {
     max_log_size_ = size;
   }
 
-  bool should_log(const LOG_LEVEL &level);
+  bool should_log(const LOG_LEVEL &level) override;
 
-  virtual void log_string(LOG_LEVEL level, std::string str);
+  void log_string(LOG_LEVEL level, std::string str) override;
+
+  virtual std::optional<std::string> get_id() = 0;
 
  protected:
   Logger(std::shared_ptr<spdlog::logger> delegate, std::shared_ptr<LoggerControl> controller);
@@ -233,7 +231,10 @@ class Logger : public BaseLogger {
     if (!delegate_->should_log(level)) {
       return;
     }
-    const auto str = format_string(max_log_size_.load(), format, conditional_stringify(std::forward<Args>(args))...);
+    auto str = format_string(max_log_size_.load(), format, conditional_stringify(std::forward<Args>(args))...);
+    if (const auto id = get_id()) {
+      str = str + *id;
+    }
     delegate_->log(level, str);
   }
 
@@ -250,11 +251,4 @@ class Logger : public BaseLogger {
 
 #define LOG_WARN(x) LogBuilder((x).get(), org::apache::nifi::minifi::core::logging::LOG_LEVEL::warn)
 
-}  // namespace logging
-}  // namespace core
-}  // namespace minifi
-}  // namespace nifi
-}  // namespace apache
-}  // namespace org
-
-#endif  // LIBMINIFI_INCLUDE_CORE_LOGGING_LOGGER_H_
+}  // namespace org::apache::nifi::minifi::core::logging

--- a/libminifi/include/core/logging/Logger.h
+++ b/libminifi/include/core/logging/Logger.h
@@ -153,6 +153,9 @@ class LogBuilder {
 
 class Logger : public BaseLogger {
  public:
+  Logger(Logger const&) = delete;
+  Logger& operator=(Logger const&) = delete;
+
   /**
    * @brief Log error message
    * @param format format string ('man printf' for syntax)
@@ -216,7 +219,6 @@ class Logger : public BaseLogger {
 
   Logger(std::shared_ptr<spdlog::logger> delegate); // NOLINT
 
-
   std::shared_ptr<spdlog::logger> delegate_;
   std::shared_ptr<LoggerControl> controller_;
 
@@ -236,9 +238,6 @@ class Logger : public BaseLogger {
   }
 
   std::atomic<int> max_log_size_{LOG_BUFFER_SIZE};
-
-  Logger(Logger const&);
-  Logger& operator=(Logger const&);
 };
 
 #define LOG_DEBUG(x) LogBuilder((x).get(), org::apache::nifi::minifi::core::logging::LOG_LEVEL::debug)

--- a/libminifi/include/core/logging/LoggerConfiguration.h
+++ b/libminifi/include/core/logging/LoggerConfiguration.h
@@ -27,7 +27,6 @@
 #include <mutex>
 #include <string>
 #include <unordered_set>
-#include <utility>
 
 #include "spdlog/common.h"
 #include "spdlog/sinks/rotating_file_sink.h"

--- a/libminifi/include/core/logging/LoggerConfiguration.h
+++ b/libminifi/include/core/logging/LoggerConfiguration.h
@@ -60,8 +60,8 @@ struct LoggerNamespace {
   void forEachSink(const std::function<void(const std::shared_ptr<spdlog::sinks::sink>&)>& op) const;
 };
 
-inline std::optional<std::string> formatId(std::optional<std::string> id) {
-  return std::move(id) | utils::map([](auto str){ return " (" + str + ")"; });
+inline std::optional<std::string> formatId(std::optional<utils::Identifier> opt_id) {
+  return opt_id | utils::map([](auto id) { return " (" + std::string(id.to_string()) + ")"; });
 }
 }  // namespace internal
 
@@ -109,7 +109,7 @@ class LoggerConfiguration {
   /**
    * Can be used to get arbitrarily named Logger, LoggerFactory should be preferred within a class.
    */
-  std::shared_ptr<Logger> getLogger(const std::string& name, const std::optional<std::string>& id = {});
+  std::shared_ptr<Logger> getLogger(const std::string& name, const std::optional<utils::Identifier>& id = {});
 
   static const char *spdlog_default_pattern;
 
@@ -119,7 +119,7 @@ class LoggerConfiguration {
                                                     const std::shared_ptr<spdlog::formatter>& formatter, bool remove_if_present = false);
 
  private:
-  std::shared_ptr<Logger> getLogger(const std::string& name, const std::optional<std::string>& id, const std::lock_guard<std::mutex>& lock);
+  std::shared_ptr<Logger> getLogger(const std::string& name, const std::optional<utils::Identifier>& id, const std::lock_guard<std::mutex>& lock);
 
   void initializeCompression(const std::lock_guard<std::mutex>& lock, const std::shared_ptr<LoggerProperties>& properties);
 
@@ -132,10 +132,10 @@ class LoggerConfiguration {
 
   class LoggerImpl : public Logger {
    public:
-    explicit LoggerImpl(std::string name, std::optional<std::string> id, const std::shared_ptr<LoggerControl> &controller, const std::shared_ptr<spdlog::logger> &delegate)
+    explicit LoggerImpl(std::string name, std::optional<utils::Identifier> id, const std::shared_ptr<LoggerControl> &controller, const std::shared_ptr<spdlog::logger> &delegate)
         : Logger(delegate, controller),
           name(std::move(name)),
-          id(internal::formatId(std::move(id))) {
+          id(internal::formatId(id)) {
     }
 
     void set_delegate(std::shared_ptr<spdlog::logger> delegate) {

--- a/libminifi/include/core/logging/LoggerConfiguration.h
+++ b/libminifi/include/core/logging/LoggerConfiguration.h
@@ -58,11 +58,6 @@ struct LoggerNamespace {
   std::map<std::string, std::shared_ptr<LoggerNamespace>> children;
 
   void forEachSink(const std::function<void(const std::shared_ptr<spdlog::sinks::sink>&)>& op) const;
-
-  LoggerNamespace()
-      : sinks(std::vector<std::shared_ptr<spdlog::sinks::sink>>()),
-        children(std::map<std::string, std::shared_ptr<LoggerNamespace>>()) {
-  }
 };
 }  // namespace internal
 

--- a/libminifi/include/core/logging/LoggerFactory.h
+++ b/libminifi/include/core/logging/LoggerFactory.h
@@ -28,18 +28,19 @@ namespace org::apache::nifi::minifi::core::logging {
 
 class LoggerFactoryBase {
  public:
-  static std::shared_ptr<Logger> getAliasedLogger(const std::string &alias);
+  static std::shared_ptr<Logger> getAliasedLogger(const std::string& name, const std::optional<std::string>& id = {});
 };
 
 template<typename T>
 class LoggerFactory : public LoggerFactoryBase {
  public:
-  /**
-   * Gets an initialized logger for the template class.
-   */
   static std::shared_ptr<Logger> getLogger() {
     static std::shared_ptr<Logger> logger = getAliasedLogger(core::getClassName<T>());
     return logger;
+  }
+
+  static std::shared_ptr<Logger> getLogger(const utils::Identifier& uuid) {
+    return getAliasedLogger(core::getClassName<T>(), std::string{uuid.to_string()});
   }
 };
 

--- a/libminifi/include/core/logging/LoggerFactory.h
+++ b/libminifi/include/core/logging/LoggerFactory.h
@@ -28,7 +28,7 @@ namespace org::apache::nifi::minifi::core::logging {
 
 class LoggerFactoryBase {
  public:
-  static std::shared_ptr<Logger> getAliasedLogger(const std::string& name, const std::optional<std::string>& id = {});
+  static std::shared_ptr<Logger> getAliasedLogger(const std::string& name, const std::optional<utils::Identifier>& id = {});
 };
 
 template<typename T>
@@ -40,7 +40,7 @@ class LoggerFactory : public LoggerFactoryBase {
   }
 
   static std::shared_ptr<Logger> getLogger(const utils::Identifier& uuid) {
-    return getAliasedLogger(core::getClassName<T>(), std::string{uuid.to_string()});
+    return getAliasedLogger(core::getClassName<T>(), uuid);
   }
 };
 

--- a/libminifi/src/core/Connectable.cpp
+++ b/libminifi/src/core/Connectable.cpp
@@ -29,14 +29,14 @@ Connectable::Connectable(std::string name, const utils::Identifier &uuid)
     : CoreComponent(std::move(name), uuid),
       max_concurrent_tasks_(1),
       connectable_version_(nullptr),
-      logger_(logging::LoggerFactory<Connectable>::getLogger()) {
+      logger_(logging::LoggerFactory<Connectable>::getLogger(uuid_)) {
 }
 
 Connectable::Connectable(std::string name)
     : CoreComponent(std::move(name)),
       max_concurrent_tasks_(1),
       connectable_version_(nullptr),
-      logger_(logging::LoggerFactory<Connectable>::getLogger()) {
+      logger_(logging::LoggerFactory<Connectable>::getLogger(uuid_)) {
 }
 
 Connectable::~Connectable() = default;

--- a/libminifi/src/core/Processor.cpp
+++ b/libminifi/src/core/Processor.cpp
@@ -43,7 +43,7 @@ namespace org::apache::nifi::minifi::core {
 
 Processor::Processor(std::string name, std::shared_ptr<ProcessorMetrics> metrics)
     : Connectable(std::move(name)),
-      logger_(logging::LoggerFactory<Processor>::getLogger()),
+      logger_(logging::LoggerFactory<Processor>::getLogger(uuid_)),
       metrics_(metrics ? std::move(metrics) : std::make_shared<ProcessorMetrics>(*this)) {
   has_work_.store(false);
   // Setup the default values
@@ -62,7 +62,7 @@ Processor::Processor(std::string name, std::shared_ptr<ProcessorMetrics> metrics
 
 Processor::Processor(std::string name, const utils::Identifier& uuid, std::shared_ptr<ProcessorMetrics> metrics)
     : Connectable(std::move(name), uuid),
-      logger_(logging::LoggerFactory<Processor>::getLogger()),
+      logger_(logging::LoggerFactory<Processor>::getLogger(uuid_)),
       metrics_(metrics ? std::move(metrics) : std::make_shared<ProcessorMetrics>(*this)) {
   has_work_.store(false);
   // Setup the default values

--- a/libminifi/src/core/logging/LoggerConfiguration.cpp
+++ b/libminifi/src/core/logging/LoggerConfiguration.cpp
@@ -148,12 +148,12 @@ void LoggerConfiguration::initialize(const std::shared_ptr<LoggerProperties> &lo
   logger_->log_debug("Set following pattern on loggers: %s", spdlog_pattern);
 }
 
-std::shared_ptr<Logger> LoggerConfiguration::getLogger(const std::string& name, const std::optional<std::string>& id) {
+std::shared_ptr<Logger> LoggerConfiguration::getLogger(const std::string& name, const std::optional<utils::Identifier>& id) {
   std::lock_guard<std::mutex> lock(mutex);
   return getLogger(name, id, lock);
 }
 
-std::shared_ptr<Logger> LoggerConfiguration::getLogger(const std::string& name, const std::optional<std::string>& id, const std::lock_guard<std::mutex>& /*lock*/) {
+std::shared_ptr<Logger> LoggerConfiguration::getLogger(const std::string& name, const std::optional<utils::Identifier>& id, const std::lock_guard<std::mutex>& /*lock*/) {
   std::string adjusted_name = name;
   const std::string clazz = "class ";
   auto haz_clazz = name.find(clazz);

--- a/libminifi/src/core/logging/LoggerConfiguration.cpp
+++ b/libminifi/src/core/logging/LoggerConfiguration.cpp
@@ -91,10 +91,13 @@ std::vector<std::string> LoggerProperties::get_keys_of_type(const std::string &t
 
 LoggerConfiguration::LoggerConfiguration()
     : root_namespace_(create_default_root()),
-      formatter_(std::make_shared<spdlog::pattern_formatter>(spdlog_default_pattern)),
-      shorten_names_(false) {
+      formatter_(std::make_shared<spdlog::pattern_formatter>(spdlog_default_pattern)) {
   controller_ = std::make_shared<LoggerControl>();
-  logger_ = std::make_shared<LoggerImpl>(core::getClassName<LoggerConfiguration>(), controller_, get_logger(nullptr, root_namespace_, core::getClassName<LoggerConfiguration>(), formatter_));
+  logger_ = std::make_shared<LoggerImpl>(
+      core::getClassName<LoggerConfiguration>(),
+      std::nullopt,
+      controller_,
+      get_logger(nullptr, root_namespace_, core::getClassName<LoggerConfiguration>(), formatter_));
   loggers.push_back(logger_);
 }
 
@@ -121,9 +124,12 @@ void LoggerConfiguration::initialize(const std::shared_ptr<LoggerProperties> &lo
   /**
    * There is no need to shorten names per spdlog sink as this is a per log instance.
    */
-  std::string shorten_names_str;
-  if (logger_properties->getString("spdlog.shorten_names", shorten_names_str)) {
-    shorten_names_ = utils::StringUtils::toBool(shorten_names_str).value_or(false);
+  if (const auto shorten_names_str = logger_properties->getString("spdlog.shorten_names")) {
+    shorten_names_ = utils::StringUtils::toBool(*shorten_names_str).value_or(false);
+  }
+
+  if (const auto include_uuid_str = logger_properties->getString("logger.include.uuid")) {
+    include_uuid_ = utils::StringUtils::toBool(*include_uuid_str).value_or(true);
   }
 
   formatter_ = std::make_shared<spdlog::pattern_formatter>(spdlog_pattern);
@@ -142,12 +148,12 @@ void LoggerConfiguration::initialize(const std::shared_ptr<LoggerProperties> &lo
   logger_->log_debug("Set following pattern on loggers: %s", spdlog_pattern);
 }
 
-std::shared_ptr<Logger> LoggerConfiguration::getLogger(const std::string &name) {
+std::shared_ptr<Logger> LoggerConfiguration::getLogger(const std::string& name, const std::optional<std::string>& id) {
   std::lock_guard<std::mutex> lock(mutex);
-  return getLogger(name, lock);
+  return getLogger(name, id, lock);
 }
 
-std::shared_ptr<Logger> LoggerConfiguration::getLogger(const std::string &name, const std::lock_guard<std::mutex>& /*lock*/) {
+std::shared_ptr<Logger> LoggerConfiguration::getLogger(const std::string& name, const std::optional<std::string>& id, const std::lock_guard<std::mutex>& /*lock*/) {
   std::string adjusted_name = name;
   const std::string clazz = "class ";
   auto haz_clazz = name.find(clazz);
@@ -157,7 +163,9 @@ std::shared_ptr<Logger> LoggerConfiguration::getLogger(const std::string &name, 
     utils::ClassUtils::shortenClassName(adjusted_name, adjusted_name);
   }
 
-  std::shared_ptr<LoggerImpl> result = std::make_shared<LoggerImpl>(adjusted_name, controller_, get_logger(logger_, root_namespace_, adjusted_name, formatter_));
+  const auto id_if_enabled = include_uuid_ ? id : std::nullopt;
+
+  std::shared_ptr<LoggerImpl> result = std::make_shared<LoggerImpl>(adjusted_name, id_if_enabled, controller_, get_logger(logger_, root_namespace_, adjusted_name, formatter_));
   loggers.push_back(result);
   return result;
 }
@@ -320,7 +328,7 @@ std::shared_ptr<internal::LoggerNamespace> LoggerConfiguration::create_default_r
 }
 
 void LoggerConfiguration::initializeCompression(const std::lock_guard<std::mutex>& lock, const std::shared_ptr<LoggerProperties>& properties) {
-  auto compression_sink = compression_manager_.initialize(properties, logger_, [&] (const std::string& name) {return getLogger(name, lock);});
+  auto compression_sink = compression_manager_.initialize(properties, logger_, [&] (const std::string& name) {return getLogger(name, std::nullopt, lock);});
   if (compression_sink) {
     root_namespace_->sinks.push_back(compression_sink);
     root_namespace_->exported_sinks.push_back(compression_sink);

--- a/libminifi/src/core/logging/LoggerFactory.cpp
+++ b/libminifi/src/core/logging/LoggerFactory.cpp
@@ -21,8 +21,8 @@
 
 namespace org::apache::nifi::minifi::core::logging {
 
-std::shared_ptr<Logger> LoggerFactoryBase::getAliasedLogger(const std::string &alias) {
-  return LoggerConfiguration::getConfiguration().getLogger(alias);
+std::shared_ptr<Logger> LoggerFactoryBase::getAliasedLogger(const std::string& name, const std::optional<std::string>& id) {
+  return LoggerConfiguration::getConfiguration().getLogger(name, id);
 }
 
 }  // namespace org::apache::nifi::minifi::core::logging

--- a/libminifi/src/core/logging/LoggerFactory.cpp
+++ b/libminifi/src/core/logging/LoggerFactory.cpp
@@ -21,7 +21,7 @@
 
 namespace org::apache::nifi::minifi::core::logging {
 
-std::shared_ptr<Logger> LoggerFactoryBase::getAliasedLogger(const std::string& name, const std::optional<std::string>& id) {
+std::shared_ptr<Logger> LoggerFactoryBase::getAliasedLogger(const std::string& name, const std::optional<utils::Identifier>& id) {
   return LoggerConfiguration::getConfiguration().getLogger(name, id);
 }
 

--- a/libminifi/test/ReadFromFlowFileTestProcessor.h
+++ b/libminifi/test/ReadFromFlowFileTestProcessor.h
@@ -56,7 +56,6 @@ class ReadFromFlowFileTestProcessor : public core::Processor {
 
   ADD_COMMON_VIRTUAL_FUNCTIONS_FOR_PROCESSORS
 
- public:
   void onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory) override;
   void onTrigger(core::ProcessContext *context, core::ProcessSession *session) override;
   void initialize() override;
@@ -89,7 +88,7 @@ class ReadFromFlowFileTestProcessor : public core::Processor {
     std::map<std::string, std::string> attributes_;
   };
   bool clear_on_trigger_ = true;
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ReadFromFlowFileTestProcessor>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<ReadFromFlowFileTestProcessor>::getLogger(uuid_);
   std::vector<FlowFileData> flow_files_read_;
 };
 

--- a/libminifi/test/TestBase.cpp
+++ b/libminifi/test/TestBase.cpp
@@ -70,8 +70,8 @@ void LogTestController::setLevel(const std::string& name, spdlog::level::level_e
   logging::LoggerConfiguration::getSpdlogLogger(adjusted_name)->set_level(level);
 }
 
-std::shared_ptr<logging::Logger> LogTestController::getLoggerByClassName(const std::string& class_name) {
-  return config ? config->getLogger(class_name) : logging::LoggerConfiguration::getConfiguration().getLogger(class_name);
+std::shared_ptr<logging::Logger> LogTestController::getLoggerByClassName(const std::string& class_name, const std::optional<std::string>& id) {
+  return config ? config->getLogger(class_name, id) : logging::LoggerConfiguration::getConfiguration().getLogger(class_name, id);
 }
 
 void LogTestController::setLevelByClassName(spdlog::level::level_enum level, const std::string& class_name) {

--- a/libminifi/test/TestBase.cpp
+++ b/libminifi/test/TestBase.cpp
@@ -70,7 +70,7 @@ void LogTestController::setLevel(const std::string& name, spdlog::level::level_e
   logging::LoggerConfiguration::getSpdlogLogger(adjusted_name)->set_level(level);
 }
 
-std::shared_ptr<logging::Logger> LogTestController::getLoggerByClassName(const std::string& class_name, const std::optional<std::string>& id) {
+std::shared_ptr<logging::Logger> LogTestController::getLoggerByClassName(const std::string& class_name, const std::optional<utils::Identifier>& id) {
   return config ? config->getLogger(class_name, id) : logging::LoggerConfiguration::getConfiguration().getLogger(class_name, id);
 }
 

--- a/libminifi/test/TestBase.h
+++ b/libminifi/test/TestBase.h
@@ -118,9 +118,9 @@ class LogTestController {
    * of changeable test formats
    */
   template<typename T>
-  std::shared_ptr<logging::Logger> getLogger() { return getLoggerByClassName(minifi::core::getClassName<T>()); }
+  std::shared_ptr<logging::Logger> getLogger(const std::optional<std::string>& id = {}) { return getLoggerByClassName(minifi::core::getClassName<T>(), id); }
 
-  std::shared_ptr<logging::Logger> getLoggerByClassName(const std::string& class_name);
+  std::shared_ptr<logging::Logger> getLoggerByClassName(const std::string& class_name, const std::optional<std::string>& id = {});
 
   template<typename T>
   void setLevel(spdlog::level::level_enum level) {

--- a/libminifi/test/TestBase.h
+++ b/libminifi/test/TestBase.h
@@ -118,9 +118,9 @@ class LogTestController {
    * of changeable test formats
    */
   template<typename T>
-  std::shared_ptr<logging::Logger> getLogger(const std::optional<std::string>& id = {}) { return getLoggerByClassName(minifi::core::getClassName<T>(), id); }
+  std::shared_ptr<logging::Logger> getLogger(const std::optional<utils::Identifier>& id = {}) { return getLoggerByClassName(minifi::core::getClassName<T>(), id); }
 
-  std::shared_ptr<logging::Logger> getLoggerByClassName(const std::string& class_name, const std::optional<std::string>& id = {});
+  std::shared_ptr<logging::Logger> getLoggerByClassName(const std::string& class_name, const std::optional<utils::Identifier>& id = {});
 
   template<typename T>
   void setLevel(spdlog::level::level_enum level) {

--- a/libminifi/test/WriteToFlowFileTestProcessor.h
+++ b/libminifi/test/WriteToFlowFileTestProcessor.h
@@ -51,7 +51,6 @@ class WriteToFlowFileTestProcessor : public core::Processor {
 
   ADD_COMMON_VIRTUAL_FUNCTIONS_FOR_PROCESSORS
 
- public:
   void onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory) override;
   void onTrigger(core::ProcessContext *context, core::ProcessSession *session) override;
   void initialize() override;
@@ -66,7 +65,7 @@ class WriteToFlowFileTestProcessor : public core::Processor {
   }
 
  private:
-  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<WriteToFlowFileTestProcessor>::getLogger();
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<WriteToFlowFileTestProcessor>::getLogger(uuid_);
   std::string content_;
 };
 

--- a/libminifi/test/sql-tests/mocks/MockODBCService.h
+++ b/libminifi/test/sql-tests/mocks/MockODBCService.h
@@ -32,7 +32,7 @@ class MockODBCService : public DatabaseService {
  public:
   explicit MockODBCService(std::string name, utils::Identifier uuid = utils::Identifier())
     : DatabaseService(std::move(name), uuid),
-      logger_(logging::LoggerFactory<MockODBCService>::getLogger()) {
+      logger_(logging::LoggerFactory<MockODBCService>::getLogger(uuid)) {
     initialize();
   }
 

--- a/libminifi/test/unit/LoggerTests.cpp
+++ b/libminifi/test/unit/LoggerTests.cpp
@@ -106,7 +106,7 @@ TEST_CASE("Printing of the ID can be disabled in the config", "[logger][id][conf
   }
 
   const auto uuid = utils::IdGenerator::getIdGenerator()->generate();
-  std::shared_ptr<logging::Logger> logger = LogTestController::getInstance(properties)->getLogger<logging::Logger>(std::string{uuid.to_string()});
+  std::shared_ptr<logging::Logger> logger = LogTestController::getInstance(properties)->getLogger<logging::Logger>(uuid);
   logger->log_error("hello %s", "world");
 
   CHECK(LogTestController::getInstance().contains("[org::apache::nifi::minifi::core::logging::Logger] [error] hello world"));

--- a/libminifi/test/unit/LoggerTests.cpp
+++ b/libminifi/test/unit/LoggerTests.cpp
@@ -79,6 +79,41 @@ TEST_CASE("Test log Levels change", "[ttl5]") {
   LogTestController::getInstance().reset();
 }
 
+TEST_CASE("Logger configured with an ID prints this ID in every log line", "[logger][id]") {
+  LogTestController::getInstance().setTrace<logging::Logger>();
+  const auto uuid = utils::IdGenerator::getIdGenerator()->generate();
+  std::shared_ptr<logging::Logger> logger = logging::LoggerFactory<logging::Logger>::getLogger(uuid);
+  logger->log_error("hello %s", "world");
+
+  CHECK(LogTestController::getInstance().contains("[org::apache::nifi::minifi::core::logging::Logger] [error] hello world (" + uuid.to_string() + ")"));
+  LogTestController::getInstance().reset();
+}
+
+TEST_CASE("Printing of the ID can be disabled in the config", "[logger][id][configuration]") {
+  auto properties = std::make_shared<logging::LoggerProperties>();
+
+  bool id_is_present{};
+  SECTION("Property not set") {
+    id_is_present = true;
+  }
+  SECTION("Property set to true") {
+    properties->set("logger.include.uuid", "true");
+    id_is_present = true;
+  }
+  SECTION("Property set to false") {
+    properties->set("logger.include.uuid", "false");
+    id_is_present = false;
+  }
+
+  const auto uuid = utils::IdGenerator::getIdGenerator()->generate();
+  std::shared_ptr<logging::Logger> logger = LogTestController::getInstance(properties)->getLogger<logging::Logger>(std::string{uuid.to_string()});
+  logger->log_error("hello %s", "world");
+
+  CHECK(LogTestController::getInstance().contains("[org::apache::nifi::minifi::core::logging::Logger] [error] hello world"));
+  CHECK(id_is_present == LogTestController::getInstance().contains(uuid.to_string()));
+  LogTestController::getInstance().reset();
+}
+
 struct CStringConvertible {
   [[nodiscard]] const char* c_str() const {
     return data.c_str();

--- a/nanofi/include/cxx/CallbackProcessor.h
+++ b/nanofi/include/cxx/CallbackProcessor.h
@@ -17,8 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __CALLBACK_PROCESSOR_H__
-#define __CALLBACK_PROCESSOR_H__
+#pragma once
 
 #include <stdio.h>
 #include <string>
@@ -73,9 +72,7 @@ class CallbackProcessor : public core::Processor {
   std::function<void(core::ProcessSession*, core::ProcessContext *context)> ontrigger_callback_;
   std::function<void(core::ProcessContext *context)> onschedule_callback_;
  private:
-  std::shared_ptr<core::logging::Logger> logger_{ core::logging::LoggerFactory<CallbackProcessor>::getLogger() };
+  std::shared_ptr<core::logging::Logger> logger_{ core::logging::LoggerFactory<CallbackProcessor>::getLogger(uuid_) };
 };
 
 }  // namespace org::apache::nifi::minifi::processors
-
-#endif


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-1948

Add the component UUID to the end of lines logged by Processors and Controller Services.  See an example in the Jira.

The feature is on by default, but can be turned off in `minifi-log.properties`.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
