### PR TITLE
MINIFICPP-2188 Fix build failure on ARM64

### DIFF
--- a/cmake/BundledOpenSSL.cmake
+++ b/cmake/BundledOpenSSL.cmake
@@ -18,7 +18,7 @@
 function(use_openssl SOURCE_DIR BINARY_DIR)
     message("Using bundled OpenSSL")
 
-    if(APPLE OR WIN32 OR CMAKE_SIZEOF_VOID_P EQUAL 4)
+    if(APPLE OR WIN32 OR CMAKE_SIZEOF_VOID_P EQUAL 4 OR CMAKE_SYSTEM_PROCESSOR MATCHES "(arm64)|(ARM64)|(aarch64)|(armv8)")
         set(LIBDIR "lib")
     else()
         set(LIBDIR "lib64")


### PR DESCRIPTION
After openssl upgrade builds failed on arm based linux due to 

`make[2]: *** No rule to make target 'thirdparty/openssl-install/lib64/libcrypto.a', needed by 'bin/libcore-minifi.so'.  Stop. `

It looks like we need the same workaround on ARM64 linux what we have on WIN32 and APPLE and on x86 systems.

---
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
