### PR TITLE
MINIFICPP-2254 Fix template error in VS2022 build

### DIFF
--- a/libminifi/include/core/logging/Logger.h
+++ b/libminifi/include/core/logging/Logger.h
@@ -98,8 +98,8 @@ class BaseLogger {
   [[nodiscard]] virtual LOG_LEVEL level() const = 0;
 };
 
-const auto inline map_args = utils::overloaded {
-    [](std::invocable<> auto&& f) { return std::invoke(std::forward<decltype(f)>(f)); },
+inline constexpr auto map_args = utils::overloaded {
+    [](auto&& f) requires(std::is_invocable_v<decltype(f)>) { return std::invoke(std::forward<decltype(f)>(f)); },
     [](auto&& value) { return std::forward<decltype(value)>(value); }
 };
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-2254

The concept-based function overloading in map_args used to work in Visual Studio 2019, and also in Visual Studio 2022 up to version 19.35. Since version 19.36, it has stopped working. The version with requires instead of the concept works in all versions, up to 19.37.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
