### PR TITLE
MINIFICPP-2082 Move RocksDB stats to RepositoryMetrics

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -143,13 +143,15 @@ QueueMetrics is a system level metric that reports queue metrics for every conne
 
 RepositoryMetrics is a system level metric that reports metrics for the registered repositories (by default flowfile, content, and provenance repositories)
 
-| Metric name               | Labels          | Description                                     |
-|---------------------------|-----------------|-------------------------------------------------|
-| is_running                | repository_name | Is the repository running (1 or 0)              |
-| is_full                   | repository_name | Is the repository full (1 or 0)                 |
-| repository_size_bytes     | repository_name | Current size of the repository                  |
-| max_repository_size_bytes | repository_name | Maximum size of the repository (0 if unlimited) |
-| repository_entry_count    | repository_name | Current number of entries in the repository     |
+| Metric name                          | Labels          | Description                                                                                                      |
+|--------------------------------------|-----------------|------------------------------------------------------------------------------------------------------------------|
+| is_running                           | repository_name | Is the repository running (1 or 0)                                                                               |
+| is_full                              | repository_name | Is the repository full (1 or 0)                                                                                  |
+| repository_size_bytes                | repository_name | Current size of the repository                                                                                   |
+| max_repository_size_bytes            | repository_name | Maximum size of the repository (0 if unlimited)                                                                  |
+| repository_entry_count               | repository_name | Current number of entries in the repository                                                                      |
+| rocksdb_table_readers_size_bytes     | repository_name | RocksDB's estimated memory used for reading SST tables (only present if repository uses RocksDB)                 |
+| rocksdb_all_memory_tables_size_bytes | repository_name | RocksDB's approximate size of active and unflushed immutable memtables (only present if repository uses RocksDB) |
 
 | Label                    | Description                                                                                                                           |
 |--------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
@@ -188,17 +190,19 @@ FlowInformation is a system level metric that reports component and queue relate
 
 AgentStatus is a system level metric that defines current agent status including repository, component and resource usage information.
 
-| Metric name               | Labels                         | Description                                                                                                |
-|---------------------------|--------------------------------|------------------------------------------------------------------------------------------------------------|
-| is_running                | repository_name                | Is the repository running (1 or 0)                                                                         |
-| is_full                   | repository_name                | Is the repository full (1 or 0)                                                                            |
-| repository_size_bytes     | repository_name                | Current size of the repository                                                                             |
-| max_repository_size_bytes | repository_name                | Maximum size of the repository (0 if unlimited)                                                            |
-| repository_entry_count    | repository_name                | Current number of entries in the repository                                                                |
-| uptime_milliseconds       | -                              | Agent uptime in milliseconds                                                                               |
-| is_running                | component_uuid, component_name | Check if the component is running (1 or 0)                                                                 |
-| agent_memory_usage_bytes  | -                              | Memory used by the agent process in bytes                                                                  |
-| agent_cpu_utilization     | -                              | CPU utilization of the agent process (between 0 and 1). In case of a query error the returned value is -1. |
+| Metric name                          | Labels                         | Description                                                                                                      |
+|--------------------------------------|--------------------------------|------------------------------------------------------------------------------------------------------------------|
+| is_running                           | repository_name                | Is the repository running (1 or 0)                                                                               |
+| is_full                              | repository_name                | Is the repository full (1 or 0)                                                                                  |
+| repository_size_bytes                | repository_name                | Current size of the repository                                                                                   |
+| max_repository_size_bytes            | repository_name                | Maximum size of the repository (0 if unlimited)                                                                  |
+| repository_entry_count               | repository_name                | Current number of entries in the repository                                                                      |
+| rocksdb_table_readers_size_bytes     | repository_name                | RocksDB's estimated memory used for reading SST tables (only present if repository uses RocksDB)                 |
+| rocksdb_all_memory_tables_size_bytes | repository_name                | RocksDB's approximate size of active and unflushed immutable memtables (only present if repository uses RocksDB) |
+| uptime_milliseconds                  | -                              | Agent uptime in milliseconds                                                                                     |
+| is_running                           | component_uuid, component_name | Check if the component is running (1 or 0)                                                                       |
+| agent_memory_usage_bytes             | -                              | Memory used by the agent process in bytes                                                                        |
+| agent_cpu_utilization                | -                              | CPU utilization of the agent process (between 0 and 1). In case of a query error the returned value is -1.       |
 
 | Label           | Description                                              |
 |-----------------|----------------------------------------------------------|

--- a/docker/test/integration/cluster/checkers/PrometheusChecker.py
+++ b/docker/test/integration/cluster/checkers/PrometheusChecker.py
@@ -48,6 +48,7 @@ class PrometheusChecker:
 
     def verify_repository_metrics(self):
         label_list = [{'repository_name': 'provenance'}, {'repository_name': 'flowfile'}, {'repository_name': 'content'}]
+        # Only flowfile and content repositories are using rocksdb by default, so rocksdb specific metrics are only present there
         return all((self.verify_metrics_exist(['minifi_is_running', 'minifi_is_full', 'minifi_repository_size_bytes', 'minifi_max_repository_size_bytes', 'minifi_repository_entry_count'], 'RepositoryMetrics', labels) for labels in label_list)) and \
             all((self.verify_metric_larger_than_zero('minifi_repository_size_bytes', 'RepositoryMetrics', labels) for labels in label_list[1:3])) and \
             all((self.verify_metrics_exist(['minifi_rocksdb_table_readers_size_bytes', 'minifi_rocksdb_all_memory_tables_size_bytes'], 'RepositoryMetrics', labels) for labels in label_list[1:3]))
@@ -75,12 +76,15 @@ class PrometheusChecker:
 
     def verify_agent_status_metrics(self):
         label_list = [{'repository_name': 'flowfile'}, {'repository_name': 'content'}]
+        # Only flowfile and content repositories are using rocksdb by default, so rocksdb specific metrics are only present there
         for labels in label_list:
             if not (self.verify_metric_exists('minifi_is_running', 'AgentStatus', labels)
                     and self.verify_metric_exists('minifi_is_full', 'AgentStatus', labels)
                     and self.verify_metric_exists('minifi_max_repository_size_bytes', 'AgentStatus', labels)
                     and self.verify_metric_larger_than_zero('minifi_repository_size_bytes', 'AgentStatus', labels)
-                    and self.verify_metric_exists('minifi_repository_entry_count', 'AgentStatus', labels)):
+                    and self.verify_metric_exists('minifi_repository_entry_count', 'AgentStatus', labels)
+                    and self.verify_metric_exists('minifi_rocksdb_table_readers_size_bytes', 'AgentStatus', labels)
+                    and self.verify_metric_exists('minifi_rocksdb_all_memory_tables_size_bytes', 'AgentStatus', labels)):
                 return False
 
         # provenance repository is NoOpRepository by default which has zero size

--- a/docker/test/integration/cluster/checkers/PrometheusChecker.py
+++ b/docker/test/integration/cluster/checkers/PrometheusChecker.py
@@ -49,7 +49,8 @@ class PrometheusChecker:
     def verify_repository_metrics(self):
         label_list = [{'repository_name': 'provenance'}, {'repository_name': 'flowfile'}, {'repository_name': 'content'}]
         return all((self.verify_metrics_exist(['minifi_is_running', 'minifi_is_full', 'minifi_repository_size_bytes', 'minifi_max_repository_size_bytes', 'minifi_repository_entry_count'], 'RepositoryMetrics', labels) for labels in label_list)) and \
-            all((self.verify_metric_larger_than_zero('minifi_repository_size_bytes', 'RepositoryMetrics', labels) for labels in label_list[1:3]))
+            all((self.verify_metric_larger_than_zero('minifi_repository_size_bytes', 'RepositoryMetrics', labels) for labels in label_list[1:3])) and \
+            all((self.verify_metrics_exist(['minifi_rocksdb_table_readers_size_bytes', 'minifi_rocksdb_all_memory_tables_size_bytes'], 'RepositoryMetrics', labels) for labels in label_list[1:3]))
 
     def verify_queue_metrics(self):
         return self.verify_metrics_exist(['minifi_queue_data_size', 'minifi_queue_data_size_max', 'minifi_queue_size', 'minifi_queue_size_max'], 'QueueMetrics')

--- a/extensions/rocksdb-repos/DatabaseContentRepository.cpp
+++ b/extensions/rocksdb-repos/DatabaseContentRepository.cpp
@@ -287,29 +287,12 @@ uint64_t DatabaseContentRepository::getRepositoryEntryCount() const {
 }
 
 std::optional<RepositoryMetricsSource::RocksDbStats> DatabaseContentRepository::getRocksDbStats() const {
-  RocksDbStats stats;
   auto opendb = db_->open();
   if (!opendb) {
-    return stats;
+    return RocksDbStats{};
   }
 
-  std::string table_readers;
-  opendb->GetProperty("rocksdb.estimate-table-readers-mem", &table_readers);
-  try {
-    stats.table_readers_size = std::stoull(table_readers);
-  } catch (const std::exception&) {
-    logger_->log_error("Could not retrieve valid 'rocksdb.estimate-table-readers-mem' property value from rocksdb content repository!");
-  }
-
-  std::string all_memtables;
-  opendb->GetProperty("rocksdb.cur-size-all-mem-tables", &all_memtables);
-  try {
-    stats.all_memory_tables_size = std::stoull(all_memtables);
-  } catch (const std::exception&) {
-    logger_->log_error("Could not retrieve valid 'rocksdb.cur-size-all-mem-tables' property value from rocksdb content repository!");
-  }
-
-  return stats;
+  return opendb->getStats();
 }
 
 REGISTER_RESOURCE_AS(DatabaseContentRepository, InternalResource, ("DatabaseContentRepository", "databasecontentrepository"));

--- a/extensions/rocksdb-repos/DatabaseContentRepository.cpp
+++ b/extensions/rocksdb-repos/DatabaseContentRepository.cpp
@@ -286,7 +286,7 @@ uint64_t DatabaseContentRepository::getRepositoryEntryCount() const {
             })).value_or(0);
 }
 
-std::optional<RepositoryMetricsSource::RocksDbStats> DatabaseContentRepository::getRocksDbStats() {
+std::optional<RepositoryMetricsSource::RocksDbStats> DatabaseContentRepository::getRocksDbStats() const {
   RocksDbStats stats;
   auto opendb = db_->open();
   if (!opendb) {

--- a/extensions/rocksdb-repos/DatabaseContentRepository.cpp
+++ b/extensions/rocksdb-repos/DatabaseContentRepository.cpp
@@ -295,11 +295,19 @@ std::optional<RepositoryMetricsSource::RocksDbStats> DatabaseContentRepository::
 
   std::string table_readers;
   opendb->GetProperty("rocksdb.estimate-table-readers-mem", &table_readers);
-  stats.table_readers_size = std::stoull(table_readers);
+  try {
+    stats.table_readers_size = std::stoull(table_readers);
+  } catch (const std::exception&) {
+    logger_->log_error("Could not retrieve valid 'rocksdb.estimate-table-readers-mem' property value from rocksdb content repository!");
+  }
 
   std::string all_memtables;
   opendb->GetProperty("rocksdb.cur-size-all-mem-tables", &all_memtables);
-  stats.all_memory_tables_size = std::stoull(all_memtables);
+  try {
+    stats.all_memory_tables_size = std::stoull(all_memtables);
+  } catch (const std::exception&) {
+    logger_->log_error("Could not retrieve valid 'rocksdb.cur-size-all-mem-tables' property value from rocksdb content repository!");
+  }
 
   return stats;
 }

--- a/extensions/rocksdb-repos/DatabaseContentRepository.cpp
+++ b/extensions/rocksdb-repos/DatabaseContentRepository.cpp
@@ -286,6 +286,24 @@ uint64_t DatabaseContentRepository::getRepositoryEntryCount() const {
             })).value_or(0);
 }
 
+std::optional<RepositoryMetricsSource::RocksDbStats> DatabaseContentRepository::getRocksDbStats() {
+  RocksDbStats stats;
+  auto opendb = db_->open();
+  if (!opendb) {
+    return stats;
+  }
+
+  std::string table_readers;
+  opendb->GetProperty("rocksdb.estimate-table-readers-mem", &table_readers);
+  stats.table_readers_size = std::stoull(table_readers);
+
+  std::string all_memtables;
+  opendb->GetProperty("rocksdb.cur-size-all-mem-tables", &all_memtables);
+  stats.all_memory_tables_size = std::stoull(all_memtables);
+
+  return stats;
+}
+
 REGISTER_RESOURCE_AS(DatabaseContentRepository, InternalResource, ("DatabaseContentRepository", "databasecontentrepository"));
 
 }  // namespace org::apache::nifi::minifi::core::repository

--- a/extensions/rocksdb-repos/DatabaseContentRepository.h
+++ b/extensions/rocksdb-repos/DatabaseContentRepository.h
@@ -76,6 +76,7 @@ class DatabaseContentRepository : public core::ContentRepository {
 
   uint64_t getRepositorySize() const override;
   uint64_t getRepositoryEntryCount() const override;
+  std::optional<RepositoryMetricsSource::RocksDbStats> getRocksDbStats() override;
 
  protected:
   bool removeKey(const std::string& content_path) override;

--- a/extensions/rocksdb-repos/DatabaseContentRepository.h
+++ b/extensions/rocksdb-repos/DatabaseContentRepository.h
@@ -76,7 +76,7 @@ class DatabaseContentRepository : public core::ContentRepository {
 
   uint64_t getRepositorySize() const override;
   uint64_t getRepositoryEntryCount() const override;
-  std::optional<RepositoryMetricsSource::RocksDbStats> getRocksDbStats() override;
+  std::optional<RepositoryMetricsSource::RocksDbStats> getRocksDbStats() const override;
 
  protected:
   bool removeKey(const std::string& content_path) override;

--- a/extensions/rocksdb-repos/FlowFileRepository.cpp
+++ b/extensions/rocksdb-repos/FlowFileRepository.cpp
@@ -112,15 +112,9 @@ void FlowFileRepository::deserializeFlowFilesWithNoContentClaim(minifi::internal
 }
 
 void FlowFileRepository::run() {
-  auto last = std::chrono::steady_clock::now();
   while (isRunning()) {
     std::this_thread::sleep_for(purge_period_);
     flush();
-    auto now = std::chrono::steady_clock::now();
-    if ((now-last) > std::chrono::seconds(30)) {
-      printStats();
-      last = now;
-    }
   }
   flush();
 }

--- a/extensions/rocksdb-repos/ProvenanceRepository.cpp
+++ b/extensions/rocksdb-repos/ProvenanceRepository.cpp
@@ -23,19 +23,6 @@
 
 namespace org::apache::nifi::minifi::provenance {
 
-void ProvenanceRepository::run() {
-  size_t count = 0;
-  while (isRunning()) {
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-    count++;
-    // Hack, to be removed in scope of https://issues.apache.org/jira/browse/MINIFICPP-1145
-    count = count % 30;
-    if (count == 0) {
-      printStats();
-    }
-  }
-}
-
 bool ProvenanceRepository::initialize(const std::shared_ptr<org::apache::nifi::minifi::Configure> &config) {
   std::string value;
   if (config->get(Configure::nifi_provenance_repository_directory_default, value) && !value.empty()) {

--- a/extensions/rocksdb-repos/ProvenanceRepository.h
+++ b/extensions/rocksdb-repos/ProvenanceRepository.h
@@ -83,7 +83,7 @@ class ProvenanceRepository : public core::repository::RocksDbRepository {
 
  private:
   // Run function for the thread
-  void run() override;
+  void run() override {};
 };
 
 }  // namespace org::apache::nifi::minifi::provenance

--- a/extensions/rocksdb-repos/RocksDbRepository.cpp
+++ b/extensions/rocksdb-repos/RocksDbRepository.cpp
@@ -20,22 +20,22 @@ using namespace std::literals::chrono_literals;
 
 namespace org::apache::nifi::minifi::core::repository {
 
-void RocksDbRepository::printStats() {
+std::optional<RepositoryMetricsSource::RocksDbStats> RocksDbRepository::getRocksDbStats() {
+  RocksDbStats stats;
   auto opendb = db_->open();
   if (!opendb) {
-    return;
+    return stats;
   }
-  std::string key_count;
-  opendb->GetProperty("rocksdb.estimate-num-keys", &key_count);
 
   std::string table_readers;
   opendb->GetProperty("rocksdb.estimate-table-readers-mem", &table_readers);
+  stats.table_readers_size = std::stoull(table_readers);
 
   std::string all_memtables;
   opendb->GetProperty("rocksdb.cur-size-all-mem-tables", &all_memtables);
+  stats.all_memory_tables_size = std::stoull(all_memtables);
 
-  logger_->log_info("Repository stats: key count: %s, table readers size: %s, all memory tables size: %s",
-      key_count, table_readers, all_memtables);
+  return stats;
 }
 
 bool RocksDbRepository::ExecuteWithRetry(const std::function<rocksdb::Status()>& operation) {

--- a/extensions/rocksdb-repos/RocksDbRepository.cpp
+++ b/extensions/rocksdb-repos/RocksDbRepository.cpp
@@ -21,29 +21,12 @@ using namespace std::literals::chrono_literals;
 namespace org::apache::nifi::minifi::core::repository {
 
 std::optional<RepositoryMetricsSource::RocksDbStats> RocksDbRepository::getRocksDbStats() const {
-  RocksDbStats stats;
   auto opendb = db_->open();
   if (!opendb) {
-    return stats;
+    return RocksDbStats{};
   }
 
-  std::string table_readers;
-  opendb->GetProperty("rocksdb.estimate-table-readers-mem", &table_readers);
-  try {
-    stats.table_readers_size = std::stoull(table_readers);
-  } catch (const std::exception&) {
-    logger_->log_error("Could not retrieve valid 'rocksdb.estimate-table-readers-mem' property value from rocksdb content repository!");
-  }
-
-  std::string all_memtables;
-  opendb->GetProperty("rocksdb.cur-size-all-mem-tables", &all_memtables);
-  try {
-    stats.all_memory_tables_size = std::stoull(all_memtables);
-  } catch (const std::exception&) {
-    logger_->log_error("Could not retrieve valid 'rocksdb.cur-size-all-mem-tables' property value from rocksdb content repository!");
-  }
-
-  return stats;
+  return opendb->getStats();
 }
 
 bool RocksDbRepository::ExecuteWithRetry(const std::function<rocksdb::Status()>& operation) {

--- a/extensions/rocksdb-repos/RocksDbRepository.cpp
+++ b/extensions/rocksdb-repos/RocksDbRepository.cpp
@@ -20,7 +20,7 @@ using namespace std::literals::chrono_literals;
 
 namespace org::apache::nifi::minifi::core::repository {
 
-std::optional<RepositoryMetricsSource::RocksDbStats> RocksDbRepository::getRocksDbStats() {
+std::optional<RepositoryMetricsSource::RocksDbStats> RocksDbRepository::getRocksDbStats() const {
   RocksDbStats stats;
   auto opendb = db_->open();
   if (!opendb) {

--- a/extensions/rocksdb-repos/RocksDbRepository.cpp
+++ b/extensions/rocksdb-repos/RocksDbRepository.cpp
@@ -29,11 +29,19 @@ std::optional<RepositoryMetricsSource::RocksDbStats> RocksDbRepository::getRocks
 
   std::string table_readers;
   opendb->GetProperty("rocksdb.estimate-table-readers-mem", &table_readers);
-  stats.table_readers_size = std::stoull(table_readers);
+  try {
+    stats.table_readers_size = std::stoull(table_readers);
+  } catch (const std::exception&) {
+    logger_->log_error("Could not retrieve valid 'rocksdb.estimate-table-readers-mem' property value from rocksdb content repository!");
+  }
 
   std::string all_memtables;
   opendb->GetProperty("rocksdb.cur-size-all-mem-tables", &all_memtables);
-  stats.all_memory_tables_size = std::stoull(all_memtables);
+  try {
+    stats.all_memory_tables_size = std::stoull(all_memtables);
+  } catch (const std::exception&) {
+    logger_->log_error("Could not retrieve valid 'rocksdb.cur-size-all-mem-tables' property value from rocksdb content repository!");
+  }
 
   return stats;
 }

--- a/extensions/rocksdb-repos/RocksDbRepository.h
+++ b/extensions/rocksdb-repos/RocksDbRepository.h
@@ -46,7 +46,7 @@ class RocksDbRepository : public ThreadedRepository {
 
   uint64_t getRepositorySize() const override;
   uint64_t getRepositoryEntryCount() const override;
-  void printStats();
+  std::optional<RocksDbStats> getRocksDbStats() override;
 
  protected:
   bool ExecuteWithRetry(const std::function<rocksdb::Status()>& operation);

--- a/extensions/rocksdb-repos/RocksDbRepository.h
+++ b/extensions/rocksdb-repos/RocksDbRepository.h
@@ -46,7 +46,7 @@ class RocksDbRepository : public ThreadedRepository {
 
   uint64_t getRepositorySize() const override;
   uint64_t getRepositoryEntryCount() const override;
-  std::optional<RocksDbStats> getRocksDbStats() override;
+  std::optional<RocksDbStats> getRocksDbStats() const override;
 
  protected:
   bool ExecuteWithRetry(const std::function<rocksdb::Status()>& operation);

--- a/extensions/rocksdb-repos/database/OpenRocksDb.cpp
+++ b/extensions/rocksdb-repos/database/OpenRocksDb.cpp
@@ -142,7 +142,7 @@ minifi::core::RepositoryMetricsSource::RocksDbStats OpenRocksDb::getStats() {
   try {
     stats.table_readers_size = std::stoull(table_readers);
   } catch (const std::exception&) {
-    logger_->log_error("Could not retrieve valid 'rocksdb.estimate-table-readers-mem' property value from rocksdb content repository!");
+    logger_->log_warn("Could not retrieve valid 'rocksdb.estimate-table-readers-mem' property value from rocksdb content repository!");
   }
 
   std::string all_memtables;
@@ -150,7 +150,7 @@ minifi::core::RepositoryMetricsSource::RocksDbStats OpenRocksDb::getStats() {
   try {
     stats.all_memory_tables_size = std::stoull(all_memtables);
   } catch (const std::exception&) {
-    logger_->log_error("Could not retrieve valid 'rocksdb.cur-size-all-mem-tables' property value from rocksdb content repository!");
+    logger_->log_warn("Could not retrieve valid 'rocksdb.cur-size-all-mem-tables' property value from rocksdb content repository!");
   }
 
   return stats;

--- a/extensions/rocksdb-repos/database/OpenRocksDb.cpp
+++ b/extensions/rocksdb-repos/database/OpenRocksDb.cpp
@@ -135,4 +135,25 @@ std::optional<uint64_t> OpenRocksDb::getApproximateSizes() const {
   return std::nullopt;
 }
 
+minifi::core::RepositoryMetricsSource::RocksDbStats OpenRocksDb::getStats() {
+  minifi::core::RepositoryMetricsSource::RocksDbStats stats;
+  std::string table_readers;
+  GetProperty("rocksdb.estimate-table-readers-mem", &table_readers);
+  try {
+    stats.table_readers_size = std::stoull(table_readers);
+  } catch (const std::exception&) {
+    logger_->log_error("Could not retrieve valid 'rocksdb.estimate-table-readers-mem' property value from rocksdb content repository!");
+  }
+
+  std::string all_memtables;
+  GetProperty("rocksdb.cur-size-all-mem-tables", &all_memtables);
+  try {
+    stats.all_memory_tables_size = std::stoull(all_memtables);
+  } catch (const std::exception&) {
+    logger_->log_error("Could not retrieve valid 'rocksdb.cur-size-all-mem-tables' property value from rocksdb content repository!");
+  }
+
+  return stats;
+}
+
 }  // namespace org::apache::nifi::minifi::internal

--- a/extensions/rocksdb-repos/database/OpenRocksDb.h
+++ b/extensions/rocksdb-repos/database/OpenRocksDb.h
@@ -27,6 +27,8 @@
 #include "rocksdb/db.h"
 #include "rocksdb/utilities/checkpoint.h"
 #include "WriteBatch.h"
+#include "core/RepositoryMetricsSource.h"
+#include "core/logging/LoggerConfiguration.h"
 
 namespace org::apache::nifi::minifi::internal {
 
@@ -73,6 +75,7 @@ class OpenRocksDb {
   rocksdb::DB* get();
 
   std::optional<uint64_t> getApproximateSizes() const;
+  minifi::core::RepositoryMetricsSource::RocksDbStats getStats();
 
  private:
   void handleResult(const rocksdb::Status& result);
@@ -81,6 +84,7 @@ class OpenRocksDb {
   gsl::not_null<RocksDbInstance*> db_;
   gsl::not_null<std::shared_ptr<rocksdb::DB>> impl_;
   gsl::not_null<std::shared_ptr<ColumnHandle>> column_;
+  std::shared_ptr<minifi::core::logging::Logger> logger_{minifi::core::logging::LoggerFactory<OpenRocksDb>::getLogger()};
 };
 
 }  // namespace org::apache::nifi::minifi::internal

--- a/libminifi/include/core/RepositoryMetricsSource.h
+++ b/libminifi/include/core/RepositoryMetricsSource.h
@@ -47,7 +47,7 @@ class RepositoryMetricsSource {
     return true;
   }
 
-  virtual std::optional<RocksDbStats> getRocksDbStats() {
+  virtual std::optional<RocksDbStats> getRocksDbStats() const {
     return std::nullopt;
   }
 };

--- a/libminifi/include/core/RepositoryMetricsSource.h
+++ b/libminifi/include/core/RepositoryMetricsSource.h
@@ -24,6 +24,11 @@ namespace org::apache::nifi::minifi::core {
 
 class RepositoryMetricsSource {
  public:
+  struct RocksDbStats {
+    uint64_t table_readers_size{};
+    uint64_t all_memory_tables_size{};
+  };
+
   virtual ~RepositoryMetricsSource() = default;
   virtual uint64_t getRepositorySize() const = 0;
   virtual uint64_t getRepositoryEntryCount() const = 0;
@@ -39,6 +44,10 @@ class RepositoryMetricsSource {
 
   virtual bool isRunning() const {
     return true;
+  }
+
+  virtual std::optional<RocksDbStats> getRocksDbStats() {
+    return std::nullopt;
   }
 };
 

--- a/libminifi/include/core/state/nodes/RepositoryMetrics.h
+++ b/libminifi/include/core/state/nodes/RepositoryMetrics.h
@@ -92,6 +92,20 @@ class RepositoryMetrics : public ResponseNode {
       parent.children.push_back(max_repo_size);
       parent.children.push_back(repo_entry_count);
 
+      auto rocksdb_stats = repo->getRocksDbStats();
+      if (rocksdb_stats) {
+        SerializedResponseNode rocksdb_table_readers_size;
+        rocksdb_table_readers_size.name = "rocksDbTableReadersSize";
+        rocksdb_table_readers_size.value = rocksdb_stats->table_readers_size;
+
+        SerializedResponseNode rocksdb_all_memory_tables_size;
+        rocksdb_all_memory_tables_size.name = "rocksDbAllMemoryTablesSize";
+        rocksdb_all_memory_tables_size.value = rocksdb_stats->all_memory_tables_size;
+
+        parent.children.push_back(rocksdb_table_readers_size);
+        parent.children.push_back(rocksdb_all_memory_tables_size);
+      }
+
       serialized.push_back(parent);
     }
     return serialized;
@@ -105,6 +119,13 @@ class RepositoryMetrics : public ResponseNode {
       metrics.push_back({"repository_size_bytes", static_cast<double>(repo->getRepositorySize()), {{"metric_class", getName()}, {"repository_name", repo->getRepositoryName()}}});
       metrics.push_back({"max_repository_size_bytes", static_cast<double>(repo->getMaxRepositorySize()), {{"metric_class", getName()}, {"repository_name", repo->getRepositoryName()}}});
       metrics.push_back({"repository_entry_count", static_cast<double>(repo->getRepositoryEntryCount()), {{"metric_class", getName()}, {"repository_name", repo->getRepositoryName()}}});
+      auto rocksdb_stats = repo->getRocksDbStats();
+      if (rocksdb_stats) {
+        metrics.push_back({"rocksdb_table_readers_size_bytes", static_cast<double>(rocksdb_stats->table_readers_size),
+          {{"metric_class", getName()}, {"repository_name", repo->getRepositoryName()}}});
+        metrics.push_back({"rocksdb_all_memory_tables_size_bytes", static_cast<double>(rocksdb_stats->all_memory_tables_size),
+          {{"metric_class", getName()}, {"repository_name", repo->getRepositoryName()}}});
+      }
     }
     return metrics;
   }

--- a/libminifi/include/core/state/nodes/RepositoryMetrics.h
+++ b/libminifi/include/core/state/nodes/RepositoryMetrics.h
@@ -26,7 +26,7 @@
 
 #include "../nodes/MetricsBase.h"
 #include "Connection.h"
-#include "core/RepositoryMetricsSource.h"
+#include "RepositoryMetricsSourceStore.h"
 
 namespace org::apache::nifi::minifi::state::response {
 
@@ -38,15 +38,18 @@ namespace org::apache::nifi::minifi::state::response {
 class RepositoryMetrics : public ResponseNode {
  public:
   RepositoryMetrics(std::string name, const utils::Identifier &uuid)
-      : ResponseNode(std::move(name), uuid) {
+      : ResponseNode(std::move(name), uuid),
+        repository_metrics_source_store_(getName()) {
   }
 
   explicit RepositoryMetrics(std::string name)
-      : ResponseNode(std::move(name)) {
+      : ResponseNode(std::move(name)),
+        repository_metrics_source_store_(getName()) {
   }
 
   RepositoryMetrics()
-      : ResponseNode("RepositoryMetrics") {
+      : ResponseNode("RepositoryMetrics"),
+        repository_metrics_source_store_(getName()) {
   }
 
   MINIFIAPI static constexpr const char* Description = "Metric node that defines repository metric information";
@@ -56,82 +59,19 @@ class RepositoryMetrics : public ResponseNode {
   }
 
   void addRepository(const std::shared_ptr<core::RepositoryMetricsSource> &repo) {
-    if (nullptr != repo) {
-      repositories_.push_back(repo);
-    }
+    return repository_metrics_source_store_.addRepository(repo);
   }
 
   std::vector<SerializedResponseNode> serialize() override {
-    std::vector<SerializedResponseNode> serialized;
-    for (const auto& repo : repositories_) {
-      SerializedResponseNode parent;
-      parent.name = repo->getRepositoryName();
-      SerializedResponseNode is_running;
-      is_running.name = "running";
-      is_running.value = repo->isRunning();
-
-      SerializedResponseNode is_full;
-      is_full.name = "full";
-      is_full.value = repo->isFull();
-
-      SerializedResponseNode repo_size;
-      repo_size.name = "size";
-      repo_size.value = std::to_string(repo->getRepositorySize());
-
-      SerializedResponseNode max_repo_size;
-      max_repo_size.name = "maxSize";
-      max_repo_size.value = std::to_string(repo->getMaxRepositorySize());
-
-      SerializedResponseNode repo_entry_count;
-      repo_entry_count.name = "entryCount";
-      repo_entry_count.value = repo->getRepositoryEntryCount();
-
-      parent.children.push_back(is_running);
-      parent.children.push_back(is_full);
-      parent.children.push_back(repo_size);
-      parent.children.push_back(max_repo_size);
-      parent.children.push_back(repo_entry_count);
-
-      auto rocksdb_stats = repo->getRocksDbStats();
-      if (rocksdb_stats) {
-        SerializedResponseNode rocksdb_table_readers_size;
-        rocksdb_table_readers_size.name = "rocksDbTableReadersSize";
-        rocksdb_table_readers_size.value = rocksdb_stats->table_readers_size;
-
-        SerializedResponseNode rocksdb_all_memory_tables_size;
-        rocksdb_all_memory_tables_size.name = "rocksDbAllMemoryTablesSize";
-        rocksdb_all_memory_tables_size.value = rocksdb_stats->all_memory_tables_size;
-
-        parent.children.push_back(rocksdb_table_readers_size);
-        parent.children.push_back(rocksdb_all_memory_tables_size);
-      }
-
-      serialized.push_back(parent);
-    }
-    return serialized;
+    return repository_metrics_source_store_.serialize();
   }
 
   std::vector<PublishedMetric> calculateMetrics() override {
-    std::vector<PublishedMetric> metrics;
-    for (const auto& repo : repositories_) {
-      metrics.push_back({"is_running", (repo->isRunning() ? 1.0 : 0.0), {{"metric_class", getName()}, {"repository_name", repo->getRepositoryName()}}});
-      metrics.push_back({"is_full", (repo->isFull() ? 1.0 : 0.0), {{"metric_class", getName()}, {"repository_name", repo->getRepositoryName()}}});
-      metrics.push_back({"repository_size_bytes", static_cast<double>(repo->getRepositorySize()), {{"metric_class", getName()}, {"repository_name", repo->getRepositoryName()}}});
-      metrics.push_back({"max_repository_size_bytes", static_cast<double>(repo->getMaxRepositorySize()), {{"metric_class", getName()}, {"repository_name", repo->getRepositoryName()}}});
-      metrics.push_back({"repository_entry_count", static_cast<double>(repo->getRepositoryEntryCount()), {{"metric_class", getName()}, {"repository_name", repo->getRepositoryName()}}});
-      auto rocksdb_stats = repo->getRocksDbStats();
-      if (rocksdb_stats) {
-        metrics.push_back({"rocksdb_table_readers_size_bytes", static_cast<double>(rocksdb_stats->table_readers_size),
-          {{"metric_class", getName()}, {"repository_name", repo->getRepositoryName()}}});
-        metrics.push_back({"rocksdb_all_memory_tables_size_bytes", static_cast<double>(rocksdb_stats->all_memory_tables_size),
-          {{"metric_class", getName()}, {"repository_name", repo->getRepositoryName()}}});
-      }
-    }
-    return metrics;
+    return repository_metrics_source_store_.calculateMetrics();
   }
 
  protected:
-  std::vector<std::shared_ptr<core::RepositoryMetricsSource>> repositories_;
+  RepositoryMetricsSourceStore repository_metrics_source_store_;
 };
 
 }  // namespace org::apache::nifi::minifi::state::response

--- a/libminifi/include/core/state/nodes/RepositoryMetricsSourceStore.h
+++ b/libminifi/include/core/state/nodes/RepositoryMetricsSourceStore.h
@@ -15,41 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #pragma once
 
+#include <memory>
 #include <string>
-#include <optional>
+#include <utility>
+#include <vector>
 
-namespace org::apache::nifi::minifi::core {
+#include "core/RepositoryMetricsSource.h"
+#include "core/state/Value.h"
+#include "core/state/PublishedMetricProvider.h"
 
-class RepositoryMetricsSource {
+namespace org::apache::nifi::minifi::state::response {
+
+class RepositoryMetricsSourceStore {
  public:
-  struct RocksDbStats {
-    uint64_t table_readers_size{};
-    uint64_t all_memory_tables_size{};
-  };
+  RepositoryMetricsSourceStore(std::string name);
+  void addRepository(const std::shared_ptr<core::RepositoryMetricsSource> &repo);
+  std::vector<SerializedResponseNode> serialize();
+  std::vector<PublishedMetric> calculateMetrics();
 
-  virtual ~RepositoryMetricsSource() = default;
-  virtual uint64_t getRepositorySize() const = 0;
-  virtual uint64_t getRepositoryEntryCount() const = 0;
-  virtual std::string getRepositoryName() const = 0;
-
-  virtual uint64_t getMaxRepositorySize() const {
-    return 0;
-  }
-
-  virtual bool isFull() const {
-    return false;
-  }
-
-  virtual bool isRunning() const {
-    return true;
-  }
-
-  virtual std::optional<RocksDbStats> getRocksDbStats() {
-    return std::nullopt;
-  }
+ private:
+  std::string name_;
+  std::vector<std::shared_ptr<core::RepositoryMetricsSource>> repositories_;
 };
 
-}  // namespace org::apache::nifi::minifi::core
+}  // namespace org::apache::nifi::minifi::state::response

--- a/libminifi/include/core/state/nodes/RepositoryMetricsSourceStore.h
+++ b/libminifi/include/core/state/nodes/RepositoryMetricsSourceStore.h
@@ -31,9 +31,10 @@ namespace org::apache::nifi::minifi::state::response {
 class RepositoryMetricsSourceStore {
  public:
   RepositoryMetricsSourceStore(std::string name);
+  void setRepositories(const std::vector<std::shared_ptr<core::RepositoryMetricsSource>> &repositories);
   void addRepository(const std::shared_ptr<core::RepositoryMetricsSource> &repo);
-  std::vector<SerializedResponseNode> serialize();
-  std::vector<PublishedMetric> calculateMetrics();
+  std::vector<SerializedResponseNode> serialize() const;
+  std::vector<PublishedMetric> calculateMetrics() const;
 
  private:
   std::string name_;

--- a/libminifi/include/core/state/nodes/RepositoryMetricsSourceStore.h
+++ b/libminifi/include/core/state/nodes/RepositoryMetricsSourceStore.h
@@ -30,7 +30,7 @@ namespace org::apache::nifi::minifi::state::response {
 
 class RepositoryMetricsSourceStore {
  public:
-  RepositoryMetricsSourceStore(std::string name);
+  explicit RepositoryMetricsSourceStore(std::string name);
   void setRepositories(const std::vector<std::shared_ptr<core::RepositoryMetricsSource>> &repositories);
   void addRepository(const std::shared_ptr<core::RepositoryMetricsSource> &repo);
   std::vector<SerializedResponseNode> serialize() const;

--- a/libminifi/src/core/state/nodes/RepositoryMetricsSourceStore.cpp
+++ b/libminifi/src/core/state/nodes/RepositoryMetricsSourceStore.cpp
@@ -1,0 +1,99 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "core/state/nodes/RepositoryMetricsSourceStore.h"
+
+namespace org::apache::nifi::minifi::state::response {
+
+RepositoryMetricsSourceStore::RepositoryMetricsSourceStore(std::string name) : name_(std::move(name)) {}
+
+void RepositoryMetricsSourceStore::addRepository(const std::shared_ptr<core::RepositoryMetricsSource> &repo) {
+  if (nullptr != repo) {
+    repositories_.push_back(repo);
+  }
+}
+
+std::vector<SerializedResponseNode> RepositoryMetricsSourceStore::serialize() {
+  std::vector<SerializedResponseNode> serialized;
+  for (const auto& repo : repositories_) {
+    SerializedResponseNode parent;
+    parent.name = repo->getRepositoryName();
+    SerializedResponseNode is_running;
+    is_running.name = "running";
+    is_running.value = repo->isRunning();
+
+    SerializedResponseNode is_full;
+    is_full.name = "full";
+    is_full.value = repo->isFull();
+
+    SerializedResponseNode repo_size;
+    repo_size.name = "size";
+    repo_size.value = std::to_string(repo->getRepositorySize());
+
+    SerializedResponseNode max_repo_size;
+    max_repo_size.name = "maxSize";
+    max_repo_size.value = std::to_string(repo->getMaxRepositorySize());
+
+    SerializedResponseNode repo_entry_count;
+    repo_entry_count.name = "entryCount";
+    repo_entry_count.value = repo->getRepositoryEntryCount();
+
+    parent.children.push_back(is_running);
+    parent.children.push_back(is_full);
+    parent.children.push_back(repo_size);
+    parent.children.push_back(max_repo_size);
+    parent.children.push_back(repo_entry_count);
+
+    auto rocksdb_stats = repo->getRocksDbStats();
+    if (rocksdb_stats) {
+      SerializedResponseNode rocksdb_table_readers_size;
+      rocksdb_table_readers_size.name = "rocksDbTableReadersSize";
+      rocksdb_table_readers_size.value = rocksdb_stats->table_readers_size;
+
+      SerializedResponseNode rocksdb_all_memory_tables_size;
+      rocksdb_all_memory_tables_size.name = "rocksDbAllMemoryTablesSize";
+      rocksdb_all_memory_tables_size.value = rocksdb_stats->all_memory_tables_size;
+
+      parent.children.push_back(rocksdb_table_readers_size);
+      parent.children.push_back(rocksdb_all_memory_tables_size);
+    }
+
+    serialized.push_back(parent);
+  }
+  return serialized;
+}
+
+std::vector<PublishedMetric> RepositoryMetricsSourceStore::calculateMetrics() {
+  std::vector<PublishedMetric> metrics;
+  for (const auto& repo : repositories_) {
+    metrics.push_back({"is_running", (repo->isRunning() ? 1.0 : 0.0), {{"metric_class", name_}, {"repository_name", repo->getRepositoryName()}}});
+    metrics.push_back({"is_full", (repo->isFull() ? 1.0 : 0.0), {{"metric_class", name_}, {"repository_name", repo->getRepositoryName()}}});
+    metrics.push_back({"repository_size_bytes", static_cast<double>(repo->getRepositorySize()), {{"metric_class", name_}, {"repository_name", repo->getRepositoryName()}}});
+    metrics.push_back({"max_repository_size_bytes", static_cast<double>(repo->getMaxRepositorySize()), {{"metric_class", name_}, {"repository_name", repo->getRepositoryName()}}});
+    metrics.push_back({"repository_entry_count", static_cast<double>(repo->getRepositoryEntryCount()), {{"metric_class", name_}, {"repository_name", repo->getRepositoryName()}}});
+    auto rocksdb_stats = repo->getRocksDbStats();
+    if (rocksdb_stats) {
+      metrics.push_back({"rocksdb_table_readers_size_bytes", static_cast<double>(rocksdb_stats->table_readers_size),
+        {{"metric_class", name_}, {"repository_name", repo->getRepositoryName()}}});
+      metrics.push_back({"rocksdb_all_memory_tables_size_bytes", static_cast<double>(rocksdb_stats->all_memory_tables_size),
+        {{"metric_class", name_}, {"repository_name", repo->getRepositoryName()}}});
+    }
+  }
+  return metrics;
+}
+
+}  // namespace org::apache::nifi::minifi::state::response

--- a/libminifi/src/core/state/nodes/RepositoryMetricsSourceStore.cpp
+++ b/libminifi/src/core/state/nodes/RepositoryMetricsSourceStore.cpp
@@ -21,13 +21,17 @@ namespace org::apache::nifi::minifi::state::response {
 
 RepositoryMetricsSourceStore::RepositoryMetricsSourceStore(std::string name) : name_(std::move(name)) {}
 
+void RepositoryMetricsSourceStore::setRepositories(const std::vector<std::shared_ptr<core::RepositoryMetricsSource>> &repositories) {
+  repositories_ = repositories;
+}
+
 void RepositoryMetricsSourceStore::addRepository(const std::shared_ptr<core::RepositoryMetricsSource> &repo) {
   if (nullptr != repo) {
     repositories_.push_back(repo);
   }
 }
 
-std::vector<SerializedResponseNode> RepositoryMetricsSourceStore::serialize() {
+std::vector<SerializedResponseNode> RepositoryMetricsSourceStore::serialize() const {
   std::vector<SerializedResponseNode> serialized;
   for (const auto& repo : repositories_) {
     SerializedResponseNode parent;
@@ -42,11 +46,11 @@ std::vector<SerializedResponseNode> RepositoryMetricsSourceStore::serialize() {
 
     SerializedResponseNode repo_size;
     repo_size.name = "size";
-    repo_size.value = std::to_string(repo->getRepositorySize());
+    repo_size.value = repo->getRepositorySize();
 
     SerializedResponseNode max_repo_size;
     max_repo_size.name = "maxSize";
-    max_repo_size.value = std::to_string(repo->getMaxRepositorySize());
+    max_repo_size.value = repo->getMaxRepositorySize();
 
     SerializedResponseNode repo_entry_count;
     repo_entry_count.name = "entryCount";
@@ -77,7 +81,7 @@ std::vector<SerializedResponseNode> RepositoryMetricsSourceStore::serialize() {
   return serialized;
 }
 
-std::vector<PublishedMetric> RepositoryMetricsSourceStore::calculateMetrics() {
+std::vector<PublishedMetric> RepositoryMetricsSourceStore::calculateMetrics() const {
   std::vector<PublishedMetric> metrics;
   for (const auto& repo : repositories_) {
     metrics.push_back({"is_running", (repo->isRunning() ? 1.0 : 0.0), {{"metric_class", name_}, {"repository_name", repo->getRepositoryName()}}});

--- a/libminifi/test/unit/LogMetricsPublisherTests.cpp
+++ b/libminifi/test/unit/LogMetricsPublisherTests.cpp
@@ -38,6 +38,8 @@ class LogPublisherTestFixture {
       response_node_loader_(std::make_shared<state::response::ResponseNodeLoader>(configuration_,
         std::vector<std::shared_ptr<core::RepositoryMetricsSource>>{provenance_repo_, flow_file_repo_}, nullptr)),
       publisher_("LogMetricsPublisher") {
+    provenance_repo_->initialize(configuration_);
+    flow_file_repo_->initialize(configuration_);
   }
 
  protected:
@@ -89,14 +91,18 @@ TEST_CASE_METHOD(LogPublisherTestFixture, "Verify multiple metric nodes in logs"
                 "full": "false",
                 "size": "0",
                 "maxSize": "0",
-                "entryCount": "0"
+                "entryCount": "0",
+                "rocksDbTableReadersSize": "0",
+                "rocksDbAllMemoryTablesSize": "2048"
             },
             "flowfilerepository": {
                 "running": "false",
                 "full": "false",
                 "size": "0",
                 "maxSize": "0",
-                "entryCount": "0"
+                "entryCount": "0",
+                "rocksDbTableReadersSize": "0",
+                "rocksDbAllMemoryTablesSize": "2048"
             }
         },
         "deviceInfo": {
@@ -119,14 +125,18 @@ TEST_CASE_METHOD(LogPublisherTestFixture, "Verify reloading different metrics", 
                 "full": "false",
                 "size": "0",
                 "maxSize": "0",
-                "entryCount": "0"
+                "entryCount": "0",
+                "rocksDbTableReadersSize": "0",
+                "rocksDbAllMemoryTablesSize": "2048"
             },
             "flowfilerepository": {
                 "running": "false",
                 "full": "false",
                 "size": "0",
                 "maxSize": "0",
-                "entryCount": "0"
+                "entryCount": "0",
+                "rocksDbTableReadersSize": "0",
+                "rocksDbAllMemoryTablesSize": "2048"
             }
         }
     }
@@ -168,14 +178,18 @@ TEST_CASE_METHOD(LogPublisherTestFixture, "Verify generic and publisher specific
                 "full": "false",
                 "size": "0",
                 "maxSize": "0",
-                "entryCount": "0"
+                "entryCount": "0",
+                "rocksDbTableReadersSize": "0",
+                "rocksDbAllMemoryTablesSize": "2048"
             },
             "flowfilerepository": {
                 "running": "false",
                 "full": "false",
                 "size": "0",
                 "maxSize": "0",
-                "entryCount": "0"
+                "entryCount": "0",
+                "rocksDbTableReadersSize": "0",
+                "rocksDbAllMemoryTablesSize": "2048"
             }
         }
     }
@@ -199,14 +213,18 @@ TEST_CASE_METHOD(LogPublisherTestFixture, "Verify changing log level property fo
                 "full": "false",
                 "size": "0",
                 "maxSize": "0",
-                "entryCount": "0"
+                "entryCount": "0",
+                "rocksDbTableReadersSize": "0",
+                "rocksDbAllMemoryTablesSize": "2048"
             },
             "flowfilerepository": {
                 "running": "false",
                 "full": "false",
                 "size": "0",
                 "maxSize": "0",
-                "entryCount": "0"
+                "entryCount": "0",
+                "rocksDbTableReadersSize": "0",
+                "rocksDbAllMemoryTablesSize": "2048"
             }
         }
     }

--- a/libminifi/test/unit/ProvenanceTestHelper.h
+++ b/libminifi/test/unit/ProvenanceTestHelper.h
@@ -178,7 +178,7 @@ class TestThreadedRepository : public TestRepositoryBase<org::apache::nifi::mini
 
 class TestRocksDbRepository : public TestThreadedRepository {
  public:
-  std::optional<RocksDbStats> getRocksDbStats() override {
+  std::optional<RocksDbStats> getRocksDbStats() const override {
     return RocksDbStats {
       .table_readers_size = 100,
       .all_memory_tables_size = 200

--- a/libminifi/test/unit/ProvenanceTestHelper.h
+++ b/libminifi/test/unit/ProvenanceTestHelper.h
@@ -176,6 +176,16 @@ class TestThreadedRepository : public TestRepositoryBase<org::apache::nifi::mini
   std::thread thread_;
 };
 
+class TestRocksDbRepository : public TestThreadedRepository {
+ public:
+  std::optional<RocksDbStats> getRocksDbStats() override {
+    return RocksDbStats {
+      .table_readers_size = 100,
+      .all_memory_tables_size = 200
+    };
+  }
+};
+
 class TestFlowRepository : public org::apache::nifi::minifi::core::ThreadedRepository {
  public:
   TestFlowRepository()


### PR DESCRIPTION
Instead of printing the RocksDB specific metrics to the log file every 30 seconds, they are moved to the RepositoryMetrics. This way they can be published to any metric collector and should be able to print them to the log file as well periodically after [MINIFICPP-2076](https://github.com/apache/nifi-minifi-cpp/pull/1532) is merged.

Depends on [MINIFICPP-2022](https://github.com/apache/nifi-minifi-cpp/pull/1490)

https://issues.apache.org/jira/browse/MINIFICPP-2082

-----------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
