### PR TITLE
MINIFICPP-2233 Upgrade bustache to fix gcc13 compatibility

### DIFF
--- a/cmake/Bustache.cmake
+++ b/cmake/Bustache.cmake
@@ -21,6 +21,6 @@ include(fmt)
 set(BUSTACHE_USE_FMT ON CACHE STRING "" FORCE)
 FetchContent_Declare(Bustache
         GIT_REPOSITORY  https://github.com/jamboree/bustache.git
-        GIT_TAG         ee39a375d49677af9728722bfabf63eaed3c82fd
+        GIT_TAG         47096caa8e1f9f7ebe34e3a022dbb822c174011d
 )
 FetchContent_MakeAvailable(Bustache)


### PR DESCRIPTION
We should use the latest commit which includes https://github.com/jamboree/bustache/pull/35
This fixes gcc13 compatibility 
https://github.com/apache/nifi-minifi-cpp/actions/runs/6327016378 vs
https://github.com/martinzink/nifi-minifi-cpp/actions/runs/6348941850


---
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
