### PR TITLE
MINIFICPP-2248 Refactor string::join_pack

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,2 +1,2 @@
 set noparent
-filter=-runtime/reference,-runtime/string,-build/c++11,-build/include_subdir,-whitespace/forcolon,-build/namespaces_literals,-readability/check,-build/include_what_you_use,-readability/nolint
+filter=-runtime/reference,-runtime/string,-build/c++11,-build/include_subdir,-whitespace/forcolon,-build/namespaces_literals,-readability/check,-build/include_what_you_use,-readability/nolint,-readability/braces

--- a/cmake/RangeV3.cmake
+++ b/cmake/RangeV3.cmake
@@ -22,6 +22,3 @@ FetchContent_Declare(range-v3_src
     URL_HASH SHA256=015adb2300a98edfceaf0725beec3337f542af4915cec4d0b89fa0886f4ba9cb
 )
 FetchContent_MakeAvailable(range-v3_src)
-
-# for better error messages
-target_compile_options(range-v3 INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-fconcepts>)

--- a/libminifi/test/unit/StringUtilsTests.cpp
+++ b/libminifi/test/unit/StringUtilsTests.cpp
@@ -458,6 +458,8 @@ TEST_CASE("test string::testJoinPack", "[test join_pack]") {
   const char carr[] = "char array";  // NOLINT(cppcoreguidelines-avoid-c-arrays): testing const char[] on purpose
   REQUIRE(string::join_pack("rvalue c string, ", cstr, std::string{", rval std::string, "}, stdstr, ", ", strview, ", ", carr)
       == "rvalue c string, c string, rval std::string, std::string, std::string_view, char array");
+
+  STATIC_REQUIRE(string::join_pack(std::string{"a"}, std::string_view{"b"}, "c") == "abc");
 }
 
 TEST_CASE("test string::testJoinPackWstring", "[test join_pack wstring]") {
@@ -469,15 +471,17 @@ TEST_CASE("test string::testJoinPackWstring", "[test join_pack wstring]") {
       == L"rvalue c string, c string, rval std::string, std::string, std::string_view, char array");
 }
 
-/* doesn't and shouldn't compile
-TEST_CASE("test string::testJoinPackNegative", "[test join_pack negative]") {
-  std::wstring stdstr = L"std::string";
-  const wchar_t* cstr = L"c string";
-  const wchar_t carr[] = L"char array";
-  REQUIRE(string::join_pack("rvalue c string, ", cstr, std::string{ ", rval std::string, " }, stdstr, ", ", carr)
-              == "rvalue c string, c string, rval std::string, std::string, char array");
+namespace detail {
+template<typename... Strs>
+concept join_pack_works_with_args = requires(Strs...) {
+  string::join_pack(Strs{}...);
+};
+}  // namespace detail
+
+TEST_CASE("test string::join_pack negative", "[test join_pack negative]") {
+  // join_pack can't combine different char types
+  STATIC_REQUIRE(!detail::join_pack_works_with_args<const char*&&, const wchar_t*&, std::string, std::wstring, const char*, const wchar_t[]>);  // NOLINT: testing C array
 }
- */
 
 TEST_CASE("string::replaceOne works correctly", "[replaceOne]") {
   REQUIRE(string::replaceOne("", "x", "y") == "");

--- a/libminifi/test/unit/StringUtilsTests.cpp
+++ b/libminifi/test/unit/StringUtilsTests.cpp
@@ -459,7 +459,12 @@ TEST_CASE("test string::testJoinPack", "[test join_pack]") {
   REQUIRE(string::join_pack("rvalue c string, ", cstr, std::string{", rval std::string, "}, stdstr, ", ", strview, ", ", carr)
       == "rvalue c string, c string, rval std::string, std::string, std::string_view, char array");
 
+  // clang can't use the constexpr string implementation of libstdc++
+#if defined(__cpp_lib_constexpr_string) && __cpp_lib_constexpr_string >= 201907L && (!defined(__clang__) || defined(_LIBCPP_VERSION))
   STATIC_REQUIRE(string::join_pack(std::string{"a"}, std::string_view{"b"}, "c") == "abc");
+#else
+  REQUIRE(string::join_pack(std::string{"a"}, std::string_view{"b"}, "c") == "abc");
+#endif
 }
 
 TEST_CASE("test string::testJoinPackWstring", "[test join_pack wstring]") {

--- a/libminifi/test/unit/StringUtilsTests.cpp
+++ b/libminifi/test/unit/StringUtilsTests.cpp
@@ -478,13 +478,12 @@ TEST_CASE("test string::testJoinPackWstring", "[test join_pack wstring]") {
 
 namespace detail {
 template<typename... Strs>
-concept join_pack_works_with_args = requires(Strs...) {
-  string::join_pack(Strs{}...);
+concept join_pack_works_with_args = requires(Strs... strs) {
+  string::join_pack(strs...);
 };
 }  // namespace detail
 
-TEST_CASE("test string::join_pack negative", "[test join_pack negative]") {
-  // join_pack can't combine different char types
+TEST_CASE("test string::join_pack can't combine different char types", "[test join_pack negative][different char types]") {
   STATIC_REQUIRE(!detail::join_pack_works_with_args<const char*&&, const wchar_t*&, std::string, std::wstring, const char*, const wchar_t[]>);  // NOLINT: testing C array
 }
 

--- a/libminifi/test/unit/StringUtilsTests.cpp
+++ b/libminifi/test/unit/StringUtilsTests.cpp
@@ -484,7 +484,10 @@ concept join_pack_works_with_args = requires(Strs... strs) {
 }  // namespace detail
 
 TEST_CASE("test string::join_pack can't combine different char types", "[test join_pack negative][different char types]") {
-  STATIC_REQUIRE(!detail::join_pack_works_with_args<const char*&&, const wchar_t*&, std::string, std::wstring, const char*, const wchar_t[]>);  // NOLINT: testing C array
+  STATIC_CHECK(!detail::join_pack_works_with_args<const char*&&, const wchar_t*&, std::string, std::wstring, const char*, const wchar_t[]>);  // NOLINT: testing C array
+  STATIC_CHECK(!detail::join_pack_works_with_args<std::string, std::wstring>);
+  STATIC_CHECK(!detail::join_pack_works_with_args<std::wstring_view, std::string_view>);
+  STATIC_CHECK(!detail::join_pack_works_with_args<const char[], std::string, std::wstring>);  // NOLINT: testing C array
 }
 
 TEST_CASE("string::replaceOne works correctly", "[replaceOne]") {


### PR DESCRIPTION
+ remove obsolete `-fconcepts` flag from `RangeV3.cmake`
+ disable `readability/braces` of cpplint, because it can't handle concepts

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
