### PR TITLE
MINIFICPP-2092 Fix link issue of OpenCV on ARM64

### DIFF
--- a/cmake/BundledOpenCV.cmake
+++ b/cmake/BundledOpenCV.cmake
@@ -92,12 +92,12 @@ function(use_bundled_opencv SOURCE_DIR BINARY_DIR)
             "-DWITH_GTK=OFF"
             "-DWITH_IPP=OFF"
             "-DWITH_JASPER=OFF"
-            "-DWITH_OPENEXR=OFF"
             "-DWITH_ITT=OFF"
             "-DWITH_OPENEXR=OFF"
             "-DWITH_WEBP=OFF"
             "-DWITH_OPENJPEG=OFF"
             "-DWITH_TIFF=OFF"
+            "-DWITH_CAROTENE=OFF"
             "-DCMAKE_CXX_STANDARD=17"  # OpenCV fails to build in C++20 mode on Clang-14
     )
 


### PR DESCRIPTION
We should not depend on NVidia carotene acceleration library when building OpenCV extension

https://issues.apache.org/jira/browse/MINIFICPP-2092

----------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
