### PR TITLE
MINIFICPP-2142 Fix occasional segfault in SwapTests

### DIFF
--- a/libminifi/test/rocksdb-tests/SwapTests.cpp
+++ b/libminifi/test/rocksdb-tests/SwapTests.cpp
@@ -126,10 +126,11 @@ TEST_CASE("Connection will on-demand swap flow files") {
   std::set<std::shared_ptr<core::FlowFile>> expired;
   for (size_t i = 0; i < 200; ++i) {
     std::shared_ptr<core::FlowFile> ff;
-    minifi::utils::verifyEventHappenedInPollTime(std::chrono::seconds{1}, [&] {
+    bool got_non_null_flow_file = minifi::utils::verifyEventHappenedInPollTime(std::chrono::seconds{5}, [&] {
       ff = connection->poll(expired);
       return static_cast<bool>(ff);
     });
+    REQUIRE(got_non_null_flow_file);
     REQUIRE(ff->getAttribute("index") == std::to_string(i));
     REQUIRE(ff->getResourceClaim()->getContentFullPath() == processor->flow_files_[i]->getResourceClaim()->getContentFullPath());
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-2142

Check the result of `verifyEventHappenedInPollTime` so we get a failure instead of a segfault, and increase the timeout.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
