### PR TITLE
MINIFICPP-2132 improve error messages, refactor EL Value

### DIFF
--- a/extensions/standard-processors/processors/RouteOnAttribute.cpp
+++ b/extensions/standard-processors/processors/RouteOnAttribute.cpp
@@ -26,11 +26,7 @@
 
 #include "core/Resource.h"
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
-namespace processors {
+namespace org::apache::nifi::minifi::processors {
 
 const core::Relationship RouteOnAttribute::Unmatched("unmatched", "Files which do not match any expression are routed here");
 const core::Relationship RouteOnAttribute::Failure("failure", "Failed files are transferred to failure");
@@ -86,7 +82,7 @@ void RouteOnAttribute::onTrigger(core::ProcessContext *context, core::ProcessSes
       session->remove(flow_file);
     }
   } catch (const std::exception &e) {
-    logger_->log_error("Caught exception while updating attributes: %s", e.what());
+    logger_->log_error("Caught exception while updating attributes: type: %s, what: %s", typeid(e).name(), e.what());
     session->transfer(flow_file, Failure);
     yield();
   }
@@ -94,8 +90,4 @@ void RouteOnAttribute::onTrigger(core::ProcessContext *context, core::ProcessSes
 
 REGISTER_RESOURCE(RouteOnAttribute, Processor);
 
-} /* namespace processors */
-} /* namespace minifi */
-} /* namespace nifi */
-} /* namespace apache */
-} /* namespace org */
+}  // namespace org::apache::nifi::minifi::processors

--- a/libminifi/include/utils/GeneralUtils.h
+++ b/libminifi/include/utils/GeneralUtils.h
@@ -118,4 +118,12 @@ using remove_cvref_t = typename std::remove_cv<typename std::remove_reference<T>
 
 inline constexpr bool implies(bool a, bool b) noexcept { return !a || b; }
 
+template<typename... Funcs>
+struct overloaded : Funcs... {
+  using Funcs::operator()...;
+};
+// deduction guide. Shouldn't be necessary since C++20, but Clang doesn't implement "Class template argument deduction for aggregates" yet
+template<typename... Funcs>
+overloaded(Funcs...) -> overloaded<Funcs...>;
+
 }  // namespace org::apache::nifi::minifi::utils


### PR DESCRIPTION
The improved error message is in the `strParse` function of `Value`. It wraps number parsing functions, instead of calling them directly, and rethrows them with a friendlier message. Also, changed `RouteOnAttribute` to include the exception type.

The error that started this journey:
```
[2023-06-02 12:05:44.143] [org::apache::nifi::minifi::processors::RouteOnAttribute] [error] Caught exception while updating attributes: stoll (6741476a-bc4a-4196-8dd7-0e7faa7c7b3b)
```
`RouteOnAttribute` was used with an expression containing `:ge()`, and the referenced flow file attributes were not numbers.

------

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
