### PR TITLE
MINIFICPP-2095 fix inconsistent naming in C2 machineArch

### DIFF
--- a/C2.md
+++ b/C2.md
@@ -134,7 +134,7 @@ configuration produces the following JSON:
           "deviceInfo": {
               "systemInfo": {
                   "cpuUtilization": -1,
-                  "machinearch": "x86_64",
+                  "machineArch": "x86_64",
                   "memoryUsage": 13103550464,
                   "operatingSystem": "Linux",
                   "physicalMem": 67024097280,

--- a/extensions/http-curl/tests/C2VerifyResourceConsumptionInHeartbeat.cpp
+++ b/extensions/http-curl/tests/C2VerifyResourceConsumptionInHeartbeat.cpp
@@ -18,6 +18,7 @@
 
 #undef NDEBUG
 #include <functional>
+#include <utility>
 
 #include "TestBase.h"
 #include "Catch.h"
@@ -119,7 +120,7 @@ class VerifyResourceConsumptionInHeartbeat : public VerifyC2Base {
   }
 
   void setEventToWaitFor(std::function<bool()> event_to_wait_for) {
-    event_to_wait_for_ = event_to_wait_for;
+    event_to_wait_for_ = std::move(event_to_wait_for);
   }
 
   std::function<bool()> event_to_wait_for_;

--- a/extensions/http-curl/tests/C2VerifyResourceConsumptionInHeartbeat.cpp
+++ b/extensions/http-curl/tests/C2VerifyResourceConsumptionInHeartbeat.cpp
@@ -69,8 +69,8 @@ class ResourceConsumptionInHeartbeatHandler : public HeartbeatHandler {
       assert(system_info["cpuUtilization"].GetDouble() <= 1.0);
     }
 
-    assert(system_info.HasMember("machinearch"));
-    assert(system_info["machinearch"].GetStringLength() > 0);
+    assert(system_info.HasMember("machineArch"));
+    assert(system_info["machineArch"].GetStringLength() > 0);
   }
 
   static void verifyProcessResourceConsumption(const rapidjson::Document& root, bool firstCall) {

--- a/libminifi/include/core/state/nodes/DeviceInformation.h
+++ b/libminifi/include/core/state/nodes/DeviceInformation.h
@@ -386,7 +386,7 @@ class DeviceInfoNode : public DeviceInformation {
 
   SerializedResponseNode serializeArchitectureInformation() const {
     SerializedResponseNode arch;
-    arch.name = "machinearch";
+    arch.name = "machineArch";
     arch.value = utils::OsUtils::getMachineArchitecture();
     return arch;
   }


### PR DESCRIPTION

Nifi and minifi java uses machineArch (the other properties also use camelCase), whilst minifi cpp uses machinearch (this makes it hard to create C2 servers that can be used simultaneously with java and cpp agents.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
