### PR TITLE
MINIFICPP-1983 Modify correct minifi.properties file for test containers

### DIFF
--- a/docker/test/integration/cluster/containers/MinifiContainer.py
+++ b/docker/test/integration/cluster/containers/MinifiContainer.py
@@ -65,7 +65,7 @@ class MinifiContainer(FlowContainer):
             config_file.write(test_flow_yaml.encode('utf-8'))
 
     def _create_properties(self):
-        properties_file_path = os.path.join(self.config_dir, 'minifi.properties')
+        properties_file_path = os.path.join(self.container_specific_config_dir, 'minifi.properties')
         with open(properties_file_path, 'a') as f:
             if self.options.enable_c2:
                 f.write("nifi.c2.enable=true\n")
@@ -82,6 +82,7 @@ class MinifiContainer(FlowContainer):
                 f.write("nifi.c2.rest.url.ack=https://minifi-c2-server:10090/c2/config/acknowledge\n")
                 f.write("nifi.c2.rest.ssl.context.service=SSLContextService\n")
                 f.write("nifi.c2.flow.base.url=https://minifi-c2-server:10090/c2/config/\n")
+                f.write("nifi.c2.root.classes=DeviceInfoNode,AgentInformation,FlowInformation\n")
                 f.write("nifi.c2.full.heartbeat=false\n")
                 f.write("nifi.c2.agent.class=minifi-test-class\n")
                 f.write("nifi.c2.agent.identifier=minifi-test-id\n")
@@ -99,9 +100,9 @@ class MinifiContainer(FlowContainer):
         self._create_config()
         self._create_properties()
 
-        self.vols[os.path.join(self.config_dir, 'minifi.properties')] = {"bind": os.path.join(MinifiContainer.MINIFI_ROOT, 'conf', 'minifi.properties'), "mode": "rw"}
+        self.vols[os.path.join(self.container_specific_config_dir, 'minifi.properties')] = {"bind": os.path.join(MinifiContainer.MINIFI_ROOT, 'conf', 'minifi.properties'), "mode": "rw"}
         self.vols[os.path.join(self.container_specific_config_dir, 'config.yml')] = {"bind": os.path.join(MinifiContainer.MINIFI_ROOT, 'conf', 'config.yml'), "mode": "rw"}
-        self.vols[os.path.join(self.config_dir, 'minifi-log.properties')] = {"bind": os.path.join(MinifiContainer.MINIFI_ROOT, 'conf', 'minifi-log.properties'), "mode": "rw"}
+        self.vols[os.path.join(self.container_specific_config_dir, 'minifi-log.properties')] = {"bind": os.path.join(MinifiContainer.MINIFI_ROOT, 'conf', 'minifi-log.properties'), "mode": "rw"}
 
     def deploy(self):
         if not self.set_deployed():

--- a/docker/test/integration/resources/minifi-c2-server-ssl/config.yml
+++ b/docker/test/integration/resources/minifi-c2-server-ssl/config.yml
@@ -33,11 +33,11 @@ Controller Services:
     class: SSLContextService
     Properties:
       Client Certificate:
-          - value: /tmp/minifi-c2-server-ssl/minifi-c2-client.crt
+        - value: /tmp/resources/minifi-c2-server-ssl/minifi-cpp-flow.crt
       Private Key:
-          - value: /tmp/minifi-c2-server-ssl/minifi-c2-client.key
+        - value: /tmp/resources/minifi-c2-server-ssl/minifi-cpp-flow.key
       Passphrase:
-          - value: abcdefgh
+        - value: abcdefgh
       CA Certificate:
-          - value: /tmp/minifi-c2-server-ssl/minifi-c2-server.crt
+        - value: /tmp/resources/minifi-c2-server-ssl/root-ca.pem
 Remote Process Groups: []


### PR DESCRIPTION
The tests appended the base minifi.properties file in the base minifi_config directory instead of the minifi.properties file in the container specific config directory. Due to this the base properties file was appended for every single test that needed it and could cause the failure of all tests after a test case with a faulty configuration file. This change fixes the issue by leaving base minifi.properties file and only appending the container specific one.

https://issues.apache.org/jira/browse/MINIFICPP-1983

--------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
