### PR TITLE
MINIFICPP-2258 Update LIBLZMA_URL 

### DIFF
--- a/cmake/BundledLibLZMA.cmake
+++ b/cmake/BundledLibLZMA.cmake
@@ -41,7 +41,7 @@ function(use_bundled_liblzma SOURCE_DIR BINARY_DIR)
     endif()
 
     # Build project
-    set(LIBLZMA_URL https://tukaani.org/xz/xz-5.2.5.tar.gz https://gentoo.osuosl.org/distfiles/xz-5.2.5.tar.gz)
+    set(LIBLZMA_URL https://distfiles.gentoo.org/distfiles/22/xz-5.2.5.tar.gz https://tukaani.org/xz/xz-5.2.5.tar.gz)
     set(LIBLZMA_URL_HASH "SHA256=f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10")
 
     if (WIN32)


### PR DESCRIPTION
tukaani.org seems to be unreliable in CI, while the gentoo.org link was dead (due to gentoo restructuring its distfile based on hash)

This hopefully fixes the flaky windows CI

---
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
