### PR TITLE
MINIFICPP-2265 Implement AttributeRollingWindow and EL nextInt()

### DIFF
--- a/EXPRESSIONS.md
+++ b/EXPRESSIONS.md
@@ -225,6 +225,7 @@ token, filename.
 - [`UUID`](#uuid)
 - [`literal`](#literal)
 - [`reverseDnsLookup`](#reversednslookup)
+- [`nextInt`](#nextInt)
 
 ### Evaluating Multiple Attributes
 
@@ -258,7 +259,6 @@ token, filename.
 
 ### Subjectless Functions
 
-- `nextInt`
 - `getStateValue`
 
 ## Unsupported Features
@@ -950,7 +950,7 @@ filename.txt".
 
 **Arguments**: No arguments
 
-**Return Type**: String
+**Return Type**: Number
 
 **Examples**: If the attribute "filename" has a value of "a brand new
 filename.txt" and the attribute "hello" does not exist, then the Expression
@@ -1289,7 +1289,7 @@ found at the beginning of the Subject, the value returned will be `0`, not `1`.
 | - | - |
 | value | The value to search for in the Subject |
 
-**Return Type**: Boolean
+**Return Type**: Number
 
 **Examples**:
 
@@ -1320,7 +1320,7 @@ found at the beginning of the Subject, the value returned will be `0`, not `1`.
 | - | - |
 | value | The value to search for in the Subject |
 
-**Return Type**: Boolean
+**Return Type**: Number
 
 **Examples**:
 
@@ -1615,6 +1615,23 @@ more than 3 attributes whose names begin with the letter a.
 | `${reverseDnsLookup('::1')}`                       | `localhost`  |
 | `${reverseDnsLookup('2001:4860:4860::8888'), 100}` | `dns.google` |
 
+### nextInt
+
+**Description**: Returns a one-up value (starting at 0) and increasing over the
+lifetime of the running instance of MiNiFi. This value is not persisted across restarts.
+This counter is shared across all MiNiFi components, so calling this function multiple
+times from one Processor will not guarantee sequential values within the context of a
+particular Processor.
+
+**Subject Type**: No subject
+
+**Arguments**: No arguments
+
+**Return Type**: Number
+
+**Examples**: If the previous value returned by nextInt was 5, the Expression
+${nextInt():divide(2)} obtains the next available integer (6) and divides the result
+by 2, returning a value of 3.
 
 ## Evaluating Multiple Attributes
 

--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -17,6 +17,7 @@ limitations under the License.
 
 - [AppendHostInfo](#AppendHostInfo)
 - [ApplyTemplate](#ApplyTemplate)
+- [AttributeRollingWindow](#AttributeRollingWindow)
 - [AttributesToJSON](#AttributesToJSON)
 - [BinFiles](#BinFiles)
 - [CapturePacket](#CapturePacket)
@@ -145,6 +146,44 @@ In the list below, the names of required properties appear in bold. Any other pr
 | Name    | Description                            |
 |---------|----------------------------------------|
 | success | success operational on the flow record |
+
+
+## AttributeRollingWindow
+
+### Description
+
+Track a Rolling Window based on evaluating an Expression Language expression on each FlowFile. Each FlowFile will be emitted with the count of FlowFiles and total aggregate valueof values processed in the current window.
+
+### Properties
+
+In the list below, the names of required properties appear in bold. Any other properties (not in bold) are considered optional. The table also indicates any default values, and whether a property supports the NiFi Expression Language.
+
+| Name                      | Default Value   | Allowable Values | Description                                                                                                                                                                                      |
+|---------------------------|-----------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Value to track**        |                 |                  | The expression on which to evaluate each FlowFile. The result of the expression will be added to the rolling window value.<br/>**Supports Expression Language: true**                            |
+| Time window               |                 |                  | The amount of time for a rolling window. The format of the value is expected to be a count followed by a time unit. For example 5 millis, 10 secs, 1 min, 3 hours, 2 days, etc.                  |
+| **Window length**         | 0               |                  | The window length in number of values. Takes precedence over 'Time window'. If set to zero, the 'Time window' property is used instead.                                                          |
+| **Attribute name prefix** | rolling.window. |                  | The prefix to add to the generated attribute names. For example, if this is set to 'rolling.window.', then the full attribute names will be 'rolling.window.value', 'rolling.window.count', etc. |
+
+### Relationships
+
+| Name    | Description                                                                    |
+|---------|--------------------------------------------------------------------------------|
+| success | All FlowFiles that are successfully processed are routed to this relationship. |
+| failure | When a FlowFile fails, it is routed here.                                      |
+
+### Output Attributes
+
+| Attribute        | Relationship | Description                                            |
+|------------------|--------------|--------------------------------------------------------|
+| <prefix>count    | success      | Number of the values in the rolling window             |
+| <prefix>value    | success      | Sum of the values in the rolling window                |
+| <prefix>mean     | success      | Mean of the values in the rolling window               |
+| <prefix>median   | success      | Median of the values in the rolling window             |
+| <prefix>variance | success      | Variance of the values in the rolling window           |
+| <prefix>stddev   | success      | Standard deviation of the values in the rolling window |
+| <prefix>min      | success      | Smallest value in the rolling window                   |
+| <prefix>max      | success      | Largest value in the rolling window                    |
 
 
 ## AttributesToJSON

--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -152,7 +152,7 @@ In the list below, the names of required properties appear in bold. Any other pr
 
 ### Description
 
-Track a Rolling Window based on evaluating an Expression Language expression on each FlowFile. Each FlowFile will be emitted with the count of FlowFiles and total aggregate valueof values processed in the current window.
+Track a Rolling Window based on evaluating an Expression Language expression on each FlowFile. Each FlowFile will be emitted with the count of FlowFiles and total aggregate value of values processed in the current window.
 
 ### Properties
 

--- a/extensions/expression-language/Expression.cpp
+++ b/extensions/expression-language/Expression.cpp
@@ -1046,6 +1046,11 @@ Value expr_ifElse(const std::vector<Value> &args) {
   }
 }
 
+Value expr_nextInt(const std::vector<Value>&) {
+  static int64_t counter = 0;
+  return Value(counter++);
+}
+
 Expression make_allAttributes(const std::string &function_name, const std::vector<Expression> &args) {
   if (args.empty()) {
     std::stringstream message_ss;
@@ -1519,6 +1524,8 @@ Expression make_dynamic_function(const std::string &function_name, const std::ve
     return make_dynamic_function_incomplete<expr_toDate>(function_name, args, 0);
   } else if (function_name == "now") {
     return make_dynamic_function_incomplete<expr_now>(function_name, args, 0);
+  } else if (function_name == "nextInt") {
+    return make_dynamic_function_incomplete<expr_nextInt>(function_name, args, 0);
   } else {
     std::string msg("Unknown expression function: ");
     msg.append(function_name);

--- a/extensions/expression-language/Expression.cpp
+++ b/extensions/expression-language/Expression.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include <atomic>
 #include <chrono>
 #include <utility>
 #include <iostream>
@@ -1047,7 +1048,7 @@ Value expr_ifElse(const std::vector<Value> &args) {
 }
 
 Value expr_nextInt(const std::vector<Value>&) {
-  static int64_t counter = 0;
+  static std::atomic<int64_t> counter{0};
   return Value(counter++);
 }
 

--- a/extensions/standard-processors/CMakeLists.txt
+++ b/extensions/standard-processors/CMakeLists.txt
@@ -20,9 +20,10 @@
 
 include(${CMAKE_SOURCE_DIR}/extensions/ExtensionHeader.txt)
 
-file(GLOB SOURCES  "processors/*.cpp" "controllers/*.cpp" )
+file(GLOB SOURCES "processors/*.cpp" "controllers/*.cpp" )
 
 add_library(minifi-standard-processors SHARED ${SOURCES})
+target_include_directories(minifi-standard-processors PUBLIC "${CMAKE_SOURCE_DIR}/extensions/standard-processors")
 
 include(RangeV3)
 include(Asio)

--- a/extensions/standard-processors/RollingWindow.h
+++ b/extensions/standard-processors/RollingWindow.h
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <chrono>
+#include <mutex>
+#include <queue>
+#include <vector>
+
+namespace org::apache::nifi::minifi::processors::standard::utils {
+
+namespace detail {
+template<typename T, typename Container, typename Comparator>
+struct priority_queue : std::priority_queue<T, Container, Comparator> {
+  using std::priority_queue<T, Container, Comparator>::priority_queue;
+
+  // Expose the underlying container
+  const Container& get_container() const & { return this->c; }
+  Container get_container() && { return std::move(this->c); }
+};
+}  // namespace detail
+
+template<typename Timestamp, typename Value>
+class RollingWindow {
+ public:
+  struct Entry {
+    Timestamp timestamp{};
+    Value value{};
+  };
+  struct EntryComparator {
+    // greater-than, because std::priority_queue order is reversed. This way, top() is the oldest entry.
+    bool operator()(const Entry& lhs, const Entry& rhs) const {
+      return lhs.timestamp > rhs.timestamp;
+    }
+  };
+
+  void removeOlderThan(std::chrono::time_point<std::chrono::system_clock> timestamp) {
+    while (!state_.empty() && state_.top().timestamp < timestamp) {
+      state_.pop();
+    }
+  }
+
+  /** Remove the oldest entries until the size is <= size. */
+  void shrinkToSize(size_t size) {
+    while (state_.size() > size && !state_.empty()) {
+      state_.pop();
+    }
+  }
+
+  void add(Timestamp timestamp, Value value) { state_.push({timestamp, value}); }
+
+  std::vector<Entry> getEntries() const & { return state_.get_container(); }
+  std::vector<Entry> getEntries() && { return std::move(state_).get_container(); }
+ private:
+  detail::priority_queue<Entry, std::vector<Entry>, EntryComparator> state_;
+};
+
+}  // namespace org::apache::nifi::minifi::processors::standard::utils

--- a/extensions/standard-processors/RollingWindow.h
+++ b/extensions/standard-processors/RollingWindow.h
@@ -16,7 +16,6 @@
  */
 #pragma once
 
-#include <chrono>
 #include <mutex>
 #include <queue>
 #include <vector>
@@ -48,7 +47,7 @@ class RollingWindow {
     }
   };
 
-  void removeOlderThan(std::chrono::time_point<std::chrono::system_clock> timestamp) {
+  void removeOlderThan(Timestamp timestamp) {
     while (!state_.empty() && state_.top().timestamp < timestamp) {
       state_.pop();
     }

--- a/extensions/standard-processors/RollingWindow.h
+++ b/extensions/standard-processors/RollingWindow.h
@@ -55,7 +55,7 @@ class RollingWindow {
 
   /** Remove the oldest entries until the size is <= size. */
   void shrinkToSize(size_t size) {
-    while (state_.size() > size && !state_.empty()) {
+    while (state_.size() > size) {
       state_.pop();
     }
   }

--- a/extensions/standard-processors/RollingWindow.h
+++ b/extensions/standard-processors/RollingWindow.h
@@ -64,6 +64,7 @@ class RollingWindow {
 
   std::vector<Entry> getEntries() const & { return state_.get_container(); }
   std::vector<Entry> getEntries() && { return std::move(state_).get_container(); }
+
  private:
   detail::priority_queue<Entry, std::vector<Entry>, EntryComparator> state_;
 };

--- a/extensions/standard-processors/processors/AttributeRollingWindow.cpp
+++ b/extensions/standard-processors/processors/AttributeRollingWindow.cpp
@@ -1,0 +1,147 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "AttributeRollingWindow.h"
+#include <algorithm>
+#include <numeric>
+#include "core/ProcessContext.h"
+#include "core/ProcessSession.h"
+#include "core/Resource.h"
+#include "fmt/format.h"
+#include "utils/expected.h"
+#include "utils/OptionalUtils.h"
+
+namespace org::apache::nifi::minifi::processors {
+
+void AttributeRollingWindow::onSchedule(core::ProcessContext* context, core::ProcessSessionFactory*) {
+  gsl_Expects(context);
+  time_window_ = context->getProperty<core::TimePeriodValue>(TimeWindow)
+      | utils::transform(&core::TimePeriodValue::getMilliseconds);
+  window_length_ = context->getProperty<size_t>(WindowLength)
+      | utils::filter([](size_t value) { return value > 0; });
+  if (!time_window_ && !window_length_) {
+    throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, "Either 'Time window' or 'Window length' must be set"};
+  }
+  gsl_Ensures(runningInvariant());
+}
+
+void AttributeRollingWindow::addEntry(std::lock_guard<std::mutex>&,
+    std::chrono::time_point<std::chrono::system_clock> timestamp,
+    double value) {
+  state_.push({timestamp, value});
+}
+
+/**
+ * If the window length is set, remove the oldest entries from the state until the state size is less than or equal to the window length.
+ * If the time window is set, remove entries from the state until all entries are within the time window.
+ */
+void AttributeRollingWindow::removeOutdatedEntries(std::lock_guard<std::mutex>&,
+    std::chrono::time_point<std::chrono::system_clock> now) {
+  gsl_Expects(runningInvariant());
+  if (window_length_) {
+    // Normally this should only run once
+    while (state_.size() > *window_length_ && !state_.empty()) {
+      state_.pop();
+    }
+  } else if (time_window_) {
+    const auto oldest_allowed_timestamp = now - *time_window_;
+    while(!state_.empty() && state_.top().timestamp < oldest_allowed_timestamp) {
+      state_.pop();
+    }
+  }
+}
+
+namespace {
+template<typename T, typename Underlying, typename Comp>
+struct StateCopy : std::priority_queue<T, Underlying, Comp> {
+  explicit StateCopy(std::priority_queue<T, Underlying, Comp> source)
+    : std::priority_queue<T, Underlying, Comp>{std::move(source)} {}
+
+  // expose the protected underlying container
+  Underlying get() && {
+    return std::move(this->c);
+  }
+};
+template<typename T, typename Underlying, typename Comp>
+StateCopy(std::priority_queue<T, Underlying, Comp>) -> StateCopy<T, Underlying, Comp>;
+}  // namespace
+
+void AttributeRollingWindow::onTrigger(core::ProcessContext* context, core::ProcessSession* session) {
+  gsl_Expects(context && session && runningInvariant());
+  const auto flow_file = session->get();
+  if (!flow_file) { yield(); return; }
+  gsl_Assert(flow_file);
+  const auto current_value_opt = context->getProperty(ValueToTrack, flow_file);
+  if (!current_value_opt) {
+    logger_->log_warn("Missing value to track, flow file uuid: {}", flow_file->getUUIDStr());
+    session->transfer(flow_file, Failure);
+    return;
+  }
+  const auto current_value = [&current_value_opt] {
+    try {
+      return std::stod(*current_value_opt);
+    } catch (const std::exception& ex) {
+      throw minifi::Exception{ExceptionType::PROCESSOR_EXCEPTION,
+          fmt::format("Failed to convert 'Value to track' of '{}' to double", *current_value_opt)};
+    }
+  }();
+  // copy: so we can release the lock sooner
+  // wrap: so we can access the protected underlying container c for later calculations
+  const auto state_copy = [&, now = std::chrono::system_clock::now()] {
+    std::lock_guard lg{state_mutex_};
+    addEntry(lg, now, current_value);
+    removeOutdatedEntries(lg, now);
+    return StateCopy{state_}.get();
+  }();
+  const auto sorted_values = [&state_copy] {
+    auto values = state_copy | ranges::view::transform(&Entry::value) | ranges::to<std::vector>;
+    std::sort(std::begin(values), std::end(values));
+    return values;
+  }();
+  calculateAndSetAttributes(*flow_file, sorted_values);
+  session->transfer(flow_file, Success);
+}
+
+/**
+ * Calculate statistical properties of the values in the rolling window and set them as attributes on the flow file.
+ * Properties: count, value (sum), mean (average), median, variance, stddev
+ */
+void AttributeRollingWindow::calculateAndSetAttributes(core::FlowFile& flow_file, std::span<const double> sorted_values) {
+  flow_file.setAttribute("rolling_window_count", std::to_string(sorted_values.size()));
+  const auto sum = std::accumulate(std::begin(sorted_values), std::end(sorted_values), 0.0);
+  flow_file.setAttribute("rolling_window_value", std::to_string(sum));
+  const auto mean = sum / gsl::narrow_cast<double>(sorted_values.size());
+  flow_file.setAttribute("rolling_window_mean", std::to_string(mean));
+  const auto median = [&] {
+    if (sorted_values.size() % 2 == 0) {
+      const auto mid = sorted_values.size() / 2;
+      return (sorted_values[mid] + sorted_values[mid - 1]) / 2;
+    } else {
+      return sorted_values[sorted_values.size() / 2];
+    }
+  }();
+  flow_file.setAttribute("rolling_window_median", std::to_string(median));
+  const auto variance = std::accumulate(std::begin(sorted_values), std::end(sorted_values), 0.0, [&](double acc, double value) {
+    return acc + std::pow(value - mean, 2) / gsl::narrow_cast<double>(sorted_values.size());
+  });
+  flow_file.setAttribute("rolling_window_variance", std::to_string(variance));
+  const auto stddev = std::sqrt(variance);
+  flow_file.setAttribute("rolling_window_stddev", std::to_string(stddev));
+}
+
+REGISTER_RESOURCE(AttributeRollingWindow, Processor);
+
+} // org::apache::nifi::minifi::processors

--- a/extensions/standard-processors/processors/AttributeRollingWindow.cpp
+++ b/extensions/standard-processors/processors/AttributeRollingWindow.cpp
@@ -17,10 +17,10 @@
 #include "AttributeRollingWindow.h"
 #include <algorithm>
 #include <numeric>
+#include "fmt/format.h"
 #include "core/ProcessContext.h"
 #include "core/ProcessSession.h"
 #include "core/Resource.h"
-#include "fmt/format.h"
 #include "utils/expected.h"
 #include "utils/OptionalUtils.h"
 

--- a/extensions/standard-processors/processors/AttributeRollingWindow.cpp
+++ b/extensions/standard-processors/processors/AttributeRollingWindow.cpp
@@ -30,8 +30,9 @@ void AttributeRollingWindow::onSchedule(core::ProcessContext* context, core::Pro
   gsl_Expects(context);
   time_window_ = context->getProperty<core::TimePeriodValue>(TimeWindow)
       | utils::transform(&core::TimePeriodValue::getMilliseconds);
-  window_length_ = context->getProperty<size_t>(WindowLength)
-      | utils::filter([](size_t value) { return value > 0; });
+  window_length_ = context->getProperty<uint64_t>(WindowLength)
+      | utils::filter([](uint64_t value) { return value > 0; })
+      | utils::transform([](uint64_t value) { return size_t{value}; });
   if (!time_window_ && !window_length_) {
     throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, "Either 'Time window' or 'Window length' must be set"};
   }

--- a/extensions/standard-processors/processors/AttributeRollingWindow.cpp
+++ b/extensions/standard-processors/processors/AttributeRollingWindow.cpp
@@ -105,9 +105,11 @@ void AttributeRollingWindow::calculateAndSetAttributes(core::FlowFile &flow_file
         ? std::midpoint(sorted_values[mid], sorted_values[mid - 1])  // even number of values: average the two middle values
         : sorted_values[mid];  // odd number of values: take the middle value
   }());
-  const auto variance = std::accumulate(std::begin(sorted_values), std::end(sorted_values), 0.0, [&](double acc, double value) {
-    return acc + std::pow(value - mean, 2) / gsl::narrow_cast<double>(sorted_values.size());
+  // https://math.stackexchange.com/questions/1720876/sums-of-squares-minus-square-of-sums
+  const auto avg_of_squares = std::accumulate(std::begin(sorted_values), std::end(sorted_values), 0.0, [&](double acc, double value) {
+    return acc + std::pow(value, 2) / gsl::narrow_cast<double>(sorted_values.size());
   });
+  const auto variance = avg_of_squares - std::pow(mean, 2);
   set_aggregate("variance", variance);
   set_aggregate("stddev", std::sqrt(variance));
   set_aggregate("min", sorted_values.front());

--- a/extensions/standard-processors/processors/AttributeRollingWindow.cpp
+++ b/extensions/standard-processors/processors/AttributeRollingWindow.cpp
@@ -95,7 +95,7 @@ void AttributeRollingWindow::calculateAndSetAttributes(core::FlowFile &flow_file
   const auto set_aggregate = [&flow_file, attribute_name](std::string_view name, double value) {
     flow_file.setAttribute(attribute_name(name), std::to_string(value));
   };
-  set_aggregate("count", sorted_values.size());
+  set_aggregate("count", static_cast<double>(sorted_values.size()));
   const auto sum = std::accumulate(std::begin(sorted_values), std::end(sorted_values), 0.0);
   set_aggregate("value", sum);
   const auto mean = sum / gsl::narrow_cast<double>(sorted_values.size());

--- a/extensions/standard-processors/processors/AttributeRollingWindow.cpp
+++ b/extensions/standard-processors/processors/AttributeRollingWindow.cpp
@@ -119,4 +119,4 @@ void AttributeRollingWindow::calculateAndSetAttributes(core::FlowFile &flow_file
 
 REGISTER_RESOURCE(AttributeRollingWindow, Processor);
 
-} // org::apache::nifi::minifi::processors
+}  // namespace org::apache::nifi::minifi::processors

--- a/extensions/standard-processors/processors/AttributeRollingWindow.cpp
+++ b/extensions/standard-processors/processors/AttributeRollingWindow.cpp
@@ -32,14 +32,11 @@ void AttributeRollingWindow::onSchedule(core::ProcessContext* context, core::Pro
       | utils::transform(&core::TimePeriodValue::getMilliseconds);
   window_length_ = context->getProperty<uint64_t>(WindowLength)
       | utils::filter([](uint64_t value) { return value > 0; })
-      | utils::transform([](uint64_t value) { return size_t{value}; });
+      | utils::transform([](uint64_t value) { return gsl::narrow<size_t>(value); });  // narrowing on 32 bit ABI
   if (!time_window_ && !window_length_) {
     throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, "Either 'Time window' or 'Window length' must be set"};
   }
-  attribute_name_prefix_ = (context->getProperty(AttributeNamePrefix)
-      | utils::orElse([] {
-        throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, "'Attribute name prefix' must be set"};
-      })).value();
+  context->getProperty(AttributeNamePrefix, attribute_name_prefix_);
   gsl_Ensures(runningInvariant());
 }
 
@@ -48,24 +45,28 @@ void AttributeRollingWindow::onTrigger(core::ProcessContext* context, core::Proc
   const auto flow_file = session->get();
   if (!flow_file) { yield(); return; }
   gsl_Assert(flow_file);
-  const auto current_value_opt = context->getProperty(ValueToTrack, flow_file);
-  if (!current_value_opt) {
+  const auto current_value_opt_str = context->getProperty(ValueToTrack, flow_file);
+  if (!current_value_opt_str) {
     logger_->log_warn("Missing value to track, flow file uuid: {}", flow_file->getUUIDStr());
     session->transfer(flow_file, Failure);
     return;
   }
-  const auto current_value = [&current_value_opt] {
+  const auto current_value = [&current_value_opt_str]() -> std::optional<double> {
     try {
-      return std::stod(*current_value_opt);
+      return std::stod(*current_value_opt_str);
     } catch (const std::exception& ex) {
-      throw minifi::Exception{ExceptionType::PROCESSOR_EXCEPTION,
-          fmt::format("Failed to convert 'Value to track' of '{}' to double", *current_value_opt)};
+      return std::nullopt;
     }
   }();
+  if (!current_value) {
+    logger_->log_warn("Failed to convert 'Value to track' of '{}' to double", *current_value_opt_str);
+    session->transfer(flow_file, Failure);
+    return;
+  }
   // copy: so we can release the lock sooner
   const auto state_copy = [&, now = std::chrono::system_clock::now()] {
     const std::lock_guard lg{state_mutex_};
-    state_.add(now, current_value);
+    state_.add(now, *current_value);
     if (window_length_) {
       state_.shrinkToSize(*window_length_);
     } else {
@@ -85,10 +86,11 @@ void AttributeRollingWindow::onTrigger(core::ProcessContext* context, core::Proc
 
 /**
  * Calculate statistical properties of the values in the rolling window and set them as attributes on the flow file.
- * Properties: count, value (sum), mean (average), median, variance, stddev
+ * Properties: count, value (sum), mean (average), median, variance, stddev, min, max
  */
 void AttributeRollingWindow::calculateAndSetAttributes(core::FlowFile &flow_file,
     std::span<const double> sorted_values) const {
+  gsl_Expects(!sorted_values.empty());
   const auto attribute_name = [this](std::string_view suffix) {
     return utils::string::join_pack(attribute_name_prefix_, suffix);
   };

--- a/extensions/standard-processors/processors/AttributeRollingWindow.cpp
+++ b/extensions/standard-processors/processors/AttributeRollingWindow.cpp
@@ -63,7 +63,7 @@ void AttributeRollingWindow::onTrigger(core::ProcessContext* context, core::Proc
   }();
   // copy: so we can release the lock sooner
   const auto state_copy = [&, now = std::chrono::system_clock::now()] {
-    std::lock_guard lg{state_mutex_};
+    const std::lock_guard lg{state_mutex_};
     state_.add(now, current_value);
     if (window_length_) {
       state_.shrinkToSize(*window_length_);

--- a/extensions/standard-processors/processors/AttributeRollingWindow.h
+++ b/extensions/standard-processors/processors/AttributeRollingWindow.h
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <queue>
+#include <string_view>
+
+#include "core/AbstractProcessor.h"
+#include "core/Annotation.h"
+#include "core/logging/LoggerFactory.h"
+#include "core/PropertyDefinitionBuilder.h"
+#include "core/PropertyType.h"
+#include "core/RelationshipDefinition.h"
+#include "StateManager.h"
+
+namespace org::apache::nifi::minifi::processors {
+
+class AttributeRollingWindow final : public core::AbstractProcessor<AttributeRollingWindow> {
+ public:
+  using core::AbstractProcessor<AttributeRollingWindow>::AbstractProcessor;
+
+  EXTENSIONAPI static constexpr auto Description = "Track a Rolling Window based on evaluating an Expression Language "
+      "expression on each FlowFile and add that value to the processor's state. Each FlowFile will be emitted with the "
+      "count of FlowFiles and total aggregate value of values processed in the current time window.";
+
+  EXTENSIONAPI static constexpr auto ValueToTrack = core::PropertyDefinitionBuilder<>::createProperty("Value to track")
+      .withDescription("The expression on which to evaluate each FlowFile. The result of the expression will be added "
+          "to the rolling window value.")
+      .isRequired(true)
+      .supportsExpressionLanguage(true)
+      .build();
+  EXTENSIONAPI static constexpr auto TimeWindow = core::PropertyDefinitionBuilder<>::createProperty("Time window")
+      .withDescription("The amount of time for a rolling window. The format of the value is expected to be a "
+          "count followed by a time unit. For example 5 millis, 10 secs, 1 min, 3 hours, 2 days, etc.")
+      .withPropertyType(core::StandardPropertyTypes::TIME_PERIOD_TYPE)
+      .build();
+  EXTENSIONAPI static constexpr auto WindowLength = core::PropertyDefinitionBuilder<>::createProperty("Window length")
+      .withDescription("The window length in number of values. Takes precedence over 'Time window'. If set to zero, "
+          "the 'Time window' property is used instead.")
+      .isRequired(true)
+      .withDefaultValue("0")
+      .withPropertyType(core::StandardPropertyTypes::UNSIGNED_INT_TYPE)
+      .build();
+  EXTENSIONAPI static constexpr auto Properties = std::array<core::PropertyReference, 3>{
+    ValueToTrack,
+    TimeWindow,
+    WindowLength,
+  };
+
+  EXTENSIONAPI static constexpr auto Success = core::RelationshipDefinition{"success", "All FlowFiles that are "
+      "successfully processed are routed to this relationship."};
+  EXTENSIONAPI static constexpr auto Failure = core::RelationshipDefinition{"failure", "When a FlowFile fails for a "
+      "reason other than failing to set state, it is routed here."};
+  EXTENSIONAPI static constexpr auto Relationships = std::array{Success, Failure};
+
+  EXTENSIONAPI static constexpr bool SupportsDynamicProperties = false;
+  EXTENSIONAPI static constexpr bool SupportsDynamicRelationships = false;
+  EXTENSIONAPI static constexpr core::annotation::Input InputRequirement = core::annotation::Input::INPUT_REQUIRED;
+  EXTENSIONAPI static constexpr bool IsSingleThreaded = false;
+
+  void onSchedule(core::ProcessContext*, core::ProcessSessionFactory*) final;
+  void onTrigger(core::ProcessContext*, core::ProcessSession*) final;
+
+  struct Entry {
+    std::chrono::time_point<std::chrono::system_clock> timestamp;
+    double value{};
+  };
+  struct EntryComparator {
+    bool operator()(const Entry& lhs, const Entry& rhs) const { return lhs.timestamp > rhs.timestamp; }
+  };
+ private:
+  bool runningInvariant() const {
+    // Either time_window_ or window_length_ must be set. If window_length_ is set, it is > 0.
+    return (time_window_ || window_length_) && (!window_length_ || *window_length_ > 0);
+  }
+  void removeOutdatedEntries(std::lock_guard<std::mutex>& state_lock, std::chrono::time_point<std::chrono::system_clock> timestamp);
+  void addEntry(std::lock_guard<std::mutex>& state_lock, std::chrono::time_point<std::chrono::system_clock> timestamp, double value);
+  static void calculateAndSetAttributes(core::FlowFile&, std::span<const double> sorted_values);
+
+
+  mutable std::mutex state_mutex_;
+  std::priority_queue<Entry, std::vector<Entry>, EntryComparator> state_;
+
+  std::optional<std::chrono::milliseconds> time_window_{};
+  std::optional<size_t> window_length_{};
+  std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<AttributeRollingWindow>::getLogger(uuid_);
+};
+
+} // org::apache::nifi::minifi::processors

--- a/extensions/standard-processors/processors/AttributeRollingWindow.h
+++ b/extensions/standard-processors/processors/AttributeRollingWindow.h
@@ -95,8 +95,8 @@ class AttributeRollingWindow final : public core::AbstractProcessor<AttributeRol
   EXTENSIONAPI static constexpr core::annotation::Input InputRequirement = core::annotation::Input::INPUT_REQUIRED;
   EXTENSIONAPI static constexpr bool IsSingleThreaded = false;
 
-  void onSchedule(core::ProcessContext*, core::ProcessSessionFactory*) final;
-  void onTrigger(core::ProcessContext*, core::ProcessSession*) final;
+  void onSchedule(core::ProcessContext&, core::ProcessSessionFactory&) final;
+  void onTrigger(core::ProcessContext&, core::ProcessSession&) final;
 
  private:
   bool runningInvariant() const {

--- a/extensions/standard-processors/processors/AttributeRollingWindow.h
+++ b/extensions/standard-processors/processors/AttributeRollingWindow.h
@@ -40,7 +40,7 @@ class AttributeRollingWindow final : public core::AbstractProcessor<AttributeRol
 
   EXTENSIONAPI static constexpr auto Description = "Track a Rolling Window based on evaluating an Expression Language "
       "expression on each FlowFile. Each FlowFile will be emitted with the count of FlowFiles and total aggregate value"
-      "of values processed in the current window.";
+      " of values processed in the current window.";
 
   EXTENSIONAPI static constexpr auto ValueToTrack = core::PropertyDefinitionBuilder<>::createProperty("Value to track")
       .withDescription("The expression on which to evaluate each FlowFile. The result of the expression will be added "
@@ -79,14 +79,14 @@ class AttributeRollingWindow final : public core::AbstractProcessor<AttributeRol
       "it is routed here."};
   EXTENSIONAPI static constexpr auto Relationships = std::array{Success, Failure};
 
-  EXTENSIONAPI static constexpr auto Count = core::OutputAttributeDefinition<1>{"<prefix>count", {Success}, "Number of the values in the rolling window"};
-  EXTENSIONAPI static constexpr auto Value = core::OutputAttributeDefinition<1>{"<prefix>value", {Success}, "Sum of the values in the rolling window"};
-  EXTENSIONAPI static constexpr auto Mean = core::OutputAttributeDefinition<1>{"<prefix>mean", {Success}, "Mean of the values in the rolling window"};
-  EXTENSIONAPI static constexpr auto Median = core::OutputAttributeDefinition<1>{"<prefix>median", {Success}, "Median of the values in the rolling window"};
-  EXTENSIONAPI static constexpr auto Variance = core::OutputAttributeDefinition<1>{"<prefix>variance", {Success}, "Variance of the values in the rolling window"};
-  EXTENSIONAPI static constexpr auto Stddev = core::OutputAttributeDefinition<1>{"<prefix>stddev", {Success}, "Standard deviation of the values in the rolling window"};
-  EXTENSIONAPI static constexpr auto Min = core::OutputAttributeDefinition<1>{"<prefix>min", {Success}, "Smallest value in the rolling window"};
-  EXTENSIONAPI static constexpr auto Max = core::OutputAttributeDefinition<1>{"<prefix>max", {Success}, "Largest value in the rolling window"};
+  EXTENSIONAPI static constexpr auto Count = core::OutputAttributeDefinition<>{"<prefix>count", {Success}, "Number of the values in the rolling window"};
+  EXTENSIONAPI static constexpr auto Value = core::OutputAttributeDefinition<>{"<prefix>value", {Success}, "Sum of the values in the rolling window"};
+  EXTENSIONAPI static constexpr auto Mean = core::OutputAttributeDefinition<>{"<prefix>mean", {Success}, "Mean of the values in the rolling window"};
+  EXTENSIONAPI static constexpr auto Median = core::OutputAttributeDefinition<>{"<prefix>median", {Success}, "Median of the values in the rolling window"};
+  EXTENSIONAPI static constexpr auto Variance = core::OutputAttributeDefinition<>{"<prefix>variance", {Success}, "Variance of the values in the rolling window"};
+  EXTENSIONAPI static constexpr auto Stddev = core::OutputAttributeDefinition<>{"<prefix>stddev", {Success}, "Standard deviation of the values in the rolling window"};
+  EXTENSIONAPI static constexpr auto Min = core::OutputAttributeDefinition<>{"<prefix>min", {Success}, "Smallest value in the rolling window"};
+  EXTENSIONAPI static constexpr auto Max = core::OutputAttributeDefinition<>{"<prefix>max", {Success}, "Largest value in the rolling window"};
   EXTENSIONAPI static constexpr auto OutputAttributes = std::array<core::OutputAttributeReference, 8>{
       Count, Value, Mean, Median, Variance, Stddev, Min, Max};
 

--- a/extensions/standard-processors/processors/AttributeRollingWindow.h
+++ b/extensions/standard-processors/processors/AttributeRollingWindow.h
@@ -79,6 +79,17 @@ class AttributeRollingWindow final : public core::AbstractProcessor<AttributeRol
       "it is routed here."};
   EXTENSIONAPI static constexpr auto Relationships = std::array{Success, Failure};
 
+  EXTENSIONAPI static constexpr auto Count = core::OutputAttributeDefinition<1>{"<prefix>count", {Success}, "Number of the values in the rolling window"};
+  EXTENSIONAPI static constexpr auto Value = core::OutputAttributeDefinition<1>{"<prefix>value", {Success}, "Sum of the values in the rolling window"};
+  EXTENSIONAPI static constexpr auto Mean = core::OutputAttributeDefinition<1>{"<prefix>mean", {Success}, "Mean of the values in the rolling window"};
+  EXTENSIONAPI static constexpr auto Median = core::OutputAttributeDefinition<1>{"<prefix>median", {Success}, "Median of the values in the rolling window"};
+  EXTENSIONAPI static constexpr auto Variance = core::OutputAttributeDefinition<1>{"<prefix>variance", {Success}, "Variance of the values in the rolling window"};
+  EXTENSIONAPI static constexpr auto Stddev = core::OutputAttributeDefinition<1>{"<prefix>stddev", {Success}, "Standard deviation of the values in the rolling window"};
+  EXTENSIONAPI static constexpr auto Min = core::OutputAttributeDefinition<1>{"<prefix>min", {Success}, "Smallest value in the rolling window"};
+  EXTENSIONAPI static constexpr auto Max = core::OutputAttributeDefinition<1>{"<prefix>max", {Success}, "Largest value in the rolling window"};
+  EXTENSIONAPI static constexpr auto OutputAttributes = std::array<core::OutputAttributeReference, 8>{
+      Count, Value, Mean, Median, Variance, Stddev, Min, Max};
+
   EXTENSIONAPI static constexpr bool SupportsDynamicProperties = false;
   EXTENSIONAPI static constexpr bool SupportsDynamicRelationships = false;
   EXTENSIONAPI static constexpr core::annotation::Input InputRequirement = core::annotation::Input::INPUT_REQUIRED;

--- a/extensions/standard-processors/processors/AttributeRollingWindow.h
+++ b/extensions/standard-processors/processors/AttributeRollingWindow.h
@@ -114,4 +114,4 @@ class AttributeRollingWindow final : public core::AbstractProcessor<AttributeRol
   std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<AttributeRollingWindow>::getLogger(uuid_);
 };
 
-} // org::apache::nifi::minifi::processors
+}  // namespace org::apache::nifi::minifi::processors

--- a/extensions/standard-processors/tests/unit/AttributeRollingWindowTests.cpp
+++ b/extensions/standard-processors/tests/unit/AttributeRollingWindowTests.cpp
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <memory>
+#include <string_view>
+#include "Catch.h"
+#include "AttributeRollingWindow.h"
+#include "SingleProcessorTestController.h"
+#include "range/v3/view/zip.hpp"
+#include "range/v3/algorithm/contains.hpp"
+
+namespace org::apache::nifi::minifi::test {
+using AttributeRollingWindow = processors::AttributeRollingWindow;
+
+TEST_CASE("AttributeRollingWindow", "[attributerollingwindow]") {
+  const auto proc = std::make_shared<AttributeRollingWindow>("AttributeRollingWindow");
+  proc->setProperty(AttributeRollingWindow::ValueToTrack, "${value}");
+  proc->setProperty(AttributeRollingWindow::WindowLength, "3");
+  SingleProcessorTestController controller{proc};
+}
+
+}  // namespace org::apache::nifi::minifi::test

--- a/extensions/standard-processors/tests/unit/AttributeRollingWindowTests.cpp
+++ b/extensions/standard-processors/tests/unit/AttributeRollingWindowTests.cpp
@@ -20,8 +20,6 @@
 #include "Catch.h"
 #include "AttributeRollingWindow.h"
 #include "SingleProcessorTestController.h"
-#include "fmt/format.h"
-#include "fmt/ranges.h"
 
 namespace org::apache::nifi::minifi::test {
 using AttributeRollingWindow = processors::AttributeRollingWindow;
@@ -43,7 +41,7 @@ TEST_CASE("AttributeRollingWindow properly forwards properties to RollingWindow 
   proc->setProperty(AttributeRollingWindow::WindowLength, "3");
   const auto trigger_with_value_and_check_attributes = [&controller](const std::string& value, const std::map<std::string, std::string>& expected_out_attributes) {
     const auto rel = [](auto name) { return core::Relationship{std::move(name), "description"}; };
-    const auto out = controller.trigger({.content="content", .attributes={{"value", value}}});
+    const auto out = controller.trigger({.content = "content", .attributes = {{"value", value}}});
     REQUIRE(out.at(rel("failure")).empty());
     const auto out_flow_files = out.at(rel("success"));
     REQUIRE(out_flow_files.size() == 1);

--- a/extensions/standard-processors/tests/unit/AttributeRollingWindowTests.cpp
+++ b/extensions/standard-processors/tests/unit/AttributeRollingWindowTests.cpp
@@ -30,7 +30,7 @@ bool checkAttributes(const std::map<std::string, std::string>& expected, const s
   return std::all_of(std::begin(expected), std::end(expected), [&actual](const auto& kvpair) {
     const auto& key = kvpair.first;
     const auto& value = kvpair.second;
-    return actual.at(key) == value;
+    return actual.contains(key) && actual.at(key) == value;
   });
 }
 

--- a/extensions/standard-processors/tests/unit/AttributeRollingWindowTests.cpp
+++ b/extensions/standard-processors/tests/unit/AttributeRollingWindowTests.cpp
@@ -36,7 +36,7 @@ bool checkAttributes(const std::map<std::string, std::string>& expected, const s
   });
 }
 
-TEST_CASE("AttributeRollingWindow properly forwards properties to RollingWindow", "[attributerollingwindow]") {
+TEST_CASE("AttributeRollingWindow properly forwards properties to RollingWindow and sets attributes", "[attributerollingwindow]") {
   const auto proc = std::make_shared<AttributeRollingWindow>("AttributeRollingWindow");
   SingleProcessorTestController controller{proc};
   proc->setProperty(AttributeRollingWindow::ValueToTrack, "${value}");

--- a/extensions/standard-processors/tests/unit/RollingWindowTests.cpp
+++ b/extensions/standard-processors/tests/unit/RollingWindowTests.cpp
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string_view>
+#include "Catch.h"
+#include "RollingWindow.h"
+#include "range/v3/view/zip.hpp"
+#include "range/v3/algorithm/contains.hpp"
+
+namespace org::apache::nifi::minifi::test {
+
+using timestamp_type = int;
+using value_type = const char*;
+using RollingWindow = processors::standard::utils::RollingWindow<timestamp_type, value_type>;
+using TimestampComparator = decltype([](const RollingWindow::Entry& lhs, const RollingWindow::Entry& rhs) {
+  return lhs.timestamp < rhs.timestamp;
+});
+
+bool compareEntriesTimestamps(std::vector<RollingWindow::Entry> entries,
+    std::span<const timestamp_type> expected_timestamps) {
+  std::sort(std::begin(entries), std::end(entries), TimestampComparator{});
+  if (entries.size() != expected_timestamps.size()) {
+    return false;
+  }
+  const auto pairs = ranges::views::zip(entries, expected_timestamps);
+  return std::all_of(std::begin(pairs), std::end(pairs), [](const auto& pair) {
+    return std::get<0>(pair).timestamp == std::get<1>(pair);
+  });
+}
+
+bool compareEntriesTimestamps(std::vector<RollingWindow::Entry> entries,
+    std::initializer_list<const timestamp_type> expected_timestamps) {
+  return compareEntriesTimestamps(std::move(entries), std::span{expected_timestamps});
+}
+
+TEST_CASE("RollingWindow: fix time window, oldest entries are removed first", "[rollingwindow][timewindow]") {
+  RollingWindow window;
+  window.add(1, "1");
+  window.add(3, "3foo");
+  window.add(2, "2bar");
+  window.add(4, "4baz");
+
+  SECTION("removeOlderThan(1): identical") {
+    window.removeOlderThan(1);
+    const auto entries = window.getEntries();
+    REQUIRE(compareEntriesTimestamps(entries, {1, 2, 3, 4}));
+    REQUIRE(ranges::contains(entries, std::string_view{"1"}, &RollingWindow::Entry::value));
+    REQUIRE(ranges::contains(entries, std::string_view{"2bar"}, &RollingWindow::Entry::value));
+    REQUIRE(ranges::contains(entries, std::string_view{"3foo"}, &RollingWindow::Entry::value));
+  }
+
+  SECTION("removeOlderThan(2): removes 1") {
+    window.removeOlderThan(2);
+    REQUIRE(compareEntriesTimestamps(window.getEntries(), {2, 3, 4}));
+  }
+
+  SECTION("removeOlderThan(3): removes 1 and 2, despite 3 being added before 2") {
+    window.removeOlderThan(3);
+    REQUIRE(compareEntriesTimestamps(window.getEntries(), {3, 4}));
+  }
+
+  SECTION("removeOlderThan(100): empty") {
+    window.removeOlderThan(100);
+    REQUIRE(window.getEntries().empty());
+  }
+}
+
+TEST_CASE("RollingWindow: fix length, oldest entries are removed first", "[rollingwindow][flowfilecount]") {
+  RollingWindow window;
+  window.add(1, "1");
+  window.add(3, "3");
+  window.add(2, "2");
+  window.add(4, "4");
+  window.add(42, "foo");
+
+  SECTION("shrinkToSize(5): identical") {
+    window.shrinkToSize(5);
+    REQUIRE(compareEntriesTimestamps(window.getEntries(), {1, 2, 3, 4, 42}));
+  }
+
+  SECTION("shrinkToSize(4): removes 1") {
+    window.shrinkToSize(4);
+    REQUIRE(compareEntriesTimestamps(window.getEntries(), {2, 3, 4, 42}));
+  }
+
+  SECTION("shrinkToSize(1): only 42 remains") {
+    window.shrinkToSize(1);
+    const auto entries = window.getEntries();
+    REQUIRE(compareEntriesTimestamps(entries, {42}));
+    REQUIRE(std::string_view{entries[0].value} == "foo");
+  }
+}
+
+}  // namespace org::apache::nifi::minifi::test

--- a/extensions/standard-processors/tests/unit/RollingWindowTests.cpp
+++ b/extensions/standard-processors/tests/unit/RollingWindowTests.cpp
@@ -101,7 +101,7 @@ TEST_CASE("RollingWindow: fix length, oldest entries are removed first", "[rolli
     window.shrinkToSize(1);
     const auto entries = window.getEntries();
     REQUIRE(compareEntriesTimestamps(entries, {42}));
-    REQUIRE(std::string_view{entries[0].value} == "foo");
+    REQUIRE(std::string_view{entries[0].value} == "foo");  // NOLINT(whitespace/braces)
   }
 }
 

--- a/libminifi/include/core/AbstractProcessor.h
+++ b/libminifi/include/core/AbstractProcessor.h
@@ -15,8 +15,15 @@
  * limitations under the License.
  */
 
-#include "core/Processor.h"
+#include <string>
+#include <string_view>
+#include <type_traits>
 #include "range/v3/view/transform.hpp"
+#include "core/Annotation.h"
+#include "core/Core.h"
+#include "core/Processor.h"
+#include "core/PropertyDefinition.h"
+#include "core/RelationshipDefinition.h"
 
 namespace org::apache::nifi::minifi::core {
 template<typename ProcessorT>

--- a/libminifi/include/core/AbstractProcessor.h
+++ b/libminifi/include/core/AbstractProcessor.h
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "core/Processor.h"
+#include "range/v3/view/transform.hpp"
+
+namespace org::apache::nifi::minifi::core {
+template<typename ProcessorT>
+class AbstractProcessor : public Processor {
+  using Processor::Processor;
+
+  void initialize() final {
+    static_assert(std::is_same_v<typename decltype(ProcessorT::Properties)::value_type, PropertyReference>);
+    static_assert(std::is_same_v<typename decltype(ProcessorT::Relationships)::value_type, RelationshipDefinition>);
+    setSupportedProperties(ProcessorT::Properties);
+    setSupportedRelationships(ProcessorT::Relationships);
+  }
+
+  bool supportsDynamicProperties() const final { return ProcessorT::SupportsDynamicProperties; }
+  bool supportsDynamicRelationships() const final { return ProcessorT::SupportsDynamicRelationships; }
+  minifi::core::annotation::Input getInputRequirement() const final { return ProcessorT::InputRequirement; }
+  bool isSingleThreaded() const final { return ProcessorT::IsSingleThreaded; }
+  std::string getProcessorType() const final {
+    constexpr auto class_name = className<ProcessorT>();
+    constexpr auto last_colon_index = class_name.find_last_of(':');
+    constexpr auto end = class_name.substr(last_colon_index + 1);
+    if constexpr (last_colon_index == std::string_view::npos) {
+      return std::string{class_name};
+    }
+    return std::string{end};
+  }
+};
+}  // namespace org::apache::nifi::minifi::core

--- a/libminifi/include/core/AbstractProcessor.h
+++ b/libminifi/include/core/AbstractProcessor.h
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#pragma once
 #include <string>
 #include <string_view>
 #include <type_traits>

--- a/libminifi/include/core/AbstractProcessor.h
+++ b/libminifi/include/core/AbstractProcessor.h
@@ -28,6 +28,7 @@
 namespace org::apache::nifi::minifi::core {
 template<typename ProcessorT>
 class AbstractProcessor : public Processor {
+ public:
   using Processor::Processor;
 
   void initialize() final {
@@ -37,10 +38,13 @@ class AbstractProcessor : public Processor {
     setSupportedRelationships(ProcessorT::Relationships);
   }
 
-  bool supportsDynamicProperties() const final { return ProcessorT::SupportsDynamicProperties; }
-  bool supportsDynamicRelationships() const final { return ProcessorT::SupportsDynamicRelationships; }
-  minifi::core::annotation::Input getInputRequirement() const final { return ProcessorT::InputRequirement; }
-  bool isSingleThreaded() const final { return ProcessorT::IsSingleThreaded; }
+  void onSchedule(core::ProcessContext*, core::ProcessSessionFactory*) override = 0;
+  void onTrigger(core::ProcessContext*, core::ProcessSession*) override = 0;
+
+  bool supportsDynamicProperties() const noexcept final { return ProcessorT::SupportsDynamicProperties; }
+  bool supportsDynamicRelationships() const noexcept final { return ProcessorT::SupportsDynamicRelationships; }
+  minifi::core::annotation::Input getInputRequirement() const noexcept final { return ProcessorT::InputRequirement; }
+  bool isSingleThreaded() const noexcept final { return ProcessorT::IsSingleThreaded; }
   std::string getProcessorType() const final {
     constexpr auto class_name = className<ProcessorT>();
     constexpr auto last_colon_index = class_name.find_last_of(':');

--- a/libminifi/include/core/AbstractProcessor.h
+++ b/libminifi/include/core/AbstractProcessor.h
@@ -39,8 +39,8 @@ class AbstractProcessor : public Processor {
     setSupportedRelationships(ProcessorT::Relationships);
   }
 
-  void onSchedule(core::ProcessContext*, core::ProcessSessionFactory*) override = 0;
-  void onTrigger(core::ProcessContext*, core::ProcessSession*) override = 0;
+  void onSchedule(core::ProcessContext&, core::ProcessSessionFactory&) override = 0;
+  void onTrigger(core::ProcessContext&, core::ProcessSession&) override = 0;
 
   bool supportsDynamicProperties() const noexcept final { return ProcessorT::SupportsDynamicProperties; }
   bool supportsDynamicRelationships() const noexcept final { return ProcessorT::SupportsDynamicRelationships; }

--- a/libminifi/include/core/AbstractProcessor.h
+++ b/libminifi/include/core/AbstractProcessor.h
@@ -49,11 +49,10 @@ class AbstractProcessor : public Processor {
   std::string getProcessorType() const final {
     constexpr auto class_name = className<ProcessorT>();
     constexpr auto last_colon_index = class_name.find_last_of(':');
-    constexpr auto end = class_name.substr(last_colon_index + 1);
     if constexpr (last_colon_index == std::string_view::npos) {
       return std::string{class_name};
     }
-    return std::string{end};
+    return std::string{class_name.substr(last_colon_index + 1)};
   }
 };
 }  // namespace org::apache::nifi::minifi::core

--- a/libminifi/src/core/extension/ExtensionManager.cpp
+++ b/libminifi/src/core/extension/ExtensionManager.cpp
@@ -72,8 +72,12 @@ bool ExtensionManager::initialize(const std::shared_ptr<Configure>& config) {
     }));
     for (const auto& candidate : candidates) {
       auto library = internal::asDynamicLibrary(candidate);
-      if (!library || !library->verify(logger_)) {
+      if (!library) {
         continue;
+      }
+      if (!library->verify(logger_)) {
+        logger_->log_warn("Skipping library '{}' at '{}': failed verification, different build?",
+            library->name, library->getFullPath());
       }
       auto module = std::make_unique<DynamicLibrary>(library->name, library->getFullPath());
       active_module_ = module.get();

--- a/libminifi/src/core/extension/ExtensionManager.cpp
+++ b/libminifi/src/core/extension/ExtensionManager.cpp
@@ -78,6 +78,7 @@ bool ExtensionManager::initialize(const std::shared_ptr<Configure>& config) {
       if (!library->verify(logger_)) {
         logger_->log_warn("Skipping library '{}' at '{}': failed verification, different build?",
             library->name, library->getFullPath());
+        continue;
       }
       auto module = std::make_unique<DynamicLibrary>(library->name, library->getFullPath());
       active_module_ = module.get();

--- a/libminifi/test/unit/AbstractProcessorTest.cpp
+++ b/libminifi/test/unit/AbstractProcessorTest.cpp
@@ -16,31 +16,31 @@
  * limitations under the License.
  */
 #define EXTENSION_LIST ""  // NOLINT(cppcoreguidelines-macro-usage)
+#include <array>
 #include "../Catch.h"
 #include "core/AbstractProcessor.h"
 #include "core/PropertyDefinitionBuilder.h"
-#include <array>
 
 namespace org::apache::nifi::minifi::test {
 
 struct AbstractProcessorTestCase1 : core::AbstractProcessor<AbstractProcessorTestCase1> {
-  EXTENSIONAPI static constexpr auto SupportsDynamicProperties = true;
-  EXTENSIONAPI static constexpr auto SupportsDynamicRelationships = true;
-  EXTENSIONAPI static constexpr core::annotation::Input InputRequirement = core::annotation::Input::INPUT_FORBIDDEN;
-  EXTENSIONAPI static constexpr auto IsSingleThreaded = true;
-  EXTENSIONAPI static constexpr auto Property1 = core::PropertyDefinitionBuilder<>::createProperty("Property 1")
+  static constexpr auto SupportsDynamicProperties = true;
+  static constexpr auto SupportsDynamicRelationships = true;
+  static constexpr core::annotation::Input InputRequirement = core::annotation::Input::INPUT_FORBIDDEN;
+  static constexpr auto IsSingleThreaded = true;
+  static constexpr auto Property1 = core::PropertyDefinitionBuilder<>::createProperty("Property 1")
       .withDefaultValue("foo")
       .supportsExpressionLanguage(true)
       .isRequired(true)
       .build();
-  EXTENSIONAPI static constexpr auto Property2 = core::PropertyDefinitionBuilder<>::createProperty("Property 2")
+  static constexpr auto Property2 = core::PropertyDefinitionBuilder<>::createProperty("Property 2")
       .withDefaultValue("bar")
       .supportsExpressionLanguage(false)
       .isRequired(false)
       .build();
-  EXTENSIONAPI static constexpr auto Properties = std::array<core::PropertyReference, 2>{Property1, Property2};
-  EXTENSIONAPI static constexpr core::RelationshipDefinition Rel1{"rel1", "rel1 description"};
-  EXTENSIONAPI static constexpr auto Relationships = std::array{Rel1};
+  static constexpr auto Properties = std::array<core::PropertyReference, 2>{Property1, Property2};
+  static constexpr core::RelationshipDefinition Rel1{"rel1", "rel1 description"};
+  static constexpr auto Relationships = std::array{Rel1};
   AbstractProcessorTestCase1() :core::AbstractProcessor<AbstractProcessorTestCase1>{"TestCase1"} {}
   void onSchedule(core::ProcessContext *, core::ProcessSessionFactory *) override {}
   void onTrigger(core::ProcessContext *, core::ProcessSession *) override {}

--- a/libminifi/test/unit/AbstractProcessorTest.cpp
+++ b/libminifi/test/unit/AbstractProcessorTest.cpp
@@ -42,8 +42,8 @@ struct AbstractProcessorTestCase1 : core::AbstractProcessor<AbstractProcessorTes
   static constexpr core::RelationshipDefinition Rel1{"rel1", "rel1 description"};
   static constexpr auto Relationships = std::array{Rel1};
   AbstractProcessorTestCase1() :core::AbstractProcessor<AbstractProcessorTestCase1>{"TestCase1"} {}
-  void onSchedule(core::ProcessContext *, core::ProcessSessionFactory *) override {}
-  void onTrigger(core::ProcessContext *, core::ProcessSession *) override {}
+  void onSchedule(core::ProcessContext&, core::ProcessSessionFactory&) override {}
+  void onTrigger(core::ProcessContext&, core::ProcessSession&) override {}
 };
 
 TEST_CASE("AbstractProcessor case1", "[processor][abstractprocessor][case1]") {
@@ -86,8 +86,8 @@ struct AbstractProcessorTestCase2 : core::AbstractProcessor<AbstractProcessorTes
   static constexpr core::RelationshipDefinition Rel1{"Relationship1", "rel1 description"};
   static constexpr auto Relationships = std::array{Rel1};
   AbstractProcessorTestCase2() :core::AbstractProcessor<AbstractProcessorTestCase2>{"TestCase2"} {}
-  void onSchedule(core::ProcessContext *, core::ProcessSessionFactory *) override {}
-  void onTrigger(core::ProcessContext *, core::ProcessSession *) override {}
+  void onSchedule(core::ProcessContext&, core::ProcessSessionFactory&) override {}
+  void onTrigger(core::ProcessContext&, core::ProcessSession&) override {}
 };
 
 TEST_CASE("AbstractProcessor case2", "[processor][abstractprocessor][case2]") {

--- a/libminifi/test/unit/AbstractProcessorTest.cpp
+++ b/libminifi/test/unit/AbstractProcessorTest.cpp
@@ -1,0 +1,114 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#define EXTENSION_LIST ""  // NOLINT(cppcoreguidelines-macro-usage)
+#include "../Catch.h"
+#include "core/AbstractProcessor.h"
+#include "core/PropertyDefinitionBuilder.h"
+#include <array>
+
+namespace org::apache::nifi::minifi::test {
+
+struct AbstractProcessorTestCase1 : core::AbstractProcessor<AbstractProcessorTestCase1> {
+  EXTENSIONAPI static constexpr auto SupportsDynamicProperties = true;
+  EXTENSIONAPI static constexpr auto SupportsDynamicRelationships = true;
+  EXTENSIONAPI static constexpr core::annotation::Input InputRequirement = core::annotation::Input::INPUT_FORBIDDEN;
+  EXTENSIONAPI static constexpr auto IsSingleThreaded = true;
+  EXTENSIONAPI static constexpr auto Property1 = core::PropertyDefinitionBuilder<>::createProperty("Property 1")
+      .withDefaultValue("foo")
+      .supportsExpressionLanguage(true)
+      .isRequired(true)
+      .build();
+  EXTENSIONAPI static constexpr auto Property2 = core::PropertyDefinitionBuilder<>::createProperty("Property 2")
+      .withDefaultValue("bar")
+      .supportsExpressionLanguage(false)
+      .isRequired(false)
+      .build();
+  EXTENSIONAPI static constexpr auto Properties = std::array<core::PropertyReference, 2>{Property1, Property2};
+  EXTENSIONAPI static constexpr core::RelationshipDefinition Rel1{"rel1", "rel1 description"};
+  EXTENSIONAPI static constexpr auto Relationships = std::array{Rel1};
+  AbstractProcessorTestCase1() :core::AbstractProcessor<AbstractProcessorTestCase1>{"TestCase1"} {}
+  void onSchedule(core::ProcessContext *, core::ProcessSessionFactory *) override {}
+  void onTrigger(core::ProcessContext *, core::ProcessSession *) override {}
+};
+
+TEST_CASE("AbstractProcessor case1", "[processor][abstractprocessor][case1]") {
+  AbstractProcessorTestCase1 processor;
+  processor.initialize();
+  REQUIRE(processor.getName() == "TestCase1");
+  REQUIRE(processor.supportsDynamicProperties() == true);
+  REQUIRE(processor.supportsDynamicRelationships() == true);
+  REQUIRE(processor.getInputRequirement() == core::annotation::Input::INPUT_FORBIDDEN);
+  REQUIRE(processor.isSingleThreaded());
+  const auto properties = processor.getProperties();
+  REQUIRE(properties.size() == 2);
+  REQUIRE(properties.contains("Property 1"));
+  REQUIRE(properties.at("Property 1").supportsExpressionLanguage());
+  REQUIRE(properties.at("Property 1").getRequired());
+  REQUIRE(properties.contains("Property 2"));
+  REQUIRE(!properties.at("Property 2").supportsExpressionLanguage());
+  REQUIRE(!properties.at("Property 2").getRequired());
+  REQUIRE(processor.getSupportedRelationships().size() == 1);
+  const auto relationships = processor.getSupportedRelationships();
+  REQUIRE(relationships[0].getName() == "rel1");
+}
+
+struct AbstractProcessorTestCase2 : core::AbstractProcessor<AbstractProcessorTestCase2> {
+  static constexpr bool SupportsDynamicProperties = false;
+  static constexpr bool SupportsDynamicRelationships = false;
+  static constexpr core::annotation::Input InputRequirement = core::annotation::Input::INPUT_REQUIRED;
+  static constexpr bool IsSingleThreaded = false;
+  static constexpr auto Property1 = core::PropertyDefinitionBuilder<>::createProperty("prop 1")
+      .withDefaultValue("foo")
+      .supportsExpressionLanguage(true)
+      .isRequired(true)
+      .build();
+  static constexpr auto Property2 = core::PropertyDefinitionBuilder<>::createProperty("prop 2")
+      .withDefaultValue("bar")
+      .supportsExpressionLanguage(false)
+      .isRequired(false)
+      .build();
+  static constexpr auto Properties = std::array<core::PropertyReference, 2>{Property1, Property2};
+  static constexpr core::RelationshipDefinition Rel1{"Relationship1", "rel1 description"};
+  static constexpr auto Relationships = std::array{Rel1};
+  AbstractProcessorTestCase2() :core::AbstractProcessor<AbstractProcessorTestCase2>{"TestCase2"} {}
+  void onSchedule(core::ProcessContext *, core::ProcessSessionFactory *) override {}
+  void onTrigger(core::ProcessContext *, core::ProcessSession *) override {}
+};
+
+TEST_CASE("AbstractProcessor case2", "[processor][abstractprocessor][case2]") {
+  AbstractProcessorTestCase2 processor;
+  processor.initialize();
+  REQUIRE(processor.getName() == "TestCase2");
+  REQUIRE(!processor.supportsDynamicProperties());
+  REQUIRE(!processor.supportsDynamicRelationships());
+  REQUIRE(processor.getInputRequirement() == core::annotation::Input::INPUT_REQUIRED);
+  REQUIRE(!processor.isSingleThreaded());
+  const auto properties = processor.getProperties();
+  REQUIRE(properties.size() == 2);
+  REQUIRE(properties.contains("prop 1"));
+  REQUIRE(properties.at("prop 1").supportsExpressionLanguage());
+  REQUIRE(properties.at("prop 1").getRequired());
+  REQUIRE(properties.contains("prop 2"));
+  REQUIRE(!properties.at("prop 2").supportsExpressionLanguage());
+  REQUIRE(!properties.at("prop 2").getRequired());
+  REQUIRE(processor.getSupportedRelationships().size() == 1);
+  const auto relationships = processor.getSupportedRelationships();
+  REQUIRE(relationships[0].getName() == "Relationship1");
+}
+
+}  // namespace org::apache::nifi::minifi::test


### PR DESCRIPTION
Including [NIFI-12389](https://issues.apache.org/jira/browse/NIFI-12389) and a few extras: median, min, max.

Added customizable attribute name prefix, so multiple instances of the processor can be used to calculate statistics over different inputs, without having to use UpdateAttribute boilerplate.

Also adds the `nextInt` EL function to generate globally sequential ints.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
