### PR TITLE
MINIFICPP-2173 Fix MergeContent error handling issues

### DIFF
--- a/extensions/libarchive/BinFiles.cpp
+++ b/extensions/libarchive/BinFiles.cpp
@@ -223,7 +223,7 @@ bool BinFiles::resurrectFlowFiles(core::ProcessSession &session) {
   return had_failure;
 }
 
-void BinFiles::assumeOwnerShipOfNextBatch(core::ProcessSession &session) {
+void BinFiles::assumeOwnershipOfNextBatch(core::ProcessSession &session) {
   for (size_t i = 0; i < batchSize_; ++i) {
     auto flow = session.get();
 
@@ -283,7 +283,7 @@ void BinFiles::onTrigger(const std::shared_ptr<core::ProcessContext> &context, c
     return;
   }
 
-  assumeOwnerShipOfNextBatch(*session);
+  assumeOwnershipOfNextBatch(*session);
   processReadyBins(gatherReadyBins(*context), *session);
 }
 

--- a/extensions/libarchive/BinFiles.h
+++ b/extensions/libarchive/BinFiles.h
@@ -281,7 +281,7 @@ class BinFiles : public core::Processor {
 
   // Sort flow files retrieved from the flow file repository after restart to their respective bins
   bool resurrectFlowFiles(core::ProcessSession &session);
-  void assumeOwnerShipOfNextBatch(core::ProcessSession &session);
+  void assumeOwnershipOfNextBatch(core::ProcessSession &session);
   std::deque<std::unique_ptr<Bin>> gatherReadyBins(core::ProcessContext &context);
   void processReadyBins(std::deque<std::unique_ptr<Bin>> ready_bins, core::ProcessSession &session);
 

--- a/extensions/libarchive/BinFiles.h
+++ b/extensions/libarchive/BinFiles.h
@@ -285,24 +285,24 @@ class BinFiles : public core::Processor {
 
  protected:
   // Allows general pre-processing of a flow file before it is offered to a bin. This is called before getGroupId().
-  virtual void preprocessFlowFile(core::ProcessContext *context, core::ProcessSession *session, const std::shared_ptr<core::FlowFile>& flow);
+  virtual void preprocessFlowFile(const std::shared_ptr<core::FlowFile>& flow);
   // Returns a group ID representing a bin. This allows flow files to be binned into like groups
-  virtual std::string getGroupId(core::ProcessContext* /*context*/, const std::shared_ptr<core::FlowFile>& /*flow*/) {
+  virtual std::string getGroupId(const std::shared_ptr<core::FlowFile>& /*flow*/) {
     return "";
   }
   // Processes a single bin.
-  virtual bool processBin(core::ProcessContext* /*context*/, core::ProcessSession* /*session*/, std::unique_ptr<Bin>& /*bin*/) {
+  virtual bool processBin(core::ProcessSession& /*session*/, std::unique_ptr<Bin>& /*bin*/) {
     return false;
   }
   // transfer flows to failure in bin
-  static void transferFlowsToFail(core::ProcessContext *context, core::ProcessSession *session, std::unique_ptr<Bin> &bin);
+  static void transferFlowsToFail(core::ProcessSession &session, std::unique_ptr<Bin> &bin);
   // moves owned flows to session
-  static void addFlowsToSession(core::ProcessContext *context, core::ProcessSession *session, std::unique_ptr<Bin> &bin);
+  static void addFlowsToSession(core::ProcessSession &session, std::unique_ptr<Bin> &bin);
 
-  bool resurrectFlowFiles(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session);
-  void assumeOwnerShipOfNextBatch(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session);
-  std::deque<std::unique_ptr<Bin>> gatherReadyBins(const std::shared_ptr<core::ProcessContext> &context);
-  void processReadyBins(std::deque<std::unique_ptr<Bin>> ready_bins, const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session);
+  bool resurrectFlowFiles(core::ProcessSession &session);
+  void assumeOwnerShipOfNextBatch(core::ProcessSession &session);
+  std::deque<std::unique_ptr<Bin>> gatherReadyBins(core::ProcessContext &context);
+  void processReadyBins(std::deque<std::unique_ptr<Bin>> ready_bins, core::ProcessSession &session);
 
   BinManager binManager_;
 

--- a/extensions/libarchive/BinFiles.h
+++ b/extensions/libarchive/BinFiles.h
@@ -177,6 +177,7 @@ class BinManager {
   void removeOldestBin();
   // get ready bin from binManager
   void getReadyBin(std::deque<std::unique_ptr<Bin>> &retBins);
+  void addReadyBin(std::unique_ptr<Bin> ready_bin);
 
  private:
   std::mutex mutex_;
@@ -297,6 +298,11 @@ class BinFiles : public core::Processor {
   static void transferFlowsToFail(core::ProcessContext *context, core::ProcessSession *session, std::unique_ptr<Bin> &bin);
   // moves owned flows to session
   static void addFlowsToSession(core::ProcessContext *context, core::ProcessSession *session, std::unique_ptr<Bin> &bin);
+
+  bool resurrectFlowFiles(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session);
+  void assumeOwnerShipOfNextBatch(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session);
+  std::deque<std::unique_ptr<Bin>> gatherReadyBins(const std::shared_ptr<core::ProcessContext> &context);
+  void processReadyBins(std::deque<std::unique_ptr<Bin>> ready_bins, const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session);
 
   BinManager binManager_;
 

--- a/extensions/libarchive/MergeContent.cpp
+++ b/extensions/libarchive/MergeContent.cpp
@@ -220,6 +220,7 @@ bool MergeContent::processBin(core::ProcessContext *context, core::ProcessSessio
     KeepAllUniqueAttributesMerger(bin->getFlowFile()).mergeAttributes(session, merge_flow);
   } else {
     logger_->log_error("Attribute strategy not supported %s", attributeStrategy_);
+    session->remove(merge_flow);
     return false;
   }
 
@@ -246,6 +247,7 @@ bool MergeContent::processBin(core::ProcessContext *context, core::ProcessSessio
     mimeType = "application/zip";
   } else {
     logger_->log_error("Merge format not supported %s", mergeFormat_);
+    session->remove(merge_flow);
     return false;
   }
 
@@ -255,9 +257,11 @@ bool MergeContent::processBin(core::ProcessContext *context, core::ProcessSessio
     session->putAttribute(merge_flow, core::SpecialFlowAttribute::MIME_TYPE, mimeType);
   } catch (const std::exception& ex) {
     logger_->log_error("Merge Content merge catch exception, type: %s, what: %s", typeid(ex).name(), ex.what());
+    session->remove(merge_flow);
     return false;
   } catch (...) {
     logger_->log_error("Merge Content merge catch exception, type: %s", getCurrentExceptionTypeName());
+    session->remove(merge_flow);
     return false;
   }
   session->putAttribute(merge_flow, BinFiles::FRAGMENT_COUNT_ATTRIBUTE, std::to_string(bin->getSize()));

--- a/extensions/libarchive/MergeContent.h
+++ b/extensions/libarchive/MergeContent.h
@@ -287,6 +287,17 @@ class KeepAllUniqueAttributesMerger: public AttributeMerger {
   std::vector<std::string> removed_attributes_;
 };
 
+/**
+ * A processor that merges multiple correlated flow files to a single flow file
+ *
+ * Concepts:
+ * - Batch size: represents the maximum number of flow files to be processed from the incoming relationship
+ * - Bin (or bundle): represents a set of flow files that belong together defined by the processor properties. Correlated flow files are defined by the CorrelationAttributeName property which
+ *                    defines the attribute that provides the groupid for the bin the flow file belongs to
+ * - Ready bin: when a bin reaches a limit defined by the maximum age or the maximum size, the bin becomes ready, and ready bins can be merged
+ * - Group: a set of bins with the same groupid. In case a bin cannot accept a new flow files (e.g. it would go above its size limit), a new bin is created with this new flow file and added
+ *          to the same group of bins
+ */
 class MergeContent : public processors::BinFiles {
  public:
   explicit MergeContent(const std::string& name, const utils::Identifier& uuid = {})

--- a/extensions/libarchive/MergeContent.h
+++ b/extensions/libarchive/MergeContent.h
@@ -56,7 +56,7 @@ class MergeBin {
  public:
   virtual ~MergeBin() = default;
   // merge the flows in the bin
-  virtual void merge(core::ProcessContext *context, core::ProcessSession *session,
+  virtual void merge(core::ProcessSession &session,
       std::deque<std::shared_ptr<core::FlowFile>> &flows, FlowFileSerializer& serializer, const std::shared_ptr<core::FlowFile> &flowFile) = 0;
 };
 
@@ -64,7 +64,7 @@ class BinaryConcatenationMerge : public MergeBin {
  public:
   BinaryConcatenationMerge(std::string header, std::string footer, std::string demarcator);
 
-  void merge(core::ProcessContext* context, core::ProcessSession *session,
+  void merge(core::ProcessSession &session,
     std::deque<std::shared_ptr<core::FlowFile>>& flows, FlowFileSerializer& serializer, const std::shared_ptr<core::FlowFile>& merge_flow) override;
   // Nest Callback Class for write stream
   class WriteCallback {
@@ -242,13 +242,13 @@ class ArchiveMerge {
 
 class TarMerge: public ArchiveMerge, public MergeBin {
  public:
-  void merge(core::ProcessContext *context, core::ProcessSession *session, std::deque<std::shared_ptr<core::FlowFile>> &flows,
+  void merge(core::ProcessSession &session, std::deque<std::shared_ptr<core::FlowFile>> &flows,
              FlowFileSerializer& serializer, const std::shared_ptr<core::FlowFile> &merge_flow) override;
 };
 
 class ZipMerge: public ArchiveMerge, public MergeBin {
  public:
-  void merge(core::ProcessContext *context, core::ProcessSession *session, std::deque<std::shared_ptr<core::FlowFile>> &flows,
+  void merge(core::ProcessSession &session, std::deque<std::shared_ptr<core::FlowFile>> &flows,
              FlowFileSerializer& serializer, const std::shared_ptr<core::FlowFile> &merge_flow) override;
 };
 
@@ -256,7 +256,7 @@ class AttributeMerger {
  public:
   explicit AttributeMerger(std::deque<std::shared_ptr<org::apache::nifi::minifi::core::FlowFile>> &flows)
     : flows_(flows) {}
-  void mergeAttributes(core::ProcessSession *session, const std::shared_ptr<core::FlowFile> &merge_flow);
+  void mergeAttributes(core::ProcessSession &session, const std::shared_ptr<core::FlowFile> &merge_flow);
   virtual ~AttributeMerger() = default;
 
  protected:
@@ -373,11 +373,11 @@ class MergeContent : public processors::BinFiles {
   void onSchedule(core::ProcessContext *context, core::ProcessSessionFactory *sessionFactory) override;
   void onTrigger(core::ProcessContext *context, core::ProcessSession *session) override;
   void initialize() override;
-  bool processBin(core::ProcessContext *context, core::ProcessSession *session, std::unique_ptr<Bin> &bin) override;
+  bool processBin(core::ProcessSession &session, std::unique_ptr<Bin> &bin) override;
 
  protected:
   // Returns a group ID representing a bin. This allows flow files to be binned into like groups
-  std::string getGroupId(core::ProcessContext *context, const std::shared_ptr<core::FlowFile>& flow) override;
+  std::string getGroupId(const std::shared_ptr<core::FlowFile>& flow) override;
   // check whether the defragment bin is validate
   static bool checkDefragment(std::unique_ptr<Bin> &bin);
 

--- a/libminifi/include/core/ProcessSession.h
+++ b/libminifi/include/core/ProcessSession.h
@@ -151,6 +151,8 @@ class ProcessSession : public ReferenceContainer {
     metrics_ = metrics;
   }
 
+  bool hasBeenTransferred(const core::FlowFile &flow) const;
+
 // Prevent default copy constructor and assignment operation
 // Only support pass by reference or pointer
   ProcessSession(const ProcessSession &parent) = delete;

--- a/libminifi/src/core/ProcessSession.cpp
+++ b/libminifi/src/core/ProcessSession.cpp
@@ -1148,7 +1148,8 @@ bool ProcessSession::existsFlowFileInRelationship(const Relationship &relationsh
 }
 
 bool ProcessSession::hasBeenTransferred(const core::FlowFile &flow) const {
-  return updated_relationships_.contains(flow.getUUID()) || added_flowfiles_.contains(flow.getUUID());
+  return (updated_relationships_.contains(flow.getUUID()) && updated_relationships_.at(flow.getUUID()) != nullptr) ||
+    (added_flowfiles_.contains(flow.getUUID()) && added_flowfiles_.at(flow.getUUID()).rel != nullptr);
 }
 
 }  // namespace org::apache::nifi::minifi::core

--- a/libminifi/src/core/ProcessSession.cpp
+++ b/libminifi/src/core/ProcessSession.cpp
@@ -1147,4 +1147,8 @@ bool ProcessSession::existsFlowFileInRelationship(const Relationship &relationsh
   });
 }
 
+bool ProcessSession::hasBeenTransferred(const core::FlowFile &flow) const {
+  return updated_relationships_.contains(flow.getUUID()) || added_flowfiles_.contains(flow.getUUID());
+}
+
 }  // namespace org::apache::nifi::minifi::core

--- a/libminifi/src/io/StreamSlice.cpp
+++ b/libminifi/src/io/StreamSlice.cpp
@@ -23,7 +23,8 @@ namespace org::apache::nifi::minifi::io {
 StreamSlice::StreamSlice(std::shared_ptr<io::InputStream> stream, size_t offset, size_t size) : stream_(std::move(stream)), slice_offset_(offset), slice_size_(size) {
   stream_->seek(slice_offset_);
   if (stream_->size() < slice_offset_ + slice_size_)
-    throw std::invalid_argument("StreamSlice is bigger than the Stream");
+    throw std::invalid_argument("StreamSlice is bigger than the Stream, Stream size: " + std::to_string(stream_->size()) +
+      ", StreamSlice size: " + std::to_string(slice_size_) + ", offset: " + std::to_string(slice_offset_));
 }
 
 size_t StreamSlice::read(std::span<std::byte> out_buffer) {

--- a/libminifi/src/io/StreamSlice.cpp
+++ b/libminifi/src/io/StreamSlice.cpp
@@ -23,8 +23,7 @@ namespace org::apache::nifi::minifi::io {
 StreamSlice::StreamSlice(std::shared_ptr<io::InputStream> stream, size_t offset, size_t size) : stream_(std::move(stream)), slice_offset_(offset), slice_size_(size) {
   stream_->seek(slice_offset_);
   if (stream_->size() < slice_offset_ + slice_size_)
-    throw std::invalid_argument("StreamSlice is bigger than the Stream, Stream size: " + std::to_string(stream_->size()) +
-      ", StreamSlice size: " + std::to_string(slice_size_) + ", offset: " + std::to_string(slice_offset_));
+    throw std::invalid_argument(fmt::format("StreamSlice is bigger than the Stream, Stream size: {}, StreamSlice size: {}, offset: {}", stream_->size(), slice_size_, slice_offset_));
 }
 
 size_t StreamSlice::read(std::span<std::byte> out_buffer) {

--- a/libminifi/test/unit/StreamTests.cpp
+++ b/libminifi/test/unit/StreamTests.cpp
@@ -85,8 +85,8 @@ TEST_CASE("InvalidStreamSliceTest", "[teststreamslice]") {
   std::shared_ptr<minifi::io::BaseStream> base = std::make_shared<minifi::io::BufferStream>();
   base->write((const uint8_t*)"\x01\x02\x03\x04\x05\x06\x07\x08", 8);
   auto input_stream = std::static_pointer_cast<minifi::io::InputStream>(base);
-  REQUIRE_THROWS_WITH(std::make_shared<minifi::io::StreamSlice>(input_stream, 0, 9), "StreamSlice is bigger than the Stream");
-  REQUIRE_THROWS_WITH(std::make_shared<minifi::io::StreamSlice>(input_stream, 7, 3), "StreamSlice is bigger than the Stream");
+  REQUIRE_THROWS_WITH(std::make_shared<minifi::io::StreamSlice>(input_stream, 0, 9), "StreamSlice is bigger than the Stream, Stream size: 8, StreamSlice size: 9, offset: 0");
+  REQUIRE_THROWS_WITH(std::make_shared<minifi::io::StreamSlice>(input_stream, 7, 3), "StreamSlice is bigger than the Stream, Stream size: 8, StreamSlice size: 3, offset: 7");
 }
 
 TEST_CASE("StreamSliceTest1", "[teststreamslice]") {


### PR DESCRIPTION
- Remove intermediate individual `ProcessSession` for every processed bin
- Rollback flow files of a merge if the merge fails with an exception and put them back to the ready bins
- Remove `merge_flow` from session in case the merge fails to avoid throwing an exception for not finding the transfer relationship
- Do not yield and continue processing of the bins in case putting one of the flow files in a bin fails
- Log stream size and offset values in case of a `StreamSlice` creation failure
- Remove unused function parameters and use references instead of raw pointers

https://issues.apache.org/jira/browse/MINIFICPP-2173

-------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
