### PR TITLE
MINIFICPP-2078 Remove cleanup from __del__ functions

### DIFF
--- a/docker/test/integration/MiNiFi_integration_test_driver.py
+++ b/docker/test/integration/MiNiFi_integration_test_driver.py
@@ -48,9 +48,6 @@ class MiNiFi_integration_test:
         self.docker_directory_bindings = context.directory_bindings
         self.cluster.set_directory_bindings(self.docker_directory_bindings.get_directory_bindings(self.test_id), self.docker_directory_bindings.get_data_directories(self.test_id))
 
-    def __del__(self):
-        self.cleanup()
-
     def cleanup(self):
         self.cluster.cleanup()
 

--- a/docker/test/integration/cluster/ContainerStore.py
+++ b/docker/test/integration/cluster/ContainerStore.py
@@ -46,9 +46,6 @@ class ContainerStore:
         self.image_store = image_store
         self.kubernetes_proxy = kubernetes_proxy
 
-    def __del__(self):
-        self.cleanup()
-
     def cleanup(self):
         for container in self.containers.values():
             container.cleanup()

--- a/docker/test/integration/cluster/DockerTestCluster.py
+++ b/docker/test/integration/cluster/DockerTestCluster.py
@@ -43,9 +43,6 @@ class DockerTestCluster:
         self.splunk_checker = SplunkChecker(self.container_communicator)
         self.prometheus_checker = PrometheusChecker()
 
-    def __del__(self):
-        self.cleanup()
-
     def cleanup(self):
         self.container_store.cleanup()
 

--- a/docker/test/integration/cluster/ImageStore.py
+++ b/docker/test/integration/cluster/ImageStore.py
@@ -29,9 +29,6 @@ class ImageStore:
         self.images = dict()
         self.test_dir = os.environ['TEST_DIRECTORY']  # Based on DockerVerify.sh
 
-    def __del__(self):
-        self.cleanup()
-
     def cleanup(self):
         # Clean up images
         for image in self.images.values():

--- a/docker/test/integration/cluster/KubernetesProxy.py
+++ b/docker/test/integration/cluster/KubernetesProxy.py
@@ -35,9 +35,6 @@ class KubernetesProxy:
         self.__download_kind()
         self.docker_client = docker.from_env()
 
-    def __del__(self):
-        self.cleanup()
-
     def cleanup(self):
         if os.path.exists(self.kind_binary_path):
             subprocess.run([self.kind_binary_path, 'delete', 'cluster'])

--- a/docker/test/integration/cluster/containers/Container.py
+++ b/docker/test/integration/cluster/containers/Container.py
@@ -33,9 +33,6 @@ class Container:
         self.client = docker.from_env()
         self.deployed = False
 
-    def __del__(self):
-        self.cleanup()
-
     def cleanup(self):
         logging.info('Cleaning up container: %s', self.name)
         try:


### PR DESCRIPTION
Cleaning up docker resources is done manually in the behave `environment.py` file manually by calling the `cleanup` functions. The was cleanup is also called redundantly from the resources' `__del__` function which is called by the GC at unpredictable times. This caused that the docker remove function could be called while a new container with the same name is instantiated in a next test case which killed that container.

https://issues.apache.org/jira/browse/MINIFICPP-2078

---------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
