### PR TITLE
MINIFICPP-2227 Upgrade docker base image to alpine:3.18

### DIFF
--- a/cmake/BundledLibcURL.cmake
+++ b/cmake/BundledLibcURL.cmake
@@ -42,6 +42,8 @@ function(use_bundled_curl SOURCE_DIR BINARY_DIR)
             -DCURL_DISABLE_CRYPTO_AUTH=ON
             -DCURL_CA_PATH=none
             -DCURL_USE_LIBSSH2=OFF
+            -DUSE_LIBIDN2=OFF
+            -DCURL_USE_LIBPSL=OFF
             -DCMAKE_DEBUG_POSTFIX=
             -DHAVE_GLIBC_STRERROR_R=1
             -DHAVE_GLIBC_STRERROR_R__TRYRUN_OUTPUT=""

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 #
 
-ARG BASE_IMAGE="alpine:3.17"
+ARG BASE_IMAGE="alpine:3.18"
 
 # Build image
 FROM ${BASE_IMAGE} AS build


### PR DESCRIPTION
The same linking issue is present on arch linux, so libidn2 and libpsl are turned off when building curl.

https://issues.apache.org/jira/browse/MINIFICPP-2227

------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
