### PR TITLE
MINIFICPP-2183 fix MacOS CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   macos_xcode:
     name: "macos-xcode"
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 180
     env:
       CCACHE_BASEDIR: ${{ GITHUB.WORKSPACE }}
@@ -28,21 +28,19 @@ jobs:
         run: |
           # Skip brew update until https://github.com/actions/setup-python/issues/577 is fixed
           # brew update
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install ossp-uuid flex lua ccache sqliteodbc automake autoconf
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install ossp-uuid flex lua ccache sqliteodbc automake autoconf ninja
       - id: setup_env
         name: setup enviroment
         run: |
           echo "PATH=/usr/lib/ccache:/usr/local/opt/ccache/bin:/usr/local/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
           echo -e "127.0.0.1\t$HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
-          # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md#xcode
-          sudo xcode-select -switch /Applications/Xcode_14.0.1.app
       - name: build
         run: |
           export PATH="/usr/local/opt/flex/bin:$PATH"
           export LDFLAGS="-L/usr/local/opt/flex/lib"
           export CPPFLAGS="-I/usr/local/opt/flex/include"
           # CPPFLAGS are not recognized by cmake, so we have to force them to CFLAGS and CXXFLAGS to have flex 2.6 working
-          ./bootstrap.sh -e -t && cd build  && cmake -DCMAKE_BUILD_TYPE=Release -DCI_BUILD=ON -DCMAKE_C_FLAGS="${CPPFLAGS} ${CFLAGS}" -DCMAKE_CXX_FLAGS="${CPPFLAGS} ${CXXFLAGS}" -DENABLE_PYTHON_SCRIPTING=ON -DENABLE_LUA_SCRIPTING=ON -DENABLE_SQL=ON -DUSE_REAL_ODBC_TEST_DRIVER=ON -DENABLE_AZURE=ON -DENABLE_GCP=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES=OFF -DSTRICT_GSL_CHECKS=AUDIT -DFAIL_ON_WARNINGS=ON .. && cmake --build . --parallel 4
+          ./bootstrap.sh -e -t && cd build  && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCI_BUILD=ON -DCMAKE_C_FLAGS="${CPPFLAGS} ${CFLAGS}" -DCMAKE_CXX_FLAGS="${CPPFLAGS} ${CXXFLAGS}" -DENABLE_PYTHON_SCRIPTING=ON -DENABLE_LUA_SCRIPTING=ON -DENABLE_SQL=ON -DUSE_REAL_ODBC_TEST_DRIVER=ON -DENABLE_AZURE=ON -DENABLE_GCP=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES=OFF -DSTRICT_GSL_CHECKS=AUDIT -DFAIL_ON_WARNINGS=ON .. && cmake --build . --parallel 4
       - name: cache save
         uses: actions/cache/save@v3
         if: always()
@@ -54,9 +52,9 @@ jobs:
         run: |
           # Set core file size limit to 1GiB
           ulimit -c 1048576
-          cd build && make test ARGS="--timeout 300 -j4 --output-on-failure"
+          cd build && ctest -j4 --output-on-failure --timeout 300
       - name: linter
-        run: cd build && make -j4 linter
+        run: cd build && ninja linter
       - name: check-cores
         if: ${{ failure() && steps.test.conclusion == 'failure' }}
         run: |

--- a/cmake/BuildTests.cmake
+++ b/cmake/BuildTests.cmake
@@ -32,10 +32,17 @@ ENDMACRO()
 set(NANOFI_TEST_DIR "${CMAKE_SOURCE_DIR}/nanofi/tests/")
 
 function(copyTestResources SOURCE_DIR DEST_DIR)
-    file(GLOB RESOURCE_FILES  "${SOURCE_DIR}/*")
+    file(GLOB_RECURSE RESOURCE_FILES "${SOURCE_DIR}/*")
     foreach(RESOURCE_FILE ${RESOURCE_FILES})
-        get_filename_component(RESOURCE_FILENAME "${RESOURCE_FILE}" NAME)
-        set(dest_file "${DEST_DIR}/${RESOURCE_FILENAME}")
+        if(IS_DIRECTORY "${RESOURCE_FILE}")
+            continue()
+        endif()
+
+        file(RELATIVE_PATH RESOURCE_RELATIVE_PATH "${SOURCE_DIR}" "${RESOURCE_FILE}")
+        get_filename_component(RESOURCE_DEST_DIR "${DEST_DIR}/${RESOURCE_RELATIVE_PATH}" DIRECTORY)
+
+        file(MAKE_DIRECTORY "${RESOURCE_DEST_DIR}")
+        set(dest_file "${DEST_DIR}/${RESOURCE_RELATIVE_PATH}")
 
         configure_file(${RESOURCE_FILE} ${dest_file} COPYONLY)
     endforeach()

--- a/extensions/lua/tests/CMakeLists.txt
+++ b/extensions/lua/tests/CMakeLists.txt
@@ -34,4 +34,5 @@ FOREACH(testfile ${EXECUTESCRIPT_LUA_TESTS})
     add_test(NAME "${testfilename}" COMMAND "${testfilename}" WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 ENDFOREACH()
 
+copyTestResources(${CMAKE_CURRENT_SOURCE_DIR}/test_lua_scripts/ ${CMAKE_BINARY_DIR}/bin/resources/test_lua_scripts/)
 message("-- Finished building ${EXTENSIONS_TEST_COUNT} tests for minifi-lua-script-extension...")

--- a/extensions/lua/tests/TestExecuteScriptProcessorWithLuaScript.cpp
+++ b/extensions/lua/tests/TestExecuteScriptProcessorWithLuaScript.cpp
@@ -275,8 +275,7 @@ TEST_CASE("Lua: Test Module Directory property", "[executescriptLuaModuleDirecto
   minifi::test::SingleProcessorTestController controller{execute_script};
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
-  const auto script_files_directory = std::filesystem::path(__FILE__).parent_path() / "test_lua_scripts";
-
+  const auto script_files_directory =  minifi::utils::file::FileUtils::get_executable_dir() / "resources" / "test_lua_scripts";
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "lua");
   execute_script->setProperty(ExecuteScript::ScriptFile, (script_files_directory / "foo_bar_processor.lua").string());

--- a/extensions/python/tests/CMakeLists.txt
+++ b/extensions/python/tests/CMakeLists.txt
@@ -33,15 +33,6 @@ FOREACH(testfile ${EXECUTESCRIPT_PYTHON_TESTS})
     createTests("${testfilename}")
     MATH(EXPR EXTENSIONS_TEST_COUNT "${EXTENSIONS_TEST_COUNT}+1")
     add_test(NAME "${testfilename}" COMMAND "${testfilename}" WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-
-    if(EXTENSIONS_TEST_COUNT EQUAL 1)
-        add_custom_command(
-                TARGET "${testfilename}"
-                POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy_directory
-                "${CMAKE_SOURCE_DIR}/extensions/python/tests/test_python_scripts"
-                "$<TARGET_FILE_DIR:${testfilename}>/test_python_scripts")
-    endif()
 ENDFOREACH()
 
 FOREACH(testfile ${EXECUTEPYTHONPROCESSOR_UNIT_TESTS})
@@ -62,15 +53,7 @@ FOREACH(testfile ${EXECUTEPYTHONPROCESSOR_UNIT_TESTS})
     createTests("${testfilename}")
     MATH(EXPR EXTENSIONS_TEST_COUNT "${EXTENSIONS_TEST_COUNT}+1")
     add_test(NAME "${testfilename}" COMMAND "${testfilename}"  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-
-    if(EXTENSIONS_TEST_COUNT EQUAL 1)
-        add_custom_command(
-                TARGET "${testfilename}"
-                POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy_directory
-                "${CMAKE_SOURCE_DIR}/extensions/script/tests/test_python_scripts"
-                "$<TARGET_FILE_DIR:${testfilename}>/test_python_scripts")
-    endif()
 ENDFOREACH()
 
+copyTestResources(${CMAKE_CURRENT_SOURCE_DIR}/test_python_scripts/ ${CMAKE_BINARY_DIR}/bin/resources/test_python_scripts/)
 message("-- Finished building ${EXTENSIONS_TEST_COUNT} tests for minifi-python-script-extension...")

--- a/extensions/python/tests/ExecutePythonProcessorTests.cpp
+++ b/extensions/python/tests/ExecutePythonProcessorTests.cpp
@@ -40,8 +40,7 @@ class ExecutePythonProcessorTestBase {
   ExecutePythonProcessorTestBase() :
       logTestController_(LogTestController::getInstance()),
       logger_(logging::LoggerFactory<ExecutePythonProcessorTestBase>::getLogger()) {
-    auto path = std::filesystem::path(__FILE__).parent_path();
-    SCRIPT_FILES_DIRECTORY = minifi::utils::file::FileUtils::get_executable_dir() / "test_python_scripts";
+    SCRIPT_FILES_DIRECTORY = minifi::utils::file::FileUtils::get_executable_dir() / "resources" / "test_python_scripts";
     reInitialize();
   }
   virtual ~ExecutePythonProcessorTestBase() {

--- a/extensions/python/tests/TestExecuteScriptProcessorWithPythonScript.cpp
+++ b/extensions/python/tests/TestExecuteScriptProcessorWithPythonScript.cpp
@@ -221,8 +221,7 @@ TEST_CASE("Python: Test Module Directory property", "[executescriptPythonModuleD
   minifi::test::SingleProcessorTestController controller{execute_script};
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
-  const auto script_files_directory = std::filesystem::path(__FILE__).parent_path() / "test_python_scripts";
-
+  const auto script_files_directory =  minifi::utils::file::FileUtils::get_executable_dir() / "resources" / "test_python_scripts";
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "python");
   execute_script->setProperty(ExecuteScript::ScriptFile, (script_files_directory / "foo_bar_processor.py").string());


### PR DESCRIPTION
I am not sure what exactly caused the failures only that I was able to reproduce it with cmake >= 3.27 and make as the generator. With ninja the problem doesnt occur, so I've changed generator that the mac CI uses to ninja.

I've also changed where the test resources are loaded from during lua/python tests because that also failed (couldnt reproduce locally), but this method is better anyways because the tests dont rely on the source folder. (and also the other tests work similarly)

I want to merge this PR asap, if we want we could further investigate what caused these issues, but it would be best if we regained macOS test coverage without further delays so the merging of new features can continue.

---
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
