### PR TITLE
MINIFICPP-2120 Fix debian bookworm, and various bootstrap issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,10 +121,10 @@ jobs:
           echo -e "127.0.0.1\t$HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
       - name: build
         run: |
-          ./bootstrap.sh -e -t
-          cd build
           export CC=gcc-11
           export CXX=g++-11
+          ./bootstrap.sh -e -t
+          cd build
           cmake -DUSE_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DCI_BUILD=ON -DSTRICT_GSL_CHECKS=AUDIT -DFAIL_ON_WARNINGS=ON -DENABLE_SQL=OFF -DENABLE_LIBRDKAFKA=OFF -DENABLE_AWS=OFF \
               -DENABLE_AZURE=OFF -DENABLE_SPLUNK=OFF -DENABLE_GCP=OFF -DENABLE_PROCFS=OFF -DENABLE_BUSTACHE=ON -DENABLE_PCAP=ON -DENABLE_JNI=ON -DENABLE_SFTP=ON  \
               -DENABLE_LUA_SCRIPTING=OFF -DENABLE_PYTHON_SCRIPTING=OFF -DENABLE_MQTT=OFF -DENABLE_ELASTICSEARCH=OFF -DENABLE_KUBERNETES=OFF -DENABLE_OPC=OFF ..
@@ -177,10 +177,10 @@ jobs:
           echo -e "127.0.0.1\t$HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
       - name: build
         run: |
-          ./bootstrap.sh -e -t
-          cd build
           export CC=clang-14
           export CXX=clang++-14
+          ./bootstrap.sh -e -t
+          cd build
           export CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
           export LDFLAGS="${LDFLAGS} -stdlib=libc++"
           cmake -DUSE_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCI_BUILD=ON -DSTRICT_GSL_CHECKS=AUDIT -DFAIL_ON_WARNINGS=ON -DENABLE_AWS=ON -DENABLE_AZURE=ON -DENABLE_BUSTACHE=ON -DENABLE_COAP=ON \

--- a/aptitude.sh
+++ b/aptitude.sh
@@ -47,6 +47,7 @@ bootstrap_compiler() {
         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
         compiler_pkgs="gcc-11 g++-11"
     fi
+    # shellcheck disable=SC2086
     sudo apt-get -y install $compiler_pkgs
 }
 build_deps(){

--- a/aptitude.sh
+++ b/aptitude.sh
@@ -41,14 +41,16 @@ bootstrap_cmake(){
     fi
     sudo apt-get -y install cmake
 }
-build_deps(){
-    ## need to account for debian
+bootstrap_compiler() {
     compiler_pkgs="gcc g++"
     if [[ "$OS" = Ubuntu* && "$OS_MAJOR" -lt 22 ]]; then
         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
         compiler_pkgs="gcc-11 g++-11"
     fi
-    COMMAND="sudo apt-get -y install cmake $compiler_pkgs zlib1g-dev libssl-dev uuid uuid-dev"
+    sudo apt-get -y install $compiler_pkgs
+}
+build_deps(){
+    COMMAND="sudo apt-get -y install zlib1g-dev libssl-dev uuid uuid-dev"
 
     export DEBIAN_FRONTEND=noninteractive
     INSTALLED=()
@@ -97,6 +99,8 @@ build_deps(){
                         INSTALLED+=("libgps-dev")
                     elif [ "$FOUND_VALUE" = "libarchive" ]; then
                         INSTALLED+=("liblzma-dev")
+                    elif [ "$FOUND_VALUE" = "boost" ]; then
+                        INSTALLED+=("libboost-dev")
                     fi
                 fi
             done

--- a/aptitude.sh
+++ b/aptitude.sh
@@ -21,11 +21,11 @@ verify_enable_platform(){
     verify_gcc_enable "$feature"
 }
 add_os_flags() {
-    CC=gcc
-    CXX=g++
+    CC=${CC:-gcc}
+    CXX=${CXX:-g++}
     if [[ "$OS" = Ubuntu* && "$OS_MAJOR" -lt 22 ]]; then
-        CC=gcc-11
-        CXX=g++-11
+        CC=${CC:-gcc-11}
+        CXX=${CXX:-g++-11}
     fi
     export CC
     export CXX

--- a/arch.sh
+++ b/arch.sh
@@ -27,8 +27,11 @@ add_os_flags() {
 bootstrap_cmake(){
     sudo pacman -S --noconfirm cmake
 }
+bootstrap_compiler(){
+    sudo pacman -S --noconfirm gcc
+}
 build_deps(){
-    COMMAND="sudo pacman -S --noconfirm --needed cmake gcc zlib openssl util-linux"
+    COMMAND="sudo pacman -S --noconfirm --needed cmake zlib openssl util-linux make patch which pkgconf"
 
     INSTALLED=()
     INSTALLED+=("bzip2")

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -202,9 +202,6 @@ COMPILER_VERSION="0.0.0"
 COMPILER_COMMAND="${CXX:-g++}"
 
 if [ -z "$(command -v "$COMPILER_COMMAND")" ]; then
-  COMPILER_COMMAND=g++
-fi
-if [ -z "$(command -v "$COMPILER_COMMAND")" ]; then
   echo "Couldn't find compiler, attempting to install GCC"
   bootstrap_compiler
 fi

--- a/centos.sh
+++ b/centos.sh
@@ -64,22 +64,19 @@ bootstrap_cmake(){
             ;;
         *) install_pkgs cmake ;;
     esac
-    extra_bootstrap_flags=""
-    if [ "$NO_PROMPT" = "true" ]; then extra_bootstrap_flags="$extra_bootstrap_flags -n"; fi
+}
+
+bootstrap_compiler() {
     get_toolset_name
     if [ -n "$TOOLSET_NAME" ]; then
         install_pkgs centos-release-scl
-        scl enable $TOOLSET_NAME "bash ./bootstrap.sh $extra_bootstrap_flags"
-    else
-        # cli flags splitting is intentional
-        # shellcheck disable=SC2086
-        bash ./bootstrap.sh $extra_bootstrap_flags
+        install_pkgs "$TOOLSET_NAME"
     fi
+    source "/opt/rh/$TOOLSET_NAME/enable"
 }
 
 build_deps() {
-    get_toolset_name
-    COMMAND="install_pkgs libuuid libuuid-devel libtool patch epel-release $TOOLSET_NAME"
+    COMMAND="install_pkgs libuuid libuuid-devel libtool patch epel-release"
     INSTALLED=()
     for option in "${OPTIONS[@]}" ; do
         option_value="${!option}"
@@ -111,6 +108,7 @@ build_deps() {
                         INSTALLED+=("python36-devel")
                     elif [ "$FOUND_VALUE" = "lua" ]; then
                         INSTALLED+=("lua-libs")
+                        INSTALLED+=("lua-devel")
                     elif [ "$FOUND_VALUE" = "gpsd" ]; then
                         INSTALLED+=("gpsd-devel")
                     elif [ "$FOUND_VALUE" = "libarchive" ]; then
@@ -118,6 +116,8 @@ build_deps() {
                         INSTALLED+=("bzip2-devel")
                     elif [ "$FOUND_VALUE" = "libssh2" ]; then
                         INSTALLED+=("libssh2-devel")
+                    elif [ "$FOUND_VALUE" = "boost" ]; then
+                        INSTALLED+=("boost-devel")
                     fi
                 fi
             done

--- a/darwin.sh
+++ b/darwin.sh
@@ -61,6 +61,9 @@ install_bison() {
 bootstrap_cmake(){
     brew install cmake
 }
+bootstrap_compiler() {
+    :
+}
 build_deps(){
 
     COMMAND="brew install cmake"

--- a/debian.sh
+++ b/debian.sh
@@ -25,18 +25,20 @@ add_os_flags() {
   :
 }
 bootstrap_cmake(){
-  sudo bash -c 'source /etc/os-release; grep "$VERSION_CODENAME-backports" /etc/apt/sources.list &>/dev/null || echo "deb http://deb.debian.org/debian $VERSION_CODENAME-backports main" >> /etc/apt/sources.list'
-  sudo apt-get -y update
   if [ "$VERSION_CODENAME" = buster ]; then
+    sudo bash -c 'source /etc/os-release; grep "$VERSION_CODENAME-backports" /etc/apt/sources.list &>/dev/null || echo "deb http://deb.debian.org/debian $VERSION_CODENAME-backports main" >> /etc/apt/sources.list'
+    sudo apt-get -y update
     sudo apt-get -t buster-backports install -y cmake
   else
+    sudo apt-get -y update
     sudo apt-get install -y cmake
   fi
 }
+bootstrap_compiler(){
+  sudo apt-get -y install build-essential
+}
 build_deps(){
   sudo apt-get -y update
-  ## need to account for debian
-  sudo apt-get install -y libssl1.0-dev > /dev/null
   RETVAL=$?
   if [ "$RETVAL" -ne "0" ]; then
     sudo apt-get install -y libssl-dev > /dev/null
@@ -85,6 +87,8 @@ build_deps(){
             INSTALLED+=("liblzma-dev")
           elif [ "$FOUND_VALUE" = "libssh2" ]; then
             INSTALLED+=("libssh2-1-dev")
+          elif [ "$FOUND_VALUE" = "boost" ]; then
+            INSTALLED+=("libboost-dev")
           fi
         fi
       done

--- a/fedora.sh
+++ b/fedora.sh
@@ -29,13 +29,16 @@ bootstrap_cmake(){
     sudo yum -y install epel-release-latest-7.noarch.rpm
     sudo yum -y install cmake3
 }
+bootstrap_compiler() {
+    sudo yum -y install gcc gcc-c++
+}
 build_deps(){
     # Install epel-release so that cmake3 will be available for installation
     sudo yum -y install wget
     wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     sudo yum -y install epel-release-latest-7.noarch.rpm
 
-    COMMAND="sudo yum -y install gcc gcc-c++ libuuid libuuid-devel patch"
+    COMMAND="sudo yum -y install libuuid libuuid-devel patch"
     INSTALLED=()
     INSTALLED+=("bzip2-devel")
     for option in "${OPTIONS[@]}" ; do
@@ -52,7 +55,7 @@ build_deps(){
                     if [ "$FOUND_VALUE" = "libpcap" ]; then
                         INSTALLED+=("libpcap-devel")
                     elif [ "$FOUND_VALUE" = "libusb" ]; then
-                        INSTALLED+=("libusb-devel")
+                        INSTALLED+=("libusb1-devel")
                     elif [ "$FOUND_VALUE" = "libpng" ]; then
                         INSTALLED+=("libpng-devel")
                     elif [ "$FOUND_VALUE" = "bison" ]; then
@@ -79,6 +82,8 @@ build_deps(){
                         INSTALLED+=("xz-devel")
                     elif [ "$FOUND_VALUE" = "libssh2" ]; then
                         INSTALLED+=("libssh2-devel")
+                    elif [ "$FOUND_VALUE" = "boost" ]; then
+                        INSTALLED+=("boost-devel")
                     fi
                 fi
             done

--- a/linux.sh
+++ b/linux.sh
@@ -17,5 +17,5 @@
 # under the License.
 verify_gcc_enable(){
   #feature="$1"
-  { [ "$COMPILER_MAJOR" -eq 8 ] && [ "$COMPILER_MINOR" -ge 2 ] || [ "$COMPILER_MAJOR" -gt 8 ]; } && echo true || echo false
+  [ "$COMPILER_MAJOR" -ge 11 ] && echo true || echo false
 }

--- a/rheldistro.sh
+++ b/rheldistro.sh
@@ -71,13 +71,16 @@ bootstrap_cmake(){
   sudo yum -y install epel-release-latest-7.noarch.rpm
   sudo yum -y install cmake3
 }
+bootstrap_compiler() {
+  sudo yum -y install gcc gcc-c++
+}
 build_deps(){
 # Install epel-release so that cmake3 will be available for installation
   sudo yum -y install wget
   wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   sudo yum -y install epel-release-latest-7.noarch.rpm
 
-  COMMAND="sudo yum install cmake3 gcc gcc-c++ libuuid libuuid-devel"
+  COMMAND="sudo yum install cmake3 libuuid libuuid-devel"
   INSTALLED=()
   INSTALLED+=("bzip2-devel")
   for option in "${OPTIONS[@]}" ; do

--- a/suse.sh
+++ b/suse.sh
@@ -48,9 +48,6 @@ install_bison() {
     fi
   fi
   if [ "$BISON_INSTALLED" = "false" ]; then
-    ## ensure that the toolchain is installed
-    INSTALL_BASE="sudo zypper in -y gcc gcc-c++"
-    ${INSTALL_BASE}
     wget https://ftp.gnu.org/gnu/bison/bison-3.0.4.tar.xz
     tar xvf bison-3.0.4.tar.xz
     pushd bison-3.0.4 || exit 1
@@ -64,10 +61,12 @@ install_bison() {
 bootstrap_cmake(){
   sudo zypper in -y cmake
 }
+bootstrap_compiler() {
+  sudo zypper in -y gcc gcc-c++
+}
 build_deps(){
-# Install epel-release so that cmake3 will be available for installation
-
-  COMMAND="sudo zypper in -y gcc gcc-c++ libuuid1 libuuid-devel"
+  # Install epel-release so that cmake3 will be available for installation
+  COMMAND="sudo zypper in -y libuuid1 libuuid-devel"
   INSTALLED=()
   INSTALLED+=("libbz2-devel")
   for option in "${OPTIONS[@]}" ; do


### PR DESCRIPTION
- move backports code to buster only, because cmake is new enough
- install compiler before the menu, so that entries can be selected
- Add boost package names
- devtoolset no longer requires nested calling of bootstrap
- fix compiler version checks

Manually verified on:
- Debian bookworm (bullseye is incompatible due to too old GCC)
- Fedora 38 (build fails due to GCC 13 incompatibility, but package installation and cmake generation looks good)
- Arch Linux (fails due to GCC 13 incompatibility, works with workarounds)
- Ubuntu 22.04
- CentOS 7

-------

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
