### PR TITLE
MINIFICPP-2209 Small HTTPClient refactor: preconditions and exception…

### DIFF
--- a/extensions/http-curl/client/HTTPClient.cpp
+++ b/extensions/http-curl/client/HTTPClient.cpp
@@ -519,8 +519,8 @@ std::string HTTPClient::replaceInvalidCharactersInHttpHeaderFieldName(std::strin
 
   // RFC822 3.1.2: The  field-name must be composed of printable ASCII characters
   // (i.e., characters that  have  values  between  33.  and  126., decimal, except colon).
-  ranges::actions::transform(field_name, [](char ch) {
-      return (ch >= 33 && ch <= 126 && ch != ':') ? ch : '-';
+  ranges::actions::transform(field_name, [](char ch) {  // NOLINT: false positive: Add #include <algorithm> for transform  [build/include_what_you_use] [4]
+    return (ch >= 33 && ch <= 126 && ch != ':') ? ch : '-';
   });
   return field_name;
 }

--- a/extensions/http-curl/client/HTTPClient.cpp
+++ b/extensions/http-curl/client/HTTPClient.cpp
@@ -328,10 +328,11 @@ namespace {
 using CurlSlistDeleter = decltype([](struct curl_slist* slist) { curl_slist_free_all(slist); });
 
 std::unique_ptr<struct curl_slist, CurlSlistDeleter> toCurlSlist(const std::unordered_map<std::string, std::string>& request_headers) {
-  curl_slist* new_list = nullptr;
+  gsl::owner<curl_slist*> new_list = nullptr;
   const auto guard = gsl::finally([&new_list]() { curl_slist_free_all(new_list); });
   for (const auto& [header_key, header_value] : request_headers)
-    new_list = curl_slist_append(new_list, utils::StringUtils::join_pack(header_key, ": ", header_value).c_str());
+    new_list = (utils::optional_from_ptr(curl_slist_append(new_list, utils::StringUtils::join_pack(header_key, ": ", header_value).c_str()))
+        | utils::orElse([]() { throw std::runtime_error{"curl_slist_append failed"}; })).value();
 
   return {std::exchange(new_list, nullptr), {}};
 }

--- a/extensions/http-curl/client/HTTPClient.h
+++ b/extensions/http-curl/client/HTTPClient.h
@@ -208,8 +208,10 @@ class HTTPClient : public utils::BaseHTTPClient, public core::Connectable {
  protected:
   static CURLcode configure_ssl_context(CURL* /*curl*/, void *ctx, void *param) {
 #ifdef OPENSSL_SUPPORT
-    auto* ssl_context_service = static_cast<minifi::controllers::SSLContextService*>(param);
-    if (!ssl_context_service->configure_ssl_context(static_cast<SSL_CTX*>(ctx))) {
+    gsl_Expects(ctx);
+    gsl_Expects(param);
+    auto& ssl_context_service = *static_cast<minifi::controllers::SSLContextService*>(param);
+    if (!ssl_context_service.configure_ssl_context(static_cast<SSL_CTX*>(ctx))) {
       return CURLE_FAILED_INIT;
     }
     return CURLE_OK;


### PR DESCRIPTION
… safety

- Remove unused header includes
- Fix exception safety in curl_slist generation: no longer leaks partial slist
- Rename `getCurlSList` to `toCurlSlist`, which is a function that converts an `unordered_map<string,string>` of HTTP headers to a `curl_slist*` linked list
- Simplified `curl_slist` deleter to a decltype(lambda)
- Remove unused `result` from `replaceInvalidCharactersInHttpHeaderFieldName`. (`ranges::actions::transform` is in-place)
- Tightened callback preconditions to fail fast on programming errors

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
