### PR TITLE
MINIFICPP-2020 Improve error messages when MiNiFi is not able to start

### DIFF
--- a/minifi_main/MiNiFiMain.cpp
+++ b/minifi_main/MiNiFiMain.cpp
@@ -260,8 +260,9 @@ int main(int argc, char **argv) {
     minifi::core::extension::ExtensionManager::get().initialize(configure);
 
     if (argc >= 2 && std::string("docs") == argv[1]) {
-      if (argc == 2) {
-        std::cerr << "Usage: <minifiexe> docs <directory where to write individual doc files> <file where to write PROCESSORS.md>\n";
+      if (argc < 3 || argc > 4) {
+        std::cerr << "Usage: <minifiexe> docs <directory where to write individual doc files> [file where to write PROCESSORS.md]\n";
+        std::cerr << "    If no file name is given for PROCESSORS.md, it will be printed to stdout.\n";
         exit(1);
       }
       if (utils::file::create_dir(argv[2]) != 0) {

--- a/minifi_main/MiNiFiWindowsService.cpp
+++ b/minifi_main/MiNiFiWindowsService.cpp
@@ -246,18 +246,10 @@ void RunAsServiceIfNeeded() {
   ExitProcess(0);
 }
 
-HANDLE GetTerminationEventHandle(bool* isStartedByService) {
-  *isStartedByService = true;
-  HANDLE hEvent = CreateEvent(0, TRUE, FALSE, SERVICE_TERMINATION_EVENT_NAME);
-  if (!hEvent) {
-    return nullptr;
-  }
+std::tuple<bool, HANDLE> GetTerminationEventHandle() {
+  HANDLE hEvent = CreateEvent(nullptr, TRUE, FALSE, SERVICE_TERMINATION_EVENT_NAME);
 
-  if (GetLastError() != ERROR_ALREADY_EXISTS) {
-    *isStartedByService = false;
-  }
-
-  return hEvent;
+  return std::make_tuple(GetLastError() == ERROR_ALREADY_EXISTS, hEvent);
 }
 
 bool CreateServiceTerminationThread(std::shared_ptr<minifi::core::logging::Logger> logger, HANDLE terminationEventHandle) {

--- a/minifi_main/MiNiFiWindowsService.cpp
+++ b/minifi_main/MiNiFiWindowsService.cpp
@@ -246,10 +246,13 @@ void RunAsServiceIfNeeded() {
   ExitProcess(0);
 }
 
-std::tuple<bool, HANDLE> GetTerminationEventHandle() {
+GetTerminationEventHandleReturnType GetTerminationEventHandle() {
   HANDLE hEvent = CreateEvent(nullptr, TRUE, FALSE, SERVICE_TERMINATION_EVENT_NAME);
 
-  return std::make_tuple(GetLastError() == ERROR_ALREADY_EXISTS, hEvent);
+  return {
+    .is_started_by_service = (GetLastError() == ERROR_ALREADY_EXISTS),
+    .termination_event_handler = hEvent
+  };
 }
 
 bool CreateServiceTerminationThread(std::shared_ptr<minifi::core::logging::Logger> logger, HANDLE terminationEventHandle) {

--- a/minifi_main/MiNiFiWindowsService.h
+++ b/minifi_main/MiNiFiWindowsService.h
@@ -20,12 +20,16 @@
 #ifdef WIN32
 
 #include <memory>
-#include <utility>
 
 #include "core/Core.h"
 
+struct GetTerminationEventHandleReturnType {
+  bool is_started_by_service;
+  HANDLE termination_event_handler;
+};
+
 void RunAsServiceIfNeeded();
-std::tuple<bool, HANDLE> GetTerminationEventHandle();
+GetTerminationEventHandleReturnType GetTerminationEventHandle();
 bool CreateServiceTerminationThread(std::shared_ptr<org::apache::nifi::minifi::core::logging::Logger> logger, HANDLE terminationEventHandle);
 
 #endif

--- a/minifi_main/MiNiFiWindowsService.h
+++ b/minifi_main/MiNiFiWindowsService.h
@@ -20,10 +20,12 @@
 #ifdef WIN32
 
 #include <memory>
+#include <utility>
+
 #include "core/Core.h"
 
 void RunAsServiceIfNeeded();
-HANDLE GetTerminationEventHandle(bool* isStartedByService);
+std::tuple<bool, HANDLE> GetTerminationEventHandle();
 bool CreateServiceTerminationThread(std::shared_ptr<org::apache::nifi::minifi::core::logging::Logger> logger, HANDLE terminationEventHandle);
 
 #endif


### PR DESCRIPTION
This came out of investigating https://issues.apache.org/jira/browse/MINIFICPP-2020, and doesn't solve any of the problems (also, it's not clear whether there are any problems really), but at least it improves the error messages.

In particular, it was quite bad that in one case MiNiFi just quit without giving any error messages at all.  Also, I did not like the fact that `minifi docs` (without any arguments) started up MiNiFi in normal mode, ignoring the "docs" argument, instead of telling the user to give additional arguments.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
