### PR TITLE
MINIFICPP-2116 upgrade OpenCV and RocksDB, add missing <cstdint> includes in libminifi

### DIFF
--- a/cmake/BundledOpenCV.cmake
+++ b/cmake/BundledOpenCV.cmake
@@ -98,7 +98,6 @@ function(use_bundled_opencv SOURCE_DIR BINARY_DIR)
             "-DWITH_OPENJPEG=OFF"
             "-DWITH_TIFF=OFF"
             "-DWITH_CAROTENE=OFF"
-            "-DCMAKE_CXX_STANDARD=17"  # OpenCV fails to build in C++20 mode on Clang-14
     )
 
     append_third_party_passthrough_args(OPENCV_CMAKE_ARGS "${OPENCV_CMAKE_ARGS}")
@@ -106,8 +105,8 @@ function(use_bundled_opencv SOURCE_DIR BINARY_DIR)
     # Build project
     ExternalProject_Add(
             opencv-external
-            GIT_REPOSITORY "https://github.com/opencv/opencv.git"
-            GIT_TAG "4.5.5"
+            URL "https://github.com/opencv/opencv/archive/refs/tags/4.7.0.tar.gz"
+            URL_HASH "SHA256=8df0079cdbe179748a18d44731af62a245a45ebf5085223dc03133954c662973"
             SOURCE_DIR "${BINARY_DIR}/thirdparty/opencv-src"
             CMAKE_ARGS ${OPENCV_CMAKE_ARGS}
             BUILD_BYPRODUCTS "${BYPRODUCTS}"

--- a/cmake/BundledRocksDB.cmake
+++ b/cmake/BundledRocksDB.cmake
@@ -68,7 +68,7 @@ function(use_bundled_rocksdb SOURCE_DIR BINARY_DIR)
     ExternalProject_Add(
             rocksdb-external
             URL "https://github.com/facebook/rocksdb/archive/refs/tags/v8.1.1.tar.gz"
-	    URL_HASH "SHA256=9102704e169cfb53e7724a30750eeeb3e71307663852f01fa08d5a320e6155a8"
+            URL_HASH "SHA256=9102704e169cfb53e7724a30750eeeb3e71307663852f01fa08d5a320e6155a8"
             SOURCE_DIR "${BINARY_DIR}/thirdparty/rocksdb-src"
             CMAKE_ARGS ${ROCKSDB_CMAKE_ARGS}
             BUILD_BYPRODUCTS "${BINARY_DIR}/thirdparty/rocksdb-install/${BYPRODUCT}"

--- a/cmake/BundledRocksDB.cmake
+++ b/cmake/BundledRocksDB.cmake
@@ -67,8 +67,8 @@ function(use_bundled_rocksdb SOURCE_DIR BINARY_DIR)
     # Build project
     ExternalProject_Add(
             rocksdb-external
-            URL "https://github.com/facebook/rocksdb/archive/refs/tags/v7.7.3.tar.gz"
-            URL_HASH "SHA256=b8ac9784a342b2e314c821f6d701148912215666ac5e9bdbccd93cf3767cb611"
+            URL "https://github.com/facebook/rocksdb/archive/refs/tags/v8.1.1.tar.gz"
+	    URL_HASH "SHA256=9102704e169cfb53e7724a30750eeeb3e71307663852f01fa08d5a320e6155a8"
             SOURCE_DIR "${BINARY_DIR}/thirdparty/rocksdb-src"
             CMAKE_ARGS ${ROCKSDB_CMAKE_ARGS}
             BUILD_BYPRODUCTS "${BINARY_DIR}/thirdparty/rocksdb-install/${BYPRODUCT}"

--- a/libminifi/include/core/Annotation.h
+++ b/libminifi/include/core/Annotation.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace org {

--- a/libminifi/include/utils/SystemCpuUsageTracker.h
+++ b/libminifi/include/utils/SystemCpuUsageTracker.h
@@ -16,6 +16,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 #ifdef __linux__
 #include <stdlib.h>
 #include <stdio.h>
@@ -24,7 +26,6 @@
 #endif
 
 #ifdef WIN32
-#include <cstdint>
 #include "TCHAR.h"
 #include "windows.h"
 #endif


### PR DESCRIPTION
Required but not sufficient for workaround-free GCC 13 support.

----

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
