### PR TITLE
MINIFICPP-2219 Refactor utils::StringUtils -> utils::string

### DIFF
--- a/libminifi/include/utils/StringUtils.h
+++ b/libminifi/include/utils/StringUtils.h
@@ -52,452 +52,394 @@ constexpr std::strong_ordering operator<=>(const std::string& lhs, const std::st
 
 namespace org::apache::nifi::minifi::utils {
 
-template<class Char>
-struct string_traits;
-template<>
-struct string_traits<char>{
-  template<class T>
-  static std::string convert_to_string(T&& t){
-    return std::to_string(std::forward<T>(t));
-  }
-};
-
-template<>
-struct string_traits<wchar_t>{
-  template<class T>
-  static std::wstring convert_to_string(T&& t){
-    return std::to_wstring(std::forward<T>(t));
-  }
-};
-
 struct as_string_tag_t {};
 inline constexpr as_string_tag_t as_string;
 
 /**
- * Stateless String utility class.
- *
- * Design: Static class, with no member variables
+ * String utilities
  *
  * Purpose: Houses many useful string utilities.
  */
-class StringUtils {
- public:
-  /**
-   * Checks and converts a string to a boolean
-   * @param input input string
-   * @returns an optional of a boolean: true if the string is "true" (ignoring case), false if it is "false" (ignoring case), nullopt for any other value
-   */
-  static std::optional<bool> toBool(const std::string& input);
+namespace string {
+/**
+ * Checks and converts a string to a boolean
+ * @param input input string
+ * @returns an optional of a boolean: true if the string is "true" (ignoring case), false if it is "false" (ignoring case), nullopt for any other value
+ */
+std::optional<bool> toBool(const std::string& input);
 
-  static inline std::string toLower(std::string str) {
-    const auto tolower = [](auto c) { return std::tolower(static_cast<unsigned char>(c)); };
-    std::transform(std::begin(str), std::end(str), std::begin(str), tolower);
-    return str;
+inline std::string toLower(std::string str) {
+  const auto tolower = [](auto c) { return std::tolower(static_cast<unsigned char>(c)); };
+  std::transform(std::begin(str), std::end(str), std::begin(str), tolower);
+  return str;
+}
+
+inline std::string toUpper(std::string str)  {
+  const auto toupper = [](auto c) { return std::toupper(static_cast<unsigned char>(c)); };
+  std::transform(std::begin(str), std::end(str), std::begin(str), toupper);
+  return str;
+}
+
+/**
+ * Strips the line ending (\n or \r\n) from the end of the input line.
+ * @param input_line
+ * @return (stripped line, line ending) pair
+ */
+std::pair<std::string, std::string> chomp(const std::string& input_line);
+
+/**
+ * Trims a string left to right
+ * @param s incoming string
+ * @returns modified string
+ */
+std::string trim(const std::string& s);
+
+/**
+ * Trims left most part of a string
+ * @param s incoming string
+ * @returns modified string
+ */
+inline std::string trimLeft(std::string s) {
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char c) -> bool { return !isspace(c); }));
+  return s;
+}
+
+/**
+ * Trims a string on the right
+ * @param s incoming string
+ * @returns modified string
+ */
+
+inline std::string trimRight(std::string s) {
+  s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char c) -> bool { return !isspace(c); }).base(), s.end());
+  return s;
+}
+
+std::string_view trim(std::string_view sv);
+
+std::string_view trim(const char* str);
+
+/**
+ * Compares strings by lower casing them.
+ */
+constexpr bool equalsIgnoreCase(std::string_view left, std::string_view right) {
+  if (left.length() != right.length()) {
+    return false;
   }
+  return std::equal(right.cbegin(), right.cend(), left.cbegin(), [](unsigned char lc, unsigned char rc) { return std::tolower(lc) == std::tolower(rc); });
+}
 
-  static inline std::string toUpper(std::string str)  {
-    const auto toupper = [](auto c) { return std::toupper(static_cast<unsigned char>(c)); };
-    std::transform(std::begin(str), std::end(str), std::begin(str), toupper);
-    return str;
+constexpr bool equals(std::string_view left, std::string_view right, bool case_sensitive = true) {
+  if (case_sensitive) {
+    return left == right;
   }
-
-  /**
-   * Strips the line ending (\n or \r\n) from the end of the input line.
-   * @param input_line
-   * @return (stripped line, line ending) pair
-   */
-  static std::pair<std::string, std::string> chomp(const std::string& input_line);
-
-  /**
-   * Trims a string left to right
-   * @param s incoming string
-   * @returns modified string
-   */
-  static std::string trim(const std::string& s);
-
-  /**
-   * Trims left most part of a string
-   * @param s incoming string
-   * @returns modified string
-   */
-  static inline std::string trimLeft(std::string s) {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char c) -> bool { return !isspace(c); }));
-    return s;
+  if (left.length() != right.length()) {
+    return false;
   }
+  return std::equal(left.begin(), left.end(), right.begin(), [](unsigned char lc, unsigned char rc) { return std::tolower(lc) == std::tolower(rc); });
+}
 
-  /**
-   * Trims a string on the right
-   * @param s incoming string
-   * @returns modified string
-   */
+std::vector<std::string> split(std::string_view str, std::string_view delimiter);
+std::vector<std::string> splitRemovingEmpty(std::string_view str, std::string_view delimiter);
+std::vector<std::string> splitAndTrim(std::string_view str, std::string_view delimiter);
+std::vector<std::string> splitAndTrimRemovingEmpty(std::string_view str, std::string_view delimiter);
 
-  static inline std::string trimRight(std::string s) {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char c) -> bool { return !isspace(c); }).base(), s.end());
-    return s;
+std::string replaceEnvironmentVariables(std::string source_string);
+
+std::string replaceOne(const std::string &input, const std::string &from, const std::string &to);
+
+std::string& replaceAll(std::string& source_string, const std::string &from_string, const std::string &to_string);
+
+constexpr bool startsWith(std::string_view value, std::string_view start, bool case_sensitive = true) {
+  if (case_sensitive) {
+    return value.starts_with(start);
   }
-
-  static std::string_view trim(std::string_view sv);
-
-  static std::string_view trim(const char* str);
-
-  /**
-   * Compares strings by lower casing them.
-   */
-  static inline bool equalsIgnoreCase(std::string_view left, std::string_view right) {
-    if (left.length() != right.length()) {
-      return false;
-    }
-    return std::equal(right.cbegin(), right.cend(), left.cbegin(), [](unsigned char lc, unsigned char rc) { return std::tolower(lc) == std::tolower(rc); });
+  if (start.length() > value.length()) {
+    return false;
   }
+  return std::equal(start.begin(), start.end(), value.begin(), [](unsigned char lc, unsigned char rc) {return tolower(lc) == tolower(rc);});
+}
 
-  static constexpr bool equals(const char* left, const char* right, bool caseSensitive = true) {
-    if (caseSensitive) {
-      return std::strcmp(left, right) == 0;
-    }
-    size_t left_len = std::strlen(left);
-    size_t right_len = std::strlen(right);
-    if (left_len != right_len) {
-      return false;
-    }
-    return std::equal(right, right + right_len, left, [](unsigned char lc, unsigned char rc) { return std::tolower(lc) == std::tolower(rc); });
+constexpr bool endsWith(std::string_view value, std::string_view end, bool case_sensitive = true) {
+  if (case_sensitive) {
+    return value.ends_with(end);
   }
-
-  static constexpr bool equals(std::string_view left, std::string_view right, bool case_sensitive = true) {
-    if (case_sensitive) {
-      return left == right;
-    }
-    if (left.length() != right.length()) {
-      return false;
-    }
-    return std::equal(left.begin(), left.end(), right.begin(), [](unsigned char lc, unsigned char rc) { return std::tolower(lc) == std::tolower(rc); });
+  if (end.length() > value.length()) {
+    return false;
   }
+  return std::equal(end.rbegin(), end.rend(), value.rbegin(), [](unsigned char lc, unsigned char rc) {return tolower(lc) == tolower(rc);});
+}
 
-  static std::vector<std::string> split(std::string_view str, std::string_view delimiter);
-  static std::vector<std::string> splitRemovingEmpty(std::string_view str, std::string_view delimiter);
-  static std::vector<std::string> splitAndTrim(std::string_view str, std::string_view delimiter);
-  static std::vector<std::string> splitAndTrimRemovingEmpty(std::string_view str, std::string_view delimiter);
+/**
+ * Returns the size of the passed std::w?string, C string or char array. Returns the array size - 1 in case of arrays.
+ * @tparam CharT Character type, typically char or wchar_t (deduced)
+ * @param str
+ * @return The size of the argument string
+ */
+template<typename CharT>
+constexpr size_t size(const std::basic_string<CharT>& str) noexcept { return str.size(); }
 
-  /**
-   * Converts a string to a float
-   * @param input input string
-   * @param output output float
-   * @param cp failure policy
-   */
-  static bool StringToFloat(const std::string& input, float &output, FailurePolicy cp = RETURN);
+template<typename CharT>
+constexpr size_t size(const CharT* str) noexcept { return std::char_traits<CharT>::length(str); }
 
-  static std::string replaceEnvironmentVariables(std::string source_string);
+template<typename CharT>
+constexpr size_t size(const std::basic_string_view<CharT>& str) noexcept { return str.size(); }
 
-  static std::string replaceOne(const std::string &input, const std::string &from, const std::string &to);
-
-  static std::string& replaceAll(std::string& source_string, const std::string &from_string, const std::string &to_string);
-
-  inline static bool startsWith(std::string_view value, std::string_view start, bool case_sensitive = true) {
-    if (start.length() > value.length()) {
-      return false;
-    }
-    if (case_sensitive) {
-      return std::equal(start.begin(), start.end(), value.begin());
-    }
-    return std::equal(start.begin(), start.end(), value.begin(), [](unsigned char lc, unsigned char rc) {return tolower(lc) == tolower(rc);});
-  }
-
-  inline static bool endsWith(std::string_view value, std::string_view end, bool case_sensitive = true) {
-    if (end.length() > value.length()) {
-      return false;
-    }
-    if (case_sensitive) {
-      return std::equal(end.rbegin(), end.rend(), value.rbegin());
-    }
-    return std::equal(end.rbegin(), end.rend(), value.rbegin(), [](unsigned char lc, unsigned char rc) {return tolower(lc) == tolower(rc);});
-  }
-
-  inline static std::string hex_ascii(const std::string& in) {
-    std::string newString;
-    newString.reserve(in.length() / 2);
-    for (size_t i = 0; i < in.length(); i += 2) {
-      std::string sstr = in.substr(i, 2);
-      char chr = (char) (int) strtol(sstr.c_str(), 0x00, 16); // NOLINT
-      newString.push_back(chr);
-    }
-    return newString;
-  }
-
-  /**
-   * Returns the size of the passed std::w?string, C string or char array. Returns the array size - 1 in case of arrays.
-   * @tparam CharT Character type, typically char or wchar_t (deduced)
-   * @param str
-   * @return The size of the argument string
-   */
-  template<typename CharT>
-  static size_t size(const std::basic_string<CharT>& str) noexcept { return str.size(); }
-
-  template<typename CharT>
-  static size_t size(const CharT* str) noexcept { return std::char_traits<CharT>::length(str); }
-
-  template<typename CharT>
-  static size_t size(const std::basic_string_view<CharT>& str) noexcept { return str.size(); }
-
-  struct detail {
-    // implementation detail of join_pack
-    template<typename CharT>
-    struct str_detector {
-      template<typename Str>
-      using valid_string_t = decltype(std::declval<std::basic_string<CharT>>().append(std::declval<Str>()));
-    };
-
-    template<typename ResultT, typename CharT, typename... Strs>
-    using valid_string_pack_t = std::enable_if_t<(meta::is_detected_v<str_detector<CharT>::template valid_string_t, Strs> && ...), ResultT>;
-
-    template<typename CharT, typename... Strs, valid_string_pack_t<void, CharT, Strs...>* = nullptr>
-    static std::basic_string<CharT> join_pack(const Strs&... strs) {
-      std::basic_string<CharT> result;
-      result.reserve((size(strs) + ...));
-      (result.append(strs), ...);
-      return result;
-    }
-  }; /* struct detail */
-
-  /**
-   * Join all arguments
-   * @tparam CharT Deduced character type
-   * @tparam Strs Deduced string types
-   * @param head First string, used for CharT deduction
-   * @param tail Rest of the strings
-   * @return std::basic_string<CharT> containing the resulting string
-   */
-  template<typename CharT, typename... Strs>
-  static detail::valid_string_pack_t<std::basic_string<CharT>, CharT, Strs...>
-  join_pack(const std::basic_string<CharT>& head, const Strs&... tail) {
-    return detail::join_pack<CharT>(head, tail...);
-  }
-
-  template<typename CharT, typename... Strs>
-  static detail::valid_string_pack_t<std::basic_string<CharT>, CharT, Strs...>
-  join_pack(const CharT* head, const Strs&... tail) {
-    return detail::join_pack<CharT>(head, tail...);
-  }
-
-  template<typename CharT, typename... Strs>
-  static detail::valid_string_pack_t<std::basic_string<CharT>, CharT, Strs...>
-  join_pack(const std::basic_string_view<CharT>& head, const Strs&... tail) {
-    return detail::join_pack<CharT>(head, tail...);
-  }
-
-  /**
-   * Concatenates elements stored in a container to a string, using the separator.
-   * @param separator that is inserted between the elements (no separator at the end)
-   * @param container that contains the elements to be joined
-   * @param projection function object which can convert an element to a string
-   * @return the elements of the container (transformed by the projection) joined using the separator
-   */
-  template<typename Separator, typename Container, typename Projection>
-  static auto join(Separator&& separator, Container&& container, Projection&& projection) {
-    const auto separator_view = [&separator] {
-      if constexpr (std::is_convertible_v<Separator, std::string_view>) { return std::string_view{separator}; }
-      else if constexpr (std::is_convertible_v<Separator, std::wstring_view>) { return std::wstring_view{separator}; }
-    }();
-
-    return container
-        | ranges::views::transform(projection)
-        | ranges::views::join(separator_view)
-        | ranges::to<std::basic_string>();
-  }
-
-  template<typename Separator, typename Container>
-  requires(std::is_arithmetic_v<typename std::remove_reference_t<Container>::value_type> && std::is_convertible_v<Separator, std::string_view>)
-  static auto join(Separator&& separator, Container&& container) {
-    return join(separator, container, [](auto number) { return std::to_string(number); });
-  }
-
-  template<typename Separator, typename Container>
-  requires(std::is_arithmetic_v<typename std::remove_reference_t<Container>::value_type> && std::is_convertible_v<Separator, std::wstring_view>)
-  static auto join(Separator&& separator, Container&& container) {
-    return join(separator, container, [](auto number) { return std::to_wstring(number); });
-  }
-
-  template<typename Separator, typename Container>
-  static auto join(Separator&& separator, Container&& container) {
-    return join(separator, container, [](auto x) { return x; });  // std::identity is not supported by AppleClang 13
-  }
-
-  /**
-   * Hexdecodes a single character in the set [0-9a-fA-F]
-   * @param ch the character to be decoded
-   * @param output the reference where the result should be written
-   * @return true on success
-   */
-  static bool from_hex(uint8_t ch, uint8_t& output);
-
-  /**
-   * Creates a string that is a concatenation of count instances of the provided string.
-   * @tparam TChar char type of the string (char or wchar_t)
-   * @param str that is to be repeated
-   * @param count the number of times the string is repeated
-   * @return the result string
-   */
-  template<typename TChar>
-  static std::basic_string<TChar> repeat(const TChar* str, size_t count) {
-    return repeat(std::basic_string<TChar>(str), count);
-  }
-
-  template<typename TChar>
-  static std::basic_string<TChar> repeat(const std::basic_string<TChar>& str, size_t count) {
-    return join("", std::vector<std::basic_string<TChar>>(count, str));
-  }
-
-  /**
-   * Hexdecodes the hexencoded string in data, ignoring every character that is not [0-9a-fA-F]
-   * @param data the output buffer where the hexdecoded bytes will be written. Must be at least length / 2 bytes long.
-   * @param data_length pointer to the length of data the data buffer. It will be filled with the length of the decoded bytes.
-   * @param hex the hexencoded string
-   * @param hex_length the length of hex
-   * @return true on success
-   */
-  static bool from_hex(std::byte* data, size_t* data_length, std::string_view hex);
-
-  /**
-   * Hexdecodes a string
-   * @param hex the hexencoded string
-   * @param hex_length the length of hex
-   * @return the vector containing the hexdecoded bytes
-   */
-  static std::vector<std::byte> from_hex(std::string_view hex);
-  static std::string from_hex(std::string_view hex, as_string_tag_t) {
-    const auto decoded = from_hex(hex);
-    return utils::span_to<std::string>(utils::as_span<const char>(std::span(decoded)));
-  }
-
-
-  /**
-   * Hexencodes bytes and writes the result to hex
-   * @param hex the output buffer where the hexencoded bytes will be written. Must be at least length * 2 bytes long.
-   * @param data the bytes to be hexencoded
-   * @param length the length of data. Must not be larger than std::numeric_limits<size_t>::max() / 2
-   * @param uppercase whether the hexencoded string should be upper case
-   * @return the size of hexencoded bytes
-   */
-  static size_t to_hex(char* hex, std::span<const std::byte> data_to_be_transformed, bool uppercase);
-
-  /**
-   * Creates a hexencoded string from data
-   * @param data the bytes to be hexencoded
-   * @param length the length of data. Must not be larger than std::numeric_limits<size_t>::max() / 2 - 1
-   * @param uppercase whether the hexencoded string should be upper case
-   * @return the hexencoded string
-   */
-  static std::string to_hex(std::span<const std::byte> data_to_be_transformed, bool uppercase = false);
-
-  /**
-   * Hexencodes a string
-   * @param str the string to be hexencoded
-   * @param uppercase whether the hexencoded string should be upper case
-   * @return the hexencoded string
-   */
-  inline static std::string to_hex(std::string_view str, bool uppercase = false) {
-    return to_hex(gsl::make_span(str).as_span<const std::byte>(), uppercase);
-  }
-
-
-  /**
-   * Decodes the Base64 encoded string into data
-   * @param data the output buffer where the decoded bytes will be written. Must be at least (base64_length / 4 + 1) * 3 bytes long.
-   * @param data_length pointer to the length of data the data buffer. It will be filled with the length of the decoded bytes.
-   * @param base64 the Base64 encoded string
-   * @param base64_length the length of base64
-   * @return true on success
-   */
-  static bool from_base64(std::byte* data, size_t* data_length, std::string_view base64);
-
-  /**
-   * Base64 decodes a string
-   * @param base64 the Base64 encoded string
-   * @param base64_length the length of base64
-   * @return the vector containing the decoded bytes
-   */
-  static std::vector<std::byte> from_base64(std::string_view base64);
-  static std::string from_base64(std::string_view base64, as_string_tag_t) {
-    const auto decoded = from_base64(base64);
-    return utils::span_to<std::string>(utils::as_span<const char>(std::span(decoded)));
-  }
-
-  /**
-   * Base64 encodes bytes and writes the result to base64
-   * @param base64 the output buffer where the Base64 encoded bytes will be written. Must be at least (base64_length / 3 + 1) * 4 bytes long.
-   * @param raw_data the bytes to be Base64 encoded. Must not be larger than std::numeric_limits<size_t>::max() * 3 / 4 - 3
-   * @param url if true, the URL-safe Base64 encoding will be used
-   * @param padded if true, padding is added to the Base64 encoded string
-   * @return the size of Base64 encoded bytes
-   */
-  static size_t to_base64(char* base64, std::span<const std::byte> raw_data, bool url, bool padded);
-
-  /**
-   * Creates a Base64 encoded string from data
-   * @param raw_data the bytes to be Base64 encoded
-   * @param url if true, the URL-safe Base64 encoding will be used
-   * @param padded if true, padding is added to the Base64 encoded string
-   * @return the Base64 encoded string
-   */
-  static std::string to_base64(std::span<const std::byte> raw_data, bool url = false, bool padded = true);
-
-  /**
-   * Base64 encodes a string
-   * @param str the string to be Base64 encoded
-   * @param url if true, the URL-safe Base64 encoding will be used
-   * @param padded if true, padding is added to the Base64 encoded string
-   * @return the Base64 encoded string
-   */
-  inline static std::string to_base64(std::string_view str, bool url = false, bool padded = true) {
-    return to_base64(gsl::make_span(str).as_span<const std::byte>(), url, padded);
-  }
-
-  static std::string replaceMap(std::string source_string, const std::map<std::string, std::string> &replace_map);
-
-  static std::pair<size_t, int> countOccurrences(const std::string &str, const std::string &pattern) {
-    if (pattern.empty()) {
-      return {str.size(), gsl::narrow<int>(str.size() + 1)};
-    }
-
-    size_t last_pos = 0;
-    int occurrences = 0;
-    for (size_t pos = 0; (pos = str.find(pattern, pos)) != std::string::npos; pos += pattern.size()) {
-      last_pos = pos;
-      ++occurrences;
-    }
-    return {last_pos, occurrences};
-  }
-
-  /**
-   * If the string starts and ends with the given character, the leading and trailing characters are removed.
-   * @param str incoming string
-   * @param c the character to be removed
-   * @return the modified string if the framing character matches otherwise the incoming string
-   */
-  static std::string removeFramingCharacters(const std::string& str, char c) {
-    if (str.size() < 2) {
-      return str;
-    }
-    if (str[0] == c && str[str.size() - 1] == c) {
-      return str.substr(1, str.size() - 2);
-    }
-    return str;
-  }
-
-  static std::string escapeUnprintableBytes(std::span<const std::byte> data);
-
-  /**
-   * Returns whether sequence of patterns are found in given string in their incoming order
-   * Non-regex search!
-   * @param str string to search in
-   * @param patterns sequence of patterns to search
-   * @return success of string sequence matching
-   */
-  static bool matchesSequence(std::string_view str, const std::vector<std::string>& patterns);
-
-  static bool splitToValueAndUnit(std::string_view input, int64_t& value, std::string& unit);
-
-  struct ParseError {};
-
-  static nonstd::expected<std::optional<char>, ParseError> parseCharacter(const std::string &input);
+namespace detail {
+// implementation detail of join_pack
+template<typename CharT>
+struct str_detector {
+  template<typename Str>
+  using valid_string_t = decltype(std::declval<std::basic_string<CharT>>().append(std::declval<Str>()));
 };
+
+template<typename ResultT, typename CharT, typename... Strs>
+using valid_string_pack_t = std::enable_if_t<(meta::is_detected_v<str_detector<CharT>::template valid_string_t, Strs> && ...), ResultT>;
+
+template<typename CharT, typename... Strs, valid_string_pack_t<void, CharT, Strs...>* = nullptr>
+static std::basic_string<CharT> join_pack(const Strs&... strs) {
+  std::basic_string<CharT> result;
+  result.reserve((size(strs) + ...));
+  (result.append(strs), ...);
+  return result;
+}
+}  // namespace detail
+
+/**
+ * Join all arguments
+ * @tparam CharT Deduced character type
+ * @tparam Strs Deduced string types
+ * @param head First string, used for CharT deduction
+ * @param tail Rest of the strings
+ * @return std::basic_string<CharT> containing the resulting string
+ */
+template<typename CharT, typename... Strs>
+inline detail::valid_string_pack_t<std::basic_string<CharT>, CharT, Strs...>
+join_pack(const std::basic_string<CharT>& head, const Strs&... tail) {
+  return detail::join_pack<CharT>(head, tail...);
+}
+
+template<typename CharT, typename... Strs>
+inline detail::valid_string_pack_t<std::basic_string<CharT>, CharT, Strs...>
+join_pack(const CharT* head, const Strs&... tail) {
+  return detail::join_pack<CharT>(head, tail...);
+}
+
+template<typename CharT, typename... Strs>
+inline detail::valid_string_pack_t<std::basic_string<CharT>, CharT, Strs...>
+join_pack(const std::basic_string_view<CharT>& head, const Strs&... tail) {
+  return detail::join_pack<CharT>(head, tail...);
+}
+
+/**
+ * Concatenates elements stored in a container to a string, using the separator.
+ * @param separator that is inserted between the elements (no separator at the end)
+ * @param container that contains the elements to be joined
+ * @param projection function object which can convert an element to a string
+ * @return the elements of the container (transformed by the projection) joined using the separator
+ */
+template<typename Separator, typename Container, typename Projection>
+inline auto join(Separator&& separator, Container&& container, Projection&& projection) {
+  const auto separator_view = [&separator] {
+    if constexpr (std::is_convertible_v<Separator, std::string_view>) { return std::string_view{separator}; }
+    else if constexpr (std::is_convertible_v<Separator, std::wstring_view>) { return std::wstring_view{separator}; }
+  }();
+
+  return container
+      | ranges::views::transform(projection)
+      | ranges::views::join(separator_view)
+      | ranges::to<std::basic_string>();
+}
+
+template<typename Separator, typename Container>
+requires(std::is_arithmetic_v<typename std::remove_reference_t<Container>::value_type> && std::is_convertible_v<Separator, std::string_view>)
+inline auto join(Separator&& separator, Container&& container) {
+  return join(separator, container, [](auto number) { return std::to_string(number); });
+}
+
+template<typename Separator, typename Container>
+requires(std::is_arithmetic_v<typename std::remove_reference_t<Container>::value_type> && std::is_convertible_v<Separator, std::wstring_view>)
+inline auto join(Separator&& separator, Container&& container) {
+  return join(separator, container, [](auto number) { return std::to_wstring(number); });
+}
+
+template<typename Separator, typename Container>
+inline auto join(Separator&& separator, Container&& container) {
+  return join(separator, container, [](auto x) { return x; });  // std::identity is not supported by AppleClang 13
+}
+
+/**
+ * Hexdecodes a single character in the set [0-9a-fA-F]
+ * @param ch the character to be decoded
+ * @param output the reference where the result should be written
+ * @return true on success
+ */
+bool from_hex(uint8_t ch, uint8_t& output);
+
+/**
+ * Creates a string that is a concatenation of count instances of the provided string.
+ * @tparam TChar char type of the string (char or wchar_t)
+ * @param str that is to be repeated
+ * @param count the number of times the string is repeated
+ * @return the result string
+ */
+std::string repeat(std::string_view str, size_t count);
+
+/**
+ * Hexdecodes the hexencoded string in data, ignoring every character that is not [0-9a-fA-F]
+ * @param data the output buffer where the hexdecoded bytes will be written. Must be at least length / 2 bytes long.
+ * @param data_length pointer to the length of data the data buffer. It will be filled with the length of the decoded bytes.
+ * @param hex the hexencoded string
+ * @param hex_length the length of hex
+ * @return true on success
+ */
+bool from_hex(std::byte* data, size_t* data_length, std::string_view hex);
+
+/**
+ * Hexdecodes a string
+ * @param hex the hexencoded string
+ * @param hex_length the length of hex
+ * @return the vector containing the hexdecoded bytes
+ */
+std::vector<std::byte> from_hex(std::string_view hex);
+inline std::string from_hex(std::string_view hex, as_string_tag_t) {
+  const auto decoded = from_hex(hex);
+  return utils::span_to<std::string>(utils::as_span<const char>(std::span(decoded)));
+}
+
+
+/**
+ * Hexencodes bytes and writes the result to hex
+ * @param hex the output buffer where the hexencoded bytes will be written. Must be at least length * 2 bytes long.
+ * @param data the bytes to be hexencoded
+ * @param length the length of data. Must not be larger than std::numeric_limits<size_t>::max() / 2
+ * @param uppercase whether the hexencoded string should be upper case
+ * @return the size of hexencoded bytes
+ */
+size_t to_hex(char* hex, std::span<const std::byte> data_to_be_transformed, bool uppercase);
+
+/**
+ * Creates a hexencoded string from data
+ * @param data the bytes to be hexencoded
+ * @param length the length of data. Must not be larger than std::numeric_limits<size_t>::max() / 2 - 1
+ * @param uppercase whether the hexencoded string should be upper case
+ * @return the hexencoded string
+ */
+std::string to_hex(std::span<const std::byte> data_to_be_transformed, bool uppercase = false);
+
+/**
+ * Hexencodes a string
+ * @param str the string to be hexencoded
+ * @param uppercase whether the hexencoded string should be upper case
+ * @return the hexencoded string
+ */
+inline std::string to_hex(std::string_view str, bool uppercase = false) {
+  return to_hex(gsl::make_span(str).as_span<const std::byte>(), uppercase);
+}
+
+
+/**
+ * Decodes the Base64 encoded string into data
+ * @param data the output buffer where the decoded bytes will be written. Must be at least (base64_length / 4 + 1) * 3 bytes long.
+ * @param data_length pointer to the length of data the data buffer. It will be filled with the length of the decoded bytes.
+ * @param base64 the Base64 encoded string
+ * @param base64_length the length of base64
+ * @return true on success
+ */
+bool from_base64(std::byte* data, size_t* data_length, std::string_view base64);
+
+/**
+ * Base64 decodes a string
+ * @param base64 the Base64 encoded string
+ * @param base64_length the length of base64
+ * @return the vector containing the decoded bytes
+ */
+std::vector<std::byte> from_base64(std::string_view base64);
+inline std::string from_base64(std::string_view base64, as_string_tag_t) {
+  const auto decoded = from_base64(base64);
+  return utils::span_to<std::string>(utils::as_span<const char>(std::span(decoded)));
+}
+
+/**
+ * Base64 encodes bytes and writes the result to base64
+ * @param base64 the output buffer where the Base64 encoded bytes will be written. Must be at least (base64_length / 3 + 1) * 4 bytes long.
+ * @param raw_data the bytes to be Base64 encoded. Must not be larger than std::numeric_limits<size_t>::max() * 3 / 4 - 3
+ * @param url if true, the URL-safe Base64 encoding will be used
+ * @param padded if true, padding is added to the Base64 encoded string
+ * @return the size of Base64 encoded bytes
+ */
+size_t to_base64(char* base64, std::span<const std::byte> raw_data, bool url, bool padded);
+
+/**
+ * Creates a Base64 encoded string from data
+ * @param raw_data the bytes to be Base64 encoded
+ * @param url if true, the URL-safe Base64 encoding will be used
+ * @param padded if true, padding is added to the Base64 encoded string
+ * @return the Base64 encoded string
+ */
+std::string to_base64(std::span<const std::byte> raw_data, bool url = false, bool padded = true);
+
+/**
+ * Base64 encodes a string
+ * @param str the string to be Base64 encoded
+ * @param url if true, the URL-safe Base64 encoding will be used
+ * @param padded if true, padding is added to the Base64 encoded string
+ * @return the Base64 encoded string
+ */
+inline std::string to_base64(std::string_view str, bool url = false, bool padded = true) {
+  return to_base64(gsl::make_span(str).as_span<const std::byte>(), url, padded);
+}
+
+std::string replaceMap(std::string source_string, const std::map<std::string, std::string> &replace_map);
+
+constexpr std::pair<size_t, int> countOccurrences(std::string_view str, std::string_view pattern) {
+  if (pattern.empty()) {
+    return {str.size(), gsl::narrow<int>(str.size() + 1)};
+  }
+
+  size_t last_pos = 0;
+  int occurrences = 0;
+  for (size_t pos = 0; (pos = str.find(pattern, pos)) != std::string_view::npos; pos += pattern.size()) {
+    last_pos = pos;
+    ++occurrences;
+  }
+  return {last_pos, occurrences};
+}
+
+/**
+ * If the string starts and ends with the given character, the leading and trailing characters are removed.
+ * @param str incoming string
+ * @param c the character to be removed
+ * @return the modified string if the framing character matches otherwise the incoming string
+ */
+inline std::string removeFramingCharacters(std::string_view str, char c) {
+  if (str.size() < 2) {
+    return std::string{str};
+  }
+  if (str[0] == c && str[str.size() - 1] == c) {
+    return std::string{str.substr(1, str.size() - 2)};
+  }
+  return std::string{str};
+}
+
+std::string escapeUnprintableBytes(std::span<const std::byte> data);
+
+/**
+ * Returns whether sequence of patterns are found in given string in their incoming order
+ * Non-regex search!
+ * @param str string to search in
+ * @param patterns sequence of patterns to search
+ * @return success of string sequence matching
+ */
+bool matchesSequence(std::string_view str, const std::vector<std::string>& patterns);
+
+bool splitToValueAndUnit(std::string_view input, int64_t& value, std::string& unit);
+
+struct ParseError {};
+
+nonstd::expected<std::optional<char>, ParseError> parseCharacter(std::string_view input);
+}  // namespace string
+
+namespace StringUtils = string;
 
 }  // namespace org::apache::nifi::minifi::utils

--- a/libminifi/src/utils/ChecksumCalculator.cpp
+++ b/libminifi/src/utils/ChecksumCalculator.cpp
@@ -29,7 +29,7 @@ namespace {
 
 const std::string AGENT_IDENTIFIER_KEY = std::string(org::apache::nifi::minifi::Configuration::nifi_c2_agent_identifier) + "=";
 
-}
+}  // namespace
 
 namespace org::apache::nifi::minifi::utils {
 
@@ -53,11 +53,9 @@ std::string ChecksumCalculator::getChecksum() {
 }
 
 std::string ChecksumCalculator::computeChecksum(const std::filesystem::path& file_location) {
-  using org::apache::nifi::minifi::utils::StringUtils;
-
   std::ifstream input_file{file_location, std::ios::in | std::ios::binary};
   if (!input_file.is_open()) {
-    throw std::runtime_error(StringUtils::join_pack("Could not open config file '", file_location.string(), "' to compute the checksum: ", std::strerror(errno)));
+    throw std::runtime_error(string::join_pack("Could not open config file '", file_location.string(), "' to compute the checksum: ", std::strerror(errno)));
   }
 
   crypto_hash_sha256_state state;
@@ -66,7 +64,7 @@ std::string ChecksumCalculator::computeChecksum(const std::filesystem::path& fil
   std::string line;
   while (std::getline(input_file, line)) {
     // skip lines containing the agent identifier, so agents in the same class will have the same checksum
-    if (StringUtils::startsWith(line, AGENT_IDENTIFIER_KEY)) {
+    if (string::startsWith(line, AGENT_IDENTIFIER_KEY)) {
       continue;
     }
     if (!input_file.eof()) {  // eof() means we have just read the last line, which was not terminated by a newline
@@ -75,13 +73,13 @@ std::string ChecksumCalculator::computeChecksum(const std::filesystem::path& fil
     crypto_hash_sha256_update(&state, reinterpret_cast<const unsigned char*>(line.data()), line.size());
   }
   if (input_file.bad()) {
-    throw std::runtime_error(StringUtils::join_pack("Error reading config file '", file_location.string(), "' while computing the checksum: ", std::strerror(errno)));
+    throw std::runtime_error(string::join_pack("Error reading config file '", file_location.string(), "' while computing the checksum: ", std::strerror(errno)));
   }
 
   std::array<unsigned char, LENGTH_OF_HASH_IN_BYTES> hash{};
   crypto_hash_sha256_final(&state, hash.data());
 
-  return StringUtils::to_hex(gsl::make_span(hash).as_span<std::byte>());
+  return string::to_hex(gsl::make_span(hash).as_span<std::byte>());
 }
 
 }  // namespace org::apache::nifi::minifi::utils

--- a/libminifi/src/utils/StringUtils.cpp
+++ b/libminifi/src/utils/StringUtils.cpp
@@ -22,9 +22,9 @@
 #include "utils/GeneralUtils.h"
 #include "utils/StringUtils.h"
 
-namespace org::apache::nifi::minifi::utils {
+namespace org::apache::nifi::minifi::utils::string {
 
-std::optional<bool> StringUtils::toBool(const std::string& input) {
+std::optional<bool> toBool(const std::string& input) {
   std::string trimmed = trim(input);
   if (equalsIgnoreCase(trimmed, "true")) {
     return true;
@@ -35,7 +35,7 @@ std::optional<bool> StringUtils::toBool(const std::string& input) {
   return std::nullopt;
 }
 
-std::pair<std::string, std::string> StringUtils::chomp(const std::string& input_line) {
+std::pair<std::string, std::string> chomp(const std::string& input_line) {
   if (endsWith(input_line, "\r\n")) {
     return std::make_pair(input_line.substr(0, input_line.size() - 2), "\r\n");
   } else if (endsWith(input_line, "\n")) {
@@ -45,11 +45,11 @@ std::pair<std::string, std::string> StringUtils::chomp(const std::string& input_
   }
 }
 
-std::string StringUtils::trim(const std::string& s) {
+std::string trim(const std::string& s) {
   return trimRight(trimLeft(s));
 }
 
-std::string_view StringUtils::trim(std::string_view sv) {
+std::string_view trim(std::string_view sv) {
   auto begin = std::find_if(sv.begin(), sv.end(), [](unsigned char c) -> bool { return !isspace(c); });
   auto end = std::find_if(sv.rbegin(), std::reverse_iterator(begin), [](unsigned char c) -> bool { return !isspace(c); }).base();
   // c++20 iterator constructor
@@ -59,7 +59,7 @@ std::string_view StringUtils::trim(std::string_view sv) {
   return sv.substr(std::distance(sv.begin(), begin), std::distance(begin, end));
 }
 
-std::string_view StringUtils::trim(const char* str) {
+std::string_view trim(const char* str) {
   return trim(std::string_view(str));
 }
 
@@ -88,27 +88,27 @@ std::vector<std::string> split_transformed(std::string_view str_view, std::strin
   return result;
 }
 
-std::vector<std::string> StringUtils::split(std::string_view str, std::string_view delimiter) {
+std::vector<std::string> split(std::string_view str, std::string_view delimiter) {
   return split_transformed(str, delimiter, identity{});
 }
 
-std::vector<std::string> StringUtils::splitRemovingEmpty(std::string_view str, std::string_view delimiter) {
+std::vector<std::string> splitRemovingEmpty(std::string_view str, std::string_view delimiter) {
   auto result = split(str, delimiter);
   result.erase(std::remove_if(result.begin(), result.end(), [](const std::string& str) { return str.empty(); }), result.end());
   return result;
 }
 
-std::vector<std::string> StringUtils::splitAndTrim(std::string_view str, std::string_view delimiter) {
+std::vector<std::string> splitAndTrim(std::string_view str, std::string_view delimiter) {
   return split_transformed(str, delimiter, static_cast<std::string(*)(const std::string&)>(trim));
 }
 
-std::vector<std::string> StringUtils::splitAndTrimRemovingEmpty(std::string_view str, std::string_view delimiter) {
+std::vector<std::string> splitAndTrimRemovingEmpty(std::string_view str, std::string_view delimiter) {
   auto result = splitAndTrim(str, delimiter);
   result.erase(std::remove_if(result.begin(), result.end(), [](const std::string& str) { return str.empty(); }), result.end());
   return result;
 }
 
-bool StringUtils::StringToFloat(const std::string& input, float &output, FailurePolicy cp /*= RETURN*/) {
+bool StringToFloat(const std::string& input, float &output, FailurePolicy cp /*= RETURN*/) {
   try {
     output = std::stof(input);
   } catch (const std::invalid_argument &ie) {
@@ -136,7 +136,7 @@ bool StringUtils::StringToFloat(const std::string& input, float &output, Failure
   return true;
 }
 
-std::string StringUtils::replaceEnvironmentVariables(std::string source_string) {
+std::string replaceEnvironmentVariables(std::string source_string) {
   std::string::size_type beg_seq = 0;
   std::string::size_type end_seq = 0;
   do {
@@ -171,7 +171,7 @@ std::string StringUtils::replaceEnvironmentVariables(std::string source_string) 
   return source_string;
 }
 
-std::string StringUtils::replaceOne(const std::string &input, const std::string &from, const std::string &to) {
+std::string replaceOne(const std::string &input, const std::string &from, const std::string &to) {
   std::size_t found_at_position = input.find(from);
   if (found_at_position != std::string::npos) {
     std::string input_copy = input;
@@ -181,7 +181,7 @@ std::string StringUtils::replaceOne(const std::string &input, const std::string 
   }
 }
 
-std::string& StringUtils::replaceAll(std::string& source_string, const std::string &from_string, const std::string &to_string) {
+std::string& replaceAll(std::string& source_string, const std::string &from_string, const std::string &to_string) {
   std::size_t loc = 0;
   std::size_t lastFound;
   while ((lastFound = source_string.find(from_string, loc)) != std::string::npos) {
@@ -194,7 +194,7 @@ std::string& StringUtils::replaceAll(std::string& source_string, const std::stri
   return source_string;
 }
 
-std::string StringUtils::replaceMap(std::string source_string, const std::map<std::string, std::string> &replace_map) {
+std::string replaceMap(std::string source_string, const std::map<std::string, std::string> &replace_map) {
   auto result_string = source_string;
 
   std::vector<std::pair<size_t, std::pair<size_t, std::string>>> replacements;
@@ -275,7 +275,7 @@ constexpr uint8_t base64_dec_lut[128] =
      0x31, 0x32, 0x33, ILGL, ILGL, ILGL, ILGL, ILGL};
 }  // namespace
 
-bool StringUtils::from_hex(uint8_t ch, uint8_t& output) {
+bool from_hex(uint8_t ch, uint8_t& output) {
   if (ch > 127) {
     return false;
   }
@@ -283,7 +283,7 @@ bool StringUtils::from_hex(uint8_t ch, uint8_t& output) {
   return output != SKIP;
 }
 
-bool StringUtils::from_hex(std::byte* data, size_t* data_length, std::string_view hex) {
+bool from_hex(std::byte* data, size_t* data_length, std::string_view hex) {
   if (*data_length < hex.size() / 2) {
     return false;
   }
@@ -309,7 +309,7 @@ bool StringUtils::from_hex(std::byte* data, size_t* data_length, std::string_vie
   return !found_first_nibble;
 }
 
-std::vector<std::byte> StringUtils::from_hex(std::string_view hex) {
+std::vector<std::byte> from_hex(std::string_view hex) {
   std::vector<std::byte> decoded(hex.size() / 2);
   size_t data_length = decoded.size();
   if (!from_hex(decoded.data(), &data_length, hex)) {
@@ -319,7 +319,7 @@ std::vector<std::byte> StringUtils::from_hex(std::string_view hex) {
   return decoded;
 }
 
-size_t StringUtils::to_hex(char* hex, std::span<const std::byte> data_to_be_transformed, bool uppercase) {
+size_t to_hex(char* hex, std::span<const std::byte> data_to_be_transformed, bool uppercase) {
   if (data_to_be_transformed.size() > std::numeric_limits<size_t>::max() / 2) {
     throw std::length_error("Data is too large to be hexencoded");
   }
@@ -330,7 +330,7 @@ size_t StringUtils::to_hex(char* hex, std::span<const std::byte> data_to_be_tran
   return data_to_be_transformed.size() * 2;
 }
 
-std::string StringUtils::to_hex(std::span<const std::byte> data_to_be_transformed, bool uppercase /*= false*/) {
+std::string to_hex(std::span<const std::byte> data_to_be_transformed, bool uppercase /*= false*/) {
   if (data_to_be_transformed.size() > (std::numeric_limits<size_t>::max() / 2 - 1)) {
     throw std::length_error("Data is too large to be hexencoded");
   }
@@ -341,7 +341,7 @@ std::string StringUtils::to_hex(std::span<const std::byte> data_to_be_transforme
   return result;
 }
 
-bool StringUtils::from_base64(std::byte* const data, size_t* const data_length, const std::string_view base64) {
+bool from_base64(std::byte* const data, size_t* const data_length, const std::string_view base64) {
   if (*data_length < (base64.size() / 4 + 1) * 3) {
     return false;
   }
@@ -409,7 +409,7 @@ bool StringUtils::from_base64(std::byte* const data, size_t* const data_length, 
   return true;
 }
 
-std::vector<std::byte> StringUtils::from_base64(const std::string_view base64) {
+std::vector<std::byte> from_base64(const std::string_view base64) {
   std::vector<std::byte> decoded((base64.size() / 4 + 1) * 3);
   size_t data_length = decoded.size();
   if (!from_base64(decoded.data(), &data_length, base64)) {
@@ -419,7 +419,7 @@ std::vector<std::byte> StringUtils::from_base64(const std::string_view base64) {
   return decoded;
 }
 
-size_t StringUtils::to_base64(char* base64, const std::span<const std::byte> raw_data, bool url, bool padded) {
+size_t to_base64(char* base64, const std::span<const std::byte> raw_data, bool url, bool padded) {
   gsl_Expects(base64);
   if (raw_data.size() > std::numeric_limits<size_t>::max() * 3 / 4 - 3) {
     throw std::length_error("Data is too large to be base64 encoded");
@@ -453,7 +453,7 @@ size_t StringUtils::to_base64(char* base64, const std::span<const std::byte> raw
   return base64_length;
 }
 
-std::string StringUtils::to_base64(const std::span<const std::byte> raw_data, bool url /*= false*/, bool padded /*= true*/) {
+std::string to_base64(const std::span<const std::byte> raw_data, bool url /*= false*/, bool padded /*= true*/) {
   std::string buf;
   buf.resize((raw_data.size() / 3 + 1) * 4);
   size_t base64_length = to_base64(buf.data(), raw_data, url, padded);
@@ -462,7 +462,7 @@ std::string StringUtils::to_base64(const std::span<const std::byte> raw_data, bo
   return buf;
 }
 
-std::string StringUtils::escapeUnprintableBytes(std::span<const std::byte> data) {
+std::string escapeUnprintableBytes(std::span<const std::byte> data) {
   constexpr const char* hex_digits = "0123456789abcdef";
   std::string result;
   for (auto byte : data) {
@@ -488,7 +488,7 @@ std::string StringUtils::escapeUnprintableBytes(std::span<const std::byte> data)
   return result;
 }
 
-bool StringUtils::matchesSequence(std::string_view str, const std::vector<std::string>& patterns) {
+bool matchesSequence(std::string_view str, const std::vector<std::string>& patterns) {
   size_t pos = 0;
 
   for (const auto& pattern : patterns) {
@@ -502,7 +502,7 @@ bool StringUtils::matchesSequence(std::string_view str, const std::vector<std::s
   return true;
 }
 
-bool StringUtils::splitToValueAndUnit(std::string_view input, int64_t& value, std::string& unit) {
+bool splitToValueAndUnit(std::string_view input, int64_t& value, std::string& unit) {
   const char* begin = input.data();
   const char* end = begin + input.size();
   auto [ptr, ec] = std::from_chars(begin, end, value);
@@ -518,7 +518,7 @@ bool StringUtils::splitToValueAndUnit(std::string_view input, int64_t& value, st
   return true;
 }
 
-nonstd::expected<std::optional<char>, StringUtils::ParseError> StringUtils::parseCharacter(const std::string &input) {
+nonstd::expected<std::optional<char>, ParseError> parseCharacter(std::string_view input) {
   if (input.empty()) { return std::nullopt; }
   if (input.size() == 1) { return input[0]; }
 
@@ -538,4 +538,13 @@ nonstd::expected<std::optional<char>, StringUtils::ParseError> StringUtils::pars
   return nonstd::make_unexpected(ParseError{});
 }
 
-}  // namespace org::apache::nifi::minifi::utils
+std::string repeat(std::string_view str, size_t count) {
+  std::string result;
+  result.reserve(count * str.length());
+  for (size_t i = 0; i < count; ++i) {
+    result.append(str);
+  }
+  return result;
+}
+
+}  // namespace org::apache::nifi::minifi::utils::string

--- a/libminifi/test/unit/StringUtilsTests.cpp
+++ b/libminifi/test/unit/StringUtilsTests.cpp
@@ -28,264 +28,263 @@
 #include "utils/StringUtils.h"
 #include "utils/Environment.h"
 
-using org::apache::nifi::minifi::utils::StringUtils;
-using utils::as_string;
+namespace org::apache::nifi::minifi::utils {
 
 // NOLINTBEGIN(readability-container-size-empty)
 
-TEST_CASE("StringUtils::chomp works correctly", "[StringUtils][chomp]") {
+TEST_CASE("string::chomp works correctly", "[StringUtils][chomp]") {
   using pair_of = std::pair<std::string, std::string>;
-  CHECK(StringUtils::chomp("foobar") == pair_of{"foobar", ""});
-  CHECK(StringUtils::chomp("foobar\n") == pair_of{"foobar", "\n"});
-  CHECK(StringUtils::chomp("foobar\r\n") == pair_of{"foobar", "\r\n"});
-  CHECK(StringUtils::chomp("foo\rbar\n") == pair_of{"foo\rbar", "\n"});
+  CHECK(string::chomp("foobar") == pair_of{"foobar", ""});
+  CHECK(string::chomp("foobar\n") == pair_of{"foobar", "\n"});
+  CHECK(string::chomp("foobar\r\n") == pair_of{"foobar", "\r\n"});
+  CHECK(string::chomp("foo\rbar\n") == pair_of{"foo\rbar", "\n"});
 }
 
-TEST_CASE("TestStringUtils::split", "[test split no delimiter]") {
-  std::vector<std::string> expected = { "hello" };
-  REQUIRE(expected == StringUtils::split("hello", ","));
+TEST_CASE("test string::split", "[test split no delimiter]") {
+  std::vector<std::string> expected = {"hello"};
+  REQUIRE(expected == string::split("hello", ","));
 }
 
-TEST_CASE("TestStringUtils::split2", "[test split single delimiter]") {
-  std::vector<std::string> expected = { "hello", "world" };
-  REQUIRE(expected == StringUtils::split("hello world", " "));
+TEST_CASE("test string::split2", "[test split single delimiter]") {
+  std::vector<std::string> expected = {"hello", "world"};
+  REQUIRE(expected == string::split("hello world", " "));
 }
 
-TEST_CASE("TestStringUtils::split3", "[test split multiple delimiter]") {
-  std::vector<std::string> expected = { "hello", "world", "I'm", "a", "unit", "test" };
-  REQUIRE(expected == StringUtils::split("hello world I'm a unit test", " "));
+TEST_CASE("test string::split3", "[test split multiple delimiter]") {
+  std::vector<std::string> expected = {"hello", "world", "I'm", "a", "unit", "test"};
+  REQUIRE(expected == string::split("hello world I'm a unit test", " "));
 }
 
-TEST_CASE("TestStringUtils::split4", "[test split classname]") {
-  std::vector<std::string> expected = { "org", "apache", "nifi", "minifi", "utils", "StringUtils" };
-  REQUIRE(expected == StringUtils::split(org::apache::nifi::minifi::core::className<org::apache::nifi::minifi::utils::StringUtils>(), "::"));
+TEST_CASE("test string::split4", "[test split classname]") {
+  std::vector<std::string> expected = {"org", "apache", "nifi", "minifi", "utils", "string", "ParseError"};
+  REQUIRE(expected == string::split(org::apache::nifi::minifi::core::className<string::ParseError>(), "::"));
 }
 
-TEST_CASE("TestStringUtils::split5", "[test split with delimiter set to empty string]") {
-  std::vector<std::string> expected{ "h", "e", "l", "l", "o", " ", "w", "o", "r", "l", "d" };
-  REQUIRE(expected == StringUtils::split("hello world", ""));
+TEST_CASE("test string::split5", "[test split with delimiter set to empty string]") {
+  std::vector<std::string> expected{"h", "e", "l", "l", "o", " ", "w", "o", "r", "l", "d"};
+  REQUIRE(expected == string::split("hello world", ""));
 }
 
-TEST_CASE("TestStringUtils::split6", "[test split with delimiter with empty results]") {
+TEST_CASE("test string::split6", "[test split with delimiter with empty results]") {
   std::vector<std::string> expected = {""};
-  REQUIRE(expected == StringUtils::split("", ","));
+  REQUIRE(expected == string::split("", ","));
   expected = {"", ""};
-  REQUIRE(expected == StringUtils::split(",", ","));
+  REQUIRE(expected == string::split(",", ","));
   expected = {"", " ", "", ""};
-  REQUIRE(expected == StringUtils::split(", ,,", ","));
+  REQUIRE(expected == string::split(", ,,", ","));
 }
 
-TEST_CASE("TestStringUtils::splitRemovingEmpty", "[test splitRemovingEmpty multiple delimiter]") {
-  std::vector<std::string> expected = { "hello", "world", "I'm", "a", "unit", "test" };
-  REQUIRE(expected == StringUtils::split("hello world I'm a unit test", " "));
+TEST_CASE("test string::splitRemovingEmpty", "[test splitRemovingEmpty multiple delimiter]") {
+  std::vector<std::string> expected = {"hello", "world", "I'm", "a", "unit", "test"};
+  REQUIRE(expected == string::split("hello world I'm a unit test", " "));
 }
 
-TEST_CASE("TestStringUtils::splitRemovingEmpty2", "[test splitRemovingEmpty no delimiter]") {
-  std::vector<std::string> expected = { "hello" };
-  REQUIRE(expected == StringUtils::splitRemovingEmpty("hello", ","));
+TEST_CASE("test string::splitRemovingEmpty2", "[test splitRemovingEmpty no delimiter]") {
+  std::vector<std::string> expected = {"hello"};
+  REQUIRE(expected == string::splitRemovingEmpty("hello", ","));
 }
 
-TEST_CASE("TestStringUtils::splitRemovingEmpty3", "[test splitRemovingEmpty with delimiter with empty results]") {
+TEST_CASE("test string::splitRemovingEmpty3", "[test splitRemovingEmpty with delimiter with empty results]") {
   std::vector<std::string> expected = {};
-  REQUIRE(expected == StringUtils::splitRemovingEmpty("", ","));
-  REQUIRE(expected == StringUtils::splitRemovingEmpty(",", ","));
+  REQUIRE(expected == string::splitRemovingEmpty("", ","));
+  REQUIRE(expected == string::splitRemovingEmpty(",", ","));
   expected = {" "};
-  REQUIRE(expected == StringUtils::splitRemovingEmpty(", ,,", ","));
+  REQUIRE(expected == string::splitRemovingEmpty(", ,,", ","));
 }
 
-TEST_CASE("TestStringUtils::splitAndTrim", "[test split with trim with characters]") {
-  std::vector<std::string> expected{ "hello", "world peace" };
-  REQUIRE(expected == StringUtils::splitAndTrim("hello, world peace", ","));
+TEST_CASE("test string::splitAndTrim", "[test split with trim with characters]") {
+  std::vector<std::string> expected{"hello", "world peace"};
+  REQUIRE(expected == string::splitAndTrim("hello, world peace", ","));
   expected = {""};
-  REQUIRE(expected == StringUtils::splitAndTrim("", ","));
+  REQUIRE(expected == string::splitAndTrim("", ","));
   expected = {"", ""};
-  REQUIRE(expected == StringUtils::splitAndTrim(",", ","));
+  REQUIRE(expected == string::splitAndTrim(",", ","));
   expected = {"", "", "", ""};
-  REQUIRE(expected == StringUtils::splitAndTrim(", ,,", ","));
+  REQUIRE(expected == string::splitAndTrim(", ,,", ","));
 }
 
-TEST_CASE("StringUtils::splitAndTrim2", "[test split with trim with words]") {
-  std::vector<std::string> expected{ "tom", "jerry" };
-  REQUIRE(expected == StringUtils::splitAndTrim("tom and jerry", "and"));
+TEST_CASE("string::splitAndTrim2", "[test split with trim with words]") {
+  std::vector<std::string> expected{"tom", "jerry"};
+  REQUIRE(expected == string::splitAndTrim("tom and jerry", "and"));
   expected = {"", ""};
-  REQUIRE(expected == StringUtils::splitAndTrim("and", "and"));
+  REQUIRE(expected == string::splitAndTrim("and", "and"));
   expected = {"", "", ""};
-  REQUIRE(expected == StringUtils::splitAndTrim("andand", "and"));
+  REQUIRE(expected == string::splitAndTrim("andand", "and"));
   expected = {"stan", "pan", ""};
-  REQUIRE(expected == StringUtils::splitAndTrim("stan and pan and ", "and"));
+  REQUIRE(expected == string::splitAndTrim("stan and pan and ", "and"));
   expected = {"", ""};
-  REQUIRE(expected == StringUtils::splitAndTrim(" and ", "and"));
+  REQUIRE(expected == string::splitAndTrim(" and ", "and"));
   expected = {"a", "b", "c"};
-  REQUIRE(expected == StringUtils::splitAndTrim("a and ... b and ...  c", "and ..."));
+  REQUIRE(expected == string::splitAndTrim("a and ... b and ...  c", "and ..."));
 }
 
-TEST_CASE("StringUtils::splitAndTrimRemovingEmpty", "[test split with trim removing empty strings]") {
-  std::vector<std::string> expected{ "tom", "jerry" };
-  REQUIRE(expected == StringUtils::splitAndTrimRemovingEmpty("tom and jerry", "and"));
+TEST_CASE("string::splitAndTrimRemovingEmpty", "[test split with trim removing empty strings]") {
+  std::vector<std::string> expected{"tom", "jerry"};
+  REQUIRE(expected == string::splitAndTrimRemovingEmpty("tom and jerry", "and"));
   expected = {};
-  REQUIRE(expected == StringUtils::splitAndTrimRemovingEmpty("and", "and"));
-  REQUIRE(expected == StringUtils::splitAndTrimRemovingEmpty("andand", "and"));
+  REQUIRE(expected == string::splitAndTrimRemovingEmpty("and", "and"));
+  REQUIRE(expected == string::splitAndTrimRemovingEmpty("andand", "and"));
   expected = {"stan", "pan"};
-  REQUIRE(expected == StringUtils::splitAndTrimRemovingEmpty("stan and pan and ", "and"));
+  REQUIRE(expected == string::splitAndTrimRemovingEmpty("stan and pan and ", "and"));
   expected = {};
-  REQUIRE(expected == StringUtils::splitAndTrimRemovingEmpty(" and ", "and"));
+  REQUIRE(expected == string::splitAndTrimRemovingEmpty(" and ", "and"));
   expected = {"a", "b", "c"};
-  REQUIRE(expected == StringUtils::splitAndTrimRemovingEmpty("a and ... b and ...  c", "and ..."));
+  REQUIRE(expected == string::splitAndTrimRemovingEmpty("a and ... b and ...  c", "and ..."));
 }
 
-TEST_CASE("StringUtils::replaceEnvironmentVariables works correctly", "[replaceEnvironmentVariables]") {
+TEST_CASE("string::replaceEnvironmentVariables works correctly", "[replaceEnvironmentVariables]") {
   utils::Environment::setEnvironmentVariable("blahblahnamenamenotexist", "computer", false);
 
-  REQUIRE("hello world computer" == StringUtils::replaceEnvironmentVariables("hello world ${blahblahnamenamenotexist}"));
-  REQUIRE("hello world ${blahblahnamenamenotexist" == StringUtils::replaceEnvironmentVariables("hello world ${blahblahnamenamenotexist"));
-  REQUIRE("hello world $computer" == StringUtils::replaceEnvironmentVariables("hello world $${blahblahnamenamenotexist}"));
-  REQUIRE("hello world ${blahblahnamenamenotexist}" == StringUtils::replaceEnvironmentVariables("hello world \\${blahblahnamenamenotexist}"));
-  REQUIRE("the computer costs $123" == StringUtils::replaceEnvironmentVariables("the ${blahblahnamenamenotexist} costs \\$123"));
-  REQUIRE("computer bug" == StringUtils::replaceEnvironmentVariables("${blahblahnamenamenotexist} bug"));
-  REQUIRE("O computer! My computer!" == StringUtils::replaceEnvironmentVariables("O ${blahblahnamenamenotexist}! My ${blahblahnamenamenotexist}!"));
+  REQUIRE("hello world computer" == string::replaceEnvironmentVariables("hello world ${blahblahnamenamenotexist}"));
+  REQUIRE("hello world ${blahblahnamenamenotexist" == string::replaceEnvironmentVariables("hello world ${blahblahnamenamenotexist"));
+  REQUIRE("hello world $computer" == string::replaceEnvironmentVariables("hello world $${blahblahnamenamenotexist}"));
+  REQUIRE("hello world ${blahblahnamenamenotexist}" == string::replaceEnvironmentVariables("hello world \\${blahblahnamenamenotexist}"));
+  REQUIRE("the computer costs $123" == string::replaceEnvironmentVariables("the ${blahblahnamenamenotexist} costs \\$123"));
+  REQUIRE("computer bug" == string::replaceEnvironmentVariables("${blahblahnamenamenotexist} bug"));
+  REQUIRE("O computer! My computer!" == string::replaceEnvironmentVariables("O ${blahblahnamenamenotexist}! My ${blahblahnamenamenotexist}!"));
 
   utils::Environment::setEnvironmentVariable("blahblahnamenamenotexist_2", "no", false);
-  REQUIRE("computer says 'no'" == StringUtils::replaceEnvironmentVariables("${blahblahnamenamenotexist} says '${blahblahnamenamenotexist_2}'"));
-  REQUIRE("no computer can say no to computer nougats" == StringUtils::replaceEnvironmentVariables(
+  REQUIRE("computer says 'no'" == string::replaceEnvironmentVariables("${blahblahnamenamenotexist} says '${blahblahnamenamenotexist_2}'"));
+  REQUIRE("no computer can say no to computer nougats" == string::replaceEnvironmentVariables(
       "${blahblahnamenamenotexist_2} ${blahblahnamenamenotexist} can say ${blahblahnamenamenotexist_2} to ${blahblahnamenamenotexist} ${blahblahnamenamenotexist_2}ugats"));
 
-  REQUIRE("hello world ${}" == StringUtils::replaceEnvironmentVariables("hello world ${}"));
-  REQUIRE("hello world " == StringUtils::replaceEnvironmentVariables("hello world ${blahblahnamenamenotexist_reallydoesnotexist}"));
+  REQUIRE("hello world ${}" == string::replaceEnvironmentVariables("hello world ${}"));
+  REQUIRE("hello world " == string::replaceEnvironmentVariables("hello world ${blahblahnamenamenotexist_reallydoesnotexist}"));
 }
 
-TEST_CASE("TestStringUtils::testJoin", "[test string join]") {
+TEST_CASE("test string::testJoin", "[test string join]") {
   std::set<std::string> strings = {"3", "2", "1"};
-  CHECK(StringUtils::join(",", strings) == "1,2,3");
+  CHECK(string::join(",", strings) == "1,2,3");
 
   std::wstring sep = L"é";
   std::vector<std::wstring> wstrings = {L"1", L"2"};
-  CHECK(StringUtils::join(sep, wstrings) == L"1é2");
+  CHECK(string::join(sep, wstrings) == L"1é2");
 
   std::list<uint64_t> ulist = {1, 2};
-  CHECK(StringUtils::join(sep, ulist) == L"1é2");
+  CHECK(string::join(sep, ulist) == L"1é2");
 
-  CHECK(StringUtils::join(">", ulist) == "1>2");
+  CHECK(string::join(">", ulist) == "1>2");
 
-  CHECK(StringUtils::join("", ulist) == "12");
+  CHECK(string::join("", ulist) == "12");
 
-  CHECK(StringUtils::join("this separator wont appear", std::vector<std::string>()) == "");
+  CHECK(string::join("this separator wont appear", std::vector<std::string>()) == "");
 }
 
 TEST_CASE("Test the join function with a projection", "[join][projection]") {
-  std::vector<std::string> fruits = { "APPLE", "OrAnGe" };
-  CHECK(StringUtils::join(", ", fruits, [](auto fruit) { return StringUtils::toLower(fruit); }) == "apple, orange");
+  std::vector<std::string> fruits = {"APPLE", "OrAnGe"};
+  CHECK(string::join(", ", fruits, [](auto fruit) { return string::toLower(fruit); }) == "apple, orange");
 
-  std::set numbers_set = { 3, 2, 1 };
-  CHECK(StringUtils::join(", ", numbers_set, [](auto x) { return std::to_string(x); }) == "1, 2, 3");
+  std::set numbers_set = {3, 2, 1};
+  CHECK(string::join(", ", numbers_set, [](auto x) { return std::to_string(x); }) == "1, 2, 3");
 
   std::wstring sep = L"é";
-  std::vector numbers_vector = { 1,  2 };
-  CHECK(StringUtils::join(sep, numbers_vector, [](auto x) { return std::to_wstring(x); }) == L"1é2");
+  std::vector numbers_vector = {1, 2};
+  CHECK(string::join(sep, numbers_vector, [](auto x) { return std::to_wstring(x); }) == L"1é2");
 
-  std::list<uint64_t> numbers_list = { 1, 2, 3 };
-  CHECK(StringUtils::join(", ", numbers_list, [](auto x) { return std::to_string(x * x); }) == "1, 4, 9");
+  std::list<uint64_t> numbers_list = {1, 2, 3};
+  CHECK(string::join(", ", numbers_list, [](auto x) { return std::to_string(x * x); }) == "1, 4, 9");
 
-  CHECK(StringUtils::join(std::string_view{"-"}, numbers_list, [](auto x) { return std::to_string(5 * x); }) == "5-10-15");
+  CHECK(string::join(std::string_view{"-"}, numbers_list, [](auto x) { return std::to_string(5 * x); }) == "5-10-15");
 
-  CHECK(StringUtils::join(std::string{}, numbers_list, [](auto x) { return '<' + std::to_string(x) + '>'; }) == "<1><2><3>");
+  CHECK(string::join(std::string{}, numbers_list, [](auto x) { return '<' + std::to_string(x) + '>'; }) == "<1><2><3>");
 
-  CHECK(StringUtils::join("this separator wont appear", std::vector<int>{}, [](int) { return std::string_view{"foo"}; }) == "");
+  CHECK(string::join("this separator wont appear", std::vector<int>{}, [](int) { return std::string_view{"foo"}; }) == "");
 }
 
-TEST_CASE("TestStringUtils::trim", "[test trim]") {
-  REQUIRE("" == StringUtils::trim(""));
-  REQUIRE("" == StringUtils::trim(" \n\t"));
-  REQUIRE("foobar" == StringUtils::trim("foobar"));
-  REQUIRE("foo bar" == StringUtils::trim("foo bar"));
-  REQUIRE("foobar" == StringUtils::trim("foobar "));
-  REQUIRE("foobar" == StringUtils::trim(" foobar"));
-  REQUIRE("foobar" == StringUtils::trim("foobar  "));
-  REQUIRE("foobar" == StringUtils::trim("  foobar"));
-  REQUIRE("foobar" == StringUtils::trim("  foobar  "));
-  REQUIRE("foobar" == StringUtils::trim(" \n\tfoobar\n\t "));
+TEST_CASE("test string::trim", "[test trim]") {
+  REQUIRE("" == string::trim(""));
+  REQUIRE("" == string::trim(" \n\t"));
+  REQUIRE("foobar" == string::trim("foobar"));
+  REQUIRE("foo bar" == string::trim("foo bar"));
+  REQUIRE("foobar" == string::trim("foobar "));
+  REQUIRE("foobar" == string::trim(" foobar"));
+  REQUIRE("foobar" == string::trim("foobar  "));
+  REQUIRE("foobar" == string::trim("  foobar"));
+  REQUIRE("foobar" == string::trim("  foobar  "));
+  REQUIRE("foobar" == string::trim(" \n\tfoobar\n\t "));
 
-  REQUIRE("" == StringUtils::trimRight(" \n\t"));
-  REQUIRE("foobar" == StringUtils::trimRight("foobar"));
-  REQUIRE("foo bar" == StringUtils::trimRight("foo bar"));
-  REQUIRE("foobar" == StringUtils::trimRight("foobar "));
-  REQUIRE(" foobar" == StringUtils::trimRight(" foobar"));
-  REQUIRE("foobar" == StringUtils::trimRight("foobar  "));
-  REQUIRE("  foobar" == StringUtils::trimRight("  foobar"));
-  REQUIRE("  foobar" == StringUtils::trimRight("  foobar  "));
-  REQUIRE(" \n\tfoobar" == StringUtils::trimRight(" \n\tfoobar\n\t "));
+  REQUIRE("" == string::trimRight(" \n\t"));
+  REQUIRE("foobar" == string::trimRight("foobar"));
+  REQUIRE("foo bar" == string::trimRight("foo bar"));
+  REQUIRE("foobar" == string::trimRight("foobar "));
+  REQUIRE(" foobar" == string::trimRight(" foobar"));
+  REQUIRE("foobar" == string::trimRight("foobar  "));
+  REQUIRE("  foobar" == string::trimRight("  foobar"));
+  REQUIRE("  foobar" == string::trimRight("  foobar  "));
+  REQUIRE(" \n\tfoobar" == string::trimRight(" \n\tfoobar\n\t "));
 
-  REQUIRE("" == StringUtils::trimLeft(" \n\t"));
-  REQUIRE("foobar" == StringUtils::trimLeft("foobar"));
-  REQUIRE("foo bar" == StringUtils::trimLeft("foo bar"));
-  REQUIRE("foobar " == StringUtils::trimLeft("foobar "));
-  REQUIRE("foobar" == StringUtils::trimLeft(" foobar"));
-  REQUIRE("foobar  " == StringUtils::trimLeft("foobar  "));
-  REQUIRE("foobar" == StringUtils::trimLeft("  foobar"));
-  REQUIRE("foobar  " == StringUtils::trimLeft("  foobar  "));
-  REQUIRE("foobar\n\t " == StringUtils::trimLeft(" \n\tfoobar\n\t "));
+  REQUIRE("" == string::trimLeft(" \n\t"));
+  REQUIRE("foobar" == string::trimLeft("foobar"));
+  REQUIRE("foo bar" == string::trimLeft("foo bar"));
+  REQUIRE("foobar " == string::trimLeft("foobar "));
+  REQUIRE("foobar" == string::trimLeft(" foobar"));
+  REQUIRE("foobar  " == string::trimLeft("foobar  "));
+  REQUIRE("foobar" == string::trimLeft("  foobar"));
+  REQUIRE("foobar  " == string::trimLeft("  foobar  "));
+  REQUIRE("foobar\n\t " == string::trimLeft(" \n\tfoobar\n\t "));
 }
 
-TEST_CASE("TestStringUtils::startsWith - case sensitive", "[test startsWith]") {
-  REQUIRE(StringUtils::startsWith("abcd", ""));
-  REQUIRE(StringUtils::startsWith("abcd", "a"));
-  REQUIRE(!StringUtils::startsWith("Abcd", "a"));
-  REQUIRE(!StringUtils::startsWith("abcd", "A"));
-  REQUIRE(StringUtils::startsWith("abcd", "abcd"));
-  REQUIRE(StringUtils::startsWith("abcd", "abc"));
-  REQUIRE(!StringUtils::startsWith("abcd", "abcde"));
+TEST_CASE("test string::startsWith - case sensitive", "[test startsWith]") {
+  REQUIRE(string::startsWith("abcd", ""));
+  REQUIRE(string::startsWith("abcd", "a"));
+  REQUIRE(!string::startsWith("Abcd", "a"));
+  REQUIRE(!string::startsWith("abcd", "A"));
+  REQUIRE(string::startsWith("abcd", "abcd"));
+  REQUIRE(string::startsWith("abcd", "abc"));
+  REQUIRE(!string::startsWith("abcd", "abcde"));
 
-  REQUIRE(StringUtils::startsWith("", ""));
-  REQUIRE(!StringUtils::startsWith("", "abcd"));
-  REQUIRE(!StringUtils::startsWith("abcd", "b"));
-  REQUIRE(!StringUtils::startsWith("abcd", "d"));
+  REQUIRE(string::startsWith("", ""));
+  REQUIRE(!string::startsWith("", "abcd"));
+  REQUIRE(!string::startsWith("abcd", "b"));
+  REQUIRE(!string::startsWith("abcd", "d"));
 }
 
-TEST_CASE("TestStringUtils::endsWith - case sensitive", "[test endsWith]") {
-  REQUIRE(StringUtils::endsWith("abcd", ""));
-  REQUIRE(StringUtils::endsWith("abcd", "d"));
-  REQUIRE(!StringUtils::endsWith("abcD", "d"));
-  REQUIRE(!StringUtils::endsWith("abcd", "D"));
-  REQUIRE(StringUtils::endsWith("abcd", "abcd"));
-  REQUIRE(StringUtils::endsWith("abcd", "bcd"));
-  REQUIRE(!StringUtils::endsWith("abcd", "1abcd"));
+TEST_CASE("test string::endsWith - case sensitive", "[test endsWith]") {
+  REQUIRE(string::endsWith("abcd", ""));
+  REQUIRE(string::endsWith("abcd", "d"));
+  REQUIRE(!string::endsWith("abcD", "d"));
+  REQUIRE(!string::endsWith("abcd", "D"));
+  REQUIRE(string::endsWith("abcd", "abcd"));
+  REQUIRE(string::endsWith("abcd", "bcd"));
+  REQUIRE(!string::endsWith("abcd", "1abcd"));
 
-  REQUIRE(StringUtils::endsWith("", ""));
-  REQUIRE(!StringUtils::endsWith("", "abcd"));
-  REQUIRE(!StringUtils::endsWith("abcd", "c"));
-  REQUIRE(!StringUtils::endsWith("abcd", "a"));
+  REQUIRE(string::endsWith("", ""));
+  REQUIRE(!string::endsWith("", "abcd"));
+  REQUIRE(!string::endsWith("abcd", "c"));
+  REQUIRE(!string::endsWith("abcd", "a"));
 }
 
-TEST_CASE("TestStringUtils::startsWith - case insensitive", "[test startsWith case insensitive]") {
-  REQUIRE(StringUtils::startsWith("abcd", "", false));
-  REQUIRE(StringUtils::startsWith("abcd", "a", false));
-  REQUIRE(StringUtils::startsWith("Abcd", "a", false));
-  REQUIRE(StringUtils::startsWith("abcd", "A", false));
-  REQUIRE(StringUtils::startsWith("aBcd", "abCd", false));
-  REQUIRE(StringUtils::startsWith("abcd", "abc", false));
-  REQUIRE(!StringUtils::startsWith("abcd", "abcde", false));
+TEST_CASE("test string::startsWith - case insensitive", "[test startsWith case insensitive]") {
+  REQUIRE(string::startsWith("abcd", "", false));
+  REQUIRE(string::startsWith("abcd", "a", false));
+  REQUIRE(string::startsWith("Abcd", "a", false));
+  REQUIRE(string::startsWith("abcd", "A", false));
+  REQUIRE(string::startsWith("aBcd", "abCd", false));
+  REQUIRE(string::startsWith("abcd", "abc", false));
+  REQUIRE(!string::startsWith("abcd", "abcde", false));
 
-  REQUIRE(StringUtils::startsWith("", "", false));
-  REQUIRE(!StringUtils::startsWith("", "abcd", false));
-  REQUIRE(!StringUtils::startsWith("abcd", "b", false));
-  REQUIRE(!StringUtils::startsWith("abcd", "d", false));
+  REQUIRE(string::startsWith("", "", false));
+  REQUIRE(!string::startsWith("", "abcd", false));
+  REQUIRE(!string::startsWith("abcd", "b", false));
+  REQUIRE(!string::startsWith("abcd", "d", false));
 }
 
-TEST_CASE("TestStringUtils::endsWith - case insensitive", "[test endsWith case insensitive]") {
-  REQUIRE(StringUtils::endsWith("abcd", "", false));
-  REQUIRE(StringUtils::endsWith("abcd", "d", false));
-  REQUIRE(StringUtils::endsWith("abcd", "D", false));
-  REQUIRE(StringUtils::endsWith("abcD", "d", false));
-  REQUIRE(StringUtils::endsWith("abcd", "abcd", false));
-  REQUIRE(StringUtils::endsWith("aBcd", "bcD", false));
-  REQUIRE(!StringUtils::endsWith("abCd", "1aBcd", false));
+TEST_CASE("test string::endsWith - case insensitive", "[test endsWith case insensitive]") {
+  REQUIRE(string::endsWith("abcd", "", false));
+  REQUIRE(string::endsWith("abcd", "d", false));
+  REQUIRE(string::endsWith("abcd", "D", false));
+  REQUIRE(string::endsWith("abcD", "d", false));
+  REQUIRE(string::endsWith("abcd", "abcd", false));
+  REQUIRE(string::endsWith("aBcd", "bcD", false));
+  REQUIRE(!string::endsWith("abCd", "1aBcd", false));
 
-  REQUIRE(StringUtils::endsWith("", "", false));
-  REQUIRE(!StringUtils::endsWith("", "abcd", false));
-  REQUIRE(!StringUtils::endsWith("abcd", "c", false));
-  REQUIRE(!StringUtils::endsWith("abcd", "a", false));
+  REQUIRE(string::endsWith("", "", false));
+  REQUIRE(!string::endsWith("", "abcd", false));
+  REQUIRE(!string::endsWith("abcd", "c", false));
+  REQUIRE(!string::endsWith("abcd", "a", false));
 }
 
-TEST_CASE("TestStringUtils::toBool", "[test toBool]") {
+TEST_CASE("test string::toBool", "[test toBool]") {
   std::vector<std::pair<std::string, std::optional<bool>>> cases{
       {"", {}},
       {"true", true},
@@ -294,52 +293,52 @@ TEST_CASE("TestStringUtils::toBool", "[test toBool]") {
       {"\n \r FaLsE \t", false},
       {"not false", {}}
   };
-  for (const auto& test_case : cases) {
-    REQUIRE(StringUtils::toBool(test_case.first) == test_case.second);
+  for (const auto& test_case: cases) {
+    REQUIRE(string::toBool(test_case.first) == test_case.second);
   }
 }
 
-TEST_CASE("TestStringUtils::testHexEncode", "[test hex encode]") {
-  REQUIRE("" == StringUtils::to_hex(""));
-  REQUIRE("6f" == StringUtils::to_hex("o"));
-  REQUIRE("666f6f626172" == StringUtils::to_hex("foobar"));
-  REQUIRE("000102030405060708090a0b0c0d0e0f" == StringUtils::to_hex(gsl::make_span(std::vector<uint8_t>{
+TEST_CASE("test string::testHexEncode", "[test hex encode]") {
+  REQUIRE("" == string::to_hex(""));
+  REQUIRE("6f" == string::to_hex("o"));
+  REQUIRE("666f6f626172" == string::to_hex("foobar"));
+  REQUIRE("000102030405060708090a0b0c0d0e0f" == string::to_hex(gsl::make_span(std::vector<uint8_t>{
       0x00, 0x01, 0x02, 0x03,
       0x04, 0x05, 0x06, 0x07,
       0x08, 0x09, 0x0a, 0x0b,
       0x0c, 0x0d, 0x0e, 0x0f}).as_span<const std::byte>()));
-  REQUIRE("6F" == StringUtils::to_hex("o", true /*uppercase*/));
-  REQUIRE("666F6F626172" == StringUtils::to_hex("foobar", true /*uppercase*/));
-  REQUIRE("000102030405060708090A0B0C0D0E0F" == StringUtils::to_hex(gsl::make_span(std::vector<uint8_t>{
+  REQUIRE("6F" == string::to_hex("o", true /*uppercase*/));
+  REQUIRE("666F6F626172" == string::to_hex("foobar", true /*uppercase*/));
+  REQUIRE("000102030405060708090A0B0C0D0E0F" == string::to_hex(gsl::make_span(std::vector<uint8_t>{
       0x00, 0x01, 0x02, 0x03,
       0x04, 0x05, 0x06, 0x07,
       0x08, 0x09, 0x0a, 0x0b,
       0x0c, 0x0d, 0x0e, 0x0f}).as_span<const std::byte>(), true /*uppercase*/));
 }
 
-TEST_CASE("TestStringUtils::testHexDecode", "[test hex decode]") {
-  REQUIRE(StringUtils::from_hex("").empty());
-  REQUIRE("o" == StringUtils::from_hex("6f", utils::as_string));
-  REQUIRE("o" == StringUtils::from_hex("6F", utils::as_string));
-  REQUIRE("foobar" == StringUtils::from_hex("666f6f626172", utils::as_string));
-  REQUIRE("foobar" == StringUtils::from_hex("666F6F626172", utils::as_string));
-  REQUIRE("foobar" == StringUtils::from_hex("66:6F:6F:62:61:72", utils::as_string));
-  REQUIRE("foobar" == StringUtils::from_hex("66 6F 6F 62 61 72", utils::as_string));
+TEST_CASE("test string::testHexDecode", "[test hex decode]") {
+  REQUIRE(string::from_hex("").empty());
+  REQUIRE("o" == string::from_hex("6f", utils::as_string));
+  REQUIRE("o" == string::from_hex("6F", utils::as_string));
+  REQUIRE("foobar" == string::from_hex("666f6f626172", utils::as_string));
+  REQUIRE("foobar" == string::from_hex("666F6F626172", utils::as_string));
+  REQUIRE("foobar" == string::from_hex("66:6F:6F:62:61:72", utils::as_string));
+  REQUIRE("foobar" == string::from_hex("66 6F 6F 62 61 72", utils::as_string));
   REQUIRE(std::string({0x00, 0x01, 0x02, 0x03,
-                       0x04, 0x05, 0x06, 0x07,
-                       0x08, 0x09, 0x0a, 0x0b,
-                       0x0c, 0x0d, 0x0e, 0x0f}) == StringUtils::from_hex("000102030405060708090a0b0c0d0e0f", utils::as_string));
+      0x04, 0x05, 0x06, 0x07,
+      0x08, 0x09, 0x0a, 0x0b,
+      0x0c, 0x0d, 0x0e, 0x0f}) == string::from_hex("000102030405060708090a0b0c0d0e0f", utils::as_string));
   REQUIRE(std::string({0x00, 0x01, 0x02, 0x03,
-                       0x04, 0x05, 0x06, 0x07,
-                       0x08, 0x09, 0x0a, 0x0b,
-                       0x0c, 0x0d, 0x0e, 0x0f}) == StringUtils::from_hex("000102030405060708090A0B0C0D0E0F", utils::as_string));
+      0x04, 0x05, 0x06, 0x07,
+      0x08, 0x09, 0x0a, 0x0b,
+      0x0c, 0x0d, 0x0e, 0x0f}) == string::from_hex("000102030405060708090A0B0C0D0E0F", utils::as_string));
 
-  REQUIRE_THROWS_WITH(StringUtils::from_hex("666f6f62617"), "Hexencoded string is malformed");
-  REQUIRE_THROWS_WITH(StringUtils::from_hex("666f6f6261 7"), "Hexencoded string is malformed");
+  REQUIRE_THROWS_WITH(string::from_hex("666f6f62617"), "Hexencoded string is malformed");
+  REQUIRE_THROWS_WITH(string::from_hex("666f6f6261 7"), "Hexencoded string is malformed");
 }
 
-TEST_CASE("TestStringUtils::testHexEncodeDecode", "[test hex encode decode]") {
-  std::mt19937 gen(std::random_device { }());
+TEST_CASE("test string::testHexEncodeDecode", "[test hex encode decode]") {
+  std::mt19937 gen(std::random_device{}());
   for (size_t i = 0U; i < 1024U; i++) {
     const bool uppercase = gen() % 2;
     const size_t length = gen() % 1024;
@@ -347,27 +346,27 @@ TEST_CASE("TestStringUtils::testHexEncodeDecode", "[test hex encode decode]") {
     std::generate_n(data.begin(), data.size(), [&]() -> std::byte {
       return static_cast<std::byte>(gen() % 256);
     });
-    auto hex = utils::StringUtils::to_hex(data, uppercase);
-    REQUIRE(data == utils::StringUtils::from_hex(hex));
+    auto hex = string::to_hex(data, uppercase);
+    REQUIRE(data == string::from_hex(hex));
   }
 }
 
-TEST_CASE("TestStringUtils::testBase64Encode", "[test base64 encode]") {
-  REQUIRE("" == StringUtils::to_base64(""));
+TEST_CASE("test string::testBase64Encode", "[test base64 encode]") {
+  REQUIRE("" == string::to_base64(""));
 
-  REQUIRE("bw==" == StringUtils::to_base64("o"));
-  REQUIRE("b28=" == StringUtils::to_base64("oo"));
-  REQUIRE("b29v" == StringUtils::to_base64("ooo"));
-  REQUIRE("b29vbw==" == StringUtils::to_base64("oooo"));
-  REQUIRE("b29vb28=" == StringUtils::to_base64("ooooo"));
-  REQUIRE("b29vb29v" == StringUtils::to_base64("oooooo"));
+  REQUIRE("bw==" == string::to_base64("o"));
+  REQUIRE("b28=" == string::to_base64("oo"));
+  REQUIRE("b29v" == string::to_base64("ooo"));
+  REQUIRE("b29vbw==" == string::to_base64("oooo"));
+  REQUIRE("b29vb28=" == string::to_base64("ooooo"));
+  REQUIRE("b29vb29v" == string::to_base64("oooooo"));
 
-  REQUIRE("bw" == StringUtils::to_base64("o", false /*url*/, false /*padded*/));
-  REQUIRE("b28" == StringUtils::to_base64("oo", false /*url*/, false /*padded*/));
-  REQUIRE("b29v" == StringUtils::to_base64("ooo", false /*url*/, false /*padded*/));
-  REQUIRE("b29vbw" == StringUtils::to_base64("oooo", false /*url*/, false /*padded*/));
-  REQUIRE("b29vb28" == StringUtils::to_base64("ooooo", false /*url*/, false /*padded*/));
-  REQUIRE("b29vb29v" == StringUtils::to_base64("oooooo", false /*url*/, false /*padded*/));
+  REQUIRE("bw" == string::to_base64("o", false /*url*/, false /*padded*/));
+  REQUIRE("b28" == string::to_base64("oo", false /*url*/, false /*padded*/));
+  REQUIRE("b29v" == string::to_base64("ooo", false /*url*/, false /*padded*/));
+  REQUIRE("b29vbw" == string::to_base64("oooo", false /*url*/, false /*padded*/));
+  REQUIRE("b29vb28" == string::to_base64("ooooo", false /*url*/, false /*padded*/));
+  REQUIRE("b29vb29v" == string::to_base64("oooooo", false /*url*/, false /*padded*/));
 
   std::vector<uint8_t> message{
       0x00, 0x10, 0x83, 0x10,
@@ -384,21 +383,21 @@ TEST_CASE("TestStringUtils::testBase64Encode", "[test base64 encode]") {
       0xbb, 0xf3, 0xdf, 0xbf};
 
   REQUIRE("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/" ==
-      StringUtils::to_base64(as_bytes(std::span(message))));
+      string::to_base64(as_bytes(std::span(message))));
   REQUIRE("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_" ==
-      StringUtils::to_base64(as_bytes(std::span(message)), true /*url*/));
+      string::to_base64(as_bytes(std::span(message)), true /*url*/));
 }
 
-TEST_CASE("TestStringUtils::testBase64Decode", "[test base64 decode]") {
-  REQUIRE(StringUtils::from_base64("", as_string).empty());
-  REQUIRE("o" == StringUtils::from_base64("bw==", as_string));
-  REQUIRE("oo" == StringUtils::from_base64("b28=", as_string));
-  REQUIRE("ooo" == StringUtils::from_base64("b29v", as_string));
-  REQUIRE("oooo" == StringUtils::from_base64("b29vbw==", as_string));
-  REQUIRE("ooooo" == StringUtils::from_base64("b29vb28=", as_string));
-  REQUIRE("oooooo" == StringUtils::from_base64("b29vb29v", as_string));
-  REQUIRE("\xfb\xff\xbf" == StringUtils::from_base64("-_-_", as_string));
-  REQUIRE("\xfb\xff\xbf" == StringUtils::from_base64("+/+/", as_string));
+TEST_CASE("test string::testBase64Decode", "[test base64 decode]") {
+  REQUIRE(string::from_base64("", as_string).empty());
+  REQUIRE("o" == string::from_base64("bw==", as_string));
+  REQUIRE("oo" == string::from_base64("b28=", as_string));
+  REQUIRE("ooo" == string::from_base64("b29v", as_string));
+  REQUIRE("oooo" == string::from_base64("b29vbw==", as_string));
+  REQUIRE("ooooo" == string::from_base64("b29vb28=", as_string));
+  REQUIRE("oooooo" == string::from_base64("b29vb29v", as_string));
+  REQUIRE("\xfb\xff\xbf" == string::from_base64("-_-_", as_string));
+  REQUIRE("\xfb\xff\xbf" == string::from_base64("+/+/", as_string));
   std::string expected = {
       '\x00', '\x10', '\x83', '\x10',
       '\x51', '\x87', '\x20', '\x92',
@@ -413,28 +412,28 @@ TEST_CASE("TestStringUtils::testBase64Decode", "[test base64 decode]") {
       '\x5d', '\xb7', '\xe3', '\x9e',
       '\xbb', '\xf3', '\xdf', '\xbf'};
 
-  REQUIRE(expected == StringUtils::from_base64("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/", as_string));
-  REQUIRE(expected == StringUtils::from_base64("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_", as_string));
+  REQUIRE(expected == string::from_base64("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/", as_string));
+  REQUIRE(expected == string::from_base64("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_", as_string));
 
-  REQUIRE("foobarbuzz" == StringUtils::from_base64("Zm9vYmFyYnV6eg==", as_string));
-  REQUIRE("foobarbuzz"== StringUtils::from_base64("\r\nZm9vYmFyYnV6eg==", as_string));
-  REQUIRE("foobarbuzz" == StringUtils::from_base64("Zm9\r\nvYmFyYnV6eg==", as_string));
-  REQUIRE("foobarbuzz" == StringUtils::from_base64("Zm\r9vYmFy\n\n\n\n\n\n\n\nYnV6eg==", as_string));
-  REQUIRE("foobarbuzz" == StringUtils::from_base64("\nZ\nm\n9\nv\nY\nm\nF\ny\nY\nn\nV\n6\ne\ng\n=\n=\n", as_string));
+  REQUIRE("foobarbuzz" == string::from_base64("Zm9vYmFyYnV6eg==", as_string));
+  REQUIRE("foobarbuzz" == string::from_base64("\r\nZm9vYmFyYnV6eg==", as_string));
+  REQUIRE("foobarbuzz" == string::from_base64("Zm9\r\nvYmFyYnV6eg==", as_string));
+  REQUIRE("foobarbuzz" == string::from_base64("Zm\r9vYmFy\n\n\n\n\n\n\n\nYnV6eg==", as_string));
+  REQUIRE("foobarbuzz" == string::from_base64("\nZ\nm\n9\nv\nY\nm\nF\ny\nY\nn\nV\n6\ne\ng\n=\n=\n", as_string));
 
-  REQUIRE_THROWS_WITH(StringUtils::from_base64("a"), "Base64 encoded string is malformed");
-  REQUIRE_THROWS_WITH(StringUtils::from_base64("aaaaa"), "Base64 encoded string is malformed");
-  REQUIRE_THROWS_WITH(StringUtils::from_base64("aa="), "Base64 encoded string is malformed");
-  REQUIRE_THROWS_WITH(StringUtils::from_base64("aaaaaa="), "Base64 encoded string is malformed");
-  REQUIRE_THROWS_WITH(StringUtils::from_base64("aa==?"), "Base64 encoded string is malformed");
-  REQUIRE_THROWS_WITH(StringUtils::from_base64("aa==a"), "Base64 encoded string is malformed");
-  REQUIRE_THROWS_WITH(StringUtils::from_base64("aa==="), "Base64 encoded string is malformed");
-  REQUIRE_THROWS_WITH(StringUtils::from_base64("?"), "Base64 encoded string is malformed");
-  REQUIRE_THROWS_WITH(StringUtils::from_base64("aaaa?"), "Base64 encoded string is malformed");
+  REQUIRE_THROWS_WITH(string::from_base64("a"), "Base64 encoded string is malformed");
+  REQUIRE_THROWS_WITH(string::from_base64("aaaaa"), "Base64 encoded string is malformed");
+  REQUIRE_THROWS_WITH(string::from_base64("aa="), "Base64 encoded string is malformed");
+  REQUIRE_THROWS_WITH(string::from_base64("aaaaaa="), "Base64 encoded string is malformed");
+  REQUIRE_THROWS_WITH(string::from_base64("aa==?"), "Base64 encoded string is malformed");
+  REQUIRE_THROWS_WITH(string::from_base64("aa==a"), "Base64 encoded string is malformed");
+  REQUIRE_THROWS_WITH(string::from_base64("aa==="), "Base64 encoded string is malformed");
+  REQUIRE_THROWS_WITH(string::from_base64("?"), "Base64 encoded string is malformed");
+  REQUIRE_THROWS_WITH(string::from_base64("aaaa?"), "Base64 encoded string is malformed");
 }
 
-TEST_CASE("TestStringUtils::testBase64EncodeDecode", "[test base64 encode decode]") {
-  std::mt19937 gen(std::random_device { }());
+TEST_CASE("test string::testBase64EncodeDecode", "[test base64 encode decode]") {
+  std::mt19937 gen(std::random_device{}());
   for (size_t i = 0U; i < 1024U; i++) {
     const bool url = gen() % 2;
     const bool padded = gen() % 2;
@@ -443,53 +442,53 @@ TEST_CASE("TestStringUtils::testBase64EncodeDecode", "[test base64 encode decode
     std::generate_n(data.begin(), data.size(), [&]() -> std::byte {
       return static_cast<std::byte>(gen() % 256);
     });
-    auto base64 = utils::StringUtils::to_base64(data, url, padded);
-    REQUIRE(data == utils::StringUtils::from_base64(base64));
+    auto base64 = string::to_base64(data, url, padded);
+    REQUIRE(data == string::from_base64(base64));
   }
 }
 
-TEST_CASE("TestStringUtils::testJoinPack", "[test join_pack]") {
+TEST_CASE("test string::testJoinPack", "[test join_pack]") {
   std::string stdstr = "std::string";
   const char* cstr = "c string";
   const char carr[] = "char array";
-  REQUIRE(utils::StringUtils::join_pack("rvalue c string, ", cstr, std::string{ ", rval std::string, " }, stdstr, ", ", carr)
-              == "rvalue c string, c string, rval std::string, std::string, char array");
+  REQUIRE(string::join_pack("rvalue c string, ", cstr, std::string{", rval std::string, "}, stdstr, ", ", carr)
+      == "rvalue c string, c string, rval std::string, std::string, char array");
 }
 
-TEST_CASE("TestStringUtils::testJoinPackWstring", "[test join_pack wstring]") {
+TEST_CASE("test string::testJoinPackWstring", "[test join_pack wstring]") {
   std::wstring stdstr = L"std::string";
   const wchar_t* cstr = L"c string";
   const wchar_t carr[] = L"char array";
-  REQUIRE(utils::StringUtils::join_pack(L"rvalue c string, ", cstr, std::wstring{ L", rval std::string, " }, stdstr, L", ", carr)
-              == L"rvalue c string, c string, rval std::string, std::string, char array");
+  REQUIRE(string::join_pack(L"rvalue c string, ", cstr, std::wstring{L", rval std::string, "}, stdstr, L", ", carr)
+      == L"rvalue c string, c string, rval std::string, std::string, char array");
 }
 
 /* doesn't and shouldn't compile
-TEST_CASE("TestStringUtils::testJoinPackNegative", "[test join_pack negative]") {
+TEST_CASE("test string::testJoinPackNegative", "[test join_pack negative]") {
   std::wstring stdstr = L"std::string";
   const wchar_t* cstr = L"c string";
   const wchar_t carr[] = L"char array";
-  REQUIRE(utils::StringUtils::join_pack("rvalue c string, ", cstr, std::string{ ", rval std::string, " }, stdstr, ", ", carr)
+  REQUIRE(string::join_pack("rvalue c string, ", cstr, std::string{ ", rval std::string, " }, stdstr, ", ", carr)
               == "rvalue c string, c string, rval std::string, std::string, char array");
 }
  */
 
-TEST_CASE("StringUtils::replaceOne works correctly", "[replaceOne]") {
-  REQUIRE(utils::StringUtils::replaceOne("", "x", "y") == "");
-  REQUIRE(utils::StringUtils::replaceOne("banana", "a", "_") == "b_nana");
-  REQUIRE(utils::StringUtils::replaceOne("banana", "b", "_") == "_anana");
-  REQUIRE(utils::StringUtils::replaceOne("banana", "x", "y") == "banana");
-  REQUIRE(utils::StringUtils::replaceOne("banana", "an", "") == "bana");
-  REQUIRE(utils::StringUtils::replaceOne("banana", "an", "AN") == "bANana");
-  REQUIRE(utils::StringUtils::replaceOne("banana", "an", "***") == "b***ana");
-  REQUIRE(utils::StringUtils::replaceOne("banana", "banana", "kiwi") == "kiwi");
-  REQUIRE(utils::StringUtils::replaceOne("banana", "banana", "grapefruit") == "grapefruit");
-  REQUIRE(utils::StringUtils::replaceOne("fruit", "", "grape") == "grapefruit");
+TEST_CASE("string::replaceOne works correctly", "[replaceOne]") {
+  REQUIRE(string::replaceOne("", "x", "y") == "");
+  REQUIRE(string::replaceOne("banana", "a", "_") == "b_nana");
+  REQUIRE(string::replaceOne("banana", "b", "_") == "_anana");
+  REQUIRE(string::replaceOne("banana", "x", "y") == "banana");
+  REQUIRE(string::replaceOne("banana", "an", "") == "bana");
+  REQUIRE(string::replaceOne("banana", "an", "AN") == "bANana");
+  REQUIRE(string::replaceOne("banana", "an", "***") == "b***ana");
+  REQUIRE(string::replaceOne("banana", "banana", "kiwi") == "kiwi");
+  REQUIRE(string::replaceOne("banana", "banana", "grapefruit") == "grapefruit");
+  REQUIRE(string::replaceOne("fruit", "", "grape") == "grapefruit");
 }
 
-TEST_CASE("StringUtils::replaceAll works correctly", "[replaceAll]") {
-  auto replaceAll = [](std::string input, const std::string &from, const std::string &to) -> std::string {
-    return utils::StringUtils::replaceAll(input, from, to);
+TEST_CASE("string::replaceAll works correctly", "[replaceAll]") {
+  auto replaceAll = [](std::string input, const std::string& from, const std::string& to) -> std::string {
+    return string::replaceAll(input, from, to);
   };
   REQUIRE(replaceAll("", "x", "y") == "");
   REQUIRE(replaceAll("banana", "a", "_") == "b_n_n_");
@@ -504,99 +503,101 @@ TEST_CASE("StringUtils::replaceAll works correctly", "[replaceAll]") {
   REQUIRE(replaceAll("banana", "", "") == "banana");
 }
 
-TEST_CASE("StringUtils::countOccurrences works correctly", "[countOccurrences]") {
-  REQUIRE(utils::StringUtils::countOccurrences("", "a") == std::make_pair(size_t{0}, 0));
-  REQUIRE(utils::StringUtils::countOccurrences("abc", "a") == std::make_pair(size_t{0}, 1));
-  REQUIRE(utils::StringUtils::countOccurrences("abc", "b") == std::make_pair(size_t{1}, 1));
-  REQUIRE(utils::StringUtils::countOccurrences("abc", "x") == std::make_pair(size_t{0}, 0));
-  REQUIRE(utils::StringUtils::countOccurrences("banana", "a") == std::make_pair(size_t{5}, 3));
-  REQUIRE(utils::StringUtils::countOccurrences("banana", "an") == std::make_pair(size_t{3}, 2));
-  REQUIRE(utils::StringUtils::countOccurrences("aaaaaaaa", "aaa") == std::make_pair(size_t{3}, 2));  // overlapping occurrences are not counted
-  REQUIRE(utils::StringUtils::countOccurrences("abc", "") == std::make_pair(size_t{3}, 4));  // "" occurs at the start, between chars, and at the end
-  REQUIRE(utils::StringUtils::countOccurrences("", "") == std::make_pair(size_t{0}, 1));
+TEST_CASE("string::countOccurrences works correctly", "[countOccurrences]") {
+  REQUIRE(string::countOccurrences("", "a") == std::make_pair(size_t{0}, 0));
+  REQUIRE(string::countOccurrences("abc", "a") == std::make_pair(size_t{0}, 1));
+  REQUIRE(string::countOccurrences("abc", "b") == std::make_pair(size_t{1}, 1));
+  REQUIRE(string::countOccurrences("abc", "x") == std::make_pair(size_t{0}, 0));
+  REQUIRE(string::countOccurrences("banana", "a") == std::make_pair(size_t{5}, 3));
+  REQUIRE(string::countOccurrences("banana", "an") == std::make_pair(size_t{3}, 2));
+  REQUIRE(string::countOccurrences("aaaaaaaa", "aaa") == std::make_pair(size_t{3}, 2));  // overlapping occurrences are not counted
+  REQUIRE(string::countOccurrences("abc", "") == std::make_pair(size_t{3}, 4));  // "" occurs at the start, between chars, and at the end
+  REQUIRE(string::countOccurrences("", "") == std::make_pair(size_t{0}, 1));
 }
 
-TEST_CASE("StringUtils::removeFramingCharacters works correctly", "[removeFramingCharacters]") {
-  REQUIRE(utils::StringUtils::removeFramingCharacters("", 'a') == "");
-  REQUIRE(utils::StringUtils::removeFramingCharacters("a", 'a') == "a");
-  REQUIRE(utils::StringUtils::removeFramingCharacters("aa", 'a') == "");
-  REQUIRE(utils::StringUtils::removeFramingCharacters("\"abba\"", '"') == "abba");
-  REQUIRE(utils::StringUtils::removeFramingCharacters("\"\"abba\"\"", '"') == "\"abba\"");
+TEST_CASE("string::removeFramingCharacters works correctly", "[removeFramingCharacters]") {
+  REQUIRE(string::removeFramingCharacters("", 'a') == "");
+  REQUIRE(string::removeFramingCharacters("a", 'a') == "a");
+  REQUIRE(string::removeFramingCharacters("aa", 'a') == "");
+  REQUIRE(string::removeFramingCharacters("\"abba\"", '"') == "abba");
+  REQUIRE(string::removeFramingCharacters("\"\"abba\"\"", '"') == "\"abba\"");
 }
 
 // ignore terminating \0 character
 template<size_t N>
-std::span<const std::byte> from_cstring(const char (&str)[N]) {
-  return as_bytes(std::span<const char>(str, N-1));
+std::span<const std::byte> from_cstring(const char (& str)[N]) {
+  return as_bytes(std::span<const char>(str, N - 1));
 }
 
-TEST_CASE("StringUtils::escapeUnprintableBytes", "[escapeUnprintableBytes]") {
-  REQUIRE(StringUtils::escapeUnprintableBytes(from_cstring("abcd")) == "abcd");
-  REQUIRE(StringUtils::escapeUnprintableBytes(from_cstring("ab\n\r\t\v\fde")) == "ab\\n\\r\\t\\v\\fde");
-  REQUIRE(StringUtils::escapeUnprintableBytes(from_cstring("ab\x00""c\x01""d")) == "ab\\x00c\\x01d");
+TEST_CASE("string::escapeUnprintableBytes", "[escapeUnprintableBytes]") {
+  REQUIRE(string::escapeUnprintableBytes(from_cstring("abcd")) == "abcd");
+  REQUIRE(string::escapeUnprintableBytes(from_cstring("ab\n\r\t\v\fde")) == "ab\\n\\r\\t\\v\\fde");
+  REQUIRE(string::escapeUnprintableBytes(from_cstring("ab\x00""c\x01""d")) == "ab\\x00c\\x01d");
 }
 
-TEST_CASE("StringUtils::matchesSequence works correctly", "[matchesSequence]") {
-  REQUIRE(StringUtils::matchesSequence("abcdef", {"abc", "def"}));
-  REQUIRE(!StringUtils::matchesSequence("abcef", {"abc", "def"}));
-  REQUIRE(StringUtils::matchesSequence("xxxabcxxxdefxxx", {"abc", "def"}));
-  REQUIRE(!StringUtils::matchesSequence("defabc", {"abc", "def"}));
-  REQUIRE(StringUtils::matchesSequence("xxxabcxxxabcxxxdefxxx", {"abc", "def"}));
-  REQUIRE(StringUtils::matchesSequence("xxxabcxxxabcxxxdefxxx", {"abc", "abc", "def"}));
-  REQUIRE(!StringUtils::matchesSequence("xxxabcxxxdefxxx", {"abc", "abc", "def"}));
+TEST_CASE("string::matchesSequence works correctly", "[matchesSequence]") {
+  REQUIRE(string::matchesSequence("abcdef", {"abc", "def"}));
+  REQUIRE(!string::matchesSequence("abcef", {"abc", "def"}));
+  REQUIRE(string::matchesSequence("xxxabcxxxdefxxx", {"abc", "def"}));
+  REQUIRE(!string::matchesSequence("defabc", {"abc", "def"}));
+  REQUIRE(string::matchesSequence("xxxabcxxxabcxxxdefxxx", {"abc", "def"}));
+  REQUIRE(string::matchesSequence("xxxabcxxxabcxxxdefxxx", {"abc", "abc", "def"}));
+  REQUIRE(!string::matchesSequence("xxxabcxxxdefxxx", {"abc", "abc", "def"}));
 }
 
-TEST_CASE("StringUtils::toLower and toUpper tests") {
-  CHECK(StringUtils::toUpper("Lorem ipsum dolor sit amet") == "LOREM IPSUM DOLOR SIT AMET");
-  CHECK(StringUtils::toLower("Lorem ipsum dolor sit amet") == "lorem ipsum dolor sit amet");
+TEST_CASE("string::toLower and toUpper tests") {
+  CHECK(string::toUpper("Lorem ipsum dolor sit amet") == "LOREM IPSUM DOLOR SIT AMET");
+  CHECK(string::toLower("Lorem ipsum dolor sit amet") == "lorem ipsum dolor sit amet");
 
-  CHECK(StringUtils::toUpper("SuSpenDISse") == "SUSPENDISSE");
-  CHECK(StringUtils::toLower("SuSpenDISse") == "suspendisse");
+  CHECK(string::toUpper("SuSpenDISse") == "SUSPENDISSE");
+  CHECK(string::toLower("SuSpenDISse") == "suspendisse");
 }
 
-TEST_CASE("StringUtils::splitToValueAndUnit tests") {
+TEST_CASE("string::splitToValueAndUnit tests") {
   int64_t value;
   std::string unit_str;
   SECTION("Simple case") {
-    CHECK(StringUtils::splitToValueAndUnit("1 horse", value, unit_str));
+    CHECK(string::splitToValueAndUnit("1 horse", value, unit_str));
     CHECK(value == 1);
     CHECK(unit_str == "horse");
   }
 
   SECTION("Without whitespace") {
-    CHECK(StringUtils::splitToValueAndUnit("112KiB", value, unit_str));
+    CHECK(string::splitToValueAndUnit("112KiB", value, unit_str));
     CHECK(value == 112);
     CHECK(unit_str == "KiB");
   }
 
   SECTION("Additional whitespace in the middle") {
-    CHECK(StringUtils::splitToValueAndUnit("100    hOrSe", value, unit_str));
+    CHECK(string::splitToValueAndUnit("100    hOrSe", value, unit_str));
     CHECK(value == 100);
     CHECK(unit_str == "hOrSe");
   }
 
   SECTION("Invalid value") {
-    CHECK_FALSE(StringUtils::splitToValueAndUnit("one horse", value, unit_str));
+    CHECK_FALSE(string::splitToValueAndUnit("one horse", value, unit_str));
   }
 
   SECTION("Empty string") {
-    CHECK_FALSE(StringUtils::splitToValueAndUnit("", value, unit_str));
+    CHECK_FALSE(string::splitToValueAndUnit("", value, unit_str));
   }
 }
 
-TEST_CASE("StringUtils::parseCharacter tests") {
-  CHECK(StringUtils::parseCharacter("a") == 'a');
-  CHECK(StringUtils::parseCharacter("\\n") == '\n');
-  CHECK(StringUtils::parseCharacter("\\t") == '\t');
-  CHECK(StringUtils::parseCharacter("\\r") == '\r');
-  CHECK(StringUtils::parseCharacter("\\s") == 's');
-  CHECK(StringUtils::parseCharacter("\\'") == '\'');
-  CHECK(StringUtils::parseCharacter("\\") == '\\');
-  CHECK(StringUtils::parseCharacter("\\?") == '\?');
+TEST_CASE("string::parseCharacter tests") {
+  CHECK(string::parseCharacter("a") == 'a');
+  CHECK(string::parseCharacter("\\n") == '\n');
+  CHECK(string::parseCharacter("\\t") == '\t');
+  CHECK(string::parseCharacter("\\r") == '\r');
+  CHECK(string::parseCharacter("\\s") == 's');
+  CHECK(string::parseCharacter("\\'") == '\'');
+  CHECK(string::parseCharacter("\\") == '\\');
+  CHECK(string::parseCharacter("\\?") == '\?');
 
-  CHECK_FALSE(StringUtils::parseCharacter("abc").has_value());
-  CHECK_FALSE(StringUtils::parseCharacter("\\nd").has_value());
-  CHECK(StringUtils::parseCharacter("") == std::nullopt);
+  CHECK_FALSE(string::parseCharacter("abc").has_value());
+  CHECK_FALSE(string::parseCharacter("\\nd").has_value());
+  CHECK(string::parseCharacter("") == std::nullopt);
 }
+
+}  // namespace org::apache::nifi::minifi::utils
 
 // NOLINTEND(readability-container-size-empty)


### PR DESCRIPTION
- Marked a few implementations as `constexpr` (implies `inline`) or `inline`, where appropriate
- Removed a few unused string utilities
- Changed a few implementations to use `std::string_view` instead of `const std::string&`.
- Rewritten repeat, because this seemed easier than fixing it.
- (Resisted the urge to rewrite join_pack with concepts instead of metaprogramming hacks)

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
