### PR TITLE
MINIFICPP-2064 Do not include unloaded extensions in the manifest

### DIFF
--- a/extensions/standard-processors/tests/unit/ManifestTests.cpp
+++ b/extensions/standard-processors/tests/unit/ManifestTests.cpp
@@ -29,9 +29,9 @@
 TEST_CASE("Test Required", "[required]") {
   minifi::state::response::ComponentManifest manifest("minifi-standard-processors");
   auto serialized = manifest.serialize();
-  REQUIRE(serialized.size() > 0);
+  REQUIRE_FALSE(serialized.empty());
   const auto &resp = serialized[0];
-  REQUIRE(resp.children.size() > 0);
+  REQUIRE_FALSE(resp.children.empty());
   size_t processorIndex = resp.children.size();
   for (size_t i = 0; i < resp.children.size(); ++i) {
     if (resp.children[i].name == "processors") {
@@ -47,7 +47,7 @@ TEST_CASE("Test Required", "[required]") {
   });
   REQUIRE(get_file_it != processors.children.end());
 
-  REQUIRE(get_file_it->children.size() > 0);
+  REQUIRE_FALSE(get_file_it->children.empty());
   const auto& get_file_property_descriptors = get_file_it->children[0];
   const auto batch_size_property_it = ranges::find_if(get_file_property_descriptors.children, [](const auto& property) {
     return property.name == "Batch Size";
@@ -64,15 +64,15 @@ TEST_CASE("Test Required", "[required]") {
 TEST_CASE("Test Valid Regex", "[validRegex]") {
   minifi::state::response::ComponentManifest manifest("minifi-standard-processors");
   auto serialized = manifest.serialize();
-  REQUIRE(serialized.size() > 0);
+  REQUIRE_FALSE(serialized.empty());
   const auto &resp = serialized[0];
-  REQUIRE(resp.children.size() > 0);
+  REQUIRE_FALSE(resp.children.empty());
   const auto &processors = resp.children[0];
-  REQUIRE(processors.children.size() > 0);
+  REQUIRE_FALSE(processors.children.empty());
   const auto &proc_0 = processors.children[0];
-  REQUIRE(proc_0.children.size() > 0);
+  REQUIRE_FALSE(proc_0.children.empty());
   const auto &prop_descriptors = proc_0.children[0];
-  REQUIRE(prop_descriptors.children.size() > 0);
+  REQUIRE_FALSE(prop_descriptors.children.empty());
   const auto &prop_0 = prop_descriptors.children[0];
   REQUIRE(prop_0.children.size() >= 3);
   const auto &df = prop_0.children[3];
@@ -88,11 +88,11 @@ TEST_CASE("Test Valid Regex", "[validRegex]") {
 TEST_CASE("Test Relationships", "[rel1]") {
   minifi::state::response::ComponentManifest manifest("minifi-standard-processors");
   auto serialized = manifest.serialize();
-  REQUIRE(serialized.size() > 0);
+  REQUIRE_FALSE(serialized.empty());
   const auto &resp = serialized[0];
-  REQUIRE(resp.children.size() > 0);
+  REQUIRE_FALSE(resp.children.empty());
   const auto &processors = resp.children[0];
-  REQUIRE(processors.children.size() > 0);
+  REQUIRE_FALSE(processors.children.empty());
   minifi::state::response::SerializedResponseNode proc_0;
   for (const auto& node : processors.children) {
     if ("org.apache.nifi.minifi.processors.PutFile" == node.name) {
@@ -110,7 +110,7 @@ TEST_CASE("Test Relationships", "[rel1]") {
   REQUIRE(isSingleThreaded.value.getValue()->getTypeIndex() == org::apache::nifi::minifi::state::response::Value::BOOL_TYPE);
   REQUIRE(isSingleThreaded.value.to_string() == "false");
 
-  REQUIRE(proc_0.children.size() > 0);
+  REQUIRE_FALSE(proc_0.children.empty());
   const auto& relationships = proc_0.children[3];
   REQUIRE("supportedRelationships" == relationships.name);
   // this is because they are now nested
@@ -127,11 +127,11 @@ TEST_CASE("Test Relationships", "[rel1]") {
 TEST_CASE("Test Dependent", "[dependent]") {
   minifi::state::response::ComponentManifest manifest("minifi-standard-processors");
   auto serialized = manifest.serialize();
-  REQUIRE(serialized.size() > 0);
+  REQUIRE_FALSE(serialized.empty());
   const auto &resp = serialized[0];
-  REQUIRE(resp.children.size() > 0);
+  REQUIRE_FALSE(resp.children.empty());
   const auto &processors = resp.children[0];
-  REQUIRE(processors.children.size() > 0);
+  REQUIRE_FALSE(processors.children.empty());
   minifi::state::response::SerializedResponseNode proc_0;
   for (const auto &node : processors.children) {
     if ("org.apache.nifi.minifi.processors.PutFile" == node.name) {
@@ -139,9 +139,9 @@ TEST_CASE("Test Dependent", "[dependent]") {
     }
   }
 #ifndef WIN32
-  REQUIRE(proc_0.children.size() > 0);
+  REQUIRE_FALSE(proc_0.children.empty());
   const auto &prop_descriptors = proc_0.children[0];
-  REQUIRE(prop_descriptors.children.size() > 0);
+  REQUIRE_FALSE(prop_descriptors.children.empty());
   const auto &prop_0 = prop_descriptors.children[1];
   REQUIRE(prop_0.children.size() >= 3);
   REQUIRE("required" == prop_0.children[3].name);
@@ -155,7 +155,7 @@ TEST_CASE("Test Dependent", "[dependent]") {
 TEST_CASE("Test Scheduling Defaults", "[schedDef]") {
   minifi::state::response::AgentManifest manifest("minifi-system");
   auto serialized = manifest.serialize();
-  REQUIRE(serialized.size() > 0);
+  REQUIRE_FALSE(serialized.empty());
   minifi::state::response::SerializedResponseNode proc_0;
   for (const auto &node : serialized) {
     if ("schedulingDefaults" == node.name) {
@@ -185,7 +185,7 @@ TEST_CASE("Test Scheduling Defaults", "[schedDef]") {
 TEST_CASE("Test operatingSystem Defaults", "[opsys]") {
   minifi::state::response::DeviceInfoNode manifest("minifi-system");
   auto serialized = manifest.serialize();
-  REQUIRE(serialized.size() > 0);
+  REQUIRE_FALSE(serialized.empty());
   minifi::state::response::SerializedResponseNode proc_0;
   for (const auto &node : serialized) {
     if ("systemInfo" == node.name) {

--- a/libminifi/include/core/state/nodes/AgentInformation.h
+++ b/libminifi/include/core/state/nodes/AgentInformation.h
@@ -352,6 +352,14 @@ class Bundles : public DeviceInformation {
       SerializedResponseNode bundle;
       bundle.name = "bundles";
 
+      ComponentManifest component_manifest(group);
+      const auto components = component_manifest.serialize();
+      gsl_Expects(components.size() == 1);
+      if (components[0].children.empty()) {
+        continue;
+      }
+      bundle.children.push_back(components[0]);
+
       SerializedResponseNode bgroup;
       bgroup.name = "group";
       bgroup.value = GROUP_STR;
@@ -366,11 +374,6 @@ class Bundles : public DeviceInformation {
       bundle.children.push_back(artifact);
       bundle.children.push_back(version);
 
-      ComponentManifest compMan(group);
-      // serialize the component information.
-      for (auto component : compMan.serialize()) {
-        bundle.children.push_back(component);
-      }
       serialized.push_back(bundle);
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-2064

If the `componentManifest` node of the extension would be empty, then do not include the extension in the manifest.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
