### PR TITLE
MINIFICPP-2059 Handle content repository remove failures

### DIFF
--- a/extensions/rocksdb-repos/DatabaseContentRepository.h
+++ b/extensions/rocksdb-repos/DatabaseContentRepository.h
@@ -64,10 +64,12 @@ class DatabaseContentRepository : public core::ContentRepository {
     return remove(claim);
   }
 
-  bool remove(const minifi::ResourceClaim &claim) override;
   bool exists(const minifi::ResourceClaim &streamId) override;
 
   void clearOrphans() override;
+
+ protected:
+  bool removeKey(const std::string& content_path) override;
 
  private:
   std::shared_ptr<io::BaseStream> write(const minifi::ResourceClaim &claim, bool append, minifi::internal::WriteBatch* batch);

--- a/libminifi/include/core/ContentRepository.h
+++ b/libminifi/include/core/ContentRepository.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <list>
 
 #include "properties/Configure.h"
 #include "ResourceClaim.h"
@@ -53,10 +54,18 @@ class ContentRepository : public StreamManager<minifi::ResourceClaim>, public ut
 
   virtual void clearOrphans() = 0;
 
+  bool remove(const minifi::ResourceClaim &streamId) override {
+    return removeKey(streamId.getContentFullPath());
+  }
+
  protected:
+  void removeFromPurgeList();
+  virtual bool removeKey(const std::string& content_path) = 0;
+
   std::string directory_;
   std::mutex count_map_mutex_;
   std::map<std::string, uint32_t> count_map_;
+  std::list<std::string> purge_list_;
 };
 
 }  // namespace org::apache::nifi::minifi::core

--- a/libminifi/include/core/ContentRepository.h
+++ b/libminifi/include/core/ContentRepository.h
@@ -54,9 +54,7 @@ class ContentRepository : public StreamManager<minifi::ResourceClaim>, public ut
 
   virtual void clearOrphans() = 0;
 
-  bool remove(const minifi::ResourceClaim &streamId) override {
-    return removeKey(streamId.getContentFullPath());
-  }
+  bool remove(const minifi::ResourceClaim &streamId) final override;
 
  protected:
   void removeFromPurgeList();
@@ -64,6 +62,7 @@ class ContentRepository : public StreamManager<minifi::ResourceClaim>, public ut
 
   std::string directory_;
   std::mutex count_map_mutex_;
+  std::mutex purge_list_mutex_;
   std::map<std::string, uint32_t> count_map_;
   std::list<std::string> purge_list_;
 };

--- a/libminifi/include/core/ContentRepository.h
+++ b/libminifi/include/core/ContentRepository.h
@@ -54,7 +54,7 @@ class ContentRepository : public StreamManager<minifi::ResourceClaim>, public ut
 
   virtual void clearOrphans() = 0;
 
-  bool remove(const minifi::ResourceClaim &streamId) final override;
+  bool remove(const minifi::ResourceClaim &streamId) final;
 
  protected:
   void removeFromPurgeList();

--- a/libminifi/include/core/repository/FileSystemRepository.h
+++ b/libminifi/include/core/repository/FileSystemRepository.h
@@ -46,10 +46,12 @@ class FileSystemRepository : public core::ContentRepository {
     return remove(claim);
   }
 
-  bool remove(const minifi::ResourceClaim& claim) override;
   std::shared_ptr<ContentSession> createSession() override;
 
   void clearOrphans() override;
+
+ protected:
+  bool removeKey(const std::string& content_path) override;
 
  private:
   std::shared_ptr<logging::Logger> logger_;

--- a/libminifi/include/core/repository/VolatileContentRepository.h
+++ b/libminifi/include/core/repository/VolatileContentRepository.h
@@ -88,15 +88,16 @@ class VolatileContentRepository : public core::ContentRepository {
     return remove(claim);
   }
 
+  void clearOrphans() override {
+    // there are no persisted orphans to delete
+  }
+
+ protected:
   /**
    * Closes the claim.
    * @return whether or not the claim is associated with content stored in volatile memory.
    */
-  bool remove(const minifi::ResourceClaim &claim) override;
-
-  void clearOrphans() override {
-    // there are no persisted orphans to delete
-  }
+  bool removeKey(const std::string& content_path) override;
 
  private:
   VolatileRepositoryData repo_data_;

--- a/libminifi/src/core/repository/VolatileContentRepository.cpp
+++ b/libminifi/src/core/repository/VolatileContentRepository.cpp
@@ -122,40 +122,38 @@ std::shared_ptr<io::BaseStream> VolatileContentRepository::read(const minifi::Re
   return nullptr;
 }
 
-bool VolatileContentRepository::remove(const minifi::ResourceClaim &claim) {
+bool VolatileContentRepository::removeKey(const std::string& content_path) {
   if (LIKELY(minimize_locking_ == true)) {
     std::lock_guard<std::mutex> lock(map_mutex_);
-    auto ent = master_list_.find(claim.getContentFullPath());
+    auto ent = master_list_.find(content_path);
     if (ent != master_list_.end()) {
       auto ptr = ent->second;
       // if we cannot remove the entry we will let the owner's destructor
       // decrement the reference count and free it
-      master_list_.erase(claim.getContentFullPath());
+      master_list_.erase(content_path);
       // because of the test and set we need to decrement ownership
       ptr->decrementOwnership();
-      if (ptr->freeValue(claim.getContentFullPath())) {
-        logger_->log_info("Deleting resource %s", claim.getContentFullPath());
-        return true;
+      if (ptr->freeValue(content_path)) {
+        logger_->log_info("Deleting resource %s", content_path);
       } else {
-        logger_->log_info("free failed for %s", claim.getContentFullPath());
+        logger_->log_info("free failed for %s", content_path);
       }
     } else {
-      logger_->log_info("Could not remove %s", claim.getContentFullPath());
+      logger_->log_info("Could not remove %s", content_path);
     }
   } else {
     std::lock_guard<std::mutex> lock(map_mutex_);
-    auto claim_item = master_list_.find(claim.getContentFullPath());
+    auto claim_item = master_list_.find(content_path);
     if (claim_item != master_list_.end()) {
       auto size = claim_item->second->getLength();
       delete claim_item->second;
-      master_list_.erase(claim.getContentFullPath());
+      master_list_.erase(content_path);
       repo_data_.current_size -= size;
     }
-    return true;
   }
 
-  logger_->log_info("Could not remove %s, may not exist", claim.getContentFullPath());
-  return false;
+  logger_->log_info("Could not remove %s, may not exist", content_path);
+  return true;
 }
 
 }  // namespace org::apache::nifi::minifi::core::repository


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-2059

NOTE: This PR focuses on the FileSystemRepository as the original issue comes from files not being deleted in the content repository on a Windows filesystem when using FileSystemRepository. Testing the same retry mechanism is missing from this PR and a separate [Jira ticket](https://issues.apache.org/jira/browse/MINIFICPP-2062) is opened for it which includes creating a mock for the RocksDB content repository for easier testability.

------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
