### PR TITLE
MINIFICPP-2145 Parallelize the clang-tidy CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
           echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main" | sudo tee -a /etc/apt/sources.list
           echo "deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main" | sudo tee -a /etc/apt/sources.list
           sudo apt update
-          sudo apt install -y ccache libfl-dev libpcap-dev libboost-all-dev openjdk-8-jdk maven libusb-1.0-0-dev libpng-dev libgps-dev clang-14 clang-tidy-14 libc++-14-dev libc++abi-14-dev libsqliteodbc lua5.3 liblua5.3-dev flake8
+          sudo apt install -y ccache libfl-dev libpcap-dev libboost-all-dev openjdk-8-jdk maven libusb-1.0-0-dev libpng-dev libgps-dev clang-14 clang-tidy-14 libc++-14-dev libc++abi-14-dev libsqliteodbc lua5.3 liblua5.3-dev flake8 parallel
           echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
           echo -e "127.0.0.1\t$HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
       - name: build
@@ -197,7 +197,7 @@ jobs:
           export CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
           export LDFLAGS="${LDFLAGS} -stdlib=libc++"
           cmake -DUSE_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCI_BUILD=ON -DSTRICT_GSL_CHECKS=AUDIT -DFAIL_ON_WARNINGS=ON -DENABLE_AWS=ON -DENABLE_AZURE=ON -DENABLE_BUSTACHE=ON -DENABLE_COAP=ON \
-              -DENABLE_ENCRYPT_CONFIG=ON -DENABLE_GPS=ON -DENABLE_LIBRDKAFKA=ON -DENABLE_MQTT=ON -DENABLE_NANOFI=ON -DENABLE_OPC=ON -DENABLE_OPENCV=ON \
+              -DENABLE_ENCRYPT_CONFIG=ON -DENABLE_GPS=ON -DENABLE_LIBRDKAFKA=ON -DENABLE_MQTT=ON -DENABLE_NANOFI=ON -DENABLE_OPC=ON -DENABLE_OPENCV=ON -DENABLE_JNI=ON \
               -DENABLE_OPENWSMAN=ON -DENABLE_OPS=ON -DENABLE_PCAP=ON -DENABLE_SENSORS=ON -DENABLE_SFTP=ON -DENABLE_SQL=ON -DENABLE_SYSTEMD=ON -DENABLE_TENSORFLOW=OFF \
               -DENABLE_USB_CAMERA=ON -DENABLE_PYTHON_SCRIPTING=ON -DENABLE_LUA_SCRIPTING=ON -DENABLE_KUBERNETES=ON -DENABLE_GCP=ON -DENABLE_PROCFS=ON -DENABLE_PROMETHEUS=ON -DENABLE_ELASTICSEARCH=ON \
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
@@ -230,7 +230,7 @@ jobs:
           sed -i -e 's/\/usr\/lib\/ccache\/clang++-14/\/lib\/llvm-14\/bin\/clang++/g' build/compile_commands.json
           sed -i -e 's/\/usr\/lib\/ccache\/clang-14/\/lib\/llvm-14\/bin\/clang/g' build/compile_commands.json
 
-          ./run_clang_tidy.sh "${FILES}"
+          parallel -j$(nproc) ./run_clang_tidy.sh ::: ${FILES}
       - name: check-cores
         if: ${{ failure() && steps.test.conclusion == 'failure' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
           sed -i -e 's/\/usr\/lib\/ccache\/clang++-14/\/lib\/llvm-14\/bin\/clang++/g' build/compile_commands.json
           sed -i -e 's/\/usr\/lib\/ccache\/clang-14/\/lib\/llvm-14\/bin\/clang/g' build/compile_commands.json
 
-          parallel -j$(nproc) ./run_clang_tidy.sh ::: ${FILES}
+          parallel -j$(( $(nproc) + 1 )) ./run_clang_tidy.sh ::: ${FILES}
       - name: check-cores
         if: ${{ failure() && steps.test.conclusion == 'failure' }}
         run: |

--- a/run_clang_tidy.sh
+++ b/run_clang_tidy.sh
@@ -2,27 +2,29 @@
 
 set -uo pipefail
 
-exit_code=0
-FILES=$1
+FILE=$1
 
 EXCLUDED_EXTENSIONS=("pdh" "windows-event-log" "tensorflow")
 EXCLUDED_DIRECTORY=("nanofi")
 
-for changed_file in ${FILES}; do
-  for excluded_extension in "${EXCLUDED_EXTENSIONS[@]}"; do
-    if [[ "${changed_file}" =~ extensions/${excluded_extension}/ ]]; then
-      continue 2
-    fi
-  done
-  for excluded_directory in "${EXCLUDED_DIRECTORY[@]}"; do
-    if [[ "${changed_file}" =~ ${excluded_directory}/ ]]; then
-      continue 2
-    fi
-  done
-  if [[ "${changed_file}" == *.cpp ]] && [[ -f "${changed_file}" ]]; then
-    clang-tidy-14 -warnings-as-errors=* -quiet -p build "${changed_file}"
-    exit_code=$(( $? | exit_code ))
-  fi;
+for excluded_extension in "${EXCLUDED_EXTENSIONS[@]}"; do
+  if [[ "${FILE}" =~ extensions/${excluded_extension}/ ]]; then
+    exit 0
+  fi
 done
 
-exit $exit_code
+for excluded_directory in "${EXCLUDED_DIRECTORY[@]}"; do
+  if [[ "${FILE}" =~ ${excluded_directory}/ ]]; then
+    exit 0
+  fi
+done
+
+if ! [[ "${FILE}" == *.cpp ]]; then
+  exit 0
+fi
+
+if ! [[ -f "${FILE}" ]]; then
+  exit 0
+fi
+
+clang-tidy-14 -warnings-as-errors=* -quiet -p build "$FILE"


### PR DESCRIPTION
Also: enable the JNI extension in the `clang-tidy` CI job.  Without this, clang-tidy fails if there are any changes in `extensions/jni`, even if there are no `clang-tidy` errors.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
