### PR TITLE
MINIFICPP-2162 Use className() instead of getClassName()

### DIFF
--- a/extensions/rocksdb-repos/DatabaseContentRepository.h
+++ b/extensions/rocksdb-repos/DatabaseContentRepository.h
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <thread>
 
@@ -44,8 +45,8 @@ class DatabaseContentRepository : public core::ContentRepository {
  public:
   static constexpr const char* ENCRYPTION_KEY_NAME = "nifi.database.content.repository.encryption.key";
 
-  explicit DatabaseContentRepository(std::string name = getClassName<DatabaseContentRepository>(), const utils::Identifier& uuid = {})
-    : core::ContentRepository(std::move(name), uuid),
+  explicit DatabaseContentRepository(std::string_view name = className<DatabaseContentRepository>(), const utils::Identifier& uuid = {})
+    : core::ContentRepository(name, uuid),
       is_valid_(false),
       db_(nullptr),
       logger_(logging::LoggerFactory<DatabaseContentRepository>::getLogger()) {

--- a/extensions/rocksdb-repos/FlowFileRepository.h
+++ b/extensions/rocksdb-repos/FlowFileRepository.h
@@ -19,6 +19,7 @@
 #include <utility>
 #include <vector>
 #include <string>
+#include <string_view>
 #include <memory>
 #include <list>
 
@@ -68,16 +69,16 @@ class FlowFileRepository : public RocksDbRepository, public SwapManager {
  public:
   static constexpr const char* ENCRYPTION_KEY_NAME = "nifi.flowfile.repository.encryption.key";
 
-  FlowFileRepository(std::string name, const utils::Identifier& /*uuid*/)
-    : FlowFileRepository(std::move(name)) {
+  FlowFileRepository(std::string_view name, const utils::Identifier& /*uuid*/)
+    : FlowFileRepository(name) {
   }
 
-  explicit FlowFileRepository(const std::string& repo_name = "",
+  explicit FlowFileRepository(const std::string_view repo_name = "",
                               std::string directory = FLOWFILE_REPOSITORY_DIRECTORY,
                               std::chrono::milliseconds maxPartitionMillis = MAX_FLOWFILE_REPOSITORY_ENTRY_LIFE_TIME,
                               int64_t maxPartitionBytes = MAX_FLOWFILE_REPOSITORY_STORAGE_SIZE,
                               std::chrono::milliseconds purgePeriod = FLOWFILE_REPOSITORY_PURGE_PERIOD)
-    : RocksDbRepository(repo_name.length() > 0 ? std::move(repo_name) : core::getClassName<FlowFileRepository>(),
+    : RocksDbRepository(repo_name.length() > 0 ? repo_name : core::className<FlowFileRepository>(),
                         std::move(directory), maxPartitionMillis, maxPartitionBytes, purgePeriod, logging::LoggerFactory<FlowFileRepository>::getLogger()) {
   }
 

--- a/extensions/rocksdb-repos/ProvenanceRepository.h
+++ b/extensions/rocksdb-repos/ProvenanceRepository.h
@@ -19,6 +19,7 @@
 #include <cinttypes>
 #include <vector>
 #include <string>
+#include <string_view>
 #include <memory>
 #include <algorithm>
 #include <utility>
@@ -44,12 +45,12 @@ class ProvenanceRepository : public core::repository::RocksDbRepository {
     : ProvenanceRepository(std::move(name)) {
   }
 
-  explicit ProvenanceRepository(std::string repo_name = "",
+  explicit ProvenanceRepository(std::string_view repo_name = "",
                                 std::string directory = PROVENANCE_DIRECTORY,
                                 std::chrono::milliseconds maxPartitionMillis = MAX_PROVENANCE_ENTRY_LIFE_TIME,
                                 int64_t maxPartitionBytes = MAX_PROVENANCE_STORAGE_SIZE,
                                 std::chrono::milliseconds purgePeriod = PROVENANCE_PURGE_PERIOD)
-    : RocksDbRepository(repo_name.length() > 0 ? std::move(repo_name) : core::getClassName<ProvenanceRepository>(),
+    : RocksDbRepository(repo_name.length() > 0 ? repo_name : core::className<ProvenanceRepository>(),
         directory, maxPartitionMillis, maxPartitionBytes, purgePeriod, core::logging::LoggerFactory<ProvenanceRepository>::getLogger()) {
   }
 

--- a/extensions/rocksdb-repos/RocksDbRepository.h
+++ b/extensions/rocksdb-repos/RocksDbRepository.h
@@ -19,6 +19,7 @@
 #include <utility>
 #include <vector>
 #include <string>
+#include <string_view>
 #include <memory>
 
 #include "database/RocksDatabase.h"
@@ -30,13 +31,13 @@ constexpr auto FLOWFILE_REPOSITORY_RETRY_INTERVAL_INCREMENTS = std::chrono::mill
 
 class RocksDbRepository : public ThreadedRepository {
  public:
-  RocksDbRepository(std::string repo_name,
+  RocksDbRepository(std::string_view repo_name,
                     std::string directory,
                     std::chrono::milliseconds max_partition_millis,
                     int64_t max_partition_bytes,
                     std::chrono::milliseconds purge_period,
                     std::shared_ptr<logging::Logger> logger)
-    : ThreadedRepository(std::move(repo_name), std::move(directory), max_partition_millis, max_partition_bytes, purge_period),
+    : ThreadedRepository(repo_name, std::move(directory), max_partition_millis, max_partition_bytes, purge_period),
       logger_(std::move(logger)) {
   }
 

--- a/libminifi/include/agent/agent_docs.h
+++ b/libminifi/include/agent/agent_docs.h
@@ -73,7 +73,7 @@ inline auto toVector(std::span<const core::RelationshipDefinition> relationships
 
 template<typename T>
 std::string classNameWithDots() {
-  std::string class_name = core::getClassName<T>();
+  std::string class_name{core::className<T>()};
   return utils::StringUtils::replaceAll(class_name, "::", ".");
 }
 }  // namespace detail

--- a/libminifi/include/core/Connectable.h
+++ b/libminifi/include/core/Connectable.h
@@ -20,6 +20,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 #include <set>
 #include <unordered_set>
@@ -45,9 +46,9 @@ class FlowFile;
  */
 class Connectable : public CoreComponent {
  public:
-  explicit Connectable(std::string name);
+  explicit Connectable(std::string_view name);
 
-  explicit Connectable(std::string name, const utils::Identifier &uuid);
+  explicit Connectable(std::string_view name, const utils::Identifier &uuid);
 
   Connectable(const Connectable &other) = delete;
   Connectable(Connectable &&other) = delete;

--- a/libminifi/include/core/ContentRepository.h
+++ b/libminifi/include/core/ContentRepository.h
@@ -20,6 +20,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <list>
 
@@ -37,7 +38,7 @@ namespace org::apache::nifi::minifi::core {
  */
 class ContentRepository : public core::CoreComponent, public StreamManager<minifi::ResourceClaim>, public utils::EnableSharedFromThis<ContentRepository>, public core::RepositoryMetricsSource {
  public:
-  explicit ContentRepository(std::string name, const utils::Identifier& uuid = {}) : core::CoreComponent(std::move(name), uuid) {}
+  explicit ContentRepository(std::string_view name, const utils::Identifier& uuid = {}) : core::CoreComponent(name, uuid) {}
   ~ContentRepository() override = default;
 
   virtual bool initialize(const std::shared_ptr<Configure> &configure) = 0;

--- a/libminifi/include/core/Core.h
+++ b/libminifi/include/core/Core.h
@@ -105,8 +105,6 @@ constexpr auto typeNameArray() {
 # error Unsupported compiler
 #endif
 
-  static_assert(function.find(prefix) != std::string_view::npos && function.rfind(suffix) != std::string_view::npos);
-
   constexpr auto start = function.find(prefix) + prefix.size();
   constexpr auto end = function.rfind(suffix);
   static_assert(start < end);

--- a/libminifi/include/core/ObjectFactory.h
+++ b/libminifi/include/core/ObjectFactory.h
@@ -89,13 +89,13 @@ class ObjectFactory {
 template<class T>
 class DefautObjectFactory : public ObjectFactory {
  public:
-  DefautObjectFactory() {
-    className = core::getClassName<T>();
+  DefautObjectFactory()
+      : className(core::className<T>()) {
   }
 
   explicit DefautObjectFactory(std::string group_name)
-      : ObjectFactory(std::move(group_name)) {
-    className = core::getClassName<T>();
+      : ObjectFactory(std::move(group_name)),
+      className(core::className<T>()) {
   }
 
   /**

--- a/libminifi/include/core/Processor.h
+++ b/libminifi/include/core/Processor.h
@@ -45,7 +45,7 @@
 
 #define ADD_GET_PROCESSOR_NAME \
   std::string getProcessorType() const override { \
-    auto class_name = org::apache::nifi::minifi::core::getClassName<decltype(*this)>(); \
+    auto class_name = org::apache::nifi::minifi::core::className<decltype(*this)>(); \
     auto splitted = org::apache::nifi::minifi::utils::StringUtils::split(class_name, "::"); \
     return splitted[splitted.size() - 1]; \
   }

--- a/libminifi/include/core/Repository.h
+++ b/libminifi/include/core/Repository.h
@@ -26,6 +26,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -57,12 +58,12 @@ constexpr auto REPOSITORY_PURGE_PERIOD = std::chrono::milliseconds(2500);
 
 class Repository : public core::CoreComponent, public core::RepositoryMetricsSource {
  public:
-  explicit Repository(std::string repo_name = "Repository",
+  explicit Repository(std::string_view repo_name = "Repository",
                       std::string directory = REPOSITORY_DIRECTORY,
                       std::chrono::milliseconds maxPartitionMillis = MAX_REPOSITORY_ENTRY_LIFE_TIME,
                       int64_t maxPartitionBytes = MAX_REPOSITORY_STORAGE_SIZE,
                       std::chrono::milliseconds purgePeriod = REPOSITORY_PURGE_PERIOD)
-    : core::CoreComponent(std::move(repo_name)),
+    : core::CoreComponent(repo_name),
       max_partition_millis_(maxPartitionMillis),
       max_partition_bytes_(maxPartitionBytes),
       purge_period_(purgePeriod),

--- a/libminifi/include/core/SerializableComponent.h
+++ b/libminifi/include/core/SerializableComponent.h
@@ -17,7 +17,7 @@
  */
 #pragma once
 
-#include <string>
+#include <string_view>
 #include <utility>
 
 #include "core/Core.h"
@@ -29,11 +29,11 @@ namespace org::apache::nifi::minifi::core {
 
 class SerializableComponent : public core::CoreComponent {
  public:
-  explicit SerializableComponent(std::string name)
-    : core::CoreComponent(std::move(name)) {
+  explicit SerializableComponent(std::string_view name)
+    : core::CoreComponent(name) {
   }
 
-  virtual ~SerializableComponent() = default;
+  ~SerializableComponent() override = default;
 
   virtual bool serialize(io::OutputStream& output_stream) = 0;
   virtual bool deserialize(io::InputStream &input_stream) = 0;

--- a/libminifi/include/core/controller/ControllerService.h
+++ b/libminifi/include/core/controller/ControllerService.h
@@ -61,7 +61,7 @@ enum ControllerServiceState {
 class ControllerService : public ConfigurableComponent, public Connectable {
  public:
   ControllerService()
-      : Connectable(core::getClassName<ControllerService>()),
+      : Connectable(core::className<ControllerService>()),
         configuration_(std::make_shared<Configure>()) {
     current_state_ = DISABLED;
   }

--- a/libminifi/include/core/controller/ControllerServiceProvider.h
+++ b/libminifi/include/core/controller/ControllerServiceProvider.h
@@ -20,9 +20,11 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <future>
 #include <vector>
+
 #include "core/Core.h"
 #include "ControllerServiceLookup.h"
 #include "core/ConfigurableComponent.h"
@@ -35,18 +37,18 @@ namespace org::apache::nifi::minifi::core::controller {
 
 class ControllerServiceProvider : public CoreComponent, public ConfigurableComponent, public ControllerServiceLookup {
  public:
-  explicit ControllerServiceProvider(std::string name)
-      : CoreComponent(std::move(name)) {
+  explicit ControllerServiceProvider(std::string_view name)
+      : CoreComponent(name) {
     controller_map_ = std::make_shared<ControllerServiceMap>();
   }
 
   explicit ControllerServiceProvider(std::shared_ptr<ControllerServiceMap> services)
-      : CoreComponent(core::getClassName<ControllerServiceProvider>()),
+      : CoreComponent(core::className<ControllerServiceProvider>()),
         controller_map_(std::move(services)) {
   }
 
-  explicit ControllerServiceProvider(std::string name, std::shared_ptr<ControllerServiceMap> services)
-      : CoreComponent(std::move(name)),
+  explicit ControllerServiceProvider(std::string_view name, std::shared_ptr<ControllerServiceMap> services)
+      : CoreComponent(name),
         controller_map_(std::move(services)) {
   }
 

--- a/libminifi/include/core/logging/LoggerConfiguration.h
+++ b/libminifi/include/core/logging/LoggerConfiguration.h
@@ -26,6 +26,7 @@
 #include <map>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 
 #include "spdlog/common.h"
@@ -109,17 +110,17 @@ class LoggerConfiguration {
   /**
    * Can be used to get arbitrarily named Logger, LoggerFactory should be preferred within a class.
    */
-  std::shared_ptr<Logger> getLogger(const std::string& name, const std::optional<utils::Identifier>& id = {});
+  std::shared_ptr<Logger> getLogger(std::string_view name, const std::optional<utils::Identifier>& id = {});
 
   static const char *spdlog_default_pattern;
 
  protected:
   static std::shared_ptr<internal::LoggerNamespace> initialize_namespaces(const std::shared_ptr<LoggerProperties> &logger_properties, const std::shared_ptr<Logger> &logger = {});
-  static std::shared_ptr<spdlog::logger> get_logger(const std::shared_ptr<Logger>& logger, const std::shared_ptr<internal::LoggerNamespace> &root_namespace, const std::string &name,
+  static std::shared_ptr<spdlog::logger> get_logger(const std::shared_ptr<Logger>& logger, const std::shared_ptr<internal::LoggerNamespace> &root_namespace, std::string_view name_view,
                                                     const std::shared_ptr<spdlog::formatter>& formatter, bool remove_if_present = false);
 
  private:
-  std::shared_ptr<Logger> getLogger(const std::string& name, const std::optional<utils::Identifier>& id, const std::lock_guard<std::mutex>& lock);
+  std::shared_ptr<Logger> getLogger(std::string_view name, const std::optional<utils::Identifier>& id, const std::lock_guard<std::mutex>& lock);
 
   void initializeCompression(const std::lock_guard<std::mutex>& lock, const std::shared_ptr<LoggerProperties>& properties);
 
@@ -132,9 +133,9 @@ class LoggerConfiguration {
 
   class LoggerImpl : public Logger {
    public:
-    explicit LoggerImpl(std::string name, std::optional<utils::Identifier> id, const std::shared_ptr<LoggerControl> &controller, const std::shared_ptr<spdlog::logger> &delegate)
+    explicit LoggerImpl(std::string_view name, std::optional<utils::Identifier> id, const std::shared_ptr<LoggerControl> &controller, const std::shared_ptr<spdlog::logger> &delegate)
         : Logger(delegate, controller),
-          name(std::move(name)),
+          name(name),
           id(internal::formatId(id)) {
     }
 

--- a/libminifi/include/core/logging/LoggerFactory.h
+++ b/libminifi/include/core/logging/LoggerFactory.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <string>
+#include <string_view>
 #include <memory>
 
 #include "core/logging/Logger.h"
@@ -28,19 +28,19 @@ namespace org::apache::nifi::minifi::core::logging {
 
 class LoggerFactoryBase {
  public:
-  static std::shared_ptr<Logger> getAliasedLogger(const std::string& name, const std::optional<utils::Identifier>& id = {});
+  static std::shared_ptr<Logger> getAliasedLogger(std::string_view name, const std::optional<utils::Identifier>& id = {});
 };
 
 template<typename T>
 class LoggerFactory : public LoggerFactoryBase {
  public:
   static std::shared_ptr<Logger> getLogger() {
-    static std::shared_ptr<Logger> logger = getAliasedLogger(core::getClassName<T>());
+    static std::shared_ptr<Logger> logger = getAliasedLogger(core::className<T>());
     return logger;
   }
 
   static std::shared_ptr<Logger> getLogger(const utils::Identifier& uuid) {
-    return getAliasedLogger(core::getClassName<T>(), uuid);
+    return getAliasedLogger(core::className<T>(), uuid);
   }
 };
 

--- a/libminifi/include/core/repository/FileSystemRepository.h
+++ b/libminifi/include/core/repository/FileSystemRepository.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <algorithm>
 
@@ -32,8 +33,8 @@ namespace org::apache::nifi::minifi::core::repository {
 
 class FileSystemRepository : public core::ContentRepository {
  public:
-  explicit FileSystemRepository(std::string name = getClassName<FileSystemRepository>())
-    : core::ContentRepository(std::move(name)),
+  explicit FileSystemRepository(std::string_view name = className<FileSystemRepository>())
+    : core::ContentRepository(name),
       logger_(logging::LoggerFactory<FileSystemRepository>::getLogger()) {
   }
 

--- a/libminifi/include/core/repository/VolatileContentRepository.h
+++ b/libminifi/include/core/repository/VolatileContentRepository.h
@@ -20,6 +20,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 
 #include "AtomicRepoEntries.h"
 #include "io/AtomicEntryStream.h"
@@ -40,7 +41,7 @@ class VolatileContentRepository : public core::ContentRepository {
  public:
   static const char *minimal_locking;
 
-  explicit VolatileContentRepository(std::string name = getClassName<VolatileContentRepository>())
+  explicit VolatileContentRepository(std::string_view name = className<VolatileContentRepository>())
     : core::ContentRepository(name),
       repo_data_(15000, static_cast<size_t>(10_MiB * 0.75)),
       minimize_locking_(true),

--- a/libminifi/include/core/repository/VolatileFlowFileRepository.h
+++ b/libminifi/include/core/repository/VolatileFlowFileRepository.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 
 #include "VolatileRepository.h"
 #include "FlowFileRecord.h"
@@ -37,12 +38,12 @@ class VolatileFlowFileRepository : public VolatileRepository {
   friend struct ::VolatileFlowFileRepositoryTestAccessor;
 
  public:
-  explicit VolatileFlowFileRepository(const std::string& repo_name = "",
+  explicit VolatileFlowFileRepository(std::string_view repo_name = "",
                                       const std::string& /*dir*/ = REPOSITORY_DIRECTORY,
                                       std::chrono::milliseconds maxPartitionMillis = MAX_REPOSITORY_ENTRY_LIFE_TIME,
                                       int64_t maxPartitionBytes = MAX_REPOSITORY_STORAGE_SIZE,
                                       std::chrono::milliseconds purgePeriod = REPOSITORY_PURGE_PERIOD)
-    : VolatileRepository(repo_name.length() > 0 ? repo_name : core::getClassName<VolatileRepository>(), "", maxPartitionMillis, maxPartitionBytes, purgePeriod) {
+    : VolatileRepository(repo_name.length() > 0 ? repo_name : core::className<VolatileRepository>(), "", maxPartitionMillis, maxPartitionBytes, purgePeriod) {
   }
 
   ~VolatileFlowFileRepository() override {

--- a/libminifi/include/core/repository/VolatileProvenanceRepository.h
+++ b/libminifi/include/core/repository/VolatileProvenanceRepository.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 #include "VolatileRepository.h"
 #include "core/ThreadedRepository.h"
@@ -26,12 +27,12 @@ namespace org::apache::nifi::minifi::core::repository {
 
 class VolatileProvenanceRepository : public VolatileRepository {
  public:
-  explicit VolatileProvenanceRepository(std::string repo_name = "",
+  explicit VolatileProvenanceRepository(std::string_view repo_name = "",
                                         std::string /*dir*/ = REPOSITORY_DIRECTORY,
                                         std::chrono::milliseconds maxPartitionMillis = MAX_REPOSITORY_ENTRY_LIFE_TIME,
                                         int64_t maxPartitionBytes = MAX_REPOSITORY_STORAGE_SIZE,
                                         std::chrono::milliseconds purgePeriod = REPOSITORY_PURGE_PERIOD)
-    : VolatileRepository(repo_name.length() > 0 ? repo_name : core::getClassName<VolatileRepository>(), "", maxPartitionMillis, maxPartitionBytes, purgePeriod) {
+    : VolatileRepository(repo_name.length() > 0 ? repo_name : core::className<VolatileRepository>(), "", maxPartitionMillis, maxPartitionBytes, purgePeriod) {
   }
 
   ~VolatileProvenanceRepository() override {

--- a/libminifi/include/core/repository/VolatileRepository.h
+++ b/libminifi/include/core/repository/VolatileRepository.h
@@ -22,6 +22,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 #include <cinttypes>
@@ -38,12 +39,12 @@ namespace org::apache::nifi::minifi::core::repository {
 
 class VolatileRepository : public core::ThreadedRepository {
  public:
-  explicit VolatileRepository(std::string repo_name = "",
+  explicit VolatileRepository(std::string_view repo_name = "",
                               std::string /*dir*/ = REPOSITORY_DIRECTORY,
                               std::chrono::milliseconds maxPartitionMillis = MAX_REPOSITORY_ENTRY_LIFE_TIME,
                               int64_t maxPartitionBytes = MAX_REPOSITORY_STORAGE_SIZE,
                               std::chrono::milliseconds purgePeriod = REPOSITORY_PURGE_PERIOD)
-    : core::ThreadedRepository(repo_name.length() > 0 ? repo_name : core::getClassName<VolatileRepository>(), "", maxPartitionMillis, maxPartitionBytes, purgePeriod),
+    : core::ThreadedRepository(repo_name.length() > 0 ? repo_name : core::className<VolatileRepository>(), "", maxPartitionMillis, maxPartitionBytes, purgePeriod),
       repo_data_(10000, static_cast<size_t>(maxPartitionBytes * 0.75)),
       current_index_(0),
       logger_(logging::LoggerFactory<VolatileRepository>::getLogger()) {

--- a/libminifi/include/provenance/Provenance.h
+++ b/libminifi/include/provenance/Provenance.h
@@ -152,7 +152,7 @@ class ProvenanceEventRecord : public core::SerializableComponent {
   ProvenanceEventRecord(ProvenanceEventType event, std::string componentId, std::string componentType);
 
   ProvenanceEventRecord()
-      : core::SerializableComponent(core::getClassName<ProvenanceEventRecord>()) {
+      : core::SerializableComponent(core::className<ProvenanceEventRecord>()) {
     _eventTime = std::chrono::system_clock::now();
   }
 

--- a/libminifi/include/utils/ClassUtils.h
+++ b/libminifi/include/utils/ClassUtils.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 namespace org::apache::nifi::minifi::utils::ClassUtils {
 
@@ -26,6 +27,6 @@ namespace org::apache::nifi::minifi::utils::ClassUtils {
  * @param out output class name that is shortened.
  * @return true if out has been updated, false otherwise
  */
-bool shortenClassName(const std::string &class_name, std::string &out);
+bool shortenClassName(std::string_view class_name, std::string &out);
 
 }  // namespace org::apache::nifi::minifi::utils::ClassUtils

--- a/libminifi/include/utils/StringUtils.h
+++ b/libminifi/include/utils/StringUtils.h
@@ -172,10 +172,10 @@ class StringUtils {
     return std::equal(left.begin(), left.end(), right.begin(), [](unsigned char lc, unsigned char rc) { return std::tolower(lc) == std::tolower(rc); });
   }
 
-  static std::vector<std::string> split(const std::string &str, const std::string &delimiter);
-  static std::vector<std::string> splitRemovingEmpty(const std::string& str, const std::string& delimiter);
-  static std::vector<std::string> splitAndTrim(const std::string &str, const std::string &delimiter);
-  static std::vector<std::string> splitAndTrimRemovingEmpty(const std::string& str, const std::string& delimiter);
+  static std::vector<std::string> split(std::string_view str, std::string_view delimiter);
+  static std::vector<std::string> splitRemovingEmpty(std::string_view str, std::string_view delimiter);
+  static std::vector<std::string> splitAndTrim(std::string_view str, std::string_view delimiter);
+  static std::vector<std::string> splitAndTrimRemovingEmpty(std::string_view str, std::string_view delimiter);
 
   /**
    * Converts a string to a float

--- a/libminifi/src/FlowController.cpp
+++ b/libminifi/src/FlowController.cpp
@@ -51,7 +51,7 @@ FlowController::FlowController(std::shared_ptr<core::Repository> provenance_repo
                                std::shared_ptr<Configure> configure, std::shared_ptr<core::FlowConfiguration> flow_configuration,
                                std::shared_ptr<core::ContentRepository> content_repo, std::unique_ptr<state::MetricsPublisherStore> metrics_publisher_store,
                                std::shared_ptr<utils::file::FileSystem> filesystem, std::function<void()> request_restart)
-    : core::controller::ForwardingControllerServiceProvider(core::getClassName<FlowController>()),
+    : core::controller::ForwardingControllerServiceProvider(core::className<FlowController>()),
       running_(false),
       initialized_(false),
       thread_pool_(5, false, nullptr, "Flowcontroller threadpool"),

--- a/libminifi/src/core/Connectable.cpp
+++ b/libminifi/src/core/Connectable.cpp
@@ -26,15 +26,15 @@
 
 namespace org::apache::nifi::minifi::core {
 
-Connectable::Connectable(std::string name, const utils::Identifier &uuid)
-    : CoreComponent(std::move(name), uuid),
+Connectable::Connectable(std::string_view name, const utils::Identifier &uuid)
+    : CoreComponent(name, uuid),
       max_concurrent_tasks_(1),
       connectable_version_(nullptr),
       logger_(logging::LoggerFactory<Connectable>::getLogger(uuid_)) {
 }
 
-Connectable::Connectable(std::string name)
-    : CoreComponent(std::move(name)),
+Connectable::Connectable(std::string_view name)
+    : CoreComponent(name),
       max_concurrent_tasks_(1),
       connectable_version_(nullptr),
       logger_(logging::LoggerFactory<Connectable>::getLogger(uuid_)) {

--- a/libminifi/src/core/Core.cpp
+++ b/libminifi/src/core/Core.cpp
@@ -22,8 +22,8 @@
 
 namespace org::apache::nifi::minifi::core {
 
-CoreComponent::CoreComponent(std::string name, const utils::Identifier& uuid, const std::shared_ptr<utils::IdGenerator>& idGenerator)
-    : name_(std::move(name)) {
+CoreComponent::CoreComponent(std::string_view name, const utils::Identifier& uuid, const std::shared_ptr<utils::IdGenerator>& idGenerator)
+    : name_(name) {
   if (uuid.isNil()) {
     // Generate the global UUID for the flow record
     uuid_ = idGenerator->generate();

--- a/libminifi/src/core/FlowConfiguration.cpp
+++ b/libminifi/src/core/FlowConfiguration.cpp
@@ -29,7 +29,7 @@
 namespace org::apache::nifi::minifi::core {
 
 FlowConfiguration::FlowConfiguration(ConfigurationContext ctx)
-    : CoreComponent(core::getClassName<FlowConfiguration>()),
+    : CoreComponent(core::className<FlowConfiguration>()),
       flow_file_repo_(std::move(ctx.flow_file_repo)),
       content_repo_(std::move(ctx.content_repo)),
       stream_factory_(std::move(ctx.stream_factory)),

--- a/libminifi/src/core/logging/LoggerConfiguration.cpp
+++ b/libminifi/src/core/logging/LoggerConfiguration.cpp
@@ -94,10 +94,10 @@ LoggerConfiguration::LoggerConfiguration()
       formatter_(std::make_shared<spdlog::pattern_formatter>(spdlog_default_pattern)) {
   controller_ = std::make_shared<LoggerControl>();
   logger_ = std::make_shared<LoggerImpl>(
-      core::getClassName<LoggerConfiguration>(),
+      core::className<LoggerConfiguration>(),
       std::nullopt,
       controller_,
-      get_logger(nullptr, root_namespace_, core::getClassName<LoggerConfiguration>(), formatter_));
+      get_logger(nullptr, root_namespace_, core::className<LoggerConfiguration>(), formatter_));
   loggers.push_back(logger_);
 }
 
@@ -148,13 +148,13 @@ void LoggerConfiguration::initialize(const std::shared_ptr<LoggerProperties> &lo
   logger_->log_debug("Set following pattern on loggers: %s", spdlog_pattern);
 }
 
-std::shared_ptr<Logger> LoggerConfiguration::getLogger(const std::string& name, const std::optional<utils::Identifier>& id) {
+std::shared_ptr<Logger> LoggerConfiguration::getLogger(std::string_view name, const std::optional<utils::Identifier>& id) {
   std::lock_guard<std::mutex> lock(mutex);
   return getLogger(name, id, lock);
 }
 
-std::shared_ptr<Logger> LoggerConfiguration::getLogger(const std::string& name, const std::optional<utils::Identifier>& id, const std::lock_guard<std::mutex>& /*lock*/) {
-  std::string adjusted_name = name;
+std::shared_ptr<Logger> LoggerConfiguration::getLogger(std::string_view name, const std::optional<utils::Identifier>& id, const std::lock_guard<std::mutex>& /*lock*/) {
+  std::string adjusted_name{name};
   const std::string clazz = "class ";
   auto haz_clazz = name.find(clazz);
   if (haz_clazz == 0)
@@ -252,8 +252,9 @@ std::shared_ptr<internal::LoggerNamespace> LoggerConfiguration::initialize_names
   return root_namespace;
 }
 
-std::shared_ptr<spdlog::logger> LoggerConfiguration::get_logger(const std::shared_ptr<Logger>& logger, const std::shared_ptr<internal::LoggerNamespace> &root_namespace, const std::string &name,
+std::shared_ptr<spdlog::logger> LoggerConfiguration::get_logger(const std::shared_ptr<Logger>& logger, const std::shared_ptr<internal::LoggerNamespace> &root_namespace, std::string_view name_view,
                                                                 const std::shared_ptr<spdlog::formatter>& formatter, bool remove_if_present) {
+  std::string name{name_view};
   std::shared_ptr<spdlog::logger> spdlogger = spdlog::get(name);
   if (spdlogger) {
     if (remove_if_present) {

--- a/libminifi/src/core/logging/LoggerFactory.cpp
+++ b/libminifi/src/core/logging/LoggerFactory.cpp
@@ -21,7 +21,7 @@
 
 namespace org::apache::nifi::minifi::core::logging {
 
-std::shared_ptr<Logger> LoggerFactoryBase::getAliasedLogger(const std::string& name, const std::optional<utils::Identifier>& id) {
+std::shared_ptr<Logger> LoggerFactoryBase::getAliasedLogger(std::string_view name, const std::optional<utils::Identifier>& id) {
   return LoggerConfiguration::getConfiguration().getLogger(name, id);
 }
 

--- a/libminifi/src/core/logging/internal/CompressionManager.cpp
+++ b/libminifi/src/core/logging/internal/CompressionManager.cpp
@@ -27,13 +27,7 @@
 #include "core/TypedValues.h"
 #include "core/Core.h"
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
-namespace core {
-namespace logging {
-namespace internal {
+namespace org::apache::nifi::minifi::core::logging::internal {
 
 std::shared_ptr<LogCompressorSink> CompressionManager::initialize(
     const std::shared_ptr<LoggerProperties>& properties, const std::shared_ptr<Logger>& error_logger, const LoggerFactory& logger_factory) {
@@ -61,15 +55,9 @@ std::shared_ptr<LogCompressorSink> CompressionManager::initialize(
     sink_ = std::make_shared<internal::LogCompressorSink>(
         LogQueueSize{cached_log_max_size, cache_segment_size},
         LogQueueSize{compressed_log_max_size, compressed_segment_size},
-        logger_factory(getClassName<LogCompressorSink>()));
+        logger_factory(std::string(className<LogCompressorSink>())));
   }
   return sink_;
 }
 
-}  // namespace internal
-}  // namespace logging
-}  // namespace core
-}  // namespace minifi
-}  // namespace nifi
-}  // namespace apache
-}  // namespace org
+}  // namespace org::apache::nifi::minifi::core::logging::internal

--- a/libminifi/src/provenance/Provenance.cpp
+++ b/libminifi/src/provenance/Provenance.cpp
@@ -41,7 +41,7 @@ const char *ProvenanceEventRecord::ProvenanceEventTypeStr[REPLAY + 1] = { "CREAT
     "ATTRIBUTES_MODIFIED", "ROUTE", "ADDINFO", "REPLAY" };
 
 ProvenanceEventRecord::ProvenanceEventRecord(ProvenanceEventRecord::ProvenanceEventType event, std::string componentId, std::string componentType)
-    : core::SerializableComponent(core::getClassName<ProvenanceEventRecord>()),
+    : core::SerializableComponent(core::className<ProvenanceEventRecord>()),
       _eventType(event),
       _componentId(std::move(componentId)),
       _componentType(std::move(componentType)),

--- a/libminifi/src/utils/ClassUtils.cpp
+++ b/libminifi/src/utils/ClassUtils.cpp
@@ -25,7 +25,7 @@
 
 namespace org::apache::nifi::minifi::utils {
 
-bool ClassUtils::shortenClassName(const std::string &class_name, std::string &out) {
+bool ClassUtils::shortenClassName(std::string_view class_name, std::string &out) {
   std::string class_delim = "::";
   auto class_split = utils::StringUtils::split(class_name, class_delim);
   // support . and ::

--- a/libminifi/src/utils/StringUtils.cpp
+++ b/libminifi/src/utils/StringUtils.cpp
@@ -64,7 +64,8 @@ std::string_view StringUtils::trim(const char* str) {
 }
 
 template<typename Fun>
-std::vector<std::string> split_transformed(std::string str, const std::string& delimiter, Fun transformation) {
+std::vector<std::string> split_transformed(std::string_view str_view, std::string_view delimiter, Fun transformation) {
+  std::string str{str_view};
   std::vector<std::string> result;
   if (delimiter.empty()) {
     for (auto c : str) {
@@ -87,21 +88,21 @@ std::vector<std::string> split_transformed(std::string str, const std::string& d
   return result;
 }
 
-std::vector<std::string> StringUtils::split(const std::string& str, const std::string& delimiter) {
+std::vector<std::string> StringUtils::split(std::string_view str, std::string_view delimiter) {
   return split_transformed(str, delimiter, identity{});
 }
 
-std::vector<std::string> StringUtils::splitRemovingEmpty(const std::string& str, const std::string& delimiter) {
+std::vector<std::string> StringUtils::splitRemovingEmpty(std::string_view str, std::string_view delimiter) {
   auto result = split(str, delimiter);
   result.erase(std::remove_if(result.begin(), result.end(), [](const std::string& str) { return str.empty(); }), result.end());
   return result;
 }
 
-std::vector<std::string> StringUtils::splitAndTrim(const std::string& str, const std::string& delimiter) {
+std::vector<std::string> StringUtils::splitAndTrim(std::string_view str, std::string_view delimiter) {
   return split_transformed(str, delimiter, static_cast<std::string(*)(const std::string&)>(trim));
 }
 
-std::vector<std::string> StringUtils::splitAndTrimRemovingEmpty(const std::string& str, const std::string& delimiter) {
+std::vector<std::string> StringUtils::splitAndTrimRemovingEmpty(std::string_view str, std::string_view delimiter) {
   auto result = splitAndTrim(str, delimiter);
   result.erase(std::remove_if(result.begin(), result.end(), [](const std::string& str) { return str.empty(); }), result.end());
   return result;

--- a/libminifi/test/TestBase.h
+++ b/libminifi/test/TestBase.h
@@ -24,6 +24,7 @@
 #include <regex>
 #include <set>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 #include <mutex>
@@ -119,16 +120,16 @@ class LogTestController {
    * of changeable test formats
    */
   template<typename T>
-  std::shared_ptr<logging::Logger> getLogger(const std::optional<utils::Identifier>& id = {}) { return getLoggerByClassName(minifi::core::getClassName<T>(), id); }
+  std::shared_ptr<logging::Logger> getLogger(const std::optional<utils::Identifier>& id = {}) { return getLoggerByClassName(minifi::core::className<T>(), id); }
 
-  std::shared_ptr<logging::Logger> getLoggerByClassName(const std::string& class_name, const std::optional<utils::Identifier>& id = {});
+  std::shared_ptr<logging::Logger> getLoggerByClassName(std::string_view class_name, const std::optional<utils::Identifier>& id = {});
 
   template<typename T>
   void setLevel(spdlog::level::level_enum level) {
-    setLevelByClassName(level, minifi::core::getClassName<T>());
+    setLevelByClassName(level, minifi::core::className<T>());
   }
 
-  void setLevelByClassName(spdlog::level::level_enum level, const std::string& class_name);
+  void setLevelByClassName(spdlog::level::level_enum level, std::string_view class_name);
 
   bool contains(const std::string &ending, std::chrono::milliseconds timeout = std::chrono::seconds(3), std::chrono::milliseconds sleep_interval = std::chrono::milliseconds(200)) const;
 
@@ -163,7 +164,7 @@ class LogTestController {
 
   explicit LogTestController(const std::shared_ptr<logging::LoggerProperties> &loggerProps);
 
-  void setLevel(const std::string& name, spdlog::level::level_enum level);
+  void setLevel(std::string_view name, spdlog::level::level_enum level);
   bool contains(const std::function<std::string()>& log_string_getter, const std::string& ending, std::chrono::milliseconds timeout, std::chrono::milliseconds sleep_interval) const;
 
   mutable std::shared_ptr<std::mutex> log_output_mutex_ = std::make_shared<std::mutex>();

--- a/libminifi/test/sql-tests/mocks/MockConnectors.cpp
+++ b/libminifi/test/sql-tests/mocks/MockConnectors.cpp
@@ -187,7 +187,7 @@ void MockDB::createTable(const std::string& query) {
   std::regex expr(R"(create table (\w+)\s*\((.*)\);)", std::regex_constants::icase);
   std::regex_search(query, match, expr);
   std::string table_name = match[1];
-  auto columns_with_type = minifi::utils::StringUtils::splitAndTrimRemovingEmpty(match[2], ",");
+  auto columns_with_type = minifi::utils::StringUtils::splitAndTrimRemovingEmpty(match[2].str(), ",");
   std::vector<std::string> col_names;
   std::vector<DataType> col_types;
   for (const auto& col_with_type : columns_with_type) {
@@ -215,11 +215,11 @@ void MockDB::insertInto(const std::string& query, const std::vector<std::string>
   if (!tables_.contains(table_name)) {
     throw sql::StatementError("No such table: '" + table_name + "'");
   }
-  std::vector<std::string> values = minifi::utils::StringUtils::splitAndTrimRemovingEmpty(match[4], ",");
+  std::vector<std::string> values = minifi::utils::StringUtils::splitAndTrimRemovingEmpty(match[4].str(), ",");
   for (auto& value : values) {
     value = minifi::utils::StringUtils::removeFramingCharacters(value, '\'');
   }
-  auto insert_col_names = minifi::utils::StringUtils::splitAndTrimRemovingEmpty(match[3], ",");
+  auto insert_col_names = minifi::utils::StringUtils::splitAndTrimRemovingEmpty(match[3].str(), ",");
   if (!insert_col_names.empty()) {
     auto col_names = tables_.at(table_name).getColumnNames();
     std::vector<std::string> row;
@@ -251,7 +251,7 @@ std::unique_ptr<Rowset> MockDB::select(const std::string& query, const std::vect
   std::smatch match;
   std::regex expr(R"(select\s+(.+)\s+from\s+(\w+)\s*(where ((.+(?= order by))|.+$))*\s*(order by (.+))*)", std::regex_constants::icase);
   std::regex_search(replaced_query, match, expr);
-  auto cols = minifi::utils::StringUtils::splitAndTrimRemovingEmpty(match[1], ",");
+  auto cols = minifi::utils::StringUtils::splitAndTrimRemovingEmpty(match[1].str(), ",");
   if (cols[0] == "*") {
     cols = {};
   }

--- a/libminifi/test/unit/CoreTests.cpp
+++ b/libminifi/test/unit/CoreTests.cpp
@@ -25,13 +25,6 @@ class DummyClass {};
 template<typename T> struct DummyStructTemplate {};
 template<typename T> class DummyClassTemplate {};
 
-TEST_CASE("getClassName() works correctly") {
-  CHECK(core::getClassName<DummyStruct>() == "org::apache::nifi::minifi::test::DummyStruct");
-  CHECK(core::getClassName<DummyClass>() == "org::apache::nifi::minifi::test::DummyClass");
-  CHECK(core::getClassName<DummyStructTemplate<int>>() == "org::apache::nifi::minifi::test::DummyStructTemplate<int>");
-  CHECK(core::getClassName<DummyClassTemplate<int>>() == "org::apache::nifi::minifi::test::DummyClassTemplate<int>");
-}
-
 TEST_CASE("className() works correctly and is constexpr") {
   static constexpr auto struct_name = core::className<DummyStruct>();
   static_assert(struct_name == "org::apache::nifi::minifi::test::DummyStruct");

--- a/libminifi/test/unit/StringUtilsTests.cpp
+++ b/libminifi/test/unit/StringUtilsTests.cpp
@@ -58,7 +58,7 @@ TEST_CASE("TestStringUtils::split3", "[test split multiple delimiter]") {
 
 TEST_CASE("TestStringUtils::split4", "[test split classname]") {
   std::vector<std::string> expected = { "org", "apache", "nifi", "minifi", "utils", "StringUtils" };
-  REQUIRE(expected == StringUtils::split(org::apache::nifi::minifi::core::getClassName<org::apache::nifi::minifi::utils::StringUtils>(), "::"));
+  REQUIRE(expected == StringUtils::split(org::apache::nifi::minifi::core::className<org::apache::nifi::minifi::utils::StringUtils>(), "::"));
 }
 
 TEST_CASE("TestStringUtils::split5", "[test split with delimiter set to empty string]") {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-2162

Replace usages of `getClassName() -> std::string` with `className() -> std::string_view`.  This led to some other `const std::string&` to `std::string_view` changes in  the parameter types of some functions.

I have also removed a `static_assert` in the `className()` implementation, because it caused CLion to show bogus errors, probably due to a confusion between `gcc` (used to compile the code) and `clang` (used to analyze the code).  If the condition fails, we will still get a compile error, just with a less useful error message.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
