### PR TITLE
MINIFICPP-2253 Remove conflicting Strawberry Perl tool executables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,10 @@ jobs:
           if ((Get-FileHash 'sqliteodbc_w64.exe').Hash -ne "0df79be4a4412542839ebf405b20d95a7dfc803da0b0b6b0dc653d30dc82ee84") {Write "Hash mismatch"; Exit 1}
           ./sqliteodbc_w64.exe /S
         shell: powershell
+      - id: remove-strawberry-perl-patch-exe
+        run: |
+          Remove-Item -Path "C:\Strawberry\c\bin" -Recurse -Force
+        shell: pwsh
       - name: build
         run: |
           for /f "usebackq delims=" %%i in (`vswhere.exe -latest -property installationPath`) do if exist "%%i\Common7\Tools\vsdevcmd.bat" call "%%i\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
         shell: powershell
       - id: remove-strawberry-perl-tool-executables
         run: |
+          # Remove conflicting Strawberry Perl executables like patch.exe and cmcldeps.exe (More information in the note under System Requirements in README.md)
           Remove-Item -Path "C:\Strawberry\c\bin" -Recurse -Force
         shell: pwsh
       - name: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           if ((Get-FileHash 'sqliteodbc_w64.exe').Hash -ne "0df79be4a4412542839ebf405b20d95a7dfc803da0b0b6b0dc653d30dc82ee84") {Write "Hash mismatch"; Exit 1}
           ./sqliteodbc_w64.exe /S
         shell: powershell
-      - id: remove-strawberry-perl-patch-exe
+      - id: remove-strawberry-perl-tool-executables
         run: |
           Remove-Item -Path "C:\Strawberry\c\bin" -Recurse -Force
         shell: pwsh


### PR DESCRIPTION
Unfortunately I could not find a way to remove a path from the PATH environment variable on the CI runners, it seems that only appending to it is possible through the GITHUB_PATH environment file. I removed the conflicting perl tool executables instead.

https://issues.apache.org/jira/browse/MINIFICPP-2253

-----------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
