### PR TITLE
MINIFICPP-2036 Use the new ccache directory in alpine 3.16

### DIFF
--- a/docker/DockerBuild.sh
+++ b/docker/DockerBuild.sh
@@ -51,7 +51,7 @@ function dump_ccache() {
   docker_ccache_dump_location=$2
   container_id=$(docker run --rm -d "${ccache_source_image}" sh -c "while true; do sleep 1; done")
   mkdir -p "${docker_ccache_dump_location}"
-  docker cp "${container_id}:/home/minificpp/.ccache/." "${docker_ccache_dump_location}"
+  docker cp "${container_id}:/opt/minifi/.ccache/." "${docker_ccache_dump_location}"
   docker rm -f "${container_id}"
 }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,17 +72,16 @@ ENV MINIFI_VERSION ${MINIFI_VERSION}
 RUN addgroup -g ${GID} ${USER} && adduser -u ${UID} -D -G ${USER} -g "" ${USER} && \
     install -d -o ${USER} -g ${USER} ${MINIFI_BASE_DIR}
 COPY --chown=${USER}:${USER} . ${MINIFI_BASE_DIR}
-RUN if [ -d "${MINIFI_BASE_DIR}/.ccache" ]; then mv ${MINIFI_BASE_DIR}/.ccache /home/${USER}/.ccache; fi
 
 USER ${USER}
 
-ENV PATH /usr/lib/ccache/bin:${PATH}
 RUN mkdir ${MINIFI_BASE_DIR}/build
 WORKDIR ${MINIFI_BASE_DIR}/build
-RUN cmake -DSTATIC_BUILD= -DSKIP_TESTS=${DOCKER_SKIP_TESTS} ${MINIFI_OPTIONS} -DAWS_ENABLE_UNITY_BUILD=OFF -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" .. && \
+RUN export PATH=/usr/lib64/ccache/bin${PATH:+:${PATH}} && \
+    export CCACHE_DIR=${MINIFI_BASE_DIR}/.ccache && \
+    cmake -DSTATIC_BUILD= -DSKIP_TESTS=${DOCKER_SKIP_TESTS} ${MINIFI_OPTIONS} -DAWS_ENABLE_UNITY_BUILD=OFF -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" .. && \
     make -j "$(nproc)" package && \
     tar -xzvf "${MINIFI_BASE_DIR}/build/nifi-minifi-cpp-${MINIFI_VERSION}.tar.gz" -C "${MINIFI_BASE_DIR}"
-
 
 # Release image
 FROM ${BASE_ALPINE_IMAGE} AS release

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -49,8 +49,7 @@ RUN cd $MINIFI_BASE_DIR && \
 
 # Setup minificpp user
 RUN groupadd -g ${GID} ${USER} && useradd -g ${GID} ${USER} && \
-    chown -R ${USER}:${USER} ${MINIFI_BASE_DIR} && \
-    if [ -d "${MINIFI_BASE_DIR}/.ccache" ]; then mv ${MINIFI_BASE_DIR}/.ccache /home/${USER}/.ccache; fi
+    chown -R ${USER}:${USER} ${MINIFI_BASE_DIR}
 
 USER ${USER}
 
@@ -59,5 +58,6 @@ RUN cd $MINIFI_BASE_DIR && \
     cd build && \
     source /opt/rh/devtoolset-11/enable && \
     export PATH=/usr/lib64/ccache${PATH:+:${PATH}} && \
+    export CCACHE_DIR=${MINIFI_BASE_DIR}/.ccache && \
     cmake3 -DSTATIC_BUILD= -DSKIP_TESTS=${DOCKER_SKIP_TESTS} ${MINIFI_OPTIONS} -DAWS_ENABLE_UNITY_BUILD=OFF -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" .. && \
     make -j "$(nproc)" package


### PR DESCRIPTION
Bugfix for PR #1495.  In alpine 3.13 -> 3.16, the default ccache directory changed from `$HOME/.ccache` to `$HOME/.cache/ccache`.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
