### PR TITLE
MINIFICPP-2057 Improve the performance of ListFile

### DIFF
--- a/extensions/standard-processors/processors/ListFile.cpp
+++ b/extensions/standard-processors/processors/ListFile.cpp
@@ -94,7 +94,6 @@ void ListFile::onSchedule(const std::shared_ptr<core::ProcessContext> &context, 
   }
   state_manager_ = std::make_unique<minifi::utils::ListingStateManager>(state_manager);
 
-  std::string input_directory_str;
   if (auto input_directory_str = context->getProperty(InputDirectory); !input_directory_str || input_directory_str->empty()) {
     throw Exception(PROCESS_SCHEDULE_EXCEPTION, "Input Directory property missing or invalid");
   } else {

--- a/extensions/standard-processors/processors/ListFile.cpp
+++ b/extensions/standard-processors/processors/ListFile.cpp
@@ -101,12 +101,13 @@ void ListFile::onSchedule(const std::shared_ptr<core::ProcessContext> &context, 
   }
 
   context->getProperty(RecurseSubdirectories.getName(), recurse_subdirectories_);
+
   std::string value;
   if (context->getProperty(FileFilter.getName(), value) && !value.empty()) {
     file_filter_ = std::regex(value);
   }
 
-  if (context->getProperty(PathFilter.getName(), value) && !value.empty()) {
+  if (recurse_subdirectories_ && context->getProperty(PathFilter.getName(), value) && !value.empty()) {
     path_filter_ = std::regex(value);
   }
 
@@ -147,7 +148,7 @@ bool ListFile::fileMatchesFilters(const ListedFile& listed_file) {
 
   if (path_filter_) {
     const auto relative_path = std::filesystem::relative(listed_file.full_file_path.parent_path(), input_directory_);
-    if (relative_path != "." && !std::regex_match(relative_path.string(), *path_filter_)) {
+    if (!std::regex_match(relative_path.string(), *path_filter_)) {
       logger_->log_debug("Relative path '%s' does not match path filter so file '%s' will not be listed", relative_path.string(), listed_file.full_file_path.string());
       return false;
     }

--- a/extensions/standard-processors/processors/ListFile.cpp
+++ b/extensions/standard-processors/processors/ListFile.cpp
@@ -245,7 +245,7 @@ void ListFile::onTrigger(const std::shared_ptr<core::ProcessContext> &context, c
       listed_file.last_modified_time = std::chrono::time_point_cast<std::chrono::milliseconds>(utils::file::to_sys(*last_modified_time));
     } else {
       logger_->log_warn("Could not get last modification time of file '%s'", listed_file.full_file_path.string());
-      continue;
+      listed_file.last_modified_time = {};
     }
 
     if (stored_listing_state.wasObjectListedAlready(listed_file)) {

--- a/extensions/standard-processors/processors/ListFile.h
+++ b/extensions/standard-processors/processors/ListFile.h
@@ -81,19 +81,15 @@ class ListFile : public core::Processor {
  private:
   struct ListedFile : public utils::ListedObject {
     [[nodiscard]] std::chrono::time_point<std::chrono::system_clock> getLastModified() const override {
-      return std::chrono::time_point_cast<std::chrono::milliseconds>(utils::file::FileUtils::to_sys(last_modified_time));
+      return last_modified_time;
     }
 
     [[nodiscard]] std::string getKey() const override {
       return full_file_path.string();
     }
 
-    std::filesystem::path filename;
-    std::filesystem::path absolute_path;
-    std::filesystem::file_time_type last_modified_time;
-    std::filesystem::path relative_path;
+    std::chrono::time_point<std::chrono::system_clock> last_modified_time;
     std::filesystem::path full_file_path;
-    uint64_t file_size = 0;
   };
 
   bool fileMatchesFilters(const ListedFile& listed_file);

--- a/extensions/standard-processors/processors/ListFile.h
+++ b/extensions/standard-processors/processors/ListFile.h
@@ -85,7 +85,7 @@ class ListFile : public core::Processor {
     }
 
     [[nodiscard]] std::string getKey() const override {
-      return absolute_path.string();
+      return full_file_path.string();
     }
 
     std::filesystem::path filename;

--- a/extensions/standard-processors/tests/unit/ListFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/ListFileTests.cpp
@@ -166,10 +166,17 @@ TEST_CASE_METHOD(ListFileTestFixture, "Test listing files matching the File Filt
 TEST_CASE_METHOD(ListFileTestFixture, "Test listing files matching the Path Filter pattern", "[testListFile]") {
   plan_->setProperty(list_file_processor_, "Path Filter", "first.*");
   test_controller_.runSession(plan_);
-  REQUIRE(verifyLogLinePresenceInPollTime(3s, "key:filename value:standard_file.log"));
-  REQUIRE(verifyLogLinePresenceInPollTime(3s, "key:filename value:empty_file.txt"));
-  REQUIRE(verifyLogLinePresenceInPollTime(3s, "key:filename value:sub_file_one.txt"));
-  REQUIRE(LogTestController::getInstance().countOccurrences("key:filename value:sub_file_two.txt") == 0);
+  CHECK(verifyLogLinePresenceInPollTime(3s, "key:filename value:sub_file_one.txt"));
+  CHECK(LogTestController::getInstance().countOccurrences("key:filename value:") == 1);
+}
+
+TEST_CASE_METHOD(ListFileTestFixture, "Test listing files matching the Path Filter pattern when the pattern also matches .", "[testListFile]") {
+  plan_->setProperty(list_file_processor_, "Path Filter", "second.*|\\.");
+  test_controller_.runSession(plan_);
+  CHECK(verifyLogLinePresenceInPollTime(3s, "key:filename value:standard_file.log"));
+  CHECK(verifyLogLinePresenceInPollTime(3s, "key:filename value:empty_file.txt"));
+  CHECK(verifyLogLinePresenceInPollTime(3s, "key:filename value:sub_file_two.txt"));
+  CHECK(LogTestController::getInstance().countOccurrences("key:filename value:") == 3);
 }
 
 TEST_CASE_METHOD(ListFileTestFixture, "Test listing files with restriction on the minimum file age", "[testListFile]") {

--- a/libminifi/include/utils/file/FileUtils.h
+++ b/libminifi/include/utils/file/FileUtils.h
@@ -126,13 +126,22 @@ inline std::optional<std::filesystem::file_time_type> last_write_time(const std:
   return std::nullopt;
 }
 
-inline std::optional<std::string> format_time(const std::filesystem::file_time_type& time, const std::string& format) {
-  auto last_write_time_t = to_time_t(time);
+inline std::optional<std::string> format_time(const time_t& time, const std::string& format) {
   std::array<char, 128U> result{};
-  if (std::strftime(result.data(), result.size(), format.c_str(), gmtime(&last_write_time_t)) != 0) {
+  if (std::strftime(result.data(), result.size(), format.c_str(), gmtime(&time)) != 0) {
     return std::string(result.data());
   }
   return std::nullopt;
+}
+
+inline std::optional<std::string> format_time(const std::chrono::system_clock::time_point& time, const std::string& format) {
+  auto as_time_t = std::chrono::system_clock::to_time_t(time);
+  return format_time(as_time_t, format);
+}
+
+inline std::optional<std::string> format_time(const std::filesystem::file_time_type& time, const std::string& format) {
+  auto as_time_t = to_time_t(time);
+  return format_time(as_time_t, format);
 }
 
 inline std::optional<std::string> get_last_modified_time_formatted_string(const std::filesystem::path& path, const std::string& format_string) {

--- a/libminifi/include/utils/file/FileUtils.h
+++ b/libminifi/include/utils/file/FileUtils.h
@@ -126,22 +126,13 @@ inline std::optional<std::filesystem::file_time_type> last_write_time(const std:
   return std::nullopt;
 }
 
-inline std::optional<std::string> format_time(const time_t& time, const std::string& format) {
+inline std::optional<std::string> format_time(const std::filesystem::file_time_type& time, const std::string& format) {
+  auto last_write_time_t = to_time_t(time);
   std::array<char, 128U> result{};
-  if (std::strftime(result.data(), result.size(), format.c_str(), gmtime(&time)) != 0) {
+  if (std::strftime(result.data(), result.size(), format.c_str(), gmtime(&last_write_time_t)) != 0) {
     return std::string(result.data());
   }
   return std::nullopt;
-}
-
-inline std::optional<std::string> format_time(const std::chrono::system_clock::time_point& time, const std::string& format) {
-  auto as_time_t = std::chrono::system_clock::to_time_t(time);
-  return format_time(as_time_t, format);
-}
-
-inline std::optional<std::string> format_time(const std::filesystem::file_time_type& time, const std::string& format) {
-  auto as_time_t = to_time_t(time);
-  return format_time(as_time_t, format);
 }
 
 inline std::optional<std::string> get_last_modified_time_formatted_string(const std::filesystem::path& path, const std::string& format_string) {


### PR DESCRIPTION
On a sample test data of 20,000 files on Windows, `onTrigger` now takes ~2.5 sec instead of ~7.5 sec in the case when all 20,000 files have been processed already.  The main changes are:
* except for the file name (with path) and modification time, only query anything else (eg. file size) when and if we need it;
* check first if the file is new, and only later if it matches the selection criteria;
* instead of collecting the file names in a vector first and then processing them in a loop, we process the files directly in the `list_dir` callback (without this, the `onTrigger` duration was ~3.5 sec).

NOTE: there are three changes in behavior:
1. When storing the list of files with the latest modification time, we used to store the path only, which doesn't uniquely identify the file.  I'm pretty sure this was a bug, now we store path + filename, and there is a new unit test to verify that this works.
2. If we are not able to find the modification time of the file (apparently, this can happen on Windows), we used to skip the file.  Now we list the file, with the modification time set to the epoch of the `system_clock` .
3. If the `Path Filter` is set, we used to list all files in the `Input Directory` root, plus all files in subdirectories the names of which match the filter.  Now we only list files in matching subdirectories, only including the root if the filter regex includes it (eg., `"good_subdir|ugly_subdir|\."`).  Also, `Path Filter` is ignored if `Recurse Subdirectories` is false -- in this case, all files in the `Input Directory` are listed, but none in the subdirectories.  The new behavior matches the current behavior of NiFi; I think the old behavior matched the behavior of an earlier version of NiFi.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
