### PR TITLE
MINIFICPP-2255 Fix MiNiFi CI badge status query in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 [<img src="https://nifi.apache.org/assets/images/minifi/minifi-logo.svg" width="300" height="126" alt="Apache NiFi MiNiFi"/>](https://nifi.apache.org/minifi/)
 
-# Apache NiFi -  MiNiFi - C++ ![MiNiFi-CPP CI](https://github.com/apache/nifi-minifi-cpp/workflows/MiNiFi-CPP%20CI/badge.svg?branch=main)
+# Apache NiFi -  MiNiFi - C++ [![MiNiFi-CPP CI](https://github.com/apache/nifi-minifi-cpp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/apache/nifi-minifi-cpp/actions/workflows/ci.yml?query=workflow%3A%22MiNiFi-CPP+CI%22+branch%3Amain)
 
 MiNiFi is a child project effort of Apache NiFi.  This repository is for a native implementation in C++.
 


### PR DESCRIPTION
According to the [Github documentation](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge) the `actions/workflows/<workflow yaml>` link should be used in the status badge instead of the `workflows/<workflow name>` link as the latter does not seem to filter the jobs correctly and seems to include the results of the eviction job too and shows the main branch to be passing in the CI while it is failing.

https://issues.apache.org/jira/browse/MINIFICPP-2255

-------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
