### PR TITLE
MINIFICPP-2252 Include all necessary DLLs in VS2022 builds

### DIFF
--- a/msi/WixWin.wsi
+++ b/msi/WixWin.wsi
@@ -384,12 +384,10 @@ Licensed to the Apache Software Foundation (ASF) under one or more
                 <File Id="MiNiFiExe_msvcp140_2" Name="msvcp140_2.dll" KeyPath="no" Source="redist\msvcp140_2.dll"/>
                 <File Id="MiNiFiExe_vccorlib140" Name="vccorlib140.dll" KeyPath="no" Source="redist\vccorlib140.dll"/>
                 <File Id="MiNiFiExe_vcruntime140" Name="vcruntime140.dll" KeyPath="no" Source="redist\vcruntime140.dll"/>
-                <?if $(env.VisualStudioVersion) = 16.0 ?>
-                  <File Id="MiNiFiExe_msvcp140_atomic_wait" Name="msvcp140_atomic_wait.dll" KeyPath="no" Source="redist\msvcp140_atomic_wait.dll"/>
-                  <File Id="MiNiFiExe_msvcp140_codecvt_ids" Name="msvcp140_codecvt_ids.dll" KeyPath="no" Source="redist\msvcp140_codecvt_ids.dll"/>
-                  <?if $(env.build_platform) = x64 ?>
-                    <File Id="MiNiFiExe_vcruntime140_1" Name="vcruntime140_1.dll" KeyPath="no" Source="redist\vcruntime140_1.dll"/>
-                  <?endif ?>
+                <File Id="MiNiFiExe_msvcp140_atomic_wait" Name="msvcp140_atomic_wait.dll" KeyPath="no" Source="redist\msvcp140_atomic_wait.dll"/>
+                <File Id="MiNiFiExe_msvcp140_codecvt_ids" Name="msvcp140_codecvt_ids.dll" KeyPath="no" Source="redist\msvcp140_codecvt_ids.dll"/>
+                <?if $(env.build_platform) = x64 ?>
+                  <File Id="MiNiFiExe_vcruntime140_1" Name="vcruntime140_1.dll" KeyPath="no" Source="redist\vcruntime140_1.dll"/>
                 <?endif ?>
               </Component>
 


### PR DESCRIPTION
A bug was introduced in [MINIFICPP-2185](https://issues.apache.org/jira/browse/MINIFICPP-2185) (#1635): some DLLs are only copied into the msi installer if the Visual Studio version is `= 16.0` (ie., VS2019) instead of `>= 16.0`, so these DLLs are missing from VS2022 builds.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
