### PR TITLE
MINIFICPP-2151 Add MiNiFi Controller to docker minimal image

### DIFF
--- a/cmake/DockerConfig.cmake
+++ b/cmake/DockerConfig.cmake
@@ -49,7 +49,7 @@ add_custom_target(
         -o \"-DENABLE_LIBRDKAFKA=ON
              -DENABLE_AWS=ON
              -DENABLE_AZURE=ON
-             -DENABLE_CONTROLLER=OFF
+             -DENABLE_CONTROLLER=ON
              -DENABLE_PROMETHEUS=ON
              -DENABLE_MQTT=OFF
              -DENABLE_ELASTICSEARCH=OFF


### PR DESCRIPTION
In kubernetes if a liveness or readiness probe is to be implemented, a good option for this is to use the minificontroller to check the minifi agent status. For cloud use cases the docker-minimal image is used which needs to be extended with the minificontroller for this use case.

https://issues.apache.org/jira/browse/MINIFICPP-2151

-------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
