### PR TITLE
MINIFICPP-2269 upgrade xz/liblzma

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2663,7 +2663,10 @@ This enables machine processing of license information based on the SPDX
 License Identifiers that are here available: http://spdx.org/licenses/
 
 
-This product bundles 'liblzma' which is in the public domain.
+This product bundles 'liblzma' (from XZ Utils) which is in the public domain.
+more details:
+- https://github.com/tukaani-project/xz/blob/v5.4.5/COPYING
+- https://github.com/tukaani-project/xz/blob/v5.4.5/AUTHORS
 
 
 This product bundles 'bzip2' under a BSD-like licence:

--- a/NOTICE
+++ b/NOTICE
@@ -77,6 +77,7 @@ This software includes third party software subject to the following copyrights:
 - bitwizeshift.github.io - Copyright (c) 2020 Matthew Rodusek
 - magic_enum - Copyright (c) 2019 - 2023 Daniil Goncharov
 - argparse - Copyright (c) 2018 Pranav Srinivas Kumar <pranav.srinivas.kumar@gmail.com>
+- liblzma from xz-utils (tukaani-project/xz) - public domain, thanks to Lasse Collin, Jia Tan, Igor Pavlov, and other contributors
 
 The licenses for these third party components are included in LICENSE.txt
 

--- a/cmake/BundledLibLZMA.cmake
+++ b/cmake/BundledLibLZMA.cmake
@@ -41,8 +41,8 @@ function(use_bundled_liblzma SOURCE_DIR BINARY_DIR)
     endif()
 
     # Build project
-    set(LIBLZMA_URL https://tukaani.org/xz/xz-5.2.5.tar.gz https://gentoo.osuosl.org/distfiles/xz-5.2.5.tar.gz)
-    set(LIBLZMA_URL_HASH "SHA256=f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10")
+    set(LIBLZMA_URL "https://github.com/tukaani-project/xz/releases/download/v5.4.5/xz-5.4.5.tar.zst")
+    set(LIBLZMA_URL_HASH "SHA256=9ab5561ce9fed7860695c14b955a0ebec2df9a00fb171862a25910546a1737cc")
 
     if (WIN32)
         ExternalProject_Add(


### PR DESCRIPTION
Also changing the mirror to github, because the old ones are both unreliable.

I chose the zstd tarball: the size was close to the smallest xz/lzma one, but zstd is known for faster decompression times in exchange for a slightly larger size.

----

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
