### PR TITLE
MINIFICPP-2238 Disable pull request updates to issues@nifi.apache.org

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -32,5 +32,4 @@ github:
 notifications:
     commits:      commits@nifi.apache.org
     issues:       issues@nifi.apache.org
-    pullrequests: issues@nifi.apache.org
     jira_options: link label worklog


### PR DESCRIPTION
GitHub is already sending PR updates to subscribed people. I feel like we shouldn't spam the issues@ list with these.

These emails started appearing today for some reason, despite the config having been there for some time. 

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
