### PR TITLE
MINIFICPP-2242 Fix ccache path setting in CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,12 @@ env:
     -DENABLE_SPLUNK=ON -DENABLE_GCP=ON -DENABLE_OPC=ON -DENABLE_PYTHON_SCRIPTING=ON -DENABLE_LUA_SCRIPTING=ON -DENABLE_KUBERNETES=ON -DENABLE_TEST_PROCESSORS=ON -DENABLE_PROMETHEUS=ON \
     -DENABLE_ELASTICSEARCH=OFF -DDOCKER_BUILD_ONLY=ON
   SCCACHE_GHA_ENABLE: true
+  CCACHE_DIR: ${{ GITHUB.WORKSPACE }}/.ccache
 jobs:
   macos_xcode:
     name: "macos-xcode"
     runs-on: macos-13
     timeout-minutes: 180
-    env:
-      CCACHE_BASEDIR: ${{ GITHUB.WORKSPACE }}
-      CCACHE_DIR: ${{ GITHUB.WORKSPACE }}/.ccache
     steps:
       - id: checkout
         uses: actions/checkout@v3
@@ -133,7 +131,7 @@ jobs:
       - name: cache restore
         uses: actions/cache/restore@v3
         with:
-          path: ~/.ccache
+          path: ${{ env.CCACHE_DIR }}
           key: ubuntu-20.04-ccache-${{github.ref}}-${{github.sha}}
           restore-keys: |
             ubuntu-20.04-ccache-${{github.ref}}-
@@ -158,7 +156,7 @@ jobs:
         uses: actions/cache/save@v3
         if: always()
         with:
-          path: ~/.ccache
+          path: ${{ env.CCACHE_DIR }}
           key: ubuntu-20.04-ccache-${{github.ref}}-${{github.sha}}
       - name: test
         id: test
@@ -190,7 +188,7 @@ jobs:
       - name: cache restore
         uses: actions/cache/restore@v3
         with:
-          path: ~/.ccache
+          path: ${{ env.CCACHE_DIR }}
           key: ubuntu-22.04-all-clang-ccache-${{github.ref}}-${{github.sha}}
           restore-keys: |
             ubuntu-22.04-all-clang-ccache-${{github.ref}}-
@@ -234,7 +232,7 @@ jobs:
         uses: actions/cache/save@v3
         if: always()
         with:
-          path: ~/.ccache
+          path: ${{ env.CCACHE_DIR }}
           key: ubuntu-22.04-all-clang-ccache-${{github.ref}}-${{github.sha}}
       - name: test
         id: test
@@ -291,7 +289,7 @@ jobs:
       - name: cache restore
         uses: actions/cache/restore@v3
         with:
-          path: ~/.ccache
+          path: ${{ env.CCACHE_DIR }}
           key: centos-ccache-${{github.ref}}-${{github.sha}}
           restore-keys: |
             centos-ccache-${{github.ref}}-
@@ -313,18 +311,17 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - id: build
         run: |
-          if [ -d ~/.ccache ]; then mv ~/.ccache .; fi
           # centos build can run out of the github runners' disk space if built with RelWithDebInfo so we keep the Release build here
           mkdir build && cd build && cmake -DUSE_SHARED_LIBS=ON -DCI_BUILD=ON -DCMAKE_BUILD_TYPE=Release -DSTRICT_GSL_CHECKS=AUDIT -DFAIL_ON_WARNINGS=ON -DENABLE_AWS=ON -DENABLE_AZURE=ON \
               -DENABLE_COAP=ON -DENABLE_ENCRYPT_CONFIG=ON -DENABLE_GPS=ON -DENABLE_LIBRDKAFKA=ON -DENABLE_MQTT=ON -DENABLE_NANOFI=ON -DENABLE_OPC=ON \
               -DENABLE_OPENCV=ON -DENABLE_OPENWSMAN=ON -DENABLE_OPS=ON -DENABLE_SENSORS=ON -DENABLE_SQL=ON -DENABLE_SYSTEMD=ON \
               -DENABLE_USB_CAMERA=ON -DENABLE_PYTHON_SCRIPTING=ON -DENABLE_LUA_SCRIPTING=ON -DENABLE_KUBERNETES=ON -DENABLE_GCP=ON -DENABLE_PROCFS=ON -DENABLE_PROMETHEUS=ON \
-              -DENABLE_ELASTICSEARCH=ON -DDOCKER_SKIP_TESTS=OFF -DDOCKER_BUILD_ONLY=ON -DDOCKER_CCACHE_DUMP_LOCATION=$HOME/.ccache .. && make centos-test
+              -DENABLE_ELASTICSEARCH=ON -DDOCKER_SKIP_TESTS=OFF -DDOCKER_BUILD_ONLY=ON -DDOCKER_CCACHE_DUMP_LOCATION=${{ env.CCACHE_DIR }} .. && make centos-test
       - name: cache save
         uses: actions/cache/save@v3
         if: always()
         with:
-          path: ~/.ccache
+          path: ${{ env.CCACHE_DIR }}
           key: centos-ccache-${{github.ref}}-${{github.sha}}
       - id: test
         run: |
@@ -362,23 +359,22 @@ jobs:
       - name: cache restore
         uses: actions/cache/restore@v3
         with:
-          path: ~/.ccache
+          path: ${{ env.CCACHE_DIR }}
           key: docker-ccache-${{github.ref}}-${{github.sha}}
           restore-keys: |
             docker-ccache-${{github.ref}}-
             docker-ccache-refs/heads/main
       - id: build
         run: |
-          if [ -d ~/.ccache ]; then mv ~/.ccache .; fi
           mkdir build
           cd build
-          cmake ${DOCKER_CMAKE_FLAGS} -DDOCKER_CCACHE_DUMP_LOCATION=$HOME/.ccache ..
+          cmake ${DOCKER_CMAKE_FLAGS} -DDOCKER_CCACHE_DUMP_LOCATION=${{ env.CCACHE_DIR }} ..
           make docker
       - name: cache save
         uses: actions/cache/save@v3
         if: always()
         with:
-          path: ~/.ccache
+          path: ${{ env.CCACHE_DIR }}
           key: docker-ccache-${{github.ref}}-${{github.sha}}
       - name: Save docker image
         run: cd build && docker save -o minifi_docker.tar apacheminificpp:$(grep CMAKE_PROJECT_VERSION:STATIC CMakeCache.txt | cut -d "=" -f2)


### PR DESCRIPTION
According to the [ccache documentation](https://ccache.dev/manual/4.5.1.html) in newer ccache versions the legacy `$HOME/.ccache` directory for cache storage is only used if the directory is present on the system. Otherwise the new default  `$HOME/.cache/ccache` is used or the path set in the `CCACHE_DIR` environment variable.

`CCACHE_DIR` is set to `${{ GITHUB.WORKSPACE }}/.ccache` for all jobs for uniformity.

--------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
