### PR TITLE
MINIFICPP-2083 case-insensitive workaround is needed for <= GCC 12.1 …

### DIFF
--- a/libminifi/src/utils/Cron.cpp
+++ b/libminifi/src/utils/Cron.cpp
@@ -45,6 +45,22 @@ using date::Sunday;
 namespace org::apache::nifi::minifi::utils {
 namespace {
 
+// https://github.com/HowardHinnant/date/issues/550
+// Due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78714
+// the month parsing with '%b' and the weekday parsing with '%a' is case-sensitive in gcc11
+// This has been fixed in gcc12.2
+std::stringstream getCaseInsensitiveStream(const std::string& str) {
+#if defined(__GNUC__) && (__GNUC__ < 12 || (__GNUC__ == 12 && __GNUC_MINOR__ < 2))
+  auto patched_str = StringUtils::toLower(str);
+  if (!patched_str.empty())
+    patched_str[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(patched_str[0])));
+  return std::stringstream{patched_str};
+#else
+  return std::stringstream{str};
+#endif
+}
+
+
 template<class T>
 std::optional<T> fromChars(const std::string& input) {
   T t{};
@@ -98,18 +114,7 @@ day parse<day>(const std::string& day_str) {
 
 template <>
 month parse<month>(const std::string& month_str) {
-// https://github.com/HowardHinnant/date/issues/550
-// Due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78714
-// the month parsing with '%b' is case sensitive in gcc11
-// This has been fixed in gcc12
-#if defined(__GNUC__) && __GNUC__ < 12
-  auto patched_month_str = StringUtils::toLower(month_str);
-  if (!patched_month_str.empty())
-    patched_month_str[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(patched_month_str[0])));
-  std::stringstream stream(patched_month_str);
-#else
-  std::stringstream stream(month_str);
-#endif
+  std::stringstream stream = getCaseInsensitiveStream(month_str);
 
   stream.imbue(std::locale("en_US.UTF-8"));
   month parsed_month{};
@@ -128,19 +133,7 @@ month parse<month>(const std::string& month_str) {
 
 template <>
 weekday parse<weekday>(const std::string& weekday_str) {
-// https://github.com/HowardHinnant/date/issues/550
-// Due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78714
-// the weekday parsing with '%a' is case sensitive in gcc11
-// This has been fixed in gcc12
-#if defined(__GNUC__) && __GNUC__ < 12
-  auto patched_weekday_str = StringUtils::toLower(weekday_str);
-  if (!patched_weekday_str.empty())
-    patched_weekday_str[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(patched_weekday_str[0])));
-  std::stringstream stream(patched_weekday_str);
-#else
-  std::stringstream stream(weekday_str);
-#endif
-  stream.imbue(std::locale("en_US.UTF-8"));
+  std::stringstream stream = getCaseInsensitiveStream(weekday_str);
 
   if (weekday_str.size() > 2) {
     weekday parsed_weekday{};


### PR DESCRIPTION
…(not simply <= GCC 12)

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
