### PR TITLE
MINIFICPP-2207 HttpRequestMethod should be an enum

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -55,7 +55,6 @@ Checks: >
   bugprone-terminating-continue,
   bugprone-throw-keyword-missing,
   bugprone-too-small-loop-variable,
-  bugprone-unchecked-optional-access,
   bugprone-undefined-memory-manipulation,
   bugprone-undelegated-constructor,
   bugprone-unhandled-exception-at-new,

--- a/extensions/civetweb/tests/ListenHTTPTests.cpp
+++ b/extensions/civetweb/tests/ListenHTTPTests.cpp
@@ -41,6 +41,7 @@
 namespace org::apache::nifi::minifi::test {
 
 using namespace std::literals::chrono_literals;
+using HttpRequestMethod = org::apache::nifi::minifi::utils::HttpRequestMethod;
 
 class ListenHTTPTestsFixture {
  public:
@@ -154,7 +155,7 @@ class ListenHTTPTestsFixture {
     for (const auto &header : headers) {
       client->setRequestHeader(header.first, header.second);
     }
-    if (method == "POST") {
+    if (method == HttpRequestMethod::POST) {
       client->setPostFields(payload);
     }
   }
@@ -173,7 +174,7 @@ class ListenHTTPTestsFixture {
   }
 
   void check_response_body() {
-    if (method != "GET" && method != "POST") {
+    if (method != HttpRequestMethod::GET && method != HttpRequestMethod::POST) {
       return;
     }
 
@@ -212,7 +213,7 @@ class ListenHTTPTestsFixture {
 
     plan->runCurrentProcessor();  // ListenHTTP
     plan->runNextProcessor();  // LogAttribute
-    if (expected_commited_requests > 0 && (method == "GET" || method == "POST")) {
+    if (expected_commited_requests > 0 && (method == HttpRequestMethod::GET || method == HttpRequestMethod::POST)) {
       REQUIRE(LogTestController::getInstance().contains("Size:" + std::to_string(payload.size()) + " Offset:0"));
     }
     REQUIRE(LogTestController::getInstance().contains("Logged " + std::to_string(expected_commited_requests) + " flow files"));
@@ -228,7 +229,7 @@ class ListenHTTPTestsFixture {
   std::shared_ptr<core::Processor> log_attribute;
 
   std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service;
-  std::string method = "GET";
+  HttpRequestMethod method = HttpRequestMethod::GET;
   std::map<std::string, std::string> headers;
   std::string payload;
   std::string endpoint = "test";
@@ -253,7 +254,7 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTP GET", "[basic]") {
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTP POST", "[basic]") {
   run_server();
 
-  method = "POST";
+  method = HttpRequestMethod::POST;
   payload = "Test payload";
 
   test_connect();
@@ -262,7 +263,7 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTP POST", "[basic]") {
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTP PUT", "[basic]") {
   run_server();
 
-  method = "PUT";
+  method = HttpRequestMethod::PUT;
 
   test_connect({HttpResponseExpectations{true, 405}}, 0);
 }
@@ -270,7 +271,7 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTP PUT", "[basic]") {
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTP DELETE", "[basic]") {
   run_server();
 
-  method = "DELETE";
+  method = HttpRequestMethod::DELETE;
 
   test_connect({HttpResponseExpectations{true, 405}}, 0);
 }
@@ -278,7 +279,7 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTP DELETE", "[basic]") {
 TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTP HEAD", "[basic]") {
   run_server();
 
-  method = "HEAD";
+  method = HttpRequestMethod::HEAD;
 
   test_connect({HttpResponseExpectations{}}, 0);
 }
@@ -288,18 +289,18 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTP no body", "[basic]") {
 
 
   SECTION("GET") {
-    method = "GET";
+    method = HttpRequestMethod::GET;
   }
   SECTION("POST") {
-    method = "POST";
+    method = HttpRequestMethod::POST;
     payload = "Test payload";
   }
   SECTION("HEAD") {
-    method = "HEAD";
+    method = HttpRequestMethod::HEAD;
   }
 
   run_server();
-  const std::size_t expected_commited_requests = (method == "POST" || method == "GET") ? 1 : 0;
+  const std::size_t expected_commited_requests = (method == HttpRequestMethod::POST || method == HttpRequestMethod::GET) ? 1 : 0;
   test_connect({HttpResponseExpectations{}}, expected_commited_requests);
 }
 
@@ -307,18 +308,18 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTP body with different mime type", "
   plan->setDynamicProperty(update_attribute, "mime.type", "text/plain");
 
   SECTION("GET") {
-    method = "GET";
+    method = HttpRequestMethod::GET;
   }
   SECTION("POST") {
-    method = "POST";
+    method = HttpRequestMethod::POST;
     payload = "Test payload";
   }
   SECTION("HEAD") {
-    method = "HEAD";
+    method = HttpRequestMethod::HEAD;
   }
 
   run_server();
-  const std::size_t expected_commited_requests = (method == "POST" || method == "GET") ? 1 : 0;
+  const std::size_t expected_commited_requests = (method == HttpRequestMethod::POST || method == HttpRequestMethod::GET) ? 1 : 0;
   test_connect({HttpResponseExpectations{}}, expected_commited_requests);
 }
 
@@ -329,10 +330,10 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTP all headers", "[basic][headers]")
              {"bar", "2"}};
 
   SECTION("GET") {
-    method = "GET";
+    method = HttpRequestMethod::GET;
   }
   SECTION("POST") {
-    method = "POST";
+    method = HttpRequestMethod::POST;
     payload = "Test payload";
   }
 
@@ -350,10 +351,10 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTP filtered headers", "[headers]") {
              {"bar", "2"}};
 
   SECTION("GET") {
-    method = "GET";
+    method = HttpRequestMethod::GET;
   }
   SECTION("POST") {
-    method = "POST";
+    method = HttpRequestMethod::POST;
     payload = "Test payload";
   }
 
@@ -382,10 +383,10 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTP Batch tests", "[batch]") {
     expected_processed_request_count = 5;
 
     SECTION("GET") {
-      method = "GET";
+      method = HttpRequestMethod::GET;
     }
     SECTION("POST") {
-      method = "POST";
+      method = HttpRequestMethod::POST;
       payload = "Test payload";
     }
   }
@@ -396,10 +397,10 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTP Batch tests", "[batch]") {
     expected_processed_request_count = 4;
 
     SECTION("GET") {
-      method = "GET";
+      method = HttpRequestMethod::GET;
     }
     SECTION("POST") {
-      method = "POST";
+      method = HttpRequestMethod::POST;
       payload = "Test payload";
     }
   }
@@ -411,10 +412,10 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTP Batch tests", "[batch]") {
     expected_processed_request_count = 3;
 
     SECTION("GET") {
-      method = "GET";
+      method = HttpRequestMethod::GET;
     }
     SECTION("POST") {
-      method = "POST";
+      method = HttpRequestMethod::POST;
       payload = "Test payload";
     }
   }
@@ -430,18 +431,18 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS without CA", "[basic][https]") {
   create_ssl_context_service("goodCA.crt", nullptr);
 
   SECTION("GET") {
-    method = "GET";
+    method = HttpRequestMethod::GET;
   }
   SECTION("POST") {
-    method = "POST";
+    method = HttpRequestMethod::POST;
     payload = "Test payload";
   }
   SECTION("HEAD") {
-    method = "HEAD";
+    method = HttpRequestMethod::HEAD;
   }
 
   run_server();
-  const std::size_t expected_commited_requests = (method == "POST" || method == "GET") ? 1 : 0;
+  const std::size_t expected_commited_requests = (method == HttpRequestMethod::POST || method == HttpRequestMethod::GET) ? 1 : 0;
   test_connect({HttpResponseExpectations{}}, expected_commited_requests);
 }
 
@@ -453,18 +454,18 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS without client cert", "[basic][h
   create_ssl_context_service("goodCA.crt", nullptr);
 
   SECTION("GET") {
-    method = "GET";
+    method = HttpRequestMethod::GET;
   }
   SECTION("POST") {
-    method = "POST";
+    method = HttpRequestMethod::POST;
     payload = "Test payload";
   }
   SECTION("HEAD") {
-    method = "HEAD";
+    method = HttpRequestMethod::HEAD;
   }
 
   run_server();
-  const std::size_t expected_commited_requests = (method == "POST" || method == "GET") ? 1 : 0;
+  const std::size_t expected_commited_requests = (method == HttpRequestMethod::POST || method == HttpRequestMethod::GET) ? 1 : 0;
   test_connect({HttpResponseExpectations{}}, expected_commited_requests);
 }
 
@@ -477,18 +478,18 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert from good CA", 
   create_ssl_context_service("goodCA.crt", "goodCA_goodClient.pem");
 
   SECTION("GET") {
-    method = "GET";
+    method = HttpRequestMethod::GET;
   }
   SECTION("POST") {
-    method = "POST";
+    method = HttpRequestMethod::POST;
     payload = "Test payload";
   }
   SECTION("HEAD") {
-    method = "HEAD";
+    method = HttpRequestMethod::HEAD;
   }
 
   run_server();
-  const std::size_t expected_commited_requests = (method == "POST" || method == "GET") ? 1 : 0;
+  const std::size_t expected_commited_requests = (method == HttpRequestMethod::POST || method == HttpRequestMethod::GET) ? 1 : 0;
   test_connect({HttpResponseExpectations{}}, expected_commited_requests);
 }
 
@@ -501,18 +502,18 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with PKCS12 client cert from goo
   create_ssl_context_service("goodCA.crt", "goodCA_goodClient.p12");
 
   SECTION("GET") {
-    method = "GET";
+    method = HttpRequestMethod::GET;
   }
   SECTION("POST") {
-    method = "POST";
+    method = HttpRequestMethod::POST;
     payload = "Test payload";
   }
   SECTION("HEAD") {
-    method = "HEAD";
+    method = HttpRequestMethod::HEAD;
   }
 
   run_server();
-  const std::size_t expected_commited_requests = (method == "POST" || method == "GET") ? 1 : 0;
+  const std::size_t expected_commited_requests = (method == HttpRequestMethod::POST || method == HttpRequestMethod::GET) ? 1 : 0;
   test_connect({HttpResponseExpectations{}}, expected_commited_requests);
 }
 
@@ -529,14 +530,14 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert from bad CA", "
     plan->setProperty(listen_http, minifi::processors::ListenHTTP::SSLVerifyPeer, "yes");
 
     SECTION("GET") {
-      method = "GET";
+      method = HttpRequestMethod::GET;
     }
     SECTION("POST") {
-      method = "POST";
+      method = HttpRequestMethod::POST;
       payload = "Test payload";
     }
     SECTION("HEAD") {
-      method = "HEAD";
+      method = HttpRequestMethod::HEAD;
     }
   }
   SECTION("do not verify peer") {
@@ -544,16 +545,16 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert from bad CA", "
     response_code = 200;
 
     SECTION("GET") {
-      method = "GET";
+      method = HttpRequestMethod::GET;
       expected_commited_requests = 1;
     }
     SECTION("POST") {
-      method = "POST";
+      method = HttpRequestMethod::POST;
       payload = "Test payload";
       expected_commited_requests = 1;
     }
     SECTION("HEAD") {
-      method = "HEAD";
+      method = HttpRequestMethod::HEAD;
     }
   }
 
@@ -573,18 +574,18 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert with matching D
   create_ssl_context_service("goodCA.crt", "goodCA_goodClient.pem");
 
   SECTION("GET") {
-    method = "GET";
+    method = HttpRequestMethod::GET;
   }
   SECTION("POST") {
-    method = "POST";
+    method = HttpRequestMethod::POST;
     payload = "Test payload";
   }
   SECTION("HEAD") {
-    method = "HEAD";
+    method = HttpRequestMethod::HEAD;
   }
 
   run_server();
-  const std::size_t expected_commited_requests = (method == "POST" || method == "GET") ? 1 : 0;
+  const std::size_t expected_commited_requests = (method == HttpRequestMethod::POST || method == HttpRequestMethod::GET) ? 1 : 0;
   test_connect({HttpResponseExpectations{}}, expected_commited_requests);
 }
 
@@ -601,30 +602,30 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS with client cert with non-matchi
     response_code = 403;
 
     SECTION("GET") {
-      method = "GET";
+      method = HttpRequestMethod::GET;
     }
     SECTION("POST") {
-      method = "POST";
+      method = HttpRequestMethod::POST;
       payload = "Test payload";
     }
     SECTION("HEAD") {
-      method = "HEAD";
+      method = HttpRequestMethod::HEAD;
     }
   }
   SECTION("do not verify peer") {
     response_code = 200;
 
     SECTION("GET") {
-      method = "GET";
+      method = HttpRequestMethod::GET;
       expected_commited_requests = 1;
     }
     SECTION("POST") {
-      method = "POST";
+      method = HttpRequestMethod::POST;
       payload = "Test payload";
       expected_commited_requests = 1;
     }
     SECTION("HEAD") {
-      method = "HEAD";
+      method = HttpRequestMethod::HEAD;
     }
   }
 
@@ -641,14 +642,14 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS minimum SSL version", "[https]")
   plan->setProperty(listen_http, minifi::processors::ListenHTTP::SSLCertificateAuthority, (executable_dir / "resources" / "goodCA.crt").string());
 
   SECTION("GET") {
-    method = "GET";
+    method = HttpRequestMethod::GET;
   }
   SECTION("POST") {
-    method = "POST";
+    method = HttpRequestMethod::POST;
     payload = "Test payload";
   }
   SECTION("HEAD") {
-    method = "HEAD";
+    method = HttpRequestMethod::HEAD;
   }
 
   create_ssl_context_service("goodCA.crt", "goodCA_goodClient.pem");
@@ -658,7 +659,7 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS minimum SSL version", "[https]")
   client = std::make_unique<minifi::extensions::curl::HTTPClient>();
   client->setVerbose(false);
   client->initialize(method, url, ssl_context_service);
-  if (method == "POST") {
+  if (method == HttpRequestMethod::POST) {
     client->setPostFields(payload);
   }
   REQUIRE(client->setSpecificSSLVersion(minifi::utils::SSLVersion::TLSv1_1));

--- a/extensions/elasticsearch/PostElasticsearch.cpp
+++ b/extensions/elasticsearch/PostElasticsearch.cpp
@@ -71,7 +71,7 @@ void PostElasticsearch::onSchedule(const std::shared_ptr<core::ProcessContext>& 
   if (!credentials_service_)
     throw Exception(PROCESS_SCHEDULE_EXCEPTION, "Missing Elasticsearch credentials service");
 
-  client_.initialize("POST", host_url_ + "/_bulk", getSSLContextService(*context));
+  client_.initialize(utils::HttpRequestMethod::POST, host_url_ + "/_bulk", getSSLContextService(*context));
   client_.setContentType("application/json");
   credentials_service_->authenticateClient(client_);
 }

--- a/extensions/http-curl/client/HTTPClient.h
+++ b/extensions/http-curl/client/HTTPClient.h
@@ -32,6 +32,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -89,7 +90,7 @@ class HTTPClient : public utils::BaseHTTPClient, public core::Connectable {
 
   void forceClose();
 
-  void initialize(std::string method, std::string url, std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service) override;
+  void initialize(utils::HttpRequestMethod method, std::string url, std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service) override;
 
   void setConnectionTimeout(std::chrono::milliseconds timeout) override;
 
@@ -118,7 +119,7 @@ class HTTPClient : public utils::BaseHTTPClient, public core::Connectable {
 
   const std::vector<char>& getResponseBody() override;
 
-  void set_request_method(std::string method) override;
+  void set_request_method(utils::HttpRequestMethod method) override;
 
   void setPeerVerification(bool peer_verification) override;
   void setHostVerification(bool host_verification) override;
@@ -227,7 +228,7 @@ class HTTPClient : public utils::BaseHTTPClient, public core::Connectable {
 
   std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service_;
   std::string url_;
-  std::string method_;
+  std::optional<utils::HttpRequestMethod> method_;
 
   std::chrono::milliseconds connect_timeout_{std::chrono::seconds(30)};
   std::chrono::milliseconds read_timeout_{std::chrono::seconds(30)};

--- a/extensions/http-curl/processors/InvokeHTTP.h
+++ b/extensions/http-curl/processors/InvokeHTTP.h
@@ -67,10 +67,10 @@ class InvokeHTTP : public core::Processor {
                                                           "The destination URL and HTTP Method are configurable. FlowFile attributes are converted to HTTP headers and the "
                                                           "FlowFile contents are included as the body of the request (if the HTTP Method is PUT, POST or PATCH).";
 
-  EXTENSIONAPI static constexpr auto Method = core::PropertyDefinitionBuilder<>::createProperty("HTTP Method")
-      .withDescription("HTTP request method (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS). "
-          "Arbitrary methods are also supported. Methods other than POST, PUT and PATCH will be sent without a message body.")
-      .withDefaultValue("GET")
+  EXTENSIONAPI static constexpr auto Method = core::PropertyDefinitionBuilder<magic_enum::enum_count<utils::HttpRequestMethod>()>::createProperty("HTTP Method")
+      .withDescription("HTTP request method. Methods other than POST, PUT and PATCH will be sent without a message body.")
+      .withAllowedValues(magic_enum::enum_names<utils::HttpRequestMethod>())
+      .withDefaultValue(magic_enum::enum_name(utils::HttpRequestMethod::GET))
       .build();
   EXTENSIONAPI static constexpr auto URL = core::PropertyDefinitionBuilder<>::createProperty("Remote URL")
       .withDescription("Remote URL which will be connected to, including scheme, host, port, path.")
@@ -267,7 +267,7 @@ class InvokeHTTP : public core::Processor {
   void setupMembersFromProperties(const core::ProcessContext& context);
   std::unique_ptr<minifi::extensions::curl::HTTPClient> createHTTPClientFromPropertiesAndMembers(const core::ProcessContext& context) const;
 
-  std::string method_;
+  utils::HttpRequestMethod method_{};
   std::optional<utils::Regex> attributes_to_send_;
   std::optional<std::string> put_response_body_in_attribute_;
   bool always_output_response_{false};

--- a/extensions/http-curl/protocols/RESTSender.cpp
+++ b/extensions/http-curl/protocols/RESTSender.cpp
@@ -93,7 +93,7 @@ C2Payload RESTSender::consumePayload(const C2Payload &payload, Direction directi
 void RESTSender::update(const std::shared_ptr<Configure> &) {
 }
 
-void RESTSender::setSecurityContext(extensions::curl::HTTPClient &client, const std::string &type, const std::string &url) {
+void RESTSender::setSecurityContext(extensions::curl::HTTPClient &client, utils::HttpRequestMethod type, const std::string &url) {
   // only use the SSL Context if we have a secure URL.
   auto generatedService = std::make_shared<minifi::controllers::SSLContextService>("Service", configuration_);
   generatedService->onEnable();
@@ -111,7 +111,7 @@ C2Payload RESTSender::sendPayload(const std::string& url, const Direction direct
   client.setKeepAliveProbe(extensions::curl::KeepAliveProbeData{2s, 2s});
   client.setConnectionTimeout(2s);
 
-  auto setUpHttpRequest = [&](const std::string& http_method) {
+  auto setUpHttpRequest = [&](utils::HttpRequestMethod http_method) {
     client.set_request_method(http_method);
     if (url.find("https://") == 0) {
       if (!ssl_context_service_) {
@@ -122,7 +122,7 @@ C2Payload RESTSender::sendPayload(const std::string& url, const Direction direct
     }
   };
   if (direction == Direction::TRANSMIT) {
-    setUpHttpRequest("POST");
+    setUpHttpRequest(utils::HttpRequestMethod::POST);
     if (payload.getOperation() == Operation::transfer) {
       // treat nested payloads as files
       for (const auto& file : payload.getNestedPayloads()) {
@@ -163,7 +163,7 @@ C2Payload RESTSender::sendPayload(const std::string& url, const Direction direct
   } else {
     // we do not need to set the upload callback
     // since we are not uploading anything on a get
-    setUpHttpRequest("GET");
+    setUpHttpRequest(utils::HttpRequestMethod::GET);
   }
 
   if (payload.getOperation() == Operation::transfer) {

--- a/extensions/http-curl/protocols/RESTSender.h
+++ b/extensions/http-curl/protocols/RESTSender.h
@@ -68,7 +68,7 @@ class RESTSender : public RESTProtocol, public C2Protocol {
    * @param type type of HTTP request
    * @param url HTTP url
    */
-  void setSecurityContext(extensions::curl::HTTPClient &client, const std::string &type, const std::string &url);
+  void setSecurityContext(extensions::curl::HTTPClient &client, utils::HttpRequestMethod type, const std::string &url);
 
   std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service_;
 

--- a/extensions/http-curl/sitetosite/HTTPProtocol.cpp
+++ b/extensions/http-curl/sitetosite/HTTPProtocol.cpp
@@ -16,7 +16,6 @@
  */
 #include "HTTPProtocol.h"
 
-#include <cstdio>
 #include <chrono>
 #include <map>
 #include <string>
@@ -48,7 +47,7 @@ std::shared_ptr<sitetosite::Transaction> HttpSiteToSiteClient::createTransaction
   std::string dir_str = direction == sitetosite::SEND ? "input-ports" : "output-ports";
   std::stringstream uri;
   uri << getBaseURI() << "data-transfer/" << dir_str << "/" << getPortId().to_string() << "/transactions";
-  auto client = create_http_client(uri.str(), "POST");
+  auto client = create_http_client(uri.str(), utils::HttpRequestMethod::POST);
   client->setRequestHeader(PROTOCOL_VERSION_HEADER, "1");
   client->setConnectionTimeout(std::chrono::milliseconds(5000));
   client->setContentType("application/json");
@@ -180,7 +179,7 @@ bool HttpSiteToSiteClient::getPeerList(std::vector<sitetosite::PeerStatus> &peer
   std::stringstream uri;
   uri << getBaseURI() << "site-to-site/peers";
 
-  auto client = create_http_client(uri.str(), "GET");
+  auto client = create_http_client(uri.str(), utils::HttpRequestMethod::GET);
 
   client->setRequestHeader(PROTOCOL_VERSION_HEADER, "1");
 
@@ -197,7 +196,7 @@ bool HttpSiteToSiteClient::getPeerList(std::vector<sitetosite::PeerStatus> &peer
 std::shared_ptr<minifi::extensions::curl::HTTPClient> HttpSiteToSiteClient::openConnectionForSending(const std::shared_ptr<HttpTransaction> &transaction) {
   std::stringstream uri;
   uri << transaction->getTransactionUrl() << "/flow-files";
-  std::shared_ptr<minifi::extensions::curl::HTTPClient> client = create_http_client(uri.str(), "POST");
+  std::shared_ptr<minifi::extensions::curl::HTTPClient> client = create_http_client(uri.str(), utils::HttpRequestMethod::POST);
   client->setContentType("application/octet-stream");
   client->setRequestHeader("Accept", "text/plain");
   client->setRequestHeader("Transfer-Encoding", "chunked");
@@ -207,7 +206,7 @@ std::shared_ptr<minifi::extensions::curl::HTTPClient> HttpSiteToSiteClient::open
 std::shared_ptr<minifi::extensions::curl::HTTPClient> HttpSiteToSiteClient::openConnectionForReceive(const std::shared_ptr<HttpTransaction> &transaction) {
   std::stringstream uri;
   uri << transaction->getTransactionUrl() << "/flow-files";
-  std::shared_ptr<minifi::extensions::curl::HTTPClient> client = create_http_client(uri.str(), "GET");
+  std::shared_ptr<minifi::extensions::curl::HTTPClient> client = create_http_client(uri.str(), utils::HttpRequestMethod::GET);
   return client;
 }
 
@@ -270,7 +269,7 @@ void HttpSiteToSiteClient::closeTransaction(const utils::Identifier &transaction
     uri << "&checksum=" << transaction->getCRC();
   }
 
-  auto client = create_http_client(uri.str(), "DELETE");
+  auto client = create_http_client(uri.str(), utils::HttpRequestMethod::DELETE);
 
   client->setRequestHeader(PROTOCOL_VERSION_HEADER, "1");
 

--- a/extensions/http-curl/sitetosite/HTTPProtocol.h
+++ b/extensions/http-curl/sitetosite/HTTPProtocol.h
@@ -127,7 +127,7 @@ class HttpSiteToSiteClient : public sitetosite::SiteToSiteClient {
 
   static std::optional<utils::Identifier> parseTransactionId(const std::string &uri);
 
-  std::unique_ptr<minifi::extensions::curl::HTTPClient> create_http_client(const std::string &uri, const std::string &method = "POST", bool setPropertyHeaders = false) {
+  std::unique_ptr<minifi::extensions::curl::HTTPClient> create_http_client(const std::string &uri, utils::HttpRequestMethod method = utils::HttpRequestMethod::POST, bool setPropertyHeaders = false) {
     std::unique_ptr<minifi::extensions::curl::HTTPClient> http_client_ = std::make_unique<minifi::extensions::curl::HTTPClient>(uri, ssl_context_service_);
     http_client_->initialize(method, uri, ssl_context_service_);
     if (setPropertyHeaders) {

--- a/extensions/splunk/SplunkHECProcessor.cpp
+++ b/extensions/splunk/SplunkHECProcessor.cpp
@@ -53,7 +53,7 @@ std::shared_ptr<minifi::controllers::SSLContextService> SplunkHECProcessor::getS
 }
 
 void SplunkHECProcessor::initializeClient(curl::HTTPClient& client, const std::string &url, std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service) const {
-  client.initialize("POST", url, std::move(ssl_context_service));
+  client.initialize(utils::HttpRequestMethod::POST, url, std::move(ssl_context_service));
   client.setRequestHeader("Authorization", token_);
   client.setRequestHeader("X-Splunk-Request-Channel", request_channel_);
 }

--- a/libminifi/include/utils/BaseHTTPClient.h
+++ b/libminifi/include/utils/BaseHTTPClient.h
@@ -178,6 +178,12 @@ namespace HTTPRequestResponse {
   int seek_callback(void *p, int64_t offset, int);
 }
 
+#undef DELETE  // this is a macro in winnt.h
+
+enum class HttpRequestMethod {
+  GET, POST, PUT, PATCH, DELETE, CONNECT, HEAD, OPTIONS, TRACE
+};
+
 class BaseHTTPClient {
  public:
   BaseHTTPClient() = default;
@@ -186,7 +192,7 @@ class BaseHTTPClient {
 
   virtual void setVerbose(bool use_stderr) = 0;
 
-  virtual void initialize(std::string method, std::string url, std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service) = 0;
+  virtual void initialize(HttpRequestMethod method, std::string url, std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service) = 0;
 
   virtual void setConnectionTimeout(std::chrono::milliseconds timeout) = 0;
 
@@ -208,7 +214,7 @@ class BaseHTTPClient {
 
   virtual void setRequestHeader(std::string key, std::optional<std::string> value) = 0;
 
-  virtual void set_request_method(std::string method) = 0;
+  virtual void set_request_method(HttpRequestMethod method) = 0;
 
   virtual void setPeerVerification(bool peer_verification) = 0;
   virtual void setHostVerification(bool host_verification) = 0;

--- a/libminifi/src/RemoteProcessorGroupPort.cpp
+++ b/libminifi/src/RemoteProcessorGroupPort.cpp
@@ -20,15 +20,10 @@
 
 #include "RemoteProcessorGroupPort.h"
 
-#include <algorithm>
-#include <cstdint>
 #include <memory>
-#include <deque>
 #include <iostream>
-#include <set>
 #include <vector>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <cinttypes>
 
@@ -41,9 +36,7 @@
 #include "core/logging/Logger.h"
 #include "core/ProcessContext.h"
 #include "core/ProcessorNode.h"
-#include "core/Relationship.h"
 #include "utils/BaseHTTPClient.h"
-#include "utils/net/DNS.h"
 
 #undef GetObject  // windows.h #defines GetObject = GetObjectA or GetObjectW, which conflicts with rapidjson
 
@@ -289,7 +282,7 @@ std::pair<std::string, int> RemoteProcessorGroupPort::refreshRemoteSite2SiteInfo
         return std::make_pair("", -1);
       }
       client = std::unique_ptr<utils::BaseHTTPClient>(dynamic_cast<utils::BaseHTTPClient*>(client_ptr));
-      client->initialize("GET", loginUrl.str(), ssl_service);
+      client->initialize(utils::HttpRequestMethod::GET, loginUrl.str(), ssl_service);
       // use a connection timeout. if this times out we will simply attempt re-connection
       // so no need for configuration parameter that isn't already defined in Processor
       client->setConnectionTimeout(10s);
@@ -308,7 +301,7 @@ std::pair<std::string, int> RemoteProcessorGroupPort::refreshRemoteSite2SiteInfo
     }
     int siteTosite_port_ = -1;
     client = std::unique_ptr<utils::BaseHTTPClient>(dynamic_cast<utils::BaseHTTPClient*>(client_ptr));
-    client->initialize("GET", fullUrl.str(), ssl_service);
+    client->initialize(utils::HttpRequestMethod::GET, fullUrl.str(), ssl_service);
     // use a connection timeout. if this times out we will simply attempt re-connection
     // so no need for configuration parameter that isn't already defined in Processor
     client->setConnectionTimeout(10s);

--- a/libminifi/src/core/logging/alert/AlertSink.cpp
+++ b/libminifi/src/core/logging/alert/AlertSink.cpp
@@ -199,7 +199,7 @@ void AlertSink::send(Services& services) {
     logger_->log_error("Could not instantiate a HTTPClient object");
     return;
   }
-  client->initialize("PUT", config_.url, services.ssl_service);
+  client->initialize(utils::HttpRequestMethod::PUT, config_.url, services.ssl_service);
 
   rapidjson::Document doc(rapidjson::kObjectType);
   std::string agent_id = services.agent_id->getAgentIdentifier();

--- a/libminifi/src/utils/BaseHTTPClient.cpp
+++ b/libminifi/src/utils/BaseHTTPClient.cpp
@@ -65,7 +65,7 @@ std::string get_token(utils::BaseHTTPClient* client, const std::string& username
 
   client->setContentType("application/x-www-form-urlencoded");
 
-  client->set_request_method("POST");
+  client->set_request_method(HttpRequestMethod::POST);
 
   std::string payload = "username=" + username + "&" + "password=" + password;
 


### PR DESCRIPTION
There is a well-defined list of possible HTTP request methods; we should not accept arbitrary strings.

https://issues.apache.org/jira/browse/MINIFICPP-2207

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
