### PR TITLE
MINIFICPP-2226 Fix LoggerTests flakiness

### DIFF
--- a/libminifi/include/core/logging/internal/LogCompressorSink.h
+++ b/libminifi/include/core/logging/internal/LogCompressorSink.h
@@ -33,13 +33,7 @@
 
 class LoggerTestAccessor;
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
-namespace core {
-namespace logging {
-namespace internal {
+namespace org::apache::nifi::minifi::core::logging::internal {
 
 struct LogQueueSize {
   size_t max_total_size;
@@ -54,7 +48,7 @@ class LogCompressorSink : public spdlog::sinks::base_sink<std::mutex> {
   void flush_() override;
 
  public:
-  explicit LogCompressorSink(LogQueueSize cache_size, LogQueueSize compressed_size, std::shared_ptr<logging::Logger> logger);
+  LogCompressorSink(LogQueueSize cache_size, LogQueueSize compressed_size, const std::shared_ptr<logging::Logger>& logger);
   ~LogCompressorSink() override;
 
   template<class Rep, class Period>
@@ -107,6 +101,7 @@ class LogCompressorSink : public spdlog::sinks::base_sink<std::mutex> {
 
   std::atomic<bool> running_{true};
   std::thread compression_thread_;
+  std::mutex compress_mutex_;
 
   utils::StagingQueue<LogBuffer> cached_logs_;
   utils::StagingQueue<ActiveCompressor, ActiveCompressor::Allocator> compressed_logs_;
@@ -114,10 +109,4 @@ class LogCompressorSink : public spdlog::sinks::base_sink<std::mutex> {
   std::shared_ptr<logging::Logger> compressor_logger_;
 };
 
-}  // namespace internal
-}  // namespace logging
-}  // namespace core
-}  // namespace minifi
-}  // namespace nifi
-}  // namespace apache
-}  // namespace org
+}  // namespace org::apache::nifi::minifi::core::logging::internal


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-2226

- don't use the static LoggerConfiguration instance, use our own instance instead
- do not call compress(), as that will conflict with the compress() calls in the background thread; wait for the background thread to finish instead
- add mutex to compress(), as it it called both from `run()` and `getContent()` in `LogCompressorSink`, and these are on different threads
- add `LogTestController::getInstance().clear()` calls to isolate tests from each other
- use different logger names in each test, because reusing the same name causes problems
- add a missing `return false` in LogCompressorSink.cpp

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
