### PR TITLE
MINIFICPP-2275 Use utils::string instead of utils::StringUtils

### DIFF
--- a/controller/MiNiFiController.cpp
+++ b/controller/MiNiFiController.cpp
@@ -77,7 +77,7 @@ std::shared_ptr<minifi::controllers::SSLContextService> getSSLContextService(con
 
   if (nullptr == secure_context) {
     std::string secureStr;
-    if (configuration->get(minifi::Configure::nifi_remote_input_secure, secureStr) && minifi::utils::StringUtils::toBool(secureStr).value_or(false)) {
+    if (configuration->get(minifi::Configure::nifi_remote_input_secure, secureStr) && minifi::utils::string::toBool(secureStr).value_or(false)) {
       secure_context = std::make_shared<minifi::controllers::SSLContextService>("ControllerSocketProtocolSSL", configuration);
       secure_context->onEnable();
     }

--- a/controller/tests/ControllerTests.cpp
+++ b/controller/tests/ControllerTests.cpp
@@ -451,7 +451,7 @@ TEST_CASE_METHOD(ControllerTestFixture, "Test connection getters", "[controllerT
   {
     std::stringstream connection_stream;
     minifi::controller::listConnections(controller_socket_data_, connection_stream);
-    auto lines = minifi::utils::StringUtils::splitRemovingEmpty(connection_stream.str(), "\n");
+    auto lines = minifi::utils::string::splitRemovingEmpty(connection_stream.str(), "\n");
     CHECK(lines.size() == 3);
     CHECK(ranges::find(lines, "Connection Names:") != ranges::end(lines));
     CHECK(ranges::find(lines, "con1") != ranges::end(lines));
@@ -461,7 +461,7 @@ TEST_CASE_METHOD(ControllerTestFixture, "Test connection getters", "[controllerT
   {
     std::stringstream connection_stream;
     minifi::controller::listConnections(controller_socket_data_, connection_stream, false);
-    auto lines = minifi::utils::StringUtils::splitRemovingEmpty(connection_stream.str(), "\n");
+    auto lines = minifi::utils::string::splitRemovingEmpty(connection_stream.str(), "\n");
     CHECK(lines.size() == 2);
     CHECK(ranges::find(lines, "con1") != ranges::end(lines));
     CHECK(ranges::find(lines, "con2") != ranges::end(lines));

--- a/encrypt-config/EncryptConfig.cpp
+++ b/encrypt-config/EncryptConfig.cpp
@@ -138,7 +138,7 @@ EncryptionKeys EncryptConfig::getEncryptionKeys() const {
 
 std::string EncryptConfig::hexDecodeAndValidateKey(const std::string& key, const std::string& key_name) const {
   // Note: from_hex() allows [and skips] non-hex characters
-  std::string binary_key = utils::StringUtils::from_hex(key, utils::as_string);
+  std::string binary_key = utils::string::from_hex(key, utils::as_string);
   if (binary_key.size() == utils::crypto::EncryptionType::keyLength()) {
     return binary_key;
   } else {
@@ -151,7 +151,7 @@ std::string EncryptConfig::hexDecodeAndValidateKey(const std::string& key, const
 }
 
 void EncryptConfig::writeEncryptionKeyToBootstrapFile(const utils::crypto::Bytes& encryption_key) const {
-  std::string key_encoded = utils::StringUtils::to_hex(utils::crypto::bytesToString(encryption_key));
+  std::string key_encoded = utils::string::to_hex(utils::crypto::bytesToString(encryption_key));
   encrypt_config::ConfigFile bootstrap_file{std::ifstream{bootstrapFilePath()}};
 
   if (bootstrap_file.hasValue(ENCRYPTION_KEY_PROPERTY_NAME)) {

--- a/encrypt-config/tests/ConfigFileEncryptorTests.cpp
+++ b/encrypt-config/tests/ConfigFileEncryptorTests.cpp
@@ -68,7 +68,7 @@ bool operator!=(const  ConfigFile& left, const  ConfigFile& right) { return !(le
 }  // namespace org::apache::nifi::minifi
 
 TEST_CASE("ConfigFileEncryptor can encrypt the sensitive properties", "[encrypt-config][encryptSensitivePropertiesInFile]") {
-  utils::crypto::Bytes KEY = utils::StringUtils::from_base64("6q9u8LEDy1/CdmSBm8oSqPS/Ds5UOD2nRouP8yUoK10=");
+  utils::crypto::Bytes KEY = utils::string::from_base64("6q9u8LEDy1/CdmSBm8oSqPS/Ds5UOD2nRouP8yUoK10=");
 
   SECTION("default properties") {
     ConfigFile test_file{std::ifstream{"resources/minifi.properties"}};

--- a/extensions/aws/processors/PutS3Object.cpp
+++ b/extensions/aws/processors/PutS3Object.cpp
@@ -46,10 +46,10 @@ void PutS3Object::fillUserMetadata(core::ProcessContext& context) {
       logger_->log_debug("PutS3Object: DynamicProperty: [{}] -> [{}]", prop_key, prop_value);
       user_metadata_map_.emplace(prop_key, prop_value);
       if (first_property) {
-        user_metadata_ = minifi::utils::StringUtils::join_pack(prop_key, "=", prop_value);
+        user_metadata_ = minifi::utils::string::join_pack(prop_key, "=", prop_value);
         first_property = false;
       } else {
-        user_metadata_ += minifi::utils::StringUtils::join_pack(",", prop_key, "=", prop_value);
+        user_metadata_ += minifi::utils::string::join_pack(",", prop_key, "=", prop_value);
       }
     }
   }
@@ -103,16 +103,16 @@ void PutS3Object::onSchedule(core::ProcessContext& context, core::ProcessSession
 }
 
 std::string PutS3Object::parseAccessControlList(const std::string &comma_separated_list) {
-  auto users = minifi::utils::StringUtils::split(comma_separated_list, ",");
+  auto users = minifi::utils::string::split(comma_separated_list, ",");
   for (auto& user : users) {
-    auto trimmed_user = minifi::utils::StringUtils::trim(user);
+    auto trimmed_user = minifi::utils::string::trim(user);
     if (trimmed_user.find('@') != std::string::npos) {
       user = "emailAddress=\"" + trimmed_user + "\"";
     } else {
       user = "id=" + trimmed_user;
     }
   }
-  return minifi::utils::StringUtils::join(", ", users);
+  return minifi::utils::string::join(", ", users);
 }
 
 bool PutS3Object::setCannedAcl(

--- a/extensions/aws/s3/MultipartUploadStateStorage.cpp
+++ b/extensions/aws/s3/MultipartUploadStateStorage.cpp
@@ -31,7 +31,7 @@ void MultipartUploadStateStorage::storeState(const std::string& bucket, const st
   stored_state[state_key + ".uploaded_size"] = std::to_string(state.uploaded_size);
   stored_state[state_key + ".part_size"] = std::to_string(state.part_size);
   stored_state[state_key + ".full_size"] = std::to_string(state.full_size);
-  stored_state[state_key + ".uploaded_etags"] = minifi::utils::StringUtils::join(";", state.uploaded_etags);
+  stored_state[state_key + ".uploaded_etags"] = minifi::utils::string::join(";", state.uploaded_etags);
   state_manager_->set(stored_state);
   state_manager_->commit();
   state_manager_->persist();
@@ -64,7 +64,7 @@ std::optional<MultipartUploadState> MultipartUploadStateStorage::getState(const 
   core::Property::StringToInt(state_map[state_key + ".uploaded_size"], state.uploaded_size);
   core::Property::StringToInt(state_map[state_key + ".part_size"], state.part_size);
   core::Property::StringToInt(state_map[state_key + ".full_size"], state.full_size);
-  state.uploaded_etags = minifi::utils::StringUtils::splitAndTrimRemovingEmpty(state_map[state_key + ".uploaded_etags"], ";");
+  state.uploaded_etags = minifi::utils::string::splitAndTrimRemovingEmpty(state_map[state_key + ".uploaded_etags"], ";");
   return state;
 }
 
@@ -109,7 +109,7 @@ void MultipartUploadStateStorage::removeAgedStates(std::chrono::milliseconds mul
   std::vector<std::string> keys_to_remove;
   for (const auto& [property_key, value] : state_map) {
     std::string upload_time_suffix = ".upload_time";
-    if (!minifi::utils::StringUtils::endsWith(property_key, upload_time_suffix)) {
+    if (!minifi::utils::string::endsWith(property_key, upload_time_suffix)) {
       continue;
     }
     int64_t stored_upload_time{};

--- a/extensions/aws/s3/S3Wrapper.cpp
+++ b/extensions/aws/s3/S3Wrapper.cpp
@@ -264,7 +264,7 @@ void S3Wrapper::addListResults(const Aws::Vector<Aws::S3::Model::ObjectVersion>&
     }
 
     ListedObjectAttributes attributes;
-    attributes.etag = minifi::utils::StringUtils::removeFramingCharacters(version.GetETag(), '"');
+    attributes.etag = minifi::utils::string::removeFramingCharacters(version.GetETag(), '"');
     attributes.filename = version.GetKey();
     attributes.is_latest = version.GetIsLatest();
     attributes.last_modified = version.GetLastModified().UnderlyingTimestamp();
@@ -283,7 +283,7 @@ void S3Wrapper::addListResults(const Aws::Vector<Aws::S3::Model::Object>& conten
     }
 
     ListedObjectAttributes attributes;
-    attributes.etag = minifi::utils::StringUtils::removeFramingCharacters(object.GetETag(), '"');
+    attributes.etag = minifi::utils::string::removeFramingCharacters(object.GetETag(), '"');
     attributes.filename = object.GetKey();
     attributes.is_latest = true;
     attributes.last_modified = object.GetLastModified().UnderlyingTimestamp();
@@ -400,7 +400,7 @@ FetchObjectResult S3Wrapper::fillFetchObjectResult(const GetObjectRequestParamet
   FetchObjectResult result;
   result.setFilePaths(get_object_params.object_key);
   result.mime_type = fetch_object_result.GetContentType();
-  result.etag = minifi::utils::StringUtils::removeFramingCharacters(fetch_object_result.GetETag(), '"');
+  result.etag = minifi::utils::string::removeFramingCharacters(fetch_object_result.GetETag(), '"');
   result.expiration = getExpiration(fetch_object_result.GetExpiration());
   result.ssealgorithm = getEncryptionString(fetch_object_result.GetServerSideEncryption());
   result.version = fetch_object_result.GetVersionId();

--- a/extensions/aws/s3/S3Wrapper.h
+++ b/extensions/aws/s3/S3Wrapper.h
@@ -301,7 +301,7 @@ class S3Wrapper {
     return {
       .version = upload_result.GetVersionId(),
       // Etags are returned by AWS in quoted form that should be removed
-      .etag = minifi::utils::StringUtils::removeFramingCharacters(upload_result.GetETag(), '"'),
+      .etag = minifi::utils::string::removeFramingCharacters(upload_result.GetETag(), '"'),
       // GetExpiration returns a string pair with a date and a ruleid in 'expiry-date=\"<DATE>\", rule-id=\"<RULEID>\"' format
       // s3.expiration only needs the date member of this pair
       .expiration = getExpiration(upload_result.GetExpiration()).expiration_time,

--- a/extensions/azure/storage/AzureDataLakeStorage.cpp
+++ b/extensions/azure/storage/AzureDataLakeStorage.cpp
@@ -34,7 +34,7 @@ namespace org::apache::nifi::minifi::azure::storage {
 
 namespace {
 bool matchesPathFilter(std::string_view base_directory, const std::optional<minifi::utils::Regex>& path_regex, std::string path) {
-  gsl_Expects(utils::implies(!base_directory.empty(), minifi::utils::StringUtils::startsWith(path, base_directory)));
+  gsl_Expects(utils::implies(!base_directory.empty(), minifi::utils::string::startsWith(path, base_directory)));
   if (!path_regex) {
     return true;
   }

--- a/extensions/civetweb/tests/ListenHTTPTests.cpp
+++ b/extensions/civetweb/tests/ListenHTTPTests.cpp
@@ -171,10 +171,10 @@ class ListenHTTPTestsFixture {
       if (!update_attribute->getDynamicProperty("mime.type", content_type)) {
         content_type = "application/octet-stream";
       }
-      REQUIRE(content_type == minifi::utils::StringUtils::trim(client->getResponseHeaderMap().at("Content-type")));
-      REQUIRE("19" == minifi::utils::StringUtils::trim(client->getResponseHeaderMap().at("Content-length")));
+      REQUIRE(content_type == minifi::utils::string::trim(client->getResponseHeaderMap().at("Content-type")));
+      REQUIRE("19" == minifi::utils::string::trim(client->getResponseHeaderMap().at("Content-length")));
     } else {
-      REQUIRE("0" == minifi::utils::StringUtils::trim(client->getResponseHeaderMap().at("Content-length")));
+      REQUIRE("0" == minifi::utils::string::trim(client->getResponseHeaderMap().at("Content-length")));
     }
   }
 

--- a/extensions/elasticsearch/PostElasticsearch.cpp
+++ b/extensions/elasticsearch/PostElasticsearch.cpp
@@ -57,7 +57,7 @@ void PostElasticsearch::onSchedule(core::ProcessContext& context, core::ProcessS
     throw Exception(PROCESS_SCHEDULE_EXCEPTION, "Max Batch Size property is invalid");
 
   if (auto hosts_str = context.getProperty(Hosts)) {
-    auto hosts = utils::StringUtils::split(*hosts_str, ",");
+    auto hosts = utils::string::split(*hosts_str, ",");
     if (hosts.size() > 1)
       throw Exception(PROCESS_SCHEDULE_EXCEPTION, "Multiple hosts not yet supported");
     host_url_ = hosts[0];

--- a/extensions/elasticsearch/tests/MockElastic.h
+++ b/extensions/elasticsearch/tests/MockElastic.h
@@ -98,7 +98,7 @@ class BulkElasticHandler : public CivetHandler {
     char request[2048];
     size_t chars_read = mg_read(conn, request, 2048);
 
-    std::vector<std::string> lines = utils::StringUtils::splitRemovingEmpty({request, chars_read}, "\n");
+    std::vector<std::string> lines = utils::string::splitRemovingEmpty({request, chars_read}, "\n");
     rapidjson::Document response{rapidjson::kObjectType};
     response.AddMember("took", 30, response.GetAllocator());
     response.AddMember("errors", ret_error_, response.GetAllocator());

--- a/extensions/expression-language/Expression.cpp
+++ b/extensions/expression-language/Expression.cpp
@@ -462,7 +462,7 @@ Value expr_unescapeJson(const std::vector<Value> &args) {
 }
 
 Value expr_escapeHtml3(const std::vector<Value> &args) {
-  return Value(utils::StringUtils::replaceMap(args[0].asString(), { { "!", "&excl;" }, { "\"", "&quot;" }, { "#", "&num;" }, { "$", "&dollar;" }, { "%", "&percnt;" }, { "&", "&amp;" },
+  return Value(utils::string::replaceMap(args[0].asString(), { { "!", "&excl;" }, { "\"", "&quot;" }, { "#", "&num;" }, { "$", "&dollar;" }, { "%", "&percnt;" }, { "&", "&amp;" },
                                                   { "'", "&apos;" }, { "(", "&lpar;" }, { ")", "&rpar;" }, { "*", "&ast;" }, { "+", "&plus;" }, { ",", "&comma;" }, { "-", "&minus;" }, { ".",
                                                       "&period;" }, { "/", "&sol;" }, { ":", "&colon;" }, { ";", "&semi;" }, { "<", "&lt;" }, { "=", "&equals;" }, { ">", "&gt;" }, { "?", "&quest;" },
                                                   { "@", "&commat;" }, { "[", "&lsqb;" }, { "\\", "&bsol;" }, { "]", "&rsqb;" }, { "^", "&circ;" }, { "_", "&lowbar;" }, { "`", "&grave;" }, { "{",
@@ -483,7 +483,7 @@ Value expr_escapeHtml3(const std::vector<Value> &args) {
 }
 
 Value expr_escapeHtml4(const std::vector<Value> &args) {
-  return Value(utils::StringUtils::replaceMap(args[0].asString(), { { "!", "&excl;" }, { "\"", "&quot;" }, { "#", "&num;" }, { "$", "&dollar;" }, { "%", "&percnt;" }, { "&", "&amp;" },
+  return Value(utils::string::replaceMap(args[0].asString(), { { "!", "&excl;" }, { "\"", "&quot;" }, { "#", "&num;" }, { "$", "&dollar;" }, { "%", "&percnt;" }, { "&", "&amp;" },
                                                   { "'", "&apos;" }, { "(", "&lpar;" }, { ")", "&rpar;" }, { "*", "&ast;" }, { "+", "&plus;" }, { ",", "&comma;" }, { "-", "&minus;" }, { ".",
                                                       "&period;" }, { "/", "&sol;" }, { ":", "&colon;" }, { ";", "&semi;" }, { "<", "&lt;" }, { "=", "&equals;" }, { ">", "&gt;" }, { "?", "&quest;" },
                                                   { "@", "&commat;" }, { "[", "&lsqb;" }, { "\\", "&bsol;" }, { "]", "&rsqb;" }, { "^", "&circ;" }, { "_", "&lowbar;" }, { "`", "&grave;" }, { "{",
@@ -531,7 +531,7 @@ Value expr_escapeHtml4(const std::vector<Value> &args) {
 }
 
 Value expr_unescapeHtml3(const std::vector<Value> &args) {
-  return Value(utils::StringUtils::replaceMap(args[0].asString(), { { "&excl;", "!" }, { "&quot;", "\"" }, { "&num;", "#" }, { "&dollar;", "$" }, { "&percnt;", "%" }, { "&amp;", "&" },
+  return Value(utils::string::replaceMap(args[0].asString(), { { "&excl;", "!" }, { "&quot;", "\"" }, { "&num;", "#" }, { "&dollar;", "$" }, { "&percnt;", "%" }, { "&amp;", "&" },
                                                   { "&apos;", "'" }, { "&lpar;", "(" }, { "&rpar;", ")" }, { "&ast;", "*" }, { "&plus;", "+" }, { "&comma;", "," }, { "&minus;", "-" }, { "&period;",
                                                       "." }, { "&sol;", "/" }, { "&colon;", ":" }, { "&semi;", ";" }, { "&lt;", "<" }, { "&equals;", "=" }, { "&gt;", ">" }, { "&quest;", "?" }, {
                                                       "&commat;", "@" }, { "&lsqb;", "[" }, { "&bsol;", "\\" }, { "&rsqb;", "]" }, { "&circ;", "^" }, { "&lowbar;", "_" }, { "&grave;", "`" }, {
@@ -552,7 +552,7 @@ Value expr_unescapeHtml3(const std::vector<Value> &args) {
 }
 
 Value expr_unescapeHtml4(const std::vector<Value> &args) {
-  return Value(utils::StringUtils::replaceMap(args[0].asString(), { { "&excl;", "!" }, { "&quot;", "\"" }, { "&num;", "#" }, { "&dollar;", "$" }, { "&percnt;", "%" }, { "&amp;", "&" },
+  return Value(utils::string::replaceMap(args[0].asString(), { { "&excl;", "!" }, { "&quot;", "\"" }, { "&num;", "#" }, { "&dollar;", "$" }, { "&percnt;", "%" }, { "&amp;", "&" },
                                                   { "&apos;", "'" }, { "&lpar;", "(" }, { "&rpar;", ")" }, { "&ast;", "*" }, { "&plus;", "+" }, { "&comma;", "," }, { "&minus;", "-" }, { "&period;",
                                                       "." }, { "&sol;", "/" }, { "&colon;", ":" }, { "&semi;", ";" }, { "&lt;", "<" }, { "&equals;", "=" }, { "&gt;", ">" }, { "&quest;", "?" }, {
                                                       "&commat;", "@" }, { "&lsqb;", "[" }, { "&bsol;", "\\" }, { "&rsqb;", "]" }, { "&circ;", "^" }, { "&lowbar;", "_" }, { "&grave;", "`" }, {
@@ -600,11 +600,11 @@ Value expr_unescapeHtml4(const std::vector<Value> &args) {
 }
 
 Value expr_escapeXml(const std::vector<Value> &args) {
-  return Value(utils::StringUtils::replaceMap(args[0].asString(), { { "\"", "&quot;" }, { "'", "&apos;" }, { "<", "&lt;" }, { ">", "&gt;" }, { "&", "&amp;" } }));
+  return Value(utils::string::replaceMap(args[0].asString(), { { "\"", "&quot;" }, { "'", "&apos;" }, { "<", "&lt;" }, { ">", "&gt;" }, { "&", "&amp;" } }));
 }
 
 Value expr_unescapeXml(const std::vector<Value> &args) {
-  return Value(utils::StringUtils::replaceMap(args[0].asString(), { { "&quot;", "\"" }, { "&apos;", "'" }, { "&lt;", "<" }, { "&gt;", ">" }, { "&amp;", "&" } }));
+  return Value(utils::string::replaceMap(args[0].asString(), { { "&quot;", "\"" }, { "&apos;", "'" }, { "&lt;", "<" }, { "&gt;", ">" }, { "&amp;", "&" } }));
 }
 
 Value expr_escapeCsv(const std::vector<Value> &args) {
@@ -621,7 +621,7 @@ Value expr_escapeCsv(const std::vector<Value> &args) {
 
   if (quote_required) {
     std::string quoted_result = "\"";
-    quoted_result.append(utils::StringUtils::replaceMap(result, { { "\"", "\"\"" } }));
+    quoted_result.append(utils::string::replaceMap(result, { { "\"", "\"\"" } }));
     quoted_result.append("\"");
     return Value(quoted_result);
   }
@@ -694,7 +694,7 @@ Value expr_unescapeCsv(const std::vector<Value> &args) {
     }
 
     if (quote_required) {
-      return Value(utils::StringUtils::replaceMap(result.substr(1, result.size() - 2), { { "\"\"", "\"" } }));
+      return Value(utils::string::replaceMap(result.substr(1, result.size() - 2), { { "\"\"", "\"" } }));
     }
   }
 
@@ -749,11 +749,11 @@ Value expr_urlDecode(const std::vector<Value> &args) {
 }
 
 Value expr_base64Encode(const std::vector<Value> &args) {
-  return Value(utils::StringUtils::to_base64(args[0].asString()));
+  return Value(utils::string::to_base64(args[0].asString()));
 }
 
 Value expr_base64Decode(const std::vector<Value> &args) {
-  return Value(utils::StringUtils::from_base64(args[0].asString(), utils::as_string));
+  return Value(utils::string::from_base64(args[0].asString(), utils::as_string));
 }
 
 Value expr_replace(const std::vector<Value> &args) {
@@ -816,7 +816,7 @@ Value expr_find(const std::vector<Value> &args) {
 }
 
 Value expr_trim(const std::vector<Value> &args) {
-  return Value{utils::StringUtils::trim(args[0].asString())};
+  return Value{utils::string::trim(args[0].asString())};
 }
 
 Value expr_append(const std::vector<Value> &args) {
@@ -1270,7 +1270,7 @@ Expression make_allDelineatedValues(const std::string &function_name, const std:
   result.make_multi([=](const Parameters &params) -> std::vector<Expression> {
     std::vector<Expression> out_exprs;
 
-    for (const auto &val : utils::StringUtils::split(args[0](params).asString(), args[1](params).asString())) {
+    for (const auto &val : utils::string::split(args[0](params).asString(), args[1](params).asString())) {
       out_exprs.emplace_back(make_static(val));
     }
 
@@ -1302,7 +1302,7 @@ Expression make_anyDelineatedValue(const std::string &function_name, const std::
   result.make_multi([=](const Parameters &params) -> std::vector<Expression> {
     std::vector<Expression> out_exprs;
 
-    for (const auto &val : utils::StringUtils::split(args[0](params).asString(), args[1](params).asString())) {
+    for (const auto &val : utils::string::split(args[0](params).asString(), args[1](params).asString())) {
       out_exprs.emplace_back(make_static(val));
     }
 

--- a/extensions/expression-language/common/Value.h
+++ b/extensions/expression-language/common/Value.h
@@ -131,7 +131,7 @@ class Value {
       [](int64_t i) { return i != 0; },
       [](uint64_t i) { return i != 0; },
       [](long double d) { return d != 0.0; },
-      [](const std::string& str) { return utils::StringUtils::toBool(str).value_or(false); },
+      [](const std::string& str) { return utils::string::toBool(str).value_or(false); },
       [](auto) { return false; }
     }, value_);
   }
@@ -143,9 +143,9 @@ class Value {
     try {
       return std::invoke(conversion_function, value);
     } catch (const std::invalid_argument&) {
-      throw std::invalid_argument{utils::StringUtils::join_pack(context, " failed to parse \"", value, "\": invalid argument")};
+      throw std::invalid_argument{utils::string::join_pack(context, " failed to parse \"", value, "\": invalid argument")};
     } catch (const std::out_of_range&) {
-      throw std::out_of_range{utils::StringUtils::join_pack(context, " failed to parse \"", value, "\": out of range")};
+      throw std::out_of_range{utils::string::join_pack(context, " failed to parse \"", value, "\": out of range")};
     }
   }
 

--- a/extensions/http-curl/client/HTTPClient.cpp
+++ b/extensions/http-curl/client/HTTPClient.cpp
@@ -332,7 +332,7 @@ std::unique_ptr<struct curl_slist, CurlSlistDeleter> toCurlSlist(const std::unor
   gsl::owner<curl_slist*> new_list = nullptr;
   const auto guard = gsl::finally([&new_list]() { curl_slist_free_all(new_list); });
   for (const auto& [header_key, header_value] : request_headers)
-    new_list = (utils::optional_from_ptr(curl_slist_append(new_list, utils::StringUtils::join_pack(header_key, ": ", header_value).c_str()))  // NOLINT(cppcoreguidelines-owning-memory)
+    new_list = (utils::optional_from_ptr(curl_slist_append(new_list, utils::string::join_pack(header_key, ": ", header_value).c_str()))  // NOLINT(cppcoreguidelines-owning-memory)
         | utils::orElse([]() { throw std::runtime_error{"curl_slist_append failed"}; })).value();
 
   return {std::exchange(new_list, nullptr), {}};

--- a/extensions/http-curl/client/HTTPClient.h
+++ b/extensions/http-curl/client/HTTPClient.h
@@ -163,7 +163,7 @@ class HTTPClient : public utils::BaseHTTPClient, public core::Connectable {
   std::string getHeaderValue(const std::string &key) {
     std::string ret;
     for (const auto &kv : response_data_.header_response.getHeaderMap()) {
-      if (utils::StringUtils::equalsIgnoreCase(key, kv.first)) {
+      if (utils::string::equalsIgnoreCase(key, kv.first)) {
         ret = kv.second;
         break;
       }

--- a/extensions/http-curl/processors/InvokeHTTP.cpp
+++ b/extensions/http-curl/processors/InvokeHTTP.cpp
@@ -76,8 +76,8 @@ void InvokeHTTP::setupMembersFromProperties(const core::ProcessContext& context)
                         | utils::transform([](const std::string& regex_str) { return utils::Regex{regex_str}; })
                         | utils::orElse([this] { logger_->log_debug("{} is missing, so the default value will be used", AttributesToSend.name); });
 
-  always_output_response_ = (context.getProperty(AlwaysOutputResponse) | utils::andThen(&utils::StringUtils::toBool)).value_or(false);
-  penalize_no_retry_ = (context.getProperty(PenalizeOnNoRetry) | utils::andThen(&utils::StringUtils::toBool)).value_or(false);
+  always_output_response_ = (context.getProperty(AlwaysOutputResponse) | utils::andThen(&utils::string::toBool)).value_or(false);
+  penalize_no_retry_ = (context.getProperty(PenalizeOnNoRetry) | utils::andThen(&utils::string::toBool)).value_or(false);
 
   invalid_http_header_field_handling_strategy_ = utils::parseEnumProperty<invoke_http::InvalidHTTPHeaderFieldHandlingOption>(context, InvalidHTTPHeaderFieldHandlingStrategy);
 
@@ -87,7 +87,7 @@ void InvokeHTTP::setupMembersFromProperties(const core::ProcessContext& context)
     put_response_body_in_attribute_.reset();
   }
 
-  use_chunked_encoding_ = (context.getProperty(UseChunkedEncoding) | utils::andThen(&utils::StringUtils::toBool)).value_or(false);
+  use_chunked_encoding_ = (context.getProperty(UseChunkedEncoding) | utils::andThen(&utils::string::toBool)).value_or(false);
   send_date_header_ = context.getProperty<bool>(DateHeader).value_or(true);
 
   context.getProperty(UploadSpeedLimit, maximum_upload_speed_);
@@ -108,7 +108,7 @@ void InvokeHTTP::setupMembersFromProperties(const core::ProcessContext& context)
   context.getProperty(InvokeHTTP::ProxyPassword, proxy_.password);
 
   follow_redirects_ = context.getProperty<bool>(InvokeHTTP::FollowRedirects).value_or(false);
-  disable_peer_verification_ = (context.getProperty(InvokeHTTP::DisablePeerVerification) | utils::andThen(&utils::StringUtils::toBool)).value_or(false);
+  disable_peer_verification_ = (context.getProperty(InvokeHTTP::DisablePeerVerification) | utils::andThen(&utils::string::toBool)).value_or(false);
   content_type_ = context.getProperty(InvokeHTTP::ContentType);
 
   if (auto ssl_context_name = context.getProperty(SSLContext)) {

--- a/extensions/http-curl/protocols/RESTSender.cpp
+++ b/extensions/http-curl/protocols/RESTSender.cpp
@@ -52,7 +52,7 @@ void RESTSender::initialize(core::controller::ControllerServiceProvider* control
     }
     if (nullptr == ssl_context_service_) {
       std::string ssl_context_str;
-      if (configure->get(Configure::nifi_remote_input_secure, ssl_context_str) && org::apache::nifi::minifi::utils::StringUtils::toBool(ssl_context_str).value_or(false)) {
+      if (configure->get(Configure::nifi_remote_input_secure, ssl_context_str) && org::apache::nifi::minifi::utils::string::toBool(ssl_context_str).value_or(false)) {
         ssl_context_service_ = std::make_shared<minifi::controllers::SSLContextService>("RESTSenderSSL", configure);
         ssl_context_service_->onEnable();
       }
@@ -170,7 +170,7 @@ C2Payload RESTSender::sendPayload(const std::string& url, const Direction direct
     auto read = std::make_unique<utils::HTTPReadCallback>(std::numeric_limits<size_t>::max());
     client.setReadCallback(std::move(read));
     if (accepted_formats && !accepted_formats->empty()) {
-      client.setRequestHeader("Accept", utils::StringUtils::join(", ", accepted_formats.value()));
+      client.setRequestHeader("Accept", utils::string::join(", ", accepted_formats.value()));
     }
   } else {
     // Due to a bug in MiNiFi C2 the Accept header is not handled properly thus we need to exclude it to be compatible
@@ -188,7 +188,7 @@ C2Payload RESTSender::sendPayload(const std::string& url, const Direction direct
     logger_->log_debug("Response code '{}' from '{}'", respCode, url);
   }
   const auto response_body_bytes = gsl::make_span(client.getResponseBody()).as_span<const std::byte>();
-  logger_->log_trace("Received response: \"{}\"", [&] { return utils::StringUtils::escapeUnprintableBytes(response_body_bytes); });
+  logger_->log_trace("Received response: \"{}\"", [&] { return utils::string::escapeUnprintableBytes(response_body_bytes); });
   if (isOkay && !clientError && !serverError) {
     if (accepted_formats) {
       C2Payload response_payload(payload.getOperation(), state::UpdateState::READ_COMPLETE, true);

--- a/extensions/http-curl/sitetosite/HTTPProtocol.cpp
+++ b/extensions/http-curl/sitetosite/HTTPProtocol.cpp
@@ -61,7 +61,7 @@ std::shared_ptr<sitetosite::Transaction> HttpSiteToSiteClient::createTransaction
   if (client->getResponseCode() == 201) {
     // parse the headers
     auto intent_name = client->getHeaderValue("x-location-uri-intent");
-    if (utils::StringUtils::equalsIgnoreCase(intent_name, "transaction-url")) {
+    if (utils::string::equalsIgnoreCase(intent_name, "transaction-url")) {
       auto url = client->getHeaderValue("Location");
 
       if (IsNullOrEmpty(url)) {

--- a/extensions/http-curl/sitetosite/PeersEntity.h
+++ b/extensions/http-curl/sitetosite/PeersEntity.h
@@ -69,12 +69,12 @@ class PeersEntity {
             } else if (peer["secure"].IsString()) {
               std::string secureStr = peer["secure"].GetString();
 
-              if (utils::StringUtils::equalsIgnoreCase(secureStr, "true")) {
+              if (utils::string::equalsIgnoreCase(secureStr, "true")) {
                 secure = true;
-              } else if (utils::StringUtils::equalsIgnoreCase(secureStr, "false")) {
+              } else if (utils::string::equalsIgnoreCase(secureStr, "false")) {
                 secure = false;
               } else {
-                const auto err = utils::StringUtils::join_pack("could not parse secure string ", secureStr);
+                const auto err = utils::string::join_pack("could not parse secure string ", secureStr);
                 logger->log_error("{}", err);
                 throw std::logic_error{err};
               }

--- a/extensions/http-curl/tests/C2ClearCoreComponentStateTest.cpp
+++ b/extensions/http-curl/tests/C2ClearCoreComponentStateTest.cpp
@@ -141,7 +141,7 @@ class ClearCoreComponentStateHandler: public HeartbeatHandler {
           const std::string tailing_file_pattern = "[debug] Tailing file " + file_1_location_.string();
           const std::string tail_file_committed_pattern = "[trace] ProcessSession committed for TailFile1";
           const std::vector<std::string> patterns = {tailing_file_pattern, tailing_file_pattern, tail_file_committed_pattern};
-          return utils::StringUtils::matchesSequence(log_contents, patterns);
+          return utils::string::matchesSequence(log_contents, patterns);
         };
         if (tail_file_ran_again_checker()) {
           flow_state_ = FlowState::CLEAR_SENT_ACK;

--- a/extensions/http-curl/tests/C2DescribeManifestTest.cpp
+++ b/extensions/http-curl/tests/C2DescribeManifestTest.cpp
@@ -51,7 +51,7 @@ int main(int argc, char **argv) {
   const cmd_args args = parse_cmdline_args(argc, argv, "heartbeat");
   std::atomic_bool verified{false};
   VerifyC2Describe harness(verified);
-  utils::crypto::Bytes encryption_key = utils::StringUtils::from_hex("4024b327fdc987ce3eb43dd1f690b9987e4072e0020e3edf4349ce1ad91a4e38");
+  utils::crypto::Bytes encryption_key = utils::string::from_hex("4024b327fdc987ce3eb43dd1f690b9987e4072e0020e3edf4349ce1ad91a4e38");
   minifi::Decryptor decryptor{utils::crypto::EncryptionProvider{encryption_key}};
   std::string encrypted_value = "l3WY1V27knTiPa6jVX0jrq4qjmKsySOu||ErntqZpHP1M+6OkA14p5sdnqJhuNHWHDVUU5EyMloTtSytKk9a5xNKo=";
 

--- a/extensions/http-curl/tests/C2LogHeartbeatTest.cpp
+++ b/extensions/http-curl/tests/C2LogHeartbeatTest.cpp
@@ -56,7 +56,7 @@ class VerifyLogC2Heartbeat : public VerifyC2Base {
     const auto log = LogTestController::getInstance().getLogs();
     auto types_in_heartbeat = log | ranges::views::split('\n')
         | ranges::views::transform([](auto&& rng) { return rng | ranges::to<std::string>; })
-        | ranges::views::filter([](auto&& line) { return utils::StringUtils::startsWith(line, "                                \"type\":"); })
+        | ranges::views::filter([](auto&& line) { return utils::string::startsWith(line, "                                \"type\":"); })
         | ranges::to<std::vector<std::string>>;
     const auto num_types = types_in_heartbeat.size();
     types_in_heartbeat |= ranges::actions::sort | ranges::actions::unique;

--- a/extensions/http-curl/tests/C2MetricsTest.cpp
+++ b/extensions/http-curl/tests/C2MetricsTest.cpp
@@ -182,8 +182,8 @@ class MetricsHandler: public HeartbeatHandler {
   [[nodiscard]] static std::string getReplacementConfigAsJsonValue(const std::string& replacement_config_path) {
     std::ifstream is(replacement_config_path);
     auto content = std::string((std::istreambuf_iterator<char>(is)), std::istreambuf_iterator<char>());
-    content = minifi::utils::StringUtils::replaceAll(content, "\n", "\\n");
-    content = minifi::utils::StringUtils::replaceAll(content, "\"", "\\\"");
+    content = minifi::utils::string::replaceAll(content, "\n", "\\n");
+    content = minifi::utils::string::replaceAll(content, "\"", "\\\"");
     return content;
   }
 
@@ -209,7 +209,7 @@ int main(int argc, char **argv) {
   harness.getConfiguration()->set("nifi.c2.root.class.definitions.metrics.metrics.processorMetrics.classes", "processorMetrics/GetTCP.*");
   harness.setKeyDir(args.key_dir);
   auto replacement_path = args.test_file;
-  minifi::utils::StringUtils::replaceAll(replacement_path, "TestC2Metrics", "TestC2MetricsUpdate");
+  minifi::utils::string::replaceAll(replacement_path, "TestC2Metrics", "TestC2MetricsUpdate");
   org::apache::nifi::minifi::test::MetricsHandler handler(metrics_updated_successfully, harness.getConfiguration(), replacement_path);
   harness.setUrl(args.url, &handler);
   harness.run(args.test_file);

--- a/extensions/http-curl/tests/C2PropertiesUpdateTests.cpp
+++ b/extensions/http-curl/tests/C2PropertiesUpdateTests.cpp
@@ -74,7 +74,7 @@ class C2HeartbeatHandler : public ServerAwareHandler {
           "operationid" : "79",
           "name": "properties",
           "args": {)" +
-            utils::StringUtils::join(", ", fields)
+            utils::string::join(", ", fields)
           + R"(}
         }]
       })";

--- a/extensions/http-curl/tests/C2UpdateAssetTest.cpp
+++ b/extensions/http-curl/tests/C2UpdateAssetTest.cpp
@@ -244,7 +244,7 @@ int main() {
       // this op failed no file made on the disk
       continue;
     }
-    expected_files[(asset_dir / op.args["file"]).string()] = utils::StringUtils::endsWith(op.args["url"], "A.txt") ? file_A : file_B;
+    expected_files[(asset_dir / op.args["file"]).string()] = utils::string::endsWith(op.args["url"], "A.txt") ? file_A : file_B;
   }
 
   size_t file_count = utils::file::list_dir_all(asset_dir.string(), controller.getLogger()).size();

--- a/extensions/http-curl/tests/HTTPHandlers.h
+++ b/extensions/http-curl/tests/HTTPHandlers.h
@@ -455,7 +455,7 @@ class HeartbeatHandler : public ServerAwareHandler {
     assert(manifestHash.length() == 128);
 
     // throws if not a valid hexadecimal hash
-    const auto hashVec = utils::StringUtils::from_hex(manifestHash);
+    const auto hashVec = utils::string::from_hex(manifestHash);
     assert(hashVec.size() == 64);
 
     for (auto &bundle : root["agentInfo"]["agentManifest"]["bundles"].GetArray()) {

--- a/extensions/jni/JVMCreator.h
+++ b/extensions/jni/JVMCreator.h
@@ -48,7 +48,7 @@ class JVMCreator : public minifi::core::CoreComponent {
   void configure(const std::vector<std::string> &jarFileListings) {
     std::vector<std::string> pathOrFiles;
     for (const auto &path : jarFileListings) {
-      const auto vec = utils::StringUtils::split(path, ",");
+      const auto vec = utils::string::split(path, ",");
       pathOrFiles.insert(pathOrFiles.end(), vec.begin(), vec.end());
     }
 
@@ -69,7 +69,7 @@ class JVMCreator : public minifi::core::CoreComponent {
       configure(paths);
 
       if (configuration->get(minifi::Configuration::nifi_jvm_options, jvmOptionsStr)) {
-        jvm_options_ = utils::StringUtils::split(jvmOptionsStr, ",");
+        jvm_options_ = utils::string::split(jvmOptionsStr, ",");
       }
 
       initializeJVM();

--- a/extensions/jni/jvm/JVMLoader.h
+++ b/extensions/jni/jvm/JVMLoader.h
@@ -153,7 +153,7 @@ class JVMLoader {
     // / to . to normalize. Forcing all classes that enter this method
     // to be a certain way isn't very defensible.
     std::string name = clazz_name;
-    name = utils::StringUtils::replaceAll(name, ".", "/");
+    name = utils::string::replaceAll(name, ".", "/");
 
     if (env == nullptr) {
       env = attach(name);
@@ -168,7 +168,7 @@ class JVMLoader {
     }
 
     std::string modifiedName = name;
-    modifiedName = utils::StringUtils::replaceAll(modifiedName, "/", ".");
+    modifiedName = utils::string::replaceAll(modifiedName, "/", ".");
 
     auto jstringclass = env->NewStringUTF(modifiedName.c_str());
 

--- a/extensions/jni/jvm/JavaControllerService.h
+++ b/extensions/jni/jvm/JavaControllerService.h
@@ -104,7 +104,7 @@ class JavaControllerService : public core::controller::ControllerService, public
 
   JavaClass loadClass(const std::string &class_name_) override {
     std::string modifiedName = class_name_;
-    modifiedName = utils::StringUtils::replaceAll(modifiedName, ".", "/");
+    modifiedName = utils::string::replaceAll(modifiedName, ".", "/");
     return loader->load_class(modifiedName);
   }
 

--- a/extensions/kubernetes/ApiClient.cpp
+++ b/extensions/kubernetes/ApiClient.cpp
@@ -29,7 +29,7 @@ namespace {
 gsl::not_null<apiClient_t*> createApiClient(char **base_path, sslConfig_t** ssl_config, list_t** api_keys) {
   int rc = load_incluster_config(base_path, ssl_config, api_keys);
   if (rc != 0) {
-    throw std::runtime_error(org::apache::nifi::minifi::utils::StringUtils::join_pack("load_incluster_config() failed with error code ", std::to_string(rc)));
+    throw std::runtime_error(org::apache::nifi::minifi::utils::string::join_pack("load_incluster_config() failed with error code ", std::to_string(rc)));
   }
   const auto api_client = apiClient_create_with_base_path(*base_path, *ssl_config, *api_keys);
   if (!api_client) {

--- a/extensions/kubernetes/MetricsFilter.cpp
+++ b/extensions/kubernetes/MetricsFilter.cpp
@@ -28,7 +28,7 @@ nonstd::expected<std::string, std::string> filter(const std::string& metrics_jso
   rapidjson::Document document;
   rapidjson::ParseResult parse_result = document.Parse<rapidjson::kParseStopWhenDoneFlag>(metrics_json.data());
   if (parse_result.IsError()) {
-    return nonstd::make_unexpected(utils::StringUtils::join_pack("Error parsing the metrics received from the Kubernetes API at offset ",
+    return nonstd::make_unexpected(utils::string::join_pack("Error parsing the metrics received from the Kubernetes API at offset ",
         std::to_string(parse_result.Offset()), ": ", rapidjson::GetParseError_En(parse_result.Code())));
   }
 

--- a/extensions/kubernetes/processors/CollectKubernetesPodMetrics.cpp
+++ b/extensions/kubernetes/processors/CollectKubernetesPodMetrics.cpp
@@ -33,17 +33,17 @@ void CollectKubernetesPodMetrics::initialize() {
 void CollectKubernetesPodMetrics::onSchedule(core::ProcessContext& context, core::ProcessSessionFactory&) {
   const auto controller_service_name = context.getProperty(KubernetesControllerService);
   if (!controller_service_name || controller_service_name->empty()) {
-    throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, utils::StringUtils::join_pack("Missing '", KubernetesControllerService.name, "' property")};
+    throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, utils::string::join_pack("Missing '", KubernetesControllerService.name, "' property")};
   }
 
   std::shared_ptr<core::controller::ControllerService> controller_service = context.getControllerService(*controller_service_name);
   if (!controller_service) {
-    throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, utils::StringUtils::join_pack("Controller service '", *controller_service_name, "' not found")};
+    throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, utils::string::join_pack("Controller service '", *controller_service_name, "' not found")};
   }
 
   kubernetes_controller_service_ = std::dynamic_pointer_cast<minifi::controllers::KubernetesControllerService>(controller_service);
   if (!kubernetes_controller_service_) {
-    throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, utils::StringUtils::join_pack("Controller service '", *controller_service_name, "' is not a KubernetesControllerService")};
+    throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, utils::string::join_pack("Controller service '", *controller_service_name, "' is not a KubernetesControllerService")};
   }
 }
 

--- a/extensions/kubernetes/tests/KubernetesMetricsFilterTests.cpp
+++ b/extensions/kubernetes/tests/KubernetesMetricsFilterTests.cpp
@@ -40,7 +40,7 @@ constexpr const char* SYSTEM_POD = R"({"metadata":{"name":"kube-apiserver-kind-c
     R"("labels":{"component":"kube-apiserver","tier":"control-plane"}},"timestamp":"2022-07-15T14:08:29Z","window":"18.516s",)"
     R"("containers":[{"name":"kube-apiserver","usage":{"cpu":"83095152n","memory":"270396Ki"}}]})";
 
-const std::string API_RESULT = minifi::utils::StringUtils::join_pack(
+const std::string API_RESULT = minifi::utils::string::join_pack(
     RESULT_HEADER, HELLO_WORLD_POD_HEADER, HELLO_WORLD_CONTAINER_ONE, ",", HELLO_WORLD_CONTAINER_TWO, "]},", MINIFI_POD, ",", SYSTEM_POD, "]}");
 
 void testSuccessfulFiltering(const std::function<bool(const minifi::kubernetes::ContainerInfo&)>& filter, const std::string& expected_result) {
@@ -58,26 +58,26 @@ TEST_CASE("Without filtering, we get the full result back", "[kubernetes][metric
 
 TEST_CASE("We can filter to get metrics for the default namespace only", "[kubernetes][metrics_filter]") {
   const auto default_namespace_only = [](const minifi::kubernetes::ContainerInfo& container_info) { return container_info.name_space == "default"; };
-  const auto expected_result = minifi::utils::StringUtils::join_pack(
+  const auto expected_result = minifi::utils::string::join_pack(
       RESULT_HEADER, HELLO_WORLD_POD_HEADER, HELLO_WORLD_CONTAINER_ONE, ",", HELLO_WORLD_CONTAINER_TWO, "]},", MINIFI_POD, "]}");
   testSuccessfulFiltering(default_namespace_only, expected_result);
 }
 
 TEST_CASE("We can filter to get metrics for a selected pod only", "[kubernetes][metrics_filter]") {
   const auto minifi_pod_only = [](const minifi::kubernetes::ContainerInfo& container_info) { return container_info.pod_name == "minifi"; };
-  const auto expected_result = minifi::utils::StringUtils::join_pack(RESULT_HEADER, MINIFI_POD, "]}");
+  const auto expected_result = minifi::utils::string::join_pack(RESULT_HEADER, MINIFI_POD, "]}");
   testSuccessfulFiltering(minifi_pod_only, expected_result);
 }
 
 TEST_CASE("We can filter to get metrics for a selected container only", "[kubernetes][metrics_filter]") {
   const auto one_container_only = [](const minifi::kubernetes::ContainerInfo& container_info) { return container_info.pod_name == "hello-world" && container_info.container_name == "echo-two"; };
-  const auto expected_result = minifi::utils::StringUtils::join_pack(RESULT_HEADER, HELLO_WORLD_POD_HEADER, HELLO_WORLD_CONTAINER_TWO, "]}]}");
+  const auto expected_result = minifi::utils::string::join_pack(RESULT_HEADER, HELLO_WORLD_POD_HEADER, HELLO_WORLD_CONTAINER_TWO, "]}]}");
   testSuccessfulFiltering(one_container_only, expected_result);
 }
 
 TEST_CASE("We can filter to get no metrics (not super useful)", "[kubernetes][metrics_filter]") {
   const auto always_false = [](const minifi::kubernetes::ContainerInfo&) { return false; };
-  const auto expected_result = minifi::utils::StringUtils::join_pack(RESULT_HEADER, "]}");
+  const auto expected_result = minifi::utils::string::join_pack(RESULT_HEADER, "]}");
   testSuccessfulFiltering(always_false, expected_result);
 }
 

--- a/extensions/libarchive/CompressContent.cpp
+++ b/extensions/libarchive/CompressContent.cpp
@@ -84,7 +84,7 @@ void CompressContent::onTrigger(core::ProcessContext& context, core::ProcessSess
 void CompressContent::processFlowFile(const std::shared_ptr<core::FlowFile>& flowFile, core::ProcessSession& session) {
   session.remove(flowFile);
 
-  io::CompressionFormat compressFormat;
+  io::CompressionFormat compressFormat{};
   if (compressFormat_ == compress_content::ExtendedCompressionFormat::USE_MIME_TYPE) {
     std::string attr;
     flowFile->getAttribute(core::SpecialFlowAttribute::MIME_TYPE, attr);

--- a/extensions/libarchive/CompressContent.cpp
+++ b/extensions/libarchive/CompressContent.cpp
@@ -188,9 +188,9 @@ void CompressContent::processFlowFile(const std::shared_ptr<core::FlowFile>& flo
     } else {
       session.removeAttribute(result, core::SpecialFlowAttribute::MIME_TYPE);
       if (updateFileName_) {
-        if (utils::StringUtils::endsWith(fileName, fileExtension)) {
+        if (utils::string::endsWith(fileName, fileExtension)) {
           fileName = fileName.substr(0, fileName.size() - fileExtension.size());
-          if (encapsulateInTar_ && utils::StringUtils::endsWith(fileName, TAR_EXT)) {
+          if (encapsulateInTar_ && utils::string::endsWith(fileName, TAR_EXT)) {
             fileName = fileName.substr(0, fileName.size() - TAR_EXT.size());
           }
           session.putAttribute(result, core::SpecialFlowAttribute::FILENAME, fileName);

--- a/extensions/libarchive/tests/CompressContentTests.cpp
+++ b/extensions/libarchive/tests/CompressContentTests.cpp
@@ -169,7 +169,7 @@ class CompressDecompressionTestController : public TestController {
     return flow;
   }
 
-  void trigger() {
+  void trigger() const {
     auto factory = core::ProcessSessionFactory(context);
     processor->onSchedule(*context, factory);
     auto session = core::ProcessSession(context);

--- a/extensions/libarchive/tests/CompressContentTests.cpp
+++ b/extensions/libarchive/tests/CompressContentTests.cpp
@@ -631,8 +631,8 @@ TEST_CASE_METHOD(TestController, "RawGzipCompressionDecompression", "[compressfi
 
 TEST_CASE_METHOD(CompressTestController, "Batch CompressFileGZip", "[compressFileBatchTest]") {
   std::vector<std::string> flowFileContents{
-    utils::StringUtils::repeat("0", 1000), utils::StringUtils::repeat("1", 1000),
-    utils::StringUtils::repeat("2", 1000), utils::StringUtils::repeat("3", 1000),
+    utils::string::repeat("0", 1000), utils::string::repeat("1", 1000),
+    utils::string::repeat("2", 1000), utils::string::repeat("3", 1000),
   };
   const std::size_t batchSize = 3;
 

--- a/extensions/libarchive/tests/MergeFileTests.cpp
+++ b/extensions/libarchive/tests/MergeFileTests.cpp
@@ -193,7 +193,7 @@ class MergeTestController : public TestController {
     context_ = std::make_shared<core::ProcessContext>(std::make_shared<core::ProcessorNode>(merge_content_processor_.get()), nullptr, repo, repo, content_repo);
 
     for (size_t i = 0; i < 6; ++i) {
-      flowFileContents_[i] = utils::StringUtils::repeat(std::to_string(i), 32);
+      flowFileContents_[i] = utils::string::repeat(std::to_string(i), 32);
     }
   }
 

--- a/extensions/librdkafka/ConsumeKafka.cpp
+++ b/extensions/librdkafka/ConsumeKafka.cpp
@@ -67,11 +67,11 @@ void ConsumeKafka::onSchedule(core::ProcessContext& context, core::ProcessSessio
   headers_to_add_as_attributes_ = utils::listFromCommaSeparatedProperty(context, HeadersToAddAsAttributes.name);
   max_poll_records_ = gsl::narrow<std::size_t>(context.getProperty<uint64_t>(MaxPollRecords).value_or(core::StandardPropertyTypes::UNSIGNED_LONG_TYPE.parse(DEFAULT_MAX_POLL_RECORDS)));
 
-  if (!utils::StringUtils::equalsIgnoreCase(KEY_ATTR_ENCODING_UTF_8, key_attribute_encoding_) && !utils::StringUtils::equalsIgnoreCase(KEY_ATTR_ENCODING_HEX, key_attribute_encoding_)) {
+  if (!utils::string::equalsIgnoreCase(KEY_ATTR_ENCODING_UTF_8, key_attribute_encoding_) && !utils::string::equalsIgnoreCase(KEY_ATTR_ENCODING_HEX, key_attribute_encoding_)) {
     throw Exception(PROCESS_SCHEDULE_EXCEPTION, "Unsupported key attribute encoding: " + key_attribute_encoding_);
   }
 
-  if (!utils::StringUtils::equalsIgnoreCase(MSG_HEADER_ENCODING_UTF_8, message_header_encoding_) && !utils::StringUtils::equalsIgnoreCase(MSG_HEADER_ENCODING_HEX, message_header_encoding_)) {
+  if (!utils::string::equalsIgnoreCase(MSG_HEADER_ENCODING_UTF_8, message_header_encoding_) && !utils::string::equalsIgnoreCase(MSG_HEADER_ENCODING_HEX, message_header_encoding_)) {
     throw Exception(PROCESS_SCHEDULE_EXCEPTION, "Unsupported message header encoding: " + key_attribute_encoding_);
   }
 
@@ -115,7 +115,7 @@ void ConsumeKafka::create_topic_partition_list() {
   kf_topic_partition_list_ = { rd_kafka_topic_partition_list_new(gsl::narrow<int>(topic_names_.size())), utils::rd_kafka_topic_partition_list_deleter() };
 
   // On subscriptions any topics prefixed with ^ will be regex matched
-  if (utils::StringUtils::equalsIgnoreCase(TOPIC_FORMAT_PATTERNS, topic_name_format_)) {
+  if (utils::string::equalsIgnoreCase(TOPIC_FORMAT_PATTERNS, topic_name_format_)) {
     for (const std::string& topic : topic_names_) {
       const std::string regex_format = "^" + topic;
       rd_kafka_topic_partition_list_add(kf_topic_partition_list_.get(), regex_format.c_str(), RD_KAFKA_PARTITION_UA);
@@ -245,20 +245,20 @@ std::vector<std::unique_ptr<rd_kafka_message_t, utils::rd_kafka_message_deleter>
 }
 
 utils::KafkaEncoding ConsumeKafka::key_attr_encoding_attr_to_enum() const {
-  if (utils::StringUtils::equalsIgnoreCase(key_attribute_encoding_, KEY_ATTR_ENCODING_UTF_8)) {
+  if (utils::string::equalsIgnoreCase(key_attribute_encoding_, KEY_ATTR_ENCODING_UTF_8)) {
     return utils::KafkaEncoding::UTF8;
   }
-  if (utils::StringUtils::equalsIgnoreCase(key_attribute_encoding_, KEY_ATTR_ENCODING_HEX)) {
+  if (utils::string::equalsIgnoreCase(key_attribute_encoding_, KEY_ATTR_ENCODING_HEX)) {
     return utils::KafkaEncoding::HEX;
   }
   throw minifi::Exception(ExceptionType::PROCESSOR_EXCEPTION, "\"Key Attribute Encoding\" property not recognized.");
 }
 
 utils::KafkaEncoding ConsumeKafka::message_header_encoding_attr_to_enum() const {
-  if (utils::StringUtils::equalsIgnoreCase(message_header_encoding_, MSG_HEADER_ENCODING_UTF_8)) {
+  if (utils::string::equalsIgnoreCase(message_header_encoding_, MSG_HEADER_ENCODING_UTF_8)) {
     return utils::KafkaEncoding::UTF8;
   }
-  if (utils::StringUtils::equalsIgnoreCase(message_header_encoding_, MSG_HEADER_ENCODING_HEX)) {
+  if (utils::string::equalsIgnoreCase(message_header_encoding_, MSG_HEADER_ENCODING_HEX)) {
     return utils::KafkaEncoding::HEX;
   }
   throw minifi::Exception(ExceptionType::PROCESSOR_EXCEPTION, "\"Message Header Encoding\" property not recognized.");
@@ -272,7 +272,7 @@ std::string ConsumeKafka::resolve_duplicate_headers(const std::vector<std::strin
     return matching_headers.back();
   }
   if (MSG_HEADER_COMMA_SEPARATED_MERGE == duplicate_header_handling_) {
-    return utils::StringUtils::join(", ", matching_headers);
+    return utils::string::join(", ", matching_headers);
   }
   throw minifi::Exception(ExceptionType::PROCESSOR_EXCEPTION, "\"Duplicate Header Handling\" property not recognized.");
 }
@@ -334,7 +334,7 @@ std::optional<std::vector<std::shared_ptr<FlowFileRecord>>> ConsumeKafka::transf
     std::string message_content = extract_message(*message);
     std::vector<std::pair<std::string, std::string>> attributes_from_headers = get_flowfile_attributes_from_message_header(*message);
     std::vector<std::string> split_message{ !message_demarcator_.empty() ?
-      utils::StringUtils::split(message_content, message_demarcator_) :
+      utils::string::split(message_content, message_demarcator_) :
       std::vector<std::string>{ message_content }};
     for (auto& flowfile_content : split_message) {
       std::shared_ptr<FlowFileRecord> flow_file = std::static_pointer_cast<FlowFileRecord>(session.create());

--- a/extensions/librdkafka/PublishKafka.cpp
+++ b/extensions/librdkafka/PublishKafka.cpp
@@ -102,7 +102,7 @@ class PublishKafka::Messages {
       }
       oss << "}, ";
     }
-    oss << "in-flight (" << flow_files_in_flight.size() << "): " << utils::StringUtils::join(",", flow_files_in_flight);
+    oss << "in-flight (" << flow_files_in_flight.size() << "): " << utils::string::join(",", flow_files_in_flight);
     return oss.str();
   }
 
@@ -436,7 +436,7 @@ bool PublishKafka::configureNewConnection(core::ProcessContext& context) {
   result = rd_kafka_conf_set(conf_.get(), "bootstrap.servers", key->brokers_.c_str(), errstr.data(), errstr.size());
   logger_->log_debug("PublishKafka: bootstrap.servers [{}]", key->brokers_);
   if (result != RD_KAFKA_CONF_OK) {
-    auto error_msg = utils::StringUtils::join_pack(PREFIX_ERROR_MSG, errstr.data());
+    auto error_msg = utils::string::join_pack(PREFIX_ERROR_MSG, errstr.data());
     throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
   }
 
@@ -446,7 +446,7 @@ bool PublishKafka::configureNewConnection(core::ProcessContext& context) {
   result = rd_kafka_conf_set(conf_.get(), "client.id", key->client_id_.c_str(), errstr.data(), errstr.size());
   logger_->log_debug("PublishKafka: client.id [{}]", key->client_id_);
   if (result != RD_KAFKA_CONF_OK) {
-    auto error_msg = utils::StringUtils::join_pack(PREFIX_ERROR_MSG, errstr.data());
+    auto error_msg = utils::string::join_pack(PREFIX_ERROR_MSG, errstr.data());
     throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
   }
 
@@ -455,7 +455,7 @@ bool PublishKafka::configureNewConnection(core::ProcessContext& context) {
     result = rd_kafka_conf_set(conf_.get(), "debug", value.c_str(), errstr.data(), errstr.size());
     logger_->log_debug("PublishKafka: debug [{}]", value);
     if (result != RD_KAFKA_CONF_OK) {
-      auto error_msg = utils::StringUtils::join_pack(PREFIX_ERROR_MSG, errstr.data());
+      auto error_msg = utils::string::join_pack(PREFIX_ERROR_MSG, errstr.data());
       throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
     }
   }
@@ -465,7 +465,7 @@ bool PublishKafka::configureNewConnection(core::ProcessContext& context) {
     result = rd_kafka_conf_set(conf_.get(), "message.max.bytes", value.c_str(), errstr.data(), errstr.size());
     logger_->log_debug("PublishKafka: message.max.bytes [{}]", value);
     if (result != RD_KAFKA_CONF_OK) {
-      auto error_msg = utils::StringUtils::join_pack(PREFIX_ERROR_MSG, errstr.data());
+      auto error_msg = utils::string::join_pack(PREFIX_ERROR_MSG, errstr.data());
       throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
     }
   }
@@ -480,7 +480,7 @@ bool PublishKafka::configureNewConnection(core::ProcessContext& context) {
     result = rd_kafka_conf_set(conf_.get(), "queue.buffering.max.messages", value.c_str(), errstr.data(), errstr.size());
     logger_->log_debug("PublishKafka: queue.buffering.max.messages [{}]", value);
     if (result != RD_KAFKA_CONF_OK) {
-      auto error_msg = utils::StringUtils::join_pack(PREFIX_ERROR_MSG, errstr.data());
+      auto error_msg = utils::string::join_pack(PREFIX_ERROR_MSG, errstr.data());
       throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
     }
   }
@@ -491,7 +491,7 @@ bool PublishKafka::configureNewConnection(core::ProcessContext& context) {
     result = rd_kafka_conf_set(conf_.get(), "queue.buffering.max.kbytes", valueConf.c_str(), errstr.data(), errstr.size());
     logger_->log_debug("PublishKafka: queue.buffering.max.kbytes [{}]", valueConf);
     if (result != RD_KAFKA_CONF_OK) {
-      auto error_msg = utils::StringUtils::join_pack(PREFIX_ERROR_MSG, errstr.data());
+      auto error_msg = utils::string::join_pack(PREFIX_ERROR_MSG, errstr.data());
       throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
     }
   }
@@ -501,7 +501,7 @@ bool PublishKafka::configureNewConnection(core::ProcessContext& context) {
     result = rd_kafka_conf_set(conf_.get(), "queue.buffering.max.ms", valueConf.c_str(), errstr.data(), errstr.size());
     logger_->log_debug("PublishKafka: queue.buffering.max.ms [{}]", valueConf);
     if (result != RD_KAFKA_CONF_OK) {
-      auto error_msg = utils::StringUtils::join_pack(PREFIX_ERROR_MSG, errstr.data());
+      auto error_msg = utils::string::join_pack(PREFIX_ERROR_MSG, errstr.data());
       throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
     }
   }
@@ -510,7 +510,7 @@ bool PublishKafka::configureNewConnection(core::ProcessContext& context) {
     result = rd_kafka_conf_set(conf_.get(), "batch.num.messages", value.c_str(), errstr.data(), errstr.size());
     logger_->log_debug("PublishKafka: batch.num.messages [{}]", value);
     if (result != RD_KAFKA_CONF_OK) {
-      auto error_msg = utils::StringUtils::join_pack(PREFIX_ERROR_MSG, errstr.data());
+      auto error_msg = utils::string::join_pack(PREFIX_ERROR_MSG, errstr.data());
       throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
     }
   }
@@ -519,7 +519,7 @@ bool PublishKafka::configureNewConnection(core::ProcessContext& context) {
     result = rd_kafka_conf_set(conf_.get(), "compression.codec", value.c_str(), errstr.data(), errstr.size());
     logger_->log_debug("PublishKafka: compression.codec [{}]", value);
     if (result != RD_KAFKA_CONF_OK) {
-      auto error_msg = utils::StringUtils::join_pack(PREFIX_ERROR_MSG, errstr.data());
+      auto error_msg = utils::string::join_pack(PREFIX_ERROR_MSG, errstr.data());
       throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
     }
   }
@@ -538,7 +538,7 @@ bool PublishKafka::configureNewConnection(core::ProcessContext& context) {
       logger_->log_debug("PublishKafka: DynamicProperty: [{}] -> [{}]", prop_key, dynamic_property_value);
       result = rd_kafka_conf_set(conf_.get(), prop_key.c_str(), dynamic_property_value.c_str(), errstr.data(), errstr.size());
       if (result != RD_KAFKA_CONF_OK) {
-        auto error_msg = utils::StringUtils::join_pack(PREFIX_ERROR_MSG, errstr.data());
+        auto error_msg = utils::string::join_pack(PREFIX_ERROR_MSG, errstr.data());
         throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
       }
     } else {
@@ -555,7 +555,7 @@ bool PublishKafka::configureNewConnection(core::ProcessContext& context) {
   // The producer takes ownership of the configuration, we must not free it
   const auto producer = gsl::owner<rd_kafka_t*>(rd_kafka_new(RD_KAFKA_PRODUCER, conf_.release(), errstr.data(), errstr.size()));
   if (producer == nullptr) {
-    auto error_msg = utils::StringUtils::join_pack("Failed to create Kafka producer ", errstr.data());
+    auto error_msg = utils::string::join_pack("Failed to create Kafka producer ", errstr.data());
     throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
   }
 

--- a/extensions/librdkafka/rdkafka_utils.cpp
+++ b/extensions/librdkafka/rdkafka_utils.cpp
@@ -61,7 +61,7 @@ std::string get_human_readable_kafka_message_headers(const rd_kafka_message_t& r
   if (RD_KAFKA_RESP_ERR_NO_ERROR == get_header_response) {
     std::vector<std::string> header_list;
     kafka_headers_for_each(*hdrs, [&] (const std::string& key, std::span<const char> val) { header_list.emplace_back(key + ": " + std::string{ val.data(), val.size() }); });
-    return StringUtils::join(", ", header_list);
+    return string::join(", ", header_list);
   }
   if (RD_KAFKA_RESP_ERR__NOENT == get_header_response) {
     return "[None]";
@@ -98,7 +98,7 @@ std::string get_encoded_string(const std::string& input, KafkaEncoding encoding)
     case KafkaEncoding::UTF8:
       return input;
     case KafkaEncoding::HEX:
-      return StringUtils::to_hex(input, /* uppercase = */ true);
+      return string::to_hex(input, /* uppercase = */ true);
   }
   throw std::runtime_error("Invalid encoding selected: " + input);
 }

--- a/extensions/librdkafka/rdkafka_utils.cpp
+++ b/extensions/librdkafka/rdkafka_utils.cpp
@@ -26,7 +26,7 @@ namespace org::apache::nifi::minifi::utils {
 
 void setKafkaConfigurationField(rd_kafka_conf_t& configuration, const std::string& field_name, const std::string& value) {
   static std::array<char, 512U> errstr{};
-  rd_kafka_conf_res_t result;
+  rd_kafka_conf_res_t result{};
   result = rd_kafka_conf_set(&configuration, field_name.c_str(), value.c_str(), errstr.data(), errstr.size());
   if (RD_KAFKA_CONF_OK != result) {
     const std::string error_msg { errstr.data() };
@@ -42,9 +42,8 @@ void print_topics_list(core::logging::Logger& logger, rd_kafka_topic_partition_l
 }
 
 std::string get_human_readable_kafka_message_timestamp(const rd_kafka_message_t& rkmessage) {
-  rd_kafka_timestamp_type_t tstype;
-  int64_t timestamp;
-  timestamp = rd_kafka_message_timestamp(&rkmessage, &tstype);
+  rd_kafka_timestamp_type_t tstype{};
+  int64_t timestamp = rd_kafka_message_timestamp(&rkmessage, &tstype);
   const char *tsname = "?";
   if (tstype == RD_KAFKA_TIMESTAMP_CREATE_TIME) {
     tsname = "create time";
@@ -56,7 +55,7 @@ std::string get_human_readable_kafka_message_timestamp(const rd_kafka_message_t&
 }
 
 std::string get_human_readable_kafka_message_headers(const rd_kafka_message_t& rkmessage, core::logging::Logger& logger) {
-  rd_kafka_headers_t* hdrs;
+  rd_kafka_headers_t* hdrs = nullptr;
   const rd_kafka_resp_err_t get_header_response = rd_kafka_message_headers(&rkmessage, &hdrs);
   if (RD_KAFKA_RESP_ERR_NO_ERROR == get_header_response) {
     std::vector<std::string> header_list;

--- a/extensions/lua/LuaScriptEngine.cpp
+++ b/extensions/lua/LuaScriptEngine.cpp
@@ -74,9 +74,9 @@ LuaScriptEngine::LuaScriptEngine() {
 void LuaScriptEngine::executeScriptWithAppendedModulePaths(std::string& script) {
   for (const auto& module_path : module_paths_) {
     if (std::filesystem::is_regular_file(std::filesystem::status(module_path))) {
-      script = utils::StringUtils::join_pack("package.path = package.path .. [[;", module_path.string(), "]]\n", script);
+      script = utils::string::join_pack("package.path = package.path .. [[;", module_path.string(), "]]\n", script);
     } else {
-      script = utils::StringUtils::join_pack("package.path = package.path .. [[;", module_path.string(), "/?.lua]]\n", script);
+      script = utils::string::join_pack("package.path = package.path .. [[;", module_path.string(), "/?.lua]]\n", script);
     }
   }
   lua_.script(script, sol::script_throw_on_error);

--- a/extensions/lua/LuaScriptExecutor.cpp
+++ b/extensions/lua/LuaScriptExecutor.cpp
@@ -31,7 +31,7 @@ void LuaScriptExecutor::onTrigger(const std::shared_ptr<core::ProcessContext>& c
   gsl_Expects(std::holds_alternative<std::filesystem::path>(script_to_run_) || std::holds_alternative<std::string>(script_to_run_));
 
   if (module_directory_) {
-    lua_script_engine->setModulePaths(utils::StringUtils::splitAndTrimRemovingEmpty(*module_directory_, ",") | ranges::to<std::vector<std::filesystem::path>>());
+    lua_script_engine->setModulePaths(utils::string::splitAndTrimRemovingEmpty(*module_directory_, ",") | ranges::to<std::vector<std::filesystem::path>>());
   }
 
   if (std::holds_alternative<std::filesystem::path>(script_to_run_))

--- a/extensions/mqtt/processors/AbstractMQTTProcessor.cpp
+++ b/extensions/mqtt/processors/AbstractMQTTProcessor.cpp
@@ -107,7 +107,7 @@ void AbstractMQTTProcessor::onSchedule(core::ProcessContext& context, core::Proc
     logger_->log_debug("AbstractMQTTProcessor: Last Will QoS [{}]", magic_enum::enum_name(last_will_qos_));
     last_will_->qos = static_cast<int>(last_will_qos_);
 
-    if (const auto value = context.getProperty(LastWillRetain) | utils::andThen(&utils::StringUtils::toBool)) {
+    if (const auto value = context.getProperty(LastWillRetain) | utils::andThen(&utils::string::toBool)) {
       logger_->log_debug("AbstractMQTTProcessor: Last Will Retain [{}]", *value);
       last_will_retain_ = {*value};
       last_will_->retained = last_will_retain_;

--- a/extensions/mqtt/processors/ConsumeMQTT.cpp
+++ b/extensions/mqtt/processors/ConsumeMQTT.cpp
@@ -51,12 +51,12 @@ void ConsumeMQTT::readProperties(core::ProcessContext& context) {
   }
   logger_->log_debug("ConsumeMQTT: Topic [{}]", topic_);
 
-  if (const auto value = context.getProperty(CleanSession) | utils::andThen(&utils::StringUtils::toBool)) {
+  if (const auto value = context.getProperty(CleanSession) | utils::andThen(&utils::string::toBool)) {
     clean_session_ = *value;
   }
   logger_->log_debug("ConsumeMQTT: CleanSession [{}]", clean_session_);
 
-  if (const auto value = context.getProperty(CleanStart) | utils::andThen(&utils::StringUtils::toBool)) {
+  if (const auto value = context.getProperty(CleanStart) | utils::andThen(&utils::string::toBool)) {
     clean_start_ = *value;
   }
   logger_->log_debug("ConsumeMQTT: CleanStart [{}]", clean_start_);
@@ -295,7 +295,7 @@ void ConsumeMQTT::checkBrokerLimitsImpl() {
     throw Exception(PROCESS_SCHEDULE_EXCEPTION, os.str());
   }
 
-  if (utils::StringUtils::startsWith(topic_, "$share/")) {
+  if (utils::string::startsWith(topic_, "$share/")) {
     if (mqtt_version_ == mqtt::MqttVersions::V_5_0) {
       // shared topic are supported on MQTT 5, unless explicitly denied by broker
       if (shared_subscription_available_ == false) {

--- a/extensions/mqtt/processors/PublishMQTT.cpp
+++ b/extensions/mqtt/processors/PublishMQTT.cpp
@@ -47,7 +47,7 @@ void PublishMQTT::readProperties(core::ProcessContext& context) {
     throw Exception(PROCESS_SCHEDULE_EXCEPTION, "PublishMQTT: Topic is required");
   }
 
-  if (const auto retain_opt = context.getProperty(Retain) | utils::andThen(&utils::StringUtils::toBool)) {
+  if (const auto retain_opt = context.getProperty(Retain) | utils::andThen(&utils::string::toBool)) {
     retain_ = *retain_opt;
   }
   logger_->log_debug("PublishMQTT: Retain [{}]", retain_);

--- a/extensions/opc/src/fetchopc.cpp
+++ b/extensions/opc/src/fetchopc.cpp
@@ -56,7 +56,7 @@ namespace org::apache::nifi::minifi::processors {
       idType_ = opc::OPCNodeIDType::Path;
     } else {
       // Where have our validators gone?
-      auto error_msg = utils::StringUtils::join_pack(value, " is not a valid node ID type!");
+      auto error_msg = utils::string::join_pack(value, " is not a valid node ID type!");
       throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
     }
 
@@ -64,13 +64,13 @@ namespace org::apache::nifi::minifi::processors {
       try {
         std::stoi(nodeID_);
       } catch(...) {
-        auto error_msg = utils::StringUtils::join_pack(nodeID_, " cannot be used as an int type node ID");
+        auto error_msg = utils::string::join_pack(nodeID_, " cannot be used as an int type node ID");
         throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
       }
     }
     if (idType_ != opc::OPCNodeIDType::Path) {
       if (!context.getProperty(NameSpaceIndex, nameSpaceIdx_)) {
-        auto error_msg = utils::StringUtils::join_pack(NameSpaceIndex.name, " is mandatory in case ", NodeIDType.name, " is not Path");
+        auto error_msg = utils::string::join_pack(NameSpaceIndex.name, " is mandatory in case ", NodeIDType.name, " is not Path");
         throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
       }
     }

--- a/extensions/opc/src/opc.cpp
+++ b/extensions/opc/src/opc.cpp
@@ -338,7 +338,7 @@ bool Client::exists(UA_NodeId nodeId) {
 UA_StatusCode Client::translateBrowsePathsToNodeIdsRequest(const std::string& path, std::vector<UA_NodeId>& foundNodeIDs, const std::shared_ptr<core::logging::Logger>& logger) {
   logger->log_trace("Trying to find node id for {}", path.c_str());
 
-  auto tokens = utils::StringUtils::split(path, "/");
+  auto tokens = utils::string::split(path, "/");
   std::vector<UA_UInt32> ids;
   for (size_t i = 0; i < tokens.size(); ++i) {
     UA_UInt32 val = (i ==0) ? UA_NS0ID_ORGANIZES : UA_NS0ID_HASCOMPONENT;

--- a/extensions/opc/src/opcbase.cpp
+++ b/extensions/opc/src/opcbase.cpp
@@ -68,11 +68,11 @@ namespace org::apache::nifi::minifi::processors {
     }
 
     if (certBuffer_.empty()) {
-      auto error_msg = utils::StringUtils::join_pack("Failed to load cert from path: ", certpath_);
+      auto error_msg = utils::string::join_pack("Failed to load cert from path: ", certpath_);
       throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
     }
     if (keyBuffer_.empty()) {
-      auto error_msg = utils::StringUtils::join_pack("Failed to load key from path: ", keypath_);
+      auto error_msg = utils::string::join_pack("Failed to load key from path: ", keypath_);
       throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
     }
 
@@ -81,7 +81,7 @@ namespace org::apache::nifi::minifi::processors {
       if (input_trust.good()) {
         trustBuffers_.push_back(std::vector<char>(std::istreambuf_iterator<char>(input_trust), {}));
       } else {
-        auto error_msg = utils::StringUtils::join_pack("Failed to load trusted server certs from path: ", trustpath_);
+        auto error_msg = utils::string::join_pack("Failed to load trusted server certs from path: ", trustpath_);
         throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
       }
     }

--- a/extensions/opc/src/putopc.cpp
+++ b/extensions/opc/src/putopc.cpp
@@ -50,7 +50,7 @@ namespace org::apache::nifi::minifi::processors {
       idType_ = opc::OPCNodeIDType::Path;
     } else {
       // Where have our validators gone?
-      auto error_msg = utils::StringUtils::join_pack(value, " is not a valid node ID type!");
+      auto error_msg = utils::string::join_pack(value, " is not a valid node ID type!");
       throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
     }
 
@@ -58,13 +58,13 @@ namespace org::apache::nifi::minifi::processors {
       try {
         std::stoi(nodeID_);
       } catch(...) {
-        auto error_msg = utils::StringUtils::join_pack(nodeID_, " cannot be used as an int type node ID");
+        auto error_msg = utils::string::join_pack(nodeID_, " cannot be used as an int type node ID");
         throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
       }
     }
     if (idType_ != opc::OPCNodeIDType::Path) {
       if (!context.getProperty(ParentNameSpaceIndex, nameSpaceIdx_)) {
-        auto error_msg = utils::StringUtils::join_pack(ParentNameSpaceIndex.name, " is mandatory in case ", ParentNodeIDType.name, " is not Path");
+        auto error_msg = utils::string::join_pack(ParentNameSpaceIndex.name, " is mandatory in case ", ParentNodeIDType.name, " is not Path");
         throw Exception(PROCESS_SCHEDULE_EXCEPTION, error_msg);
       }
     }
@@ -208,7 +208,7 @@ namespace org::apache::nifi::minifi::processors {
             break;
           }
           case opc::OPCNodeDataType::Boolean: {
-            const auto contentstr_parsed = utils::StringUtils::toBool(contentstr);
+            const auto contentstr_parsed = utils::string::toBool(contentstr);
             if (contentstr_parsed) {
               sc = connection_->update_node(targetnode, contentstr_parsed.value());
             } else {
@@ -285,7 +285,7 @@ namespace org::apache::nifi::minifi::processors {
             break;
           }
           case opc::OPCNodeDataType::Boolean: {
-            const auto contentstr_parsed = utils::StringUtils::toBool(contentstr);
+            const auto contentstr_parsed = utils::string::toBool(contentstr);
             if (contentstr_parsed) {
               sc = connection_->add_node(parentNodeID_, targetnode, browsename, contentstr_parsed.value(), &resultnode);
             } else {

--- a/extensions/openwsman/processors/SourceInitiatedSubscriptionListener.cpp
+++ b/extensions/openwsman/processors/SourceInitiatedSubscriptionListener.cpp
@@ -709,7 +709,7 @@ void SourceInitiatedSubscriptionListener::onScheduleSharedPtr(const std::shared_
   if (!context->getProperty(SSLVerifyPeer, value)) {
     throw Exception(PROCESSOR_EXCEPTION, "SSL Verify Peer attribute is missing");
   }
-  bool verify_peer = utils::StringUtils::toBool(value).value_or(true);
+  bool verify_peer = utils::string::toBool(value).value_or(true);
   context->getProperty(XPathXmlQuery, xpath_xml_query_);
   if (!context->getProperty(InitialExistingEventsStrategy, initial_existing_events_strategy_)) {
     throw Exception(PROCESSOR_EXCEPTION, "Initial Existing Events Strategy attribute is missing or invalid");
@@ -762,7 +762,7 @@ void SourceInitiatedSubscriptionListener::onScheduleSharedPtr(const std::shared_
   if (ret != 1) {
     throw Exception(PROCESSOR_EXCEPTION, "Failed to get fingerprint for CA specified by SSL Certificate Authority attribute");
   }
-  ssl_ca_cert_thumbprint_ = utils::StringUtils::to_hex(hash_buf, true /*uppercase*/);
+  ssl_ca_cert_thumbprint_ = utils::string::to_hex(hash_buf, true /*uppercase*/);
   logger_->log_debug("{} SHA-1 thumbprint is {}", ssl_ca_file.c_str(), ssl_ca_cert_thumbprint_.c_str());
 
   session_factory_ = sessionFactory;

--- a/extensions/pcap/CapturePacket.cpp
+++ b/extensions/pcap/CapturePacket.cpp
@@ -87,7 +87,7 @@ CapturePacketMechanism *CapturePacket::create_new_capture(const std::string &bas
   auto new_capture = new CapturePacketMechanism(base_path, generate_new_pcap(base_path), max_size);
   new_capture->writer_ = std::make_unique<pcpp::PcapFileWriterDevice>(new_capture->getFile());
   if (!new_capture->writer_->open())
-    throw std::runtime_error{utils::StringUtils::join_pack("Failed to open PcapFileWriterDevice with file ", new_capture->getFile().string())};
+    throw std::runtime_error{utils::string::join_pack("Failed to open PcapFileWriterDevice with file ", new_capture->getFile().string())};
 
   return new_capture;
 }
@@ -114,7 +114,7 @@ void CapturePacket::onSchedule(core::ProcessContext& context, core::ProcessSessi
 
   value = "";
   if (context.getProperty(CaptureBluetooth, value)) {
-    capture_bluetooth_ = utils::StringUtils::toBool(value).value_or(false);
+    capture_bluetooth_ = utils::string::toBool(value).value_or(false);
   }
 
   core::Property attached_controllers("Network Controllers", "List of network controllers to attach to -- each may be a regex", ".*");

--- a/extensions/pdh/PDHCounters.cpp
+++ b/extensions/pdh/PDHCounters.cpp
@@ -30,7 +30,7 @@ DWORD PDHCounter::getDWFormat() const {
 }
 
 std::unique_ptr<PDHCounter> PDHCounter::createPDHCounter(const std::string& query_name, bool is_double) {
-  auto groups = utils::StringUtils::splitRemovingEmpty(query_name, "\\");
+  auto groups = utils::string::splitRemovingEmpty(query_name, "\\");
   if (groups.size() != 2 || query_name.substr(0, 1) != "\\")
     return nullptr;
   if (query_name.find("(*)") != std::string::npos) {
@@ -45,12 +45,12 @@ const std::string& PDHCounter::getName() const {
 }
 
 std::string PDHCounter::getObjectName() const {
-  auto groups = utils::StringUtils::splitRemovingEmpty(pdh_english_counter_name_, "\\");
+  auto groups = utils::string::splitRemovingEmpty(pdh_english_counter_name_, "\\");
   return groups[0];
 }
 
 std::string PDHCounter::getCounterName() const {
-  auto groups = utils::StringUtils::splitRemovingEmpty(pdh_english_counter_name_, "\\");
+  auto groups = utils::string::splitRemovingEmpty(pdh_english_counter_name_, "\\");
   return groups[1];
 }
 

--- a/extensions/pdh/PerformanceDataMonitor.cpp
+++ b/extensions/pdh/PerformanceDataMonitor.cpp
@@ -210,7 +210,7 @@ void add_system_related_counters(std::vector<std::unique_ptr<PerformanceDataCoun
 }
 
 void PerformanceDataMonitor::addCountersFromPredefinedGroupsProperty(const std::string& predefined_groups) {
-  auto groups = utils::StringUtils::splitAndTrim(predefined_groups, ",");
+  auto groups = utils::string::splitAndTrim(predefined_groups, ",");
   for (const auto& group : groups) {
     if (group == "CPU") {
       add_cpu_related_counters(resource_consumption_counters_);
@@ -233,7 +233,7 @@ void PerformanceDataMonitor::addCountersFromPredefinedGroupsProperty(const std::
 }
 
 void PerformanceDataMonitor::addCustomPDHCountersFromProperty(const std::string& custom_pdh_counters) {
-  const auto custom_counters = utils::StringUtils::splitAndTrim(custom_pdh_counters, ",");
+  const auto custom_counters = utils::string::splitAndTrim(custom_pdh_counters, ",");
   for (const auto& custom_counter : custom_counters) {
     auto counter = PDHCounter::createPDHCounter(custom_counter);
     if (counter != nullptr)

--- a/extensions/prometheus/PrometheusMetricsPublisher.cpp
+++ b/extensions/prometheus/PrometheusMetricsPublisher.cpp
@@ -89,7 +89,7 @@ std::vector<state::response::SharedResponseNode> PrometheusMetricsPublisher::get
     metric_classes_str = configuration_->get(minifi::Configuration::nifi_metrics_publisher_metrics);
   }
   if (metric_classes_str && !metric_classes_str->empty()) {
-    auto metric_classes = utils::StringUtils::split(*metric_classes_str, ",");
+    auto metric_classes = utils::string::split(*metric_classes_str, ",");
     for (const std::string& clazz : metric_classes) {
       auto response_nodes = response_node_loader_->loadResponseNodes(clazz);
       if (response_nodes.empty()) {

--- a/extensions/python/ExecutePythonProcessor.cpp
+++ b/extensions/python/ExecutePythonProcessor.cpp
@@ -95,7 +95,7 @@ void ExecutePythonProcessor::appendPathForImportModules() {
   std::string module_directory;
   getProperty(ModuleDirectory, module_directory);
   if (!module_directory.empty()) {
-    python_script_engine_->setModulePaths(utils::StringUtils::splitAndTrimRemovingEmpty(module_directory, ",") | ranges::to<std::vector<std::filesystem::path>>());
+    python_script_engine_->setModulePaths(utils::string::splitAndTrimRemovingEmpty(module_directory, ",") | ranges::to<std::vector<std::filesystem::path>>());
   }
 }
 

--- a/extensions/python/PythonCreator.h
+++ b/extensions/python/PythonCreator.h
@@ -68,7 +68,7 @@ class PythonCreator : public minifi::core::CoreComponent {
       std::string class_name = script_name.string();
       std::string full_name = "org.apache.nifi.minifi.processors." + script_name.string();
       if (!package.empty()) {
-        full_name = utils::StringUtils::join_pack("org.apache.nifi.minifi.processors.", package, ".", script_name.string());
+        full_name = utils::string::join_pack("org.apache.nifi.minifi.processors.", package, ".", script_name.string());
         class_name = full_name;
       }
       core::getClassLoader().registerClass(class_name, std::make_unique<PythonObjectFactory>(path.string(), class_name));
@@ -111,7 +111,7 @@ class PythonCreator : public minifi::core::CoreComponent {
   void configure(const std::vector<std::string> &pythonFiles) {
     std::vector<std::string> pathOrFiles;
     for (const auto &path : pythonFiles) {
-      const auto vec = utils::StringUtils::split(path, ",");
+      const auto vec = utils::string::split(path, ",");
       pathOrFiles.insert(pathOrFiles.end(), vec.begin(), vec.end());
     }
 
@@ -121,14 +121,14 @@ class PythonCreator : public minifi::core::CoreComponent {
   }
 
   std::string getPackage(const std::string &basePath, const std::string &pythonscript) {
-    if (!minifi::utils::StringUtils::startsWith(pythonscript, basePath)) {
+    if (!minifi::utils::string::startsWith(pythonscript, basePath)) {
       return "";
     }
     const auto python_package_path = std::filesystem::relative(pythonscript, basePath).parent_path();
     std::vector<std::string> path_elements;
     path_elements.reserve(std::distance(python_package_path.begin(), python_package_path.end()));
     std::transform(python_package_path.begin(), python_package_path.end(), std::back_inserter(path_elements), [](const auto& path) { return path.string(); });
-    std::string python_package = minifi::utils::StringUtils::join(".", path_elements);
+    std::string python_package = minifi::utils::string::join(".", path_elements);
     if (python_package.length() > 1 && python_package.at(0) == '.') {
       python_package = python_package.substr(1);
     }

--- a/extensions/python/PythonScriptExecutor.cpp
+++ b/extensions/python/PythonScriptExecutor.cpp
@@ -35,7 +35,7 @@ void PythonScriptExecutor::onTrigger(const std::shared_ptr<core::ProcessContext>
   gsl_Expects(std::holds_alternative<std::filesystem::path>(script_to_run_) || std::holds_alternative<std::string>(script_to_run_));
 
   if (module_directory_) {
-    python_script_engine_->setModulePaths(utils::StringUtils::splitAndTrimRemovingEmpty(*module_directory_, ",") | ranges::to<std::vector<std::filesystem::path>>());
+    python_script_engine_->setModulePaths(utils::string::splitAndTrimRemovingEmpty(*module_directory_, ",") | ranges::to<std::vector<std::filesystem::path>>());
   }
 
   if (std::holds_alternative<std::filesystem::path>(script_to_run_))

--- a/extensions/python/tests/PythonManifestTests.cpp
+++ b/extensions/python/tests/PythonManifestTests.cpp
@@ -86,7 +86,7 @@ TEST_CASE("Python processor's description is part of the manifest") {
     // single processor in each bundle
     REQUIRE(py_processors.children.size() == 1);
 
-    return findNode(py_processors.children, [&] (auto& child) {return utils::StringUtils::endsWith(child.name, name);});
+    return findNode(py_processors.children, [&] (auto& child) {return utils::string::endsWith(child.name, name);});
   };
 
   {

--- a/extensions/rocksdb-repos/DatabaseContentRepository.cpp
+++ b/extensions/rocksdb-repos/DatabaseContentRepository.cpp
@@ -41,7 +41,7 @@ bool DatabaseContentRepository::initialize(const std::shared_ptr<minifi::Configu
   } else {
     directory_ = (configuration->getHome() / "dbcontentrepository").string();
   }
-  auto purge_period_str = utils::StringUtils::trim(configuration->get(Configure::nifi_dbcontent_repository_purge_period).value_or("1 s"));
+  auto purge_period_str = utils::string::trim(configuration->get(Configure::nifi_dbcontent_repository_purge_period).value_or("1 s"));
   if (purge_period_str == "0") {
     purge_period_ = std::chrono::seconds{0};
   } else if (auto purge_period_val = core::TimePeriodValue::fromString(purge_period_str)) {

--- a/extensions/rocksdb-repos/database/RocksDatabase.cpp
+++ b/extensions/rocksdb-repos/database/RocksDatabase.cpp
@@ -35,7 +35,7 @@ std::unique_ptr<RocksDatabase> RocksDatabase::create(const DBOptionsPatch& db_op
   logger_->log_info("Acquiring database handle '{}'", uri);
   std::string db_path = uri;
   std::string db_column = "default";
-  if (utils::StringUtils::startsWith(uri, scheme)) {
+  if (utils::string::startsWith(uri, scheme)) {
     const std::string path = uri.substr(scheme.length());
     logger_->log_info("RocksDB scheme is detected in '{}'", uri);
     // last segment is treated as the column name

--- a/extensions/sftp/client/SFTPClient.cpp
+++ b/extensions/sftp/client/SFTPClient.cpp
@@ -362,7 +362,7 @@ bool SFTPClient::connect() {
         logger_->log_warn("Host {} not found in the host key file", hostname_.c_str());
         break;
       case LIBSSH2_KNOWNHOST_CHECK_MISMATCH: {
-        auto hostkey_b64 = utils::StringUtils::to_base64(hostkey);
+        auto hostkey_b64 = utils::string::to_base64(hostkey);
         logger_->log_warn("Host key mismatch for {}, expected: {}, actual: {}", hostname_.c_str(),
                           known_host == nullptr ? "" : known_host->key, hostkey_b64.c_str());
         break;
@@ -384,7 +384,7 @@ bool SFTPClient::connect() {
     if (fingerprint == nullptr) {
       logger_->log_warn("Cannot get remote server fingerprint");
     } else {
-      auto fingerprint_hex = utils::StringUtils::to_hex(fingerprint_span.as_span<const std::byte>());
+      auto fingerprint_hex = utils::string::to_hex(fingerprint_span.as_span<const std::byte>());
       std::stringstream fingerprint_hex_colon;
       for (size_t i = 0; i < 20; i++) {
         fingerprint_hex_colon << fingerprint_hex.substr(i * 2, 2);
@@ -409,7 +409,7 @@ bool SFTPClient::connect() {
       return false;
     }
   } else {
-    auto methods_split = utils::StringUtils::split(userauthlist, ",");
+    auto methods_split = utils::string::split(userauthlist, ",");
     auth_methods.insert(std::make_move_iterator(methods_split.begin()), std::make_move_iterator(methods_split.end()));
   }
 
@@ -656,7 +656,7 @@ bool SFTPClient::createDirectoryHierarchy(const std::string& path) {
     return false;
   }
   bool absolute = path[0] == '/';
-  auto elements = utils::StringUtils::split(path, "/");
+  auto elements = utils::string::split(path, "/");
   std::stringstream dir;
   if (absolute) {
     dir << "/";

--- a/extensions/sftp/processors/FetchSFTP.cpp
+++ b/extensions/sftp/processors/FetchSFTP.cpp
@@ -54,17 +54,17 @@ void FetchSFTP::onSchedule(core::ProcessContext& context, core::ProcessSessionFa
   if (!context.getProperty(CreateDirectory, value)) {
     logger_->log_error("Create Directory attribute is missing or invalid");
   } else {
-    create_directory_ = utils::StringUtils::toBool(value).value_or(false);
+    create_directory_ = utils::string::toBool(value).value_or(false);
   }
   if (!context.getProperty(DisableDirectoryListing, value)) {
     logger_->log_error("Disable Directory Listing attribute is missing or invalid");
   } else {
-    disable_directory_listing_ = utils::StringUtils::toBool(value).value_or(false);
+    disable_directory_listing_ = utils::string::toBool(value).value_or(false);
   }
   if (!context.getProperty(UseCompression, value)) {
     logger_->log_error("Use Compression attribute is missing or invalid");
   } else {
-    use_compression_ = utils::StringUtils::toBool(value).value_or(false);
+    use_compression_ = utils::string::toBool(value).value_or(false);
   }
 
   startKeepaliveThreadIfNeeded();

--- a/extensions/sftp/processors/ListSFTP.cpp
+++ b/extensions/sftp/processors/ListSFTP.cpp
@@ -90,12 +90,12 @@ void ListSFTP::onSchedule(core::ProcessContext& context, core::ProcessSessionFac
   if (!context.getProperty(SearchRecursively, value)) {
     logger_->log_error("Search Recursively attribute is missing or invalid");
   } else {
-    search_recursively_ = utils::StringUtils::toBool(value).value_or(false);
+    search_recursively_ = utils::string::toBool(value).value_or(false);
   }
   if (!context.getProperty(FollowSymlink, value)) {
     logger_->log_error("Follow symlink attribute is missing or invalid");
   } else {
-    follow_symlink_ = utils::StringUtils::toBool(value).value_or(false);
+    follow_symlink_ = utils::string::toBool(value).value_or(false);
   }
   if (context.getProperty(FileFilterRegex, file_filter_regex_) && !file_filter_regex_.empty()) {
     try {
@@ -114,7 +114,7 @@ void ListSFTP::onSchedule(core::ProcessContext& context, core::ProcessSessionFac
   if (!context.getProperty(IgnoreDottedFiles, value)) {
     logger_->log_error("Ignore Dotted Files attribute is missing or invalid");
   } else {
-    ignore_dotted_files_ = utils::StringUtils::toBool(value).value_or(true);
+    ignore_dotted_files_ = utils::string::toBool(value).value_or(true);
   }
   context.getProperty(TargetSystemTimestampPrecision, target_system_timestamp_precision_);
   context.getProperty(EntityTrackingInitialListingTarget, entity_tracking_initial_listing_target_);
@@ -268,7 +268,7 @@ bool ListSFTP::filterDirectory(const std::string& parent_path, const std::string
 
   /* Path Filter Regex */
   if (compiled_path_filter_regex_) {
-    std::string dir_path = utils::StringUtils::join_pack(parent_path, "/", filename);
+    std::string dir_path = utils::string::join_pack(parent_path, "/", filename);
     bool match = false;
     match = utils::regexMatch(dir_path, *compiled_path_filter_regex_);
     if (!match) {

--- a/extensions/sftp/processors/PutSFTP.cpp
+++ b/extensions/sftp/processors/PutSFTP.cpp
@@ -58,7 +58,7 @@ void PutSFTP::onSchedule(core::ProcessContext& context, core::ProcessSessionFact
   if (!context.getProperty(CreateDirectory, value)) {
     logger_->log_error("Create Directory attribute is missing or invalid");
   } else {
-    create_directory_ = utils::StringUtils::toBool(value).value_or(false);
+    create_directory_ = utils::string::toBool(value).value_or(false);
   }
   if (!context.getProperty(BatchSize, value)) {
     logger_->log_error("Batch Size attribute is missing or invalid");
@@ -67,15 +67,15 @@ void PutSFTP::onSchedule(core::ProcessContext& context, core::ProcessSessionFact
   }
   context.getProperty(ConflictResolution, conflict_resolution_);
   if (context.getProperty(RejectZeroByte, value)) {
-    reject_zero_byte_ = utils::StringUtils::toBool(value).value_or(true);
+    reject_zero_byte_ = utils::string::toBool(value).value_or(true);
   }
   if (context.getProperty(DotRename, value)) {
-    dot_rename_ = utils::StringUtils::toBool(value).value_or(true);
+    dot_rename_ = utils::string::toBool(value).value_or(true);
   }
   if (!context.getProperty(UseCompression, value)) {
     logger_->log_error("Use Compression attribute is missing or invalid");
   } else {
-    use_compression_ = utils::StringUtils::toBool(value).value_or(false);
+    use_compression_ = utils::string::toBool(value).value_or(false);
   }
 
   startKeepaliveThreadIfNeeded();
@@ -121,7 +121,7 @@ bool PutSFTP::processOne(core::ProcessContext& context, core::ProcessSession& se
 
   if (context.getDynamicProperty(std::string{DisableDirectoryListing.name}, value) ||
       context.getProperty(DisableDirectoryListing, value)) {
-    disable_directory_listing = utils::StringUtils::toBool(value).value_or(false);
+    disable_directory_listing = utils::string::toBool(value).value_or(false);
   }
   context.getProperty(TempFilename, temp_file_name, flow_file);
   if (context.getProperty(LastModifiedTime, value, flow_file))

--- a/extensions/sftp/processors/SFTPProcessorBase.cpp
+++ b/extensions/sftp/processors/SFTPProcessorBase.cpp
@@ -73,7 +73,7 @@ void SFTPProcessorBase::parseCommonPropertiesOnSchedule(core::ProcessContext& co
   if (!context.getProperty(StrictHostKeyChecking, value)) {
     logger_->log_error("Strict Host Key Checking attribute is missing or invalid");
   } else {
-    strict_host_checking_ = utils::StringUtils::toBool(value).value_or(false);
+    strict_host_checking_ = utils::string::toBool(value).value_or(false);
   }
   context.getProperty(HostKeyFile, host_key_file_);
   if (auto connection_timeout = context.getProperty<core::TimePeriodValue>(ConnectionTimeout)) {
@@ -91,7 +91,7 @@ void SFTPProcessorBase::parseCommonPropertiesOnSchedule(core::ProcessContext& co
   if (!context.getProperty(SendKeepaliveOnTimeout, value)) {
     logger_->log_error("Send Keep Alive On Timeout attribute is missing or invalid");
   } else {
-    use_keepalive_on_timeout_ = utils::StringUtils::toBool(value).value_or(true);
+    use_keepalive_on_timeout_ = utils::string::toBool(value).value_or(true);
   }
   context.getProperty(ProxyType, proxy_type_);
 }

--- a/extensions/splunk/PutSplunkHTTP.cpp
+++ b/extensions/splunk/PutSplunkHTTP.cpp
@@ -57,7 +57,7 @@ std::string PutSplunkHTTP::getEndpoint(curl::HTTPClient& client) {
     parameters.push_back("index=" + client.escape(*index_));
   }
   if (!parameters.empty()) {
-    endpoint << "?" << utils::StringUtils::join("&", parameters);
+    endpoint << "?" << utils::string::join("&", parameters);
   }
   return endpoint.str();
 }

--- a/extensions/sql/processors/QueryDatabaseTable.cpp
+++ b/extensions/sql/processors/QueryDatabaseTable.cpp
@@ -67,7 +67,7 @@ void QueryDatabaseTable::processOnSchedule(core::ProcessContext& context) {
 
   return_columns_.clear();
   queried_columns_.clear();
-  for (auto&& raw_col : utils::StringUtils::splitAndTrimRemovingEmpty(context.getProperty(ColumnNames).value_or(""), ",")) {
+  for (auto&& raw_col : utils::string::splitAndTrimRemovingEmpty(context.getProperty(ColumnNames).value_or(""), ",")) {
     if (!queried_columns_.empty()) {
       queried_columns_ += ", ";
     }
@@ -76,7 +76,7 @@ void QueryDatabaseTable::processOnSchedule(core::ProcessContext& context) {
   }
 
   max_value_columns_.clear();
-  for (auto&& raw_col : utils::StringUtils::splitAndTrimRemovingEmpty(context.getProperty(MaxValueColumnNames).value_or(""), ",")) {
+  for (auto&& raw_col : utils::string::splitAndTrimRemovingEmpty(context.getProperty(MaxValueColumnNames).value_or(""), ",")) {
     sql::SQLColumnIdentifier col_id(raw_col);
     if (!queried_columns_.empty() && !return_columns_.contains(col_id)) {
       // columns will be explicitly enumerated, we need to add the max value columns as it is not yet queried
@@ -139,7 +139,7 @@ bool QueryDatabaseTable::loadMaxValuesFromStoredState(const std::unordered_map<s
     return false;
   }
   for (auto& elem : state) {
-    if (utils::StringUtils::startsWith(elem.first, MAXVALUE_KEY_PREFIX)) {
+    if (utils::string::startsWith(elem.first, MAXVALUE_KEY_PREFIX)) {
       sql::SQLColumnIdentifier column_name(elem.first.substr(MAXVALUE_KEY_PREFIX.length()));
       // add only those columns that we care about
       if (std::find(max_value_columns_.begin(), max_value_columns_.end(), column_name) != max_value_columns_.end()) {
@@ -184,7 +184,7 @@ void QueryDatabaseTable::loadMaxValuesFromDynamicProperties(core::ProcessContext
   logger_->log_info("Received {} dynamic properties", dynamic_prop_keys.size());
 
   for (const auto& key : dynamic_prop_keys) {
-    if (!utils::StringUtils::startsWith(key, InitialMaxValueDynamicPropertyPrefix)) {
+    if (!utils::string::startsWith(key, InitialMaxValueDynamicPropertyPrefix)) {
       throw minifi::Exception(PROCESSOR_EXCEPTION, "QueryDatabaseTable: Unsupported dynamic property \"" + key + "\"");
     }
     sql::SQLColumnIdentifier column_name(key.substr(InitialMaxValueDynamicPropertyPrefix.length()));
@@ -221,7 +221,7 @@ std::string QueryDatabaseTable::buildSelectQuery() {
     // Logic to differentiate ">" vs ">=" based on index is copied from:
     // https://github.com/apache/nifi/blob/master/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractQueryDatabaseTable.java
     // (under comment "Add a condition for the WHERE clause"). And implementation explanation: https://issues.apache.org/jira/browse/NIFI-2712.
-    where_clauses.push_back(utils::StringUtils::join_pack(column_name.str(), index == 0 ? " > " : " >= ", max_value));
+    where_clauses.push_back(utils::string::join_pack(column_name.str(), index == 0 ? " > " : " >= ", max_value));
   }
 
   if (!extra_where_clause_.empty()) {
@@ -229,7 +229,7 @@ std::string QueryDatabaseTable::buildSelectQuery() {
   }
 
   if (!where_clauses.empty()) {
-    query += " where " + utils::StringUtils::join(" and ", where_clauses);
+    query += " where " + utils::string::join(" and ", where_clauses);
   }
 
   return query;

--- a/extensions/standard-processors/processors/AttributesToJSON.cpp
+++ b/extensions/standard-processors/processors/AttributesToJSON.cpp
@@ -38,7 +38,7 @@ void AttributesToJSON::initialize() {
 void AttributesToJSON::onSchedule(core::ProcessContext& context, core::ProcessSessionFactory&) {
   std::string value;
   if (context.getProperty(AttributesList, value) && !value.empty()) {
-    attribute_list_ = utils::StringUtils::splitAndTrimRemovingEmpty(value, ",");
+    attribute_list_ = utils::string::splitAndTrimRemovingEmpty(value, ",");
   }
   if (context.getProperty(AttributesRegularExpression, value) && !value.empty()) {
     attributes_regular_expression_ = utils::Regex(value);

--- a/extensions/standard-processors/processors/ExecuteProcess.cpp
+++ b/extensions/standard-processors/processors/ExecuteProcess.cpp
@@ -56,7 +56,7 @@ void ExecuteProcess::onSchedule(core::ProcessContext& context, core::ProcessSess
     logger_->log_debug("Setting batch duration to {}", batch_duration_);
   }
   if (context.getProperty(RedirectErrorStream, value)) {
-    redirect_error_stream_ = org::apache::nifi::minifi::utils::StringUtils::toBool(value).value_or(false);
+    redirect_error_stream_ = org::apache::nifi::minifi::utils::string::toBool(value).value_or(false);
   }
   full_command_ = command_ + " " + command_argument_;
 }

--- a/extensions/standard-processors/processors/ExecuteProcess.cpp
+++ b/extensions/standard-processors/processors/ExecuteProcess.cpp
@@ -19,6 +19,7 @@
  */
 #ifndef WIN32
 #include "ExecuteProcess.h"
+#include <array>
 #include <memory>
 #include <string>
 #include <iomanip>
@@ -112,8 +113,8 @@ void ExecuteProcess::executeChildProcess() {
 void ExecuteProcess::readOutputInBatches(core::ProcessSession& session) {
   while (true) {
     std::this_thread::sleep_for(batch_duration_);
-    char buffer[4096];
-    const auto num_read = read(pipefd_[0], buffer, sizeof(buffer));
+    std::array<char, 4096> buffer;  // NOLINT(cppcoreguidelines-pro-type-member-init)
+    const auto num_read = read(pipefd_[0], buffer.data(), buffer.size());
     if (num_read <= 0) {
       break;
     }
@@ -125,7 +126,7 @@ void ExecuteProcess::readOutputInBatches(core::ProcessSession& session) {
     }
     flow_file->addAttribute("command", command_);
     flow_file->addAttribute("command.arguments", command_argument_);
-    session.writeBuffer(flow_file, gsl::make_span(buffer, gsl::narrow<size_t>(num_read)));
+    session.writeBuffer(flow_file, gsl::make_span(buffer.data(), gsl::narrow<size_t>(num_read)));
     session.transfer(flow_file, Success);
     session.commit();
   }
@@ -148,32 +149,32 @@ bool ExecuteProcess::writeToFlowFile(core::ProcessSession& session, std::shared_
 }
 
 void ExecuteProcess::readOutput(core::ProcessSession& session) {
-  char buffer[4096];
-  char *buf_ptr = buffer;
+  std::array<char, 4096> buffer;  // NOLINT(cppcoreguidelines-pro-type-member-init)
+  char *buf_ptr = buffer.data();
   size_t read_to_buffer = 0;
   std::shared_ptr<core::FlowFile> flow_file;
-  auto num_read = read(pipefd_[0], buf_ptr, sizeof(buffer));
+  auto num_read = read(pipefd_[0], buf_ptr, buffer.size());
   while (num_read > 0) {
-    if (num_read == static_cast<ssize_t>(sizeof(buffer) - read_to_buffer)) {
+    if (num_read == static_cast<ssize_t>(buffer.size() - read_to_buffer)) {
       // we reach the max buffer size
-      logger_->log_debug("Execute Command Max Respond {}", sizeof(buffer));
+      logger_->log_debug("Execute Command Max Respond {}", buffer.size());
       if (!writeToFlowFile(session, flow_file, buffer)) {
         continue;
       }
       // Rewind
       read_to_buffer = 0;
-      buf_ptr = buffer;
+      buf_ptr = buffer.data();
     } else {
       read_to_buffer += num_read;
       buf_ptr += num_read;
     }
-    num_read = read(pipefd_[0], buf_ptr, (sizeof(buffer) - read_to_buffer));
+    num_read = read(pipefd_[0], buf_ptr, (buffer.size() - read_to_buffer));
   }
 
   if (read_to_buffer > 0) {
     logger_->log_debug("Execute Command Respond {}", read_to_buffer);
     // child exits and close the pipe
-    const auto buffer_span = gsl::make_span(buffer, read_to_buffer);
+    const auto buffer_span = gsl::make_span(buffer.data(), read_to_buffer);
     if (!writeToFlowFile(session, flow_file, buffer_span)) {
       return;
     }

--- a/extensions/standard-processors/processors/GetFile.cpp
+++ b/extensions/standard-processors/processors/GetFile.cpp
@@ -46,10 +46,10 @@ void GetFile::onSchedule(core::ProcessContext& context, core::ProcessSessionFact
     core::Property::StringToInt(value, request_.batchSize);
   }
   if (context.getProperty(IgnoreHiddenFile, value)) {
-    request_.ignoreHiddenFile = org::apache::nifi::minifi::utils::StringUtils::toBool(value).value_or(true);
+    request_.ignoreHiddenFile = org::apache::nifi::minifi::utils::string::toBool(value).value_or(true);
   }
   if (context.getProperty(KeepSourceFile, value)) {
-    request_.keepSourceFile = org::apache::nifi::minifi::utils::StringUtils::toBool(value).value_or(false);
+    request_.keepSourceFile = org::apache::nifi::minifi::utils::string::toBool(value).value_or(false);
   }
 
   if (auto max_age = context.getProperty<core::TimePeriodValue>(MaxAge))
@@ -69,7 +69,7 @@ void GetFile::onSchedule(core::ProcessContext& context, core::ProcessSessionFact
   }
 
   if (context.getProperty(Recurse, value)) {
-    request_.recursive = org::apache::nifi::minifi::utils::StringUtils::toBool(value).value_or(true);
+    request_.recursive = org::apache::nifi::minifi::utils::string::toBool(value).value_or(true);
   }
 
   if (context.getProperty(FileFilter, value)) {

--- a/extensions/standard-processors/processors/GetTCP.cpp
+++ b/extensions/standard-processors/processors/GetTCP.cpp
@@ -44,8 +44,8 @@ void GetTCP::initialize() {
 std::vector<utils::net::ConnectionId> GetTCP::parseEndpointList(core::ProcessContext& context) {
   std::vector<utils::net::ConnectionId> connections_to_make;
   if (auto endpoint_list_str = context.getProperty(EndpointList)) {
-    for (const auto& endpoint_str : utils::StringUtils::splitAndTrim(*endpoint_list_str, ",")) {
-      auto hostname_service_pair = utils::StringUtils::splitAndTrim(endpoint_str, ":");
+    for (const auto& endpoint_str : utils::string::splitAndTrim(*endpoint_list_str, ",")) {
+      auto hostname_service_pair = utils::string::splitAndTrim(endpoint_str, ":");
       if (hostname_service_pair.size() != 2) {
         logger_->log_error("{} endpoint is invalid, expected {{hostname}}:{{service}} format", endpoint_str);
         continue;
@@ -62,7 +62,7 @@ std::vector<utils::net::ConnectionId> GetTCP::parseEndpointList(core::ProcessCon
 char GetTCP::parseDelimiter(core::ProcessContext& context) {
   char delimiter = '\n';
   if (auto delimiter_str = context.getProperty(GetTCP::MessageDelimiter)) {
-    auto parsed_delimiter = utils::StringUtils::parseCharacter(*delimiter_str);
+    auto parsed_delimiter = utils::string::parseCharacter(*delimiter_str);
     if (!parsed_delimiter || !parsed_delimiter->has_value())
       throw Exception(PROCESS_SCHEDULE_EXCEPTION, fmt::format("Invalid delimiter: {} (it must be a single (escaped or not) character", *delimiter_str));
     delimiter = **parsed_delimiter;

--- a/extensions/standard-processors/processors/HashContent.h
+++ b/extensions/standard-processors/processors/HashContent.h
@@ -71,7 +71,7 @@ namespace { // NOLINT
     if (ret_val.second > 0) {
       std::array<std::byte, MD5_DIGEST_LENGTH> digest{};
       EVP_DigestFinal_ex(context, reinterpret_cast<unsigned char*>(digest.data()), nullptr);
-      ret_val.first = org::apache::nifi::minifi::utils::StringUtils::to_hex(digest, true /*uppercase*/);
+      ret_val.first = org::apache::nifi::minifi::utils::string::to_hex(digest, true /*uppercase*/);
     }
     return ret_val;
   }
@@ -98,7 +98,7 @@ namespace { // NOLINT
     if (ret_val.second > 0) {
       std::array<std::byte, SHA_DIGEST_LENGTH> digest{};
       EVP_DigestFinal_ex(context, reinterpret_cast<unsigned char*>(digest.data()), nullptr);
-      ret_val.first = org::apache::nifi::minifi::utils::StringUtils::to_hex(digest, true /*uppercase*/);
+      ret_val.first = org::apache::nifi::minifi::utils::string::to_hex(digest, true /*uppercase*/);
     }
     return ret_val;
   }
@@ -125,7 +125,7 @@ namespace { // NOLINT
     if (ret_val.second > 0) {
       std::array<std::byte, SHA256_DIGEST_LENGTH> digest{};
       EVP_DigestFinal_ex(context, reinterpret_cast<unsigned char*>(digest.data()), nullptr);
-      ret_val.first = org::apache::nifi::minifi::utils::StringUtils::to_hex(digest, true /*uppercase*/);
+      ret_val.first = org::apache::nifi::minifi::utils::string::to_hex(digest, true /*uppercase*/);
     }
     return ret_val;
   }

--- a/extensions/standard-processors/processors/LogAttribute.cpp
+++ b/extensions/standard-processors/processors/LogAttribute.cpp
@@ -100,7 +100,7 @@ void LogAttribute::onTrigger(core::ProcessContext& context, core::ProcessSession
 
       std::string printable_payload;
       if (hexencode_) {
-        printable_payload = utils::StringUtils::to_hex(read_result.buffer);
+        printable_payload = utils::string::to_hex(read_result.buffer);
       } else {
         printable_payload = to_string(read_result);
       }

--- a/extensions/standard-processors/processors/ReplaceText.cpp
+++ b/extensions/standard-processors/processors/ReplaceText.cpp
@@ -70,7 +70,7 @@ void ReplaceText::onTrigger(core::ProcessContext& context, core::ProcessSession&
       return;
   }
 
-  throw Exception{PROCESSOR_EXCEPTION, utils::StringUtils::join_pack("Unsupported ", EvaluationMode.name, ": ", std::string{magic_enum::enum_name(evaluation_mode_)})};
+  throw Exception{PROCESSOR_EXCEPTION, utils::string::join_pack("Unsupported ", EvaluationMode.name, ": ", std::string{magic_enum::enum_name(evaluation_mode_)})};
 }
 
 ReplaceText::Parameters ReplaceText::readParameters(core::ProcessContext& context, const std::shared_ptr<core::FlowFile>& flow_file) const {
@@ -89,7 +89,7 @@ ReplaceText::Parameters ReplaceText::readParameters(core::ProcessContext& contex
     }
   }
   if ((replacement_strategy_ == ReplacementStrategyType::REGEX_REPLACE || replacement_strategy_ == ReplacementStrategyType::LITERAL_REPLACE) && parameters.search_value_.empty()) {
-    throw Exception{PROCESSOR_EXCEPTION, utils::StringUtils::join_pack("Error: missing or empty ", SearchValue.name, " property")};
+    throw Exception{PROCESSOR_EXCEPTION, utils::string::join_pack("Error: missing or empty ", SearchValue.name, " property")};
   }
 
   bool found_replacement_value;
@@ -101,11 +101,11 @@ ReplaceText::Parameters ReplaceText::readParameters(core::ProcessContext& contex
   if (found_replacement_value) {
     logger_->log_debug("the {} property is set to {}", ReplacementValue.name, parameters.replacement_value_);
   } else {
-    throw Exception{PROCESSOR_EXCEPTION, utils::StringUtils::join_pack("Missing required property: ", ReplacementValue.name)};
+    throw Exception{PROCESSOR_EXCEPTION, utils::string::join_pack("Missing required property: ", ReplacementValue.name)};
   }
 
   if (evaluation_mode_ == EvaluationModeType::LINE_BY_LINE) {
-    auto [chomped_value, line_ending] = utils::StringUtils::chomp(parameters.replacement_value_);
+    auto [chomped_value, line_ending] = utils::string::chomp(parameters.replacement_value_);
     parameters.replacement_value_ = std::move(chomped_value);
   }
 
@@ -142,7 +142,7 @@ void ReplaceText::replaceTextLineByLine(const std::shared_ptr<core::FlowFile>& f
         case LineByLineEvaluationModeType::EXCEPT_LAST_LINE:
           return is_last_line ? input_line: applyReplacements(input_line, flow_file, parameters);
       }
-      throw Exception{PROCESSOR_EXCEPTION, utils::StringUtils::join_pack("Unsupported ", LineByLineEvaluationMode.name, ": ", std::string{magic_enum::enum_name(line_by_line_evaluation_mode_)})};
+      throw Exception{PROCESSOR_EXCEPTION, utils::string::join_pack("Unsupported ", LineByLineEvaluationMode.name, ": ", std::string{magic_enum::enum_name(line_by_line_evaluation_mode_)})};
     }};
     session.readWrite(flow_file, std::move(read_write_callback));
     session.transfer(flow_file, Success);
@@ -153,7 +153,7 @@ void ReplaceText::replaceTextLineByLine(const std::shared_ptr<core::FlowFile>& f
 }
 
 std::string ReplaceText::applyReplacements(const std::string& input, const std::shared_ptr<core::FlowFile>& flow_file, const Parameters& parameters) const {
-  const auto [chomped_input, line_ending] = utils::StringUtils::chomp(input);
+  const auto [chomped_input, line_ending] = utils::string::chomp(input);
 
   switch (replacement_strategy_) {
     case ReplacementStrategyType::PREPEND:
@@ -175,7 +175,7 @@ std::string ReplaceText::applyReplacements(const std::string& input, const std::
       return applySubstituteVariables(chomped_input, flow_file) + line_ending;
   }
 
-  throw Exception{PROCESSOR_EXCEPTION, utils::StringUtils::join_pack("Unsupported ", ReplacementStrategy.name, ": ", std::string{magic_enum::enum_name(replacement_strategy_)})};
+  throw Exception{PROCESSOR_EXCEPTION, utils::string::join_pack("Unsupported ", ReplacementStrategy.name, ": ", std::string{magic_enum::enum_name(replacement_strategy_)})};
 }
 
 std::string ReplaceText::applyLiteralReplace(const std::string& input, const Parameters& parameters) {

--- a/extensions/standard-processors/processors/ReplaceText.cpp
+++ b/extensions/standard-processors/processors/ReplaceText.cpp
@@ -76,12 +76,8 @@ void ReplaceText::onTrigger(core::ProcessContext& context, core::ProcessSession&
 ReplaceText::Parameters ReplaceText::readParameters(core::ProcessContext& context, const std::shared_ptr<core::FlowFile>& flow_file) const {
   Parameters parameters;
 
-  bool found_search_value;
-  if (replacement_strategy_ == ReplacementStrategyType::REGEX_REPLACE) {
-    found_search_value = context.getProperty(SearchValue, parameters.search_value_);
-  } else {
-    found_search_value = context.getProperty(SearchValue, parameters.search_value_, flow_file);
-  }
+  bool found_search_value = (replacement_strategy_ == ReplacementStrategyType::REGEX_REPLACE ?
+      context.getProperty(SearchValue, parameters.search_value_) : context.getProperty(SearchValue, parameters.search_value_, flow_file));
   if (found_search_value) {
     logger_->log_debug("the {} property is set to {}", SearchValue.name, parameters.search_value_);
     if (replacement_strategy_ == ReplacementStrategyType::REGEX_REPLACE) {
@@ -92,12 +88,8 @@ ReplaceText::Parameters ReplaceText::readParameters(core::ProcessContext& contex
     throw Exception{PROCESSOR_EXCEPTION, utils::string::join_pack("Error: missing or empty ", SearchValue.name, " property")};
   }
 
-  bool found_replacement_value;
-  if (replacement_strategy_ == ReplacementStrategyType::REGEX_REPLACE) {
-    found_replacement_value = context.getProperty(ReplacementValue, parameters.replacement_value_);
-  } else {
-    found_replacement_value = context.getProperty(ReplacementValue, parameters.replacement_value_, flow_file);
-  }
+  bool found_replacement_value = (replacement_strategy_ == ReplacementStrategyType::REGEX_REPLACE ?
+      context.getProperty(ReplacementValue, parameters.replacement_value_) : context.getProperty(ReplacementValue, parameters.replacement_value_, flow_file));
   if (found_replacement_value) {
     logger_->log_debug("the {} property is set to {}", ReplacementValue.name, parameters.replacement_value_);
   } else {

--- a/extensions/standard-processors/processors/RouteText.cpp
+++ b/extensions/standard-processors/processors/RouteText.cpp
@@ -302,7 +302,7 @@ std::string_view RouteText::preprocess(std::string_view str) const {
     }
   }
   if (trim_) {
-    str = utils::StringUtils::trim(str);
+    str = utils::string::trim(str);
   }
   return str;
 }
@@ -320,22 +320,22 @@ bool RouteText::matchSegment(MatchingContext& context, const Segment& segment, c
       }
       std::string result;
       if (context.process_context_.getDynamicProperty(prop, result, context.flow_file_, variables)) {
-        return utils::StringUtils::toBool(result).value_or(false);
+        return utils::string::toBool(result).value_or(false);
       } else {
         throw Exception(PROCESSOR_EXCEPTION, "Missing dynamic property: '" + prop.getName() + "'");
       }
     }
     case route_text::Matching::STARTS_WITH: {
-      return utils::StringUtils::startsWith(segment.value_, context.getStringProperty(prop), case_policy_ == route_text::CasePolicy::CASE_SENSITIVE);
+      return utils::string::startsWith(segment.value_, context.getStringProperty(prop), case_policy_ == route_text::CasePolicy::CASE_SENSITIVE);
     }
     case route_text::Matching::ENDS_WITH: {
-      return utils::StringUtils::endsWith(segment.value_, context.getStringProperty(prop), case_policy_ == route_text::CasePolicy::CASE_SENSITIVE);
+      return utils::string::endsWith(segment.value_, context.getStringProperty(prop), case_policy_ == route_text::CasePolicy::CASE_SENSITIVE);
     }
     case route_text::Matching::CONTAINS: {
       return std::search(segment.value_.begin(), segment.value_.end(), context.getSearcher(prop)) != segment.value_.end();
     }
     case route_text::Matching::EQUALS: {
-      return utils::StringUtils::equals(segment.value_, context.getStringProperty(prop), case_policy_ == route_text::CasePolicy::CASE_SENSITIVE);
+      return utils::string::equals(segment.value_, context.getStringProperty(prop), case_policy_ == route_text::CasePolicy::CASE_SENSITIVE);
     }
     case route_text::Matching::CONTAINS_REGEX: {
       std::string segment_str = std::string(segment.value_);

--- a/extensions/standard-processors/processors/TailFile.cpp
+++ b/extensions/standard-processors/processors/TailFile.cpp
@@ -250,7 +250,7 @@ void TailFile::onSchedule(core::ProcessContext& context, core::ProcessSessionFac
   }
 
   if (auto delimiter_str = context.getProperty(Delimiter)) {
-    if (auto parsed_delimiter = utils::StringUtils::parseCharacter(*delimiter_str)) {
+    if (auto parsed_delimiter = utils::string::parseCharacter(*delimiter_str)) {
       delimiter_ = *parsed_delimiter;
     } else {
       logger_->log_error("Invalid {}: \"{}\" (it should be a single character, whether escaped or not). Using the first character as the {}",
@@ -329,13 +329,13 @@ void TailFile::parseAttributeProviderServiceProperty(core::ProcessContext& conte
 
   std::shared_ptr<core::controller::ControllerService> controller_service = context.getControllerService(*attribute_provider_service_name);
   if (!controller_service) {
-    throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, utils::StringUtils::join_pack("Controller service '", *attribute_provider_service_name, "' not found")};
+    throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, utils::string::join_pack("Controller service '", *attribute_provider_service_name, "' not found")};
   }
 
   // we drop ownership of the service here -- in the long term, getControllerService() should return a non-owning pointer or optional reference
   attribute_provider_service_ = dynamic_cast<minifi::controllers::AttributeProviderService*>(controller_service.get());
   if (!attribute_provider_service_) {
-    throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, utils::StringUtils::join_pack("Controller service '", *attribute_provider_service_name, "' is not an AttributeProviderService")};
+    throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, utils::string::join_pack("Controller service '", *attribute_provider_service_name, "' is not an AttributeProviderService")};
   }
 }
 
@@ -370,8 +370,8 @@ void TailFile::parseStateFileLine(char *buf, std::map<std::filesystem::path, Tai
   }
 
   std::string value = equal;
-  key = utils::StringUtils::trimRight(key);
-  value = utils::StringUtils::trimRight(value);
+  key = utils::string::trimRight(key);
+  value = utils::string::trimRight(value);
 
   if (key == "FILENAME") {
     std::filesystem::path file_path = value;
@@ -532,7 +532,7 @@ bool TailFile::storeState() {
 std::string TailFile::parseRollingFilePattern(const TailState &state) const {
   std::size_t last_dot_position = state.file_name_.string().find_last_of('.');
   std::string base_name = state.file_name_.string().substr(0, last_dot_position);
-  return utils::StringUtils::replaceOne(rolling_filename_pattern_, "${filename}", base_name);
+  return utils::string::replaceOne(rolling_filename_pattern_, "${filename}", base_name);
 }
 
 std::vector<TailState> TailFile::findAllRotatedFiles(const TailState &state) const {

--- a/extensions/standard-processors/tests/unit/ProcessGroupTestUtils.h
+++ b/extensions/standard-processors/tests/unit/ProcessGroupTestUtils.h
@@ -31,7 +31,7 @@ struct Lines {
   std::vector<std::string> lines;
 
   std::string join(const std::string& delim) const {
-    return utils::StringUtils::join(delim, lines);
+    return utils::string::join(delim, lines);
   }
 
   Lines& indentAll() & {

--- a/extensions/standard-processors/tests/unit/PutTCPTests.cpp
+++ b/extensions/standard-processors/tests/unit/PutTCPTests.cpp
@@ -208,7 +208,7 @@ class PutTCPTestFixture {
   }
 
   void setPutTCPPort(uint16_t port) {
-    put_tcp_->setProperty(PutTCP::Port, utils::StringUtils::join_pack("${literal('", std::to_string(port), "')}"));
+    put_tcp_->setProperty(PutTCP::Port, utils::string::join_pack("${literal('", std::to_string(port), "')}"));
   }
 
   void setPutTCPPort(const std::string& port_str) {

--- a/extensions/standard-processors/tests/unit/PutUDPTests.cpp
+++ b/extensions/standard-processors/tests/unit/PutUDPTests.cpp
@@ -66,7 +66,7 @@ TEST_CASE("PutUDP", "[putudp]") {
     listener.stop();
     server_thread.join();
   });
-  put_udp->setProperty(PutUDP::Port, utils::StringUtils::join_pack("${literal('", std::to_string(port), "')}"));
+  put_udp->setProperty(PutUDP::Port, utils::string::join_pack("${literal('", std::to_string(port), "')}"));
 
   {
     const char* const message = "first message: hello";

--- a/extensions/standard-processors/tests/unit/TailFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/TailFileTests.cpp
@@ -578,10 +578,10 @@ TEST_CASE("TailFile processes a very long line correctly", "[simple]") {
   std::string line1("012\n");
   std::string line2(8050, 0);
   std::mt19937 gen(std::random_device{}());  // NOLINT (linter wants a space before '{') [whitespace/braces]
-  std::generate_n(line2.begin(), line2.size() - 1, [&]() -> char {
+  std::generate_n(line2.begin(), line2.size() - 1, [&] {
     // Make sure to only generate from characters that don't intersect with line1 and 3-4
     // Starting generation from 64 ensures that no numeric digit characters are added
-    return 64 + gen() % (127 - 64);
+    return gsl::narrow<char>(64 + gen() % (127 - 64));
   });
   line2.back() = '\n';
   std::string line3("345\n");
@@ -653,10 +653,10 @@ TEST_CASE("TailFile processes a long line followed by multiple newlines correctl
   // Test having two delimiters on the buffer boundary
   std::string line1(4098, '\n');
   std::mt19937 gen(std::random_device { }());
-  std::generate_n(line1.begin(), 4095, [&]() -> char {
+  std::generate_n(line1.begin(), 4095, [&] {
     // Make sure to only generate from characters that don't intersect with line2-4
     // Starting generation from 64 ensures that no numeric digit characters are added
-    return 64 + gen() % (127 - 64);
+    return gsl::narrow<char>(64 + gen() % (127 - 64));
   });
   std::string line2("012\n");
   std::string line3("345\n");

--- a/extensions/standard-processors/tests/unit/TailFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/TailFileTests.cpp
@@ -632,8 +632,8 @@ TEST_CASE("TailFile processes a very long line correctly", "[simple]") {
   testController.runSession(plan, true);
 
   REQUIRE(LogTestController::getInstance().contains("Logged 3 flow files"));
-  REQUIRE(LogTestController::getInstance().contains(utils::StringUtils::to_hex(line1)));
-  auto line2_hex = utils::StringUtils::to_hex(line2);
+  REQUIRE(LogTestController::getInstance().contains(utils::string::to_hex(line1)));
+  auto line2_hex = utils::string::to_hex(line2);
   if (line_length == 0U) {
     REQUIRE(LogTestController::getInstance().contains(line2_hex));
   } else {
@@ -643,8 +643,8 @@ TEST_CASE("TailFile processes a very long line correctly", "[simple]") {
     }
     REQUIRE(LogTestController::getInstance().contains(line2_hex_lines.str()));
   }
-  REQUIRE(LogTestController::getInstance().contains(utils::StringUtils::to_hex(line3)));
-  REQUIRE(false == LogTestController::getInstance().contains(utils::StringUtils::to_hex(line4), std::chrono::seconds(0)));
+  REQUIRE(LogTestController::getInstance().contains(utils::string::to_hex(line3)));
+  REQUIRE(false == LogTestController::getInstance().contains(utils::string::to_hex(line4), std::chrono::seconds(0)));
 
   LogTestController::getInstance().reset();
 }
@@ -691,15 +691,15 @@ TEST_CASE("TailFile processes a long line followed by multiple newlines correctl
   testController.runSession(plan, true);
 
   REQUIRE(LogTestController::getInstance().contains("Logged 5 flow files"));
-  auto line1_hex = utils::StringUtils::to_hex(line1.substr(0, 4096));
+  auto line1_hex = utils::string::to_hex(line1.substr(0, 4096));
   std::stringstream line1_hex_lines;
   for (size_t i = 0; i < line1_hex.size(); i += 80) {
     line1_hex_lines << line1_hex.substr(i, 80) << '\n';
   }
   REQUIRE(LogTestController::getInstance().contains(line1_hex_lines.str()));
-  REQUIRE(LogTestController::getInstance().contains(utils::StringUtils::to_hex(line2)));
-  REQUIRE(LogTestController::getInstance().contains(utils::StringUtils::to_hex(line3)));
-  REQUIRE(false == LogTestController::getInstance().contains(utils::StringUtils::to_hex(line4), std::chrono::seconds(0)));
+  REQUIRE(LogTestController::getInstance().contains(utils::string::to_hex(line2)));
+  REQUIRE(LogTestController::getInstance().contains(utils::string::to_hex(line3)));
+  REQUIRE(false == LogTestController::getInstance().contains(utils::string::to_hex(line4), std::chrono::seconds(0)));
 
   LogTestController::getInstance().reset();
 }
@@ -1327,7 +1327,7 @@ TEST_CASE("TailFile handles the Delimiter setting correctly", "[delimiter]") {
     auto temp_directory = testController.createTempDirectory();
 
     std::string delimiter = test_case.second;
-    auto full_file_name = createTempFile(temp_directory, "test.log", utils::StringUtils::join_pack("one", delimiter, "two", delimiter));
+    auto full_file_name = createTempFile(temp_directory, "test.log", utils::string::join_pack("one", delimiter, "two", delimiter));
 
     auto plan = testController.createPlan();
 

--- a/extensions/standard-processors/tests/unit/YamlConfigurationTests.cpp
+++ b/extensions/standard-processors/tests/unit/YamlConfigurationTests.cpp
@@ -784,7 +784,7 @@ TEST_CASE("Test UUID duplication checks", "[YamlConfiguration]") {
               class: SSLContextService
             )";
 
-      utils::StringUtils::replaceAll(config_yaml, std::string("00000000-0000-0000-0000-00000000000") + i, "99999999-9999-9999-9999-999999999999");
+      utils::string::replaceAll(config_yaml, std::string("00000000-0000-0000-0000-00000000000") + i, "99999999-9999-9999-9999-999999999999");
       REQUIRE_THROWS_WITH(yaml_config.getRootFromPayload(config_yaml), "General Operation: UUID 99999999-9999-9999-9999-999999999999 is duplicated in the flow configuration");
     }
   }

--- a/extensions/systemd/libwrapper/DlopenWrapper.cpp
+++ b/extensions/systemd/libwrapper/DlopenWrapper.cpp
@@ -74,13 +74,13 @@ class DlopenJournal : public Journal {
     // The cast below is supported by POSIX platforms. https://stackoverflow.com/a/1096349
     F const symbol = (F)dlsym(libhandle_.get(), symbol_name);
     const char* const err = dlerror();
-    if (err) throw Exception(ExceptionType::GENERAL_EXCEPTION, utils::StringUtils::join_pack("dlsym(", symbol_name, "): ", err));
+    if (err) throw Exception(ExceptionType::GENERAL_EXCEPTION, utils::string::join_pack("dlsym(", symbol_name, "): ", err));
     return symbol;
   }
 
   std::unique_ptr<void, dlclose_deleter> libhandle_{[] {
     auto* const handle = dlopen("libsystemd.so.0", RTLD_LAZY);
-    if (!handle) throw Exception(ExceptionType::GENERAL_EXCEPTION, utils::StringUtils::join_pack("dlopen failed: ", dlerror()));
+    if (!handle) throw Exception(ExceptionType::GENERAL_EXCEPTION, utils::string::join_pack("dlopen failed: ", dlerror()));
     return handle;
   }()};
 

--- a/extensions/systemd/tests/ConsumeJournaldTest.cpp
+++ b/extensions/systemd/tests/ConsumeJournaldTest.cpp
@@ -43,16 +43,16 @@ struct JournalEntry final {
   {
     auto extra_fields_size = fields.size();
     fields.reserve(fields.size() + 4);
-    fields.push_back(utils::StringUtils::join_pack("MESSAGE=", message));
-    fields.push_back(utils::StringUtils::join_pack("SYSLOG_IDENTIFIER=", identifier));
+    fields.push_back(utils::string::join_pack("MESSAGE=", message));
+    fields.push_back(utils::string::join_pack("SYSLOG_IDENTIFIER=", identifier));
     if (pid != 0) {
       // The intention of the long expression below is a simple pseudo-random to test both branches equally
       // without having to pull in complex random logic
       const char* const pid_key =
           (int{message[0]} + int{identifier[0]} + static_cast<int>(extra_fields_size) + pid + int{hostname[0]}) % 2 == 0 ? "_PID" : "SYSLOG_PID";
-      fields.push_back(utils::StringUtils::join_pack(pid_key, "=", std::to_string(pid)));
+      fields.push_back(utils::string::join_pack(pid_key, "=", std::to_string(pid)));
     }
-    fields.push_back(utils::StringUtils::join_pack("_HOSTNAME=", hostname));
+    fields.push_back(utils::string::join_pack("_HOSTNAME=", hostname));
   }
 
   std::vector<std::string> fields;  // in KEY=VALUE format, like systemd

--- a/extensions/test-processors/KamikazeProcessor.cpp
+++ b/extensions/test-processors/KamikazeProcessor.cpp
@@ -37,11 +37,11 @@ void KamikazeProcessor::initialize() {
 void KamikazeProcessor::onSchedule(core::ProcessContext& context, core::ProcessSessionFactory&) {
   std::string value;
   context.getProperty(ThrowInOnTrigger, value);
-  _throwInOnTrigger = utils::StringUtils::toBool(value).value_or(false);
+  _throwInOnTrigger = utils::string::toBool(value).value_or(false);
 
   context.getProperty(ThrowInOnSchedule, value);
 
-  if (utils::StringUtils::toBool(value).value_or(false)) {
+  if (utils::string::toBool(value).value_or(false)) {
     throw Exception(PROCESS_SCHEDULE_EXCEPTION, OnScheduleExceptionStr);
   }
   logger_->log_error("{}", OnScheduleLogStr);

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
@@ -122,17 +122,17 @@ void ConsumeWindowsEventLog::onSchedule(core::ProcessContext& context, core::Pro
 
   header_names_.clear();
   if (auto header = context.getProperty(EventHeader)) {
-    auto keyValueSplit = utils::StringUtils::split(*header, ",");
+    auto keyValueSplit = utils::string::split(*header, ",");
     for (const auto &kv : keyValueSplit) {
-      auto splitKeyAndValue = utils::StringUtils::split(kv, "=");
+      auto splitKeyAndValue = utils::string::split(kv, "=");
       if (splitKeyAndValue.size() == 2) {
-        auto key = utils::StringUtils::trim(splitKeyAndValue.at(0));
-        auto value = utils::StringUtils::trim(splitKeyAndValue.at(1));
+        auto key = utils::string::trim(splitKeyAndValue.at(0));
+        auto value = utils::string::trim(splitKeyAndValue.at(1));
         if (!insertHeaderName(header_names_, key, value)) {
           logger_->log_error("{} is an invalid key for the header map", key);
         }
       } else if (splitKeyAndValue.size() == 1) {
-        auto key = utils::StringUtils::trim(splitKeyAndValue.at(0));
+        auto key = utils::string::trim(splitKeyAndValue.at(0));
         if (!insertHeaderName(header_names_, key, "")) {
           logger_->log_error("{} is an invalid key for the header map", key);
         }
@@ -381,7 +381,7 @@ void ConsumeWindowsEventLog::substituteXMLPercentageItems(pugi::xml_document& do
             value = pBuffer;
             LocalFree(pBuffer);
 
-            value = utils::StringUtils::trimRight(value);
+            value = utils::string::trimRight(value);
 
             xmlPercentageItemsResolutions_.insert({key, value});
           } else {
@@ -481,7 +481,7 @@ nonstd::expected<cwel::EventRender, std::string> ConsumeWindowsEventLog::createE
         if (map_entry.first.empty() || map_entry.second.empty()) {
           continue;
         }
-        utils::StringUtils::replaceAll(*event_message, map_entry.first, map_entry.second);
+        utils::string::replaceAll(*event_message, map_entry.first, map_entry.second);
       }
     }
 

--- a/extensions/windows-event-log/tests/BookmarkTests.cpp
+++ b/extensions/windows-event-log/tests/BookmarkTests.cpp
@@ -133,7 +133,7 @@ TEST_CASE("Bookmark constructor works for log file path", "[create]") {
   REQUIRE(*bookmark);
 
   std::string log_file_str = log_file.string();
-  utils::StringUtils::replaceAll(log_file_str, "\\", "\\\\");
+  utils::string::replaceAll(log_file_str, "\\", "\\\\");
 
   std::wstring pattern{L"<BookmarkList Direction='backward'>\r\n"};
   pattern += L"  <Bookmark Channel='" + std::wstring(log_file_str.begin(), log_file_str.end()) + L"' RecordId='\\d+' IsCurrent='true'/>\r\n";

--- a/extensions/windows-event-log/wel/EventPath.cpp
+++ b/extensions/windows-event-log/wel/EventPath.cpp
@@ -27,7 +27,7 @@ EventPath::EventPath(const std::wstring& wstr) : EventPath(utils::to_string(wstr
 
 EventPath::EventPath(std::string str) {
   constexpr std::string_view saved_log_prefix = "SavedLog:";
-  if (utils::StringUtils::startsWith(str, saved_log_prefix)) {
+  if (utils::string::startsWith(str, saved_log_prefix)) {
     str_ = str.substr(saved_log_prefix.size());
     kind_ = Kind::FILE;
   } else {

--- a/extensions/windows-event-log/wel/JSONUtils.cpp
+++ b/extensions/windows-event-log/wel/JSONUtils.cpp
@@ -168,7 +168,7 @@ rapidjson::Document toJSONImpl(const pugi::xml_node& root, bool flatten) {
       for (const auto& event_data_child : eventData_xml.children()) {
         std::string key = "EventData";
         if (auto name_attr = event_data_child.attribute("Name"); !name_attr.empty()) {
-          key = utils::StringUtils::join_pack(key, ".", name_attr.value());
+          key = utils::string::join_pack(key, ".", name_attr.value());
         }
 
         doc.AddMember(rapidjson::Value(createUniqueKey(key, doc), doc.GetAllocator()).Move(), rapidjson::StringRef(event_data_child.text().get()), doc.GetAllocator());

--- a/extensions/windows-event-log/wel/MetadataWalker.cpp
+++ b/extensions/windows-event-log/wel/MetadataWalker.cpp
@@ -69,7 +69,7 @@ bool MetadataWalker::for_each(pugi::xml_node &node) {
         std::string replacement = "%{" + id + "}";
         replaced_identifiers_[id] = resolved;
         replaced_identifiers_[replacement] = resolved;
-        nodeText = utils::StringUtils::replaceAll(nodeText, replacement, resolved);
+        nodeText = utils::string::replaceAll(nodeText, replacement, resolved);
       }
       node.text().set(nodeText.c_str());
     }

--- a/extensions/windows-event-log/wel/WindowsEventLog.h
+++ b/extensions/windows-event-log/wel/WindowsEventLog.h
@@ -194,7 +194,7 @@ std::string WindowsEventLogHeader::getEventHeader(const MetadataCollection& meta
       eventHeader << *custom_delimiter_;
     else
       eventHeader << createDefaultDelimiter(name.size());
-    eventHeader << utils::StringUtils::trim(metadata_collection(option.first)) << std::endl;
+    eventHeader << utils::string::trim(metadata_collection(option.first)) << std::endl;
   }
 
   return eventHeader.str();

--- a/libminifi/include/Exception.h
+++ b/libminifi/include/Exception.h
@@ -62,11 +62,11 @@ struct Exception : public std::runtime_error {
    * Create a new exception
    */
   Exception(ExceptionType type, const std::string& errorMsg)
-      :Exception{ utils::StringUtils::join_pack(ExceptionTypeToString(type), ": ", errorMsg) }
+      :Exception{ utils::string::join_pack(ExceptionTypeToString(type), ": ", errorMsg) }
   { }
 
   Exception(ExceptionType type, const char* errorMsg)
-      :Exception{ utils::StringUtils::join_pack(ExceptionTypeToString(type), ": ", errorMsg) }
+      :Exception{ utils::string::join_pack(ExceptionTypeToString(type), ": ", errorMsg) }
   { }
 
  protected:
@@ -80,7 +80,7 @@ struct Exception : public std::runtime_error {
 
 struct SystemErrorException : Exception {
   explicit SystemErrorException(const char* const operation, std::error_condition error_condition)
-      :Exception{ utils::StringUtils::join_pack(operation, ": ", error_condition.message()) },
+      :Exception{ utils::string::join_pack(operation, ": ", error_condition.message()) },
       error_condition_{ error_condition }
   {}
 

--- a/libminifi/include/RemoteProcessorGroupPort.h
+++ b/libminifi/include/RemoteProcessorGroupPort.h
@@ -161,9 +161,9 @@ class RemoteProcessorGroupPort : public core::Processor {
    * Sets the url. Supports a CSV
    */
   void setURL(std::string val) {
-    auto urls = utils::StringUtils::split(val, ",");
+    auto urls = utils::string::split(val, ",");
     for (const auto& url : urls) {
-      utils::URL parsed_url{utils::StringUtils::trim(url)};
+      utils::URL parsed_url{utils::string::trim(url)};
       if (parsed_url.isValid()) {
         logger_->log_debug("Parsed RPG URL '{}' -> '{}'", url, parsed_url.hostPort());
         nifi_instances_.push_back({parsed_url.host(), parsed_url.port(), parsed_url.protocol()});

--- a/libminifi/include/agent/agent_docs.h
+++ b/libminifi/include/agent/agent_docs.h
@@ -74,7 +74,7 @@ inline auto toVector(std::span<const core::RelationshipDefinition> relationships
 template<typename T>
 std::string classNameWithDots() {
   std::string class_name{core::className<T>()};
-  return utils::StringUtils::replaceAll(class_name, "::", ".");
+  return utils::string::replaceAll(class_name, "::", ".");
 }
 }  // namespace detail
 

--- a/libminifi/include/controllers/SSLContextService.h
+++ b/libminifi/include/controllers/SSLContextService.h
@@ -276,7 +276,7 @@ class SSLContextService : public core::controller::ControllerService {
 #endif
 
   static bool isFileTypeP12(const std::filesystem::path& filename) {
-    return utils::StringUtils::endsWith(filename.string(), "p12", false);
+    return utils::string::endsWith(filename.string(), "p12", false);
   }
 
  private:

--- a/libminifi/include/core/Processor.h
+++ b/libminifi/include/core/Processor.h
@@ -47,7 +47,7 @@
 #define ADD_GET_PROCESSOR_NAME \
   std::string getProcessorType() const override { \
     auto class_name = org::apache::nifi::minifi::core::className<decltype(*this)>(); \
-    auto splitted = org::apache::nifi::minifi::utils::StringUtils::split(class_name, "::"); \
+    auto splitted = org::apache::nifi::minifi::utils::string::split(class_name, "::"); \
     return splitted[splitted.size() - 1]; \
   }
 

--- a/libminifi/include/core/PropertyType.h
+++ b/libminifi/include/core/PropertyType.h
@@ -117,7 +117,7 @@ class BooleanPropertyType : public PropertyType {
   }
 
   [[nodiscard]] ValidationResult validate(const std::string &subject, const std::string &input) const override {
-    if (utils::StringUtils::equalsIgnoreCase(input, "true") || utils::StringUtils::equalsIgnoreCase(input, "false"))
+    if (utils::string::equalsIgnoreCase(input, "true") || utils::string::equalsIgnoreCase(input, "false"))
       return ValidationResult{.valid = true, .subject = subject, .input = input};
     else
       return ValidationResult{.valid = false, .subject = subject, .input = input};
@@ -256,7 +256,7 @@ class NonBlankPropertyType : public PropertyType {
   }
 
   [[nodiscard]] ValidationResult validate(const std::string& subject, const std::string& input) const final {
-    return ValidationResult{.valid = !utils::StringUtils::trimLeft(input).empty(), .subject = subject, .input = input};
+    return ValidationResult{.valid = !utils::string::trimLeft(input).empty(), .subject = subject, .input = input};
   }
 };
 

--- a/libminifi/include/core/TypedValues.h
+++ b/libminifi/include/core/TypedValues.h
@@ -114,7 +114,7 @@ class DataSizeValue : public TransformableValue, public state::response::UInt64V
         {"K", 1_KB}, {"M", 1_MB}, {"G", 1_GB}, {"T", 1_TB}, {"P", 1_PB},
         {"KB", 1_KiB}, {"MB", 1_MiB}, {"GB", 1_GiB}, {"TB", 1_TiB}, {"PB", 1_PiB},
     };
-    unit_str = utils::StringUtils::toUpper(unit_str);
+    unit_str = utils::string::toUpper(unit_str);
 
     return unit_map.contains(unit_str) ? std::optional(unit_map.at(unit_str)) : std::nullopt;
   }
@@ -125,7 +125,7 @@ class DataSizeValue : public TransformableValue, public state::response::UInt64V
     int64_t value;
     std::string unit_str;
     try {
-      unit_str = utils::StringUtils::trim(utils::internal::ValueParser(input).parse(value).rest());
+      unit_str = utils::string::trim(utils::internal::ValueParser(input).parse(value).rest());
     } catch (const utils::internal::ParseException&) {
       return false;
     }
@@ -163,7 +163,7 @@ class DataTransferSpeedValue : public TransformableValue, public state::response
   }
 
   static std::string removePerSecSuffix(const std::string &input) {
-    auto lower_case_input = utils::StringUtils::trim(utils::StringUtils::toLower(input));
+    auto lower_case_input = utils::string::trim(utils::string::toLower(input));
     if (lower_case_input.ends_with("/s")) {
       return lower_case_input.substr(0, lower_case_input.size() - 2);
     }

--- a/libminifi/include/core/VariableRegistry.h
+++ b/libminifi/include/core/VariableRegistry.h
@@ -62,7 +62,7 @@ class VariableRegistry {
 
     // only allow those in the white liset
     if (configuration_->get(white_list_opt, white_list)) {
-      options = utils::StringUtils::split(white_list, ",");
+      options = utils::string::split(white_list, ",");
     }
 
     for (const auto &opt : options) {
@@ -73,7 +73,7 @@ class VariableRegistry {
     // even if a white list is configured, remove the black listed fields
 
     if (configuration_->get(black_list_opt, black_list)) {
-      auto bl_opts = utils::StringUtils::split(black_list, ",");
+      auto bl_opts = utils::string::split(black_list, ",");
       for (const auto &opt : bl_opts) {
         options.erase(std::remove(options.begin(), options.end(), opt), options.end());
       }

--- a/libminifi/include/core/extension/Utils.h
+++ b/libminifi/include/core/extension/Utils.h
@@ -61,7 +61,7 @@ struct LibraryDescriptor {
     }};
     const std::string_view begin_marker = "__EXTENSION_BUILD_IDENTIFIER_BEGIN__";
     const std::string_view end_marker = "__EXTENSION_BUILD_IDENTIFIER_END__";
-    const std::string magic_constant = utils::StringUtils::join_pack(begin_marker, AgentBuild::BUILD_IDENTIFIER, end_marker);
+    const std::string magic_constant = utils::string::join_pack(begin_marker, AgentBuild::BUILD_IDENTIFIER, end_marker);
     return utils::file::contains(path, magic_constant);
   }
 

--- a/libminifi/include/core/flow/Node.h
+++ b/libminifi/include/core/flow/Node.h
@@ -145,14 +145,14 @@ class Node {
   // considers @key to be a member of this node as is
   Node getMember(std::string_view key) {
     Node result = impl_->operator[](key);
-    result.path_ = utils::StringUtils::join_pack(path_, "/", key);
+    result.path_ = utils::string::join_pack(path_, "/", key);
     return result;
   }
 
   // considers @key to be a '/'-delimited access path
   Node operator[](std::string_view key) const {
     Node result = *this;
-    for (auto& field : utils::StringUtils::split(std::string{key}, "/")) {
+    for (auto& field : utils::string::split(std::string{key}, "/")) {
       if (key == ".") {
         // pass: self
       } else {

--- a/libminifi/include/properties/Properties.h
+++ b/libminifi/include/properties/Properties.h
@@ -63,7 +63,7 @@ class Properties {
   }
   // Set the config value
   virtual void set(const std::string &key, const std::string &value, PropertyChangeLifetime lifetime) {
-    auto active_value = utils::StringUtils::replaceEnvironmentVariables(value);
+    auto active_value = utils::string::replaceEnvironmentVariables(value);
     std::lock_guard<std::mutex> lock(mutex_);
     bool should_persist = lifetime == PropertyChangeLifetime::PERSISTENT;
     if (auto it = properties_.find(key); it != properties_.end()) {

--- a/libminifi/include/utils/BaseHTTPClient.h
+++ b/libminifi/include/utils/BaseHTTPClient.h
@@ -147,13 +147,13 @@ struct HTTPHeaderResponse {
         if (separator_pos == std::string::npos) {
           if (!last_key.empty() && (header_line[0] == ' ' || header_line[0] == '\t')) {
             // This is a "folded header", which is deprecated (https://www.ietf.org/rfc/rfc7230.txt) but here we are
-            header_mapping_[last_key].append(" " + utils::StringUtils::trim(header_line));
+            header_mapping_[last_key].append(" " + utils::string::trim(header_line));
           }
           continue;
         }
         auto key = header_line.substr(0, separator_pos);
         /* This will remove leading and trailing LWS and the ending CRLF from the value */
-        auto value = utils::StringUtils::trim(header_line.substr(separator_pos + 1));
+        auto value = utils::string::trim(header_line.substr(separator_pos + 1));
         header_mapping_[key] = value;
         last_key = key;
       }

--- a/libminifi/include/utils/StringUtils.h
+++ b/libminifi/include/utils/StringUtils.h
@@ -432,6 +432,4 @@ struct ParseError {};
 nonstd::expected<std::optional<char>, ParseError> parseCharacter(std::string_view input);
 }  // namespace string
 
-namespace StringUtils = string;
-
 }  // namespace org::apache::nifi::minifi::utils

--- a/libminifi/include/utils/TimeUtil.h
+++ b/libminifi/include/utils/TimeUtil.h
@@ -234,11 +234,11 @@ template<class TargetDuration>
 std::optional<TargetDuration> StringToDuration(const std::string& input) {
   std::string unit;
   int64_t value;
-  if (!StringUtils::splitToValueAndUnit(input, value, unit))
+  if (!string::splitToValueAndUnit(input, value, unit))
     return std::nullopt;
 
 
-  unit = utils::StringUtils::toLower(unit);
+  unit = utils::string::toLower(unit);
 
   return details::cast_to_matching_unit<TargetDuration,
     std::chrono::nanoseconds,

--- a/libminifi/include/utils/file/FileUtils.h
+++ b/libminifi/include/utils/file/FileUtils.h
@@ -567,7 +567,7 @@ inline std::optional<std::string> get_file_group(const std::filesystem::path& fi
 #endif
 
 inline std::optional<std::filesystem::path> get_relative_path(const std::filesystem::path& path, const std::filesystem::path& base_path) {
-  if (!utils::StringUtils::startsWith(path.string(), base_path.string())) {
+  if (!utils::string::startsWith(path.string(), base_path.string())) {
     return std::nullopt;
   }
 

--- a/libminifi/src/Configuration.cpp
+++ b/libminifi/src/Configuration.cpp
@@ -161,7 +161,7 @@ const std::array<const char*, 2> Configuration::DEFAULT_SENSITIVE_PROPERTIES = {
 std::vector<std::string> Configuration::mergeProperties(std::vector<std::string> properties,
                                                         const std::vector<std::string>& additional_properties) {
   for (const auto& property_name : additional_properties) {
-    std::string property_name_trimmed = utils::StringUtils::trim(property_name);
+    std::string property_name_trimmed = utils::string::trim(property_name);
     if (!property_name_trimmed.empty()) {
       properties.push_back(std::move(property_name_trimmed));
     }
@@ -178,7 +178,7 @@ std::vector<std::string> Configuration::getSensitiveProperties(const std::functi
   if (reader) {
     const auto additional_sensitive_props_list = reader(Configuration::nifi_sensitive_props_additional_keys);
     if (additional_sensitive_props_list) {
-      std::vector<std::string> additional_sensitive_properties = utils::StringUtils::split(*additional_sensitive_props_list, ",");
+      std::vector<std::string> additional_sensitive_properties = utils::string::split(*additional_sensitive_props_list, ",");
       return Configuration::mergeProperties(sensitive_properties, additional_sensitive_properties);
     }
   }

--- a/libminifi/src/Configure.cpp
+++ b/libminifi/src/Configure.cpp
@@ -71,7 +71,7 @@ std::optional<std::string> Configure::getWithFallback(const std::string& key, co
 
 std::optional<std::string> Configure::getRawValue(const std::string& key) const {
   static constexpr std::string_view log_prefix = "nifi.log.";
-  if (utils::StringUtils::startsWith(key, log_prefix)) {
+  if (utils::string::startsWith(key, log_prefix)) {
     if (logger_properties_) {
       return logger_properties_->getString(key.substr(log_prefix.length()));
     }
@@ -111,7 +111,7 @@ void Configure::setFallbackAgentIdentifier(const std::string& id) {
 
 void Configure::set(const std::string& key, const std::string& value, PropertyChangeLifetime lifetime) {
   const std::string_view log_prefix = "nifi.log.";
-  if (utils::StringUtils::startsWith(key, log_prefix)) {
+  if (utils::string::startsWith(key, log_prefix)) {
     if (logger_properties_) {
       logger_properties_changed_ = true;
       logger_properties_->set(key.substr(log_prefix.length()), value, lifetime);

--- a/libminifi/src/RemoteProcessorGroupPort.cpp
+++ b/libminifi/src/RemoteProcessorGroupPort.cpp
@@ -123,7 +123,7 @@ void RemoteProcessorGroupPort::onSchedule(core::ProcessContext& context, core::P
     ssl_service = std::static_pointer_cast<minifi::controllers::SSLContextService>(service);
   } else {
     std::string secureStr;
-    if (configure_->get(Configure::nifi_remote_input_secure, secureStr) && utils::StringUtils::toBool(secureStr).value_or(false)) {
+    if (configure_->get(Configure::nifi_remote_input_secure, secureStr) && utils::string::toBool(secureStr).value_or(false)) {
       ssl_service = std::make_shared<minifi::controllers::SSLContextService>(RPG_SSL_CONTEXT_SERVICE_NAME, configure_);
       ssl_service->onEnable();
     }

--- a/libminifi/src/agent/JsonSchema.cpp
+++ b/libminifi/src/agent/JsonSchema.cpp
@@ -36,9 +36,9 @@
 namespace org::apache::nifi::minifi::docs {
 
 static std::string escape(std::string str) {
-  utils::StringUtils::replaceAll(str, "\\", "\\\\");
-  utils::StringUtils::replaceAll(str, "\"", "\\\"");
-  utils::StringUtils::replaceAll(str, "\n", "\\n");
+  utils::string::replaceAll(str, "\\", "\\\\");
+  utils::string::replaceAll(str, "\"", "\\\"");
+  utils::string::replaceAll(str, "\n", "\\n");
   return str;
 }
 
@@ -462,7 +462,7 @@ std::string generateJsonSchema() {
     }
   }
 
-  return buildSchema(relationships, utils::StringUtils::join(", ", proc_schemas), utils::StringUtils::join(", ", controller_services));
+  return buildSchema(relationships, utils::string::join(", ", proc_schemas), utils::string::join(", ", controller_services));
 }
 
 }  // namespace org::apache::nifi::minifi::docs

--- a/libminifi/src/c2/C2MetricsPublisher.cpp
+++ b/libminifi/src/c2/C2MetricsPublisher.cpp
@@ -41,7 +41,7 @@ namespace org::apache::nifi::minifi::c2 {
 
 void C2MetricsPublisher::loadNodeClasses(const std::string& class_definitions, const state::response::SharedResponseNode& new_node) {
   gsl_Expects(response_node_loader_);
-  auto classes = utils::StringUtils::split(class_definitions, ",");
+  auto classes = utils::string::split(class_definitions, ",");
   for (const std::string& clazz : classes) {
     auto response_nodes = response_node_loader_->loadResponseNodes(clazz);
     if (response_nodes.empty()) {
@@ -60,11 +60,11 @@ void C2MetricsPublisher::loadC2ResponseConfiguration(const std::string &prefix) 
     return;
   }
 
-  std::vector<std::string> classes = utils::StringUtils::split(class_definitions, ",");
+  std::vector<std::string> classes = utils::string::split(class_definitions, ",");
 
   for (const std::string& metricsClass : classes) {
     try {
-      std::string option = utils::StringUtils::join_pack(prefix, ".", metricsClass);
+      std::string option = utils::string::join_pack(prefix, ".", metricsClass);
       std::string classOption = option + ".classes";
       std::string nameOption = option + ".name";
 
@@ -76,7 +76,7 @@ void C2MetricsPublisher::loadC2ResponseConfiguration(const std::string &prefix) 
       if (configuration_->get(classOption, class_definitions)) {
         loadNodeClasses(class_definitions, new_node);
       } else {
-        std::string optionName = utils::StringUtils::join_pack(option, ".", name);
+        std::string optionName = utils::string::join_pack(option, ".", name);
         loadC2ResponseConfiguration(optionName, new_node);
       }
 
@@ -97,11 +97,11 @@ state::response::SharedResponseNode C2MetricsPublisher::loadC2ResponseConfigurat
   if (!configuration_->get(prefix, class_definitions)) {
     return prev_node;
   }
-  std::vector<std::string> classes = utils::StringUtils::split(class_definitions, ",");
+  std::vector<std::string> classes = utils::string::split(class_definitions, ",");
 
   for (const std::string& metricsClass : classes) {
     try {
-      std::string option = utils::StringUtils::join_pack(prefix, ".", metricsClass);
+      std::string option = utils::string::join_pack(prefix, ".", metricsClass);
       std::string classOption = option + ".classes";
       std::string nameOption = option + ".name";
 
@@ -111,7 +111,7 @@ state::response::SharedResponseNode C2MetricsPublisher::loadC2ResponseConfigurat
       }
       state::response::SharedResponseNode new_node = gsl::make_not_null(std::make_shared<state::response::ObjectNode>(name));
       if (name.find(',') != std::string::npos) {
-        std::vector<std::string> sub_classes = utils::StringUtils::split(name, ",");
+        std::vector<std::string> sub_classes = utils::string::split(name, ",");
         for (const std::string& subClassStr : classes) {
           auto node = loadC2ResponseConfiguration(subClassStr, prev_node);
           static_cast<state::response::ObjectNode*>(prev_node.get())->add_node(node);
@@ -123,7 +123,7 @@ state::response::SharedResponseNode C2MetricsPublisher::loadC2ResponseConfigurat
             static_cast<state::response::ObjectNode*>(prev_node.get())->add_node(new_node);
           }
         } else {
-          std::string optionName = utils::StringUtils::join_pack(option, ".", name);
+          std::string optionName = utils::string::join_pack(option, ".", name);
           auto sub_node = loadC2ResponseConfiguration(optionName, new_node);
           static_cast<state::response::ObjectNode*>(prev_node.get())->add_node(sub_node);
         }
@@ -166,7 +166,7 @@ std::optional<state::response::NodeReporter::ReportedNode> C2MetricsPublisher::g
 std::vector<state::response::NodeReporter::ReportedNode> C2MetricsPublisher::getHeartbeatNodes(bool include_manifest) const {
   gsl_Expects(configuration_);
   bool full_heartbeat = configuration_->get(minifi::Configuration::nifi_c2_full_heartbeat)
-      | utils::andThen(utils::StringUtils::toBool)
+      | utils::andThen(utils::string::toBool)
       | utils::valueOrElse([] {return true;});
 
   bool include = include_manifest || full_heartbeat;
@@ -198,7 +198,7 @@ void C2MetricsPublisher::loadMetricNodes() {
   std::string class_csv;
   std::lock_guard<std::mutex> guard{metrics_mutex_};
   if (configuration_->get(minifi::Configuration::nifi_c2_root_classes, class_csv)) {
-    std::vector<std::string> classes = utils::StringUtils::split(class_csv, ",");
+    std::vector<std::string> classes = utils::string::split(class_csv, ",");
 
     for (const std::string& clazz : classes) {
       auto response_nodes = response_node_loader_->loadResponseNodes(clazz);

--- a/libminifi/src/c2/C2Payload.cpp
+++ b/libminifi/src/c2/C2Payload.cpp
@@ -112,7 +112,7 @@ std::ostream& operator<<(std::ostream& out, const C2Payload& payload) {
     << "contents: " << payload.content_ << ", "
     << "op: " << magic_enum::enum_name(payload.op_) << ", "
     << "raw: " << payload.raw_ << ", "
-    << "data: \"" << utils::StringUtils::escapeUnprintableBytes(payload.raw_data_) << "\", "
+    << "data: \"" << utils::string::escapeUnprintableBytes(payload.raw_data_) << "\", "
     << "is_container: " << payload.is_container_ << ", "
     << "is_collapsible: " << payload.is_collapsible_
     << "}";

--- a/libminifi/src/c2/C2Utils.cpp
+++ b/libminifi/src/c2/C2Utils.cpp
@@ -25,13 +25,13 @@ namespace org::apache::nifi::minifi::c2 {
 bool isC2Enabled(const std::shared_ptr<Configure>& configuration) {
   std::string c2_enable_str;
   configuration->get(minifi::Configuration::nifi_c2_enable, "c2.enable", c2_enable_str);
-  return utils::StringUtils::toBool(c2_enable_str).value_or(false);
+  return utils::string::toBool(c2_enable_str).value_or(false);
 }
 
 bool isControllerSocketEnabled(const std::shared_ptr<Configure>& configuration) {
   std::string controller_socket_enable_str;
   configuration->get(minifi::Configuration::controller_socket_enable, controller_socket_enable_str);
-  return utils::StringUtils::toBool(controller_socket_enable_str).value_or(false);
+  return utils::string::toBool(controller_socket_enable_str).value_or(false);
 }
 
 nonstd::expected<std::shared_ptr<io::BufferStream>, std::string> createDebugBundleArchive(const std::map<std::string, std::unique_ptr<io::InputStream>>& files) {

--- a/libminifi/src/c2/ControllerSocketProtocol.cpp
+++ b/libminifi/src/c2/ControllerSocketProtocol.cpp
@@ -148,14 +148,14 @@ void ControllerSocketProtocol::initialize() {
   }
   if (nullptr == secure_context) {
     std::string secure_str;
-    if (configuration_->get(Configure::nifi_remote_input_secure, secure_str) && org::apache::nifi::minifi::utils::StringUtils::toBool(secure_str).value_or(false)) {
+    if (configuration_->get(Configure::nifi_remote_input_secure, secure_str) && org::apache::nifi::minifi::utils::string::toBool(secure_str).value_or(false)) {
       secure_context = std::make_shared<minifi::controllers::SSLContextService>("ControllerSocketProtocolSSL", configuration_);
       secure_context->onEnable();
     }
   }
 
   std::string limit_str;
-  const bool any_interface = configuration_->get(Configuration::controller_socket_local_any_interface, limit_str) && utils::StringUtils::toBool(limit_str).value_or(false);
+  const bool any_interface = configuration_->get(Configuration::controller_socket_local_any_interface, limit_str) && utils::string::toBool(limit_str).value_or(false);
 
   // if host name isn't defined we will use localhost
   std::string host = "localhost";

--- a/libminifi/src/c2/protocols/RESTProtocol.cpp
+++ b/libminifi/src/c2/protocols/RESTProtocol.cpp
@@ -148,7 +148,7 @@ void RESTProtocol::initialize(core::controller::ControllerServiceProvider* /*con
   if (configure) {
     std::string value_str;
     if (configure->get(minifi::Configuration::nifi_c2_rest_heartbeat_minimize_updates, "c2.rest.heartbeat.minimize.updates", value_str)) {
-      auto opt_value = utils::StringUtils::toBool(value_str);
+      auto opt_value = utils::string::toBool(value_str);
       if (!opt_value) {
         logger_->log_error("Cannot convert '{}' to bool for property '{}'", value_str, minifi::Configuration::nifi_c2_rest_heartbeat_minimize_updates);
         minimize_updates_ = false;

--- a/libminifi/src/c2/protocols/RESTProtocol.cpp
+++ b/libminifi/src/c2/protocols/RESTProtocol.cpp
@@ -71,7 +71,7 @@ C2Payload RESTProtocol::parseJsonResponse(const C2Payload &payload, std::span<co
         }
       }
 
-      int size = 0;
+      rapidjson::SizeType size = 0;
       for (auto key : {"requested_operations", "requestedOperations"}) {
         if (root.HasMember(key)) {
           if (!root[key].IsNull()) {

--- a/libminifi/src/controllers/LinuxPowerManagementService.cpp
+++ b/libminifi/src/controllers/LinuxPowerManagementService.cpp
@@ -159,7 +159,7 @@ void LinuxPowerManagerService::onEnable() {
   core::Property capacityPaths;
   core::Property statusPaths;
 
-  uint64_t wait;
+  uint64_t wait = 0;
   if (getProperty(TriggerThreshold, trigger_) && getProperty(WaitPeriod, wait)) {
     wait_period_ = wait;
 

--- a/libminifi/src/controllers/LinuxPowerManagementService.cpp
+++ b/libminifi/src/controllers/LinuxPowerManagementService.cpp
@@ -47,7 +47,7 @@ bool LinuxPowerManagerService::canIncrease() {
       std::getline(status_file, status_str);
       status_file.close();
 
-      if (!utils::StringUtils::equalsIgnoreCase(status_keyword_, status_str)) {
+      if (!utils::string::equalsIgnoreCase(status_keyword_, status_str)) {
         return true;
       }
     } catch (...) {
@@ -97,7 +97,7 @@ bool LinuxPowerManagerService::shouldReduce() {
       std::getline(status_file, status_str);
       status_file.close();
 
-      if (!utils::StringUtils::equalsIgnoreCase(status_keyword_, status_str)) {
+      if (!utils::string::equalsIgnoreCase(status_keyword_, status_str)) {
         all_discharging &= false;
       }
     } catch (...) {

--- a/libminifi/src/controllers/NetworkPrioritizerService.cpp
+++ b/libminifi/src/controllers/NetworkPrioritizerService.cpp
@@ -173,7 +173,7 @@ void NetworkPrioritizerService::onEnable() {
     getProperty(MaxPayload, max_payload_);
 
     if (!controllers.empty()) {
-      network_controllers_ = utils::StringUtils::split(controllers, ",");
+      network_controllers_ = utils::string::split(controllers, ",");
       for (const auto &ifc : network_controllers_) {
         logger_->log_trace("{} added to list of applied interfaces", ifc);
       }

--- a/libminifi/src/controllers/UpdatePolicyControllerService.cpp
+++ b/libminifi/src/controllers/UpdatePolicyControllerService.cpp
@@ -56,11 +56,11 @@ void UpdatePolicyControllerService::onEnable() {
 
   bool enable_all = false;
   if (getProperty(AllowAllProperties, enableStr)) {
-    enable_all = utils::StringUtils::toBool(enableStr).value_or(false);
+    enable_all = utils::string::toBool(enableStr).value_or(false);
   }
 
   if (getProperty(PersistUpdates, persistStr)) {
-    persist_updates_ = utils::StringUtils::toBool(persistStr).value_or(false);
+    persist_updates_ = utils::string::toBool(persistStr).value_or(false);
   }
 
   auto builder = state::UpdatePolicyBuilder::newBuilder(enable_all);

--- a/libminifi/src/core/FlowConfiguration.cpp
+++ b/libminifi/src/core/FlowConfiguration.cpp
@@ -101,7 +101,7 @@ std::unique_ptr<core::ProcessGroup> FlowConfiguration::updateFromPayload(const s
   if (!url.empty() && payload != nullptr) {
     std::string payload_flow_id;
     std::string bucket_id;
-    auto path_split = utils::StringUtils::split(url, "/");
+    auto path_split = utils::string::split(url, "/");
     for (auto it = path_split.cbegin(); it != path_split.cend(); ++it) {
       if (*it == "flows" && std::next(it) != path_split.cend()) {
         payload_flow_id = *++it;
@@ -126,7 +126,7 @@ bool FlowConfiguration::persist(const std::string &configuration) {
   auto config_file_backup = *config_path_;
   config_file_backup += ".bak";
   bool backup_file = (configuration_->get(minifi::Configure::nifi_flow_configuration_file_backup_update)
-                      | utils::andThen(utils::StringUtils::toBool)).value_or(false);
+                      | utils::andThen(utils::string::toBool)).value_or(false);
 
   if (backup_file) {
     if (utils::file::FileUtils::copy_file(*config_path_, config_file_backup) != 0) {

--- a/libminifi/src/core/ProcessSession.cpp
+++ b/libminifi/src/core/ProcessSession.cpp
@@ -567,13 +567,13 @@ void ProcessSession::import(const std::string& source, std::vector<std::shared_p
     std::ifstream input{source, std::ios::in | std::ios::binary};
     logger_->log_debug("Opening {}", source);
     if (!input.is_open() || !input.good()) {
-      throw Exception(FILE_OPERATION_EXCEPTION, utils::StringUtils::join_pack("File Import Error: failed to open file \'", source, "\'"));
+      throw Exception(FILE_OPERATION_EXCEPTION, utils::string::join_pack("File Import Error: failed to open file \'", source, "\'"));
     }
     if (offset != 0U) {
       input.seekg(gsl::narrow<std::streamoff>(offset), std::ifstream::beg);
       if (!input.good()) {
         logger_->log_error("Seeking to {} failed for file {} (does file/filesystem support seeking?)", offset, source);
-        throw Exception(FILE_OPERATION_EXCEPTION, utils::StringUtils::join_pack("File Import Error: Couldn't seek to offset ", std::to_string(offset)));
+        throw Exception(FILE_OPERATION_EXCEPTION, utils::string::join_pack("File Import Error: Couldn't seek to offset ", std::to_string(offset)));
       }
     }
     while (input.good()) {

--- a/libminifi/src/core/flow/CheckRequiredField.cpp
+++ b/libminifi/src/core/flow/CheckRequiredField.cpp
@@ -31,7 +31,7 @@ std::string buildErrorMessage(const Node &node, const std::vector<std::string> &
   const Node name_node = node["name"];
   // Build a helpful error message for the user so they can fix the
   // invalid config file, using the component name if present
-  auto field_list_string = utils::StringUtils::join(", ", alternate_field_names);
+  auto field_list_string = utils::string::join(", ", alternate_field_names);
   std::string err_msg =
       name_node ?
           "Unable to parse configuration file for component named '" + name_node.getString().value() + "' as none of the possible required fields [" + field_list_string + "] is available" :

--- a/libminifi/src/core/flow/Node.cpp
+++ b/libminifi/src/core/flow/Node.cpp
@@ -24,10 +24,10 @@ Node::Iterator::Value Node::Iterator::operator*() const {
   Value value = impl_->operator*();
   if (value) {
     // sequence iterator
-    value.path_ = utils::StringUtils::join_pack(path_, "/", std::to_string(idx_));
+    value.path_ = utils::string::join_pack(path_, "/", std::to_string(idx_));
   } else if (value.second) {
     // map iterator
-    value.second.path_ = utils::StringUtils::join_pack(path_, "/", value.first.getString().value());
+    value.second.path_ = utils::string::join_pack(path_, "/", value.first.getString().value());
   }
   return value;
 }

--- a/libminifi/src/core/flow/StructuredConfiguration.cpp
+++ b/libminifi/src/core/flow/StructuredConfiguration.cpp
@@ -792,10 +792,10 @@ void StructuredConfiguration::validateComponentProperties(ConfigurableComponent&
   for (const auto &prop_pair : component_properties) {
     if (prop_pair.second.getRequired()) {
       if (prop_pair.second.getValue().to_string().empty()) {
-        std::string reason = utils::StringUtils::join_pack("required property '", prop_pair.second.getName(), "' is not set");
+        std::string reason = utils::string::join_pack("required property '", prop_pair.second.getName(), "' is not set");
         raiseComponentError(component_name, section, reason);
       } else if (!prop_pair.second.getValue().validate(prop_pair.first).valid) {
-        std::string reason = utils::StringUtils::join_pack("the value '", prop_pair.first, "' is not valid for property '", prop_pair.second.getName(), "'");
+        std::string reason = utils::string::join_pack("the value '", prop_pair.first, "' is not valid for property '", prop_pair.second.getName(), "'");
         raiseComponentError(component_name, section, reason);
       }
     }
@@ -811,7 +811,7 @@ void StructuredConfiguration::validateComponentProperties(ConfigurableComponent&
 
     for (const auto &dep_prop_key : dep_props) {
       if (component_properties.at(dep_prop_key).getValue().to_string().empty()) {
-        std::string reason = utils::StringUtils::join_pack("property '", prop_pair.second.getName(),
+        std::string reason = utils::string::join_pack("property '", prop_pair.second.getName(),
             "' depends on property '", dep_prop_key, "' which is not set");
         raiseComponentError(component_name, section, reason);
       }
@@ -829,7 +829,7 @@ void StructuredConfiguration::validateComponentProperties(ConfigurableComponent&
     for (const auto &excl_pair : excl_props) {
       utils::Regex excl_expr(excl_pair.second);
       if (utils::regexMatch(component_properties.at(excl_pair.first).getValue().to_string(), excl_expr)) {
-        std::string reason = utils::StringUtils::join_pack("property '", prop_pair.second.getName(),
+        std::string reason = utils::string::join_pack("property '", prop_pair.second.getName(),
             "' must not be set when the value of property '", excl_pair.first, "' matches '", excl_pair.second, "'");
         raiseComponentError(component_name, section, reason);
       }
@@ -857,7 +857,7 @@ std::string StructuredConfiguration::getOrGenerateId(const Node& node) {
       addNewId(id);
       return id;
     }
-    throw std::invalid_argument("getOrGenerateId: idField '" + utils::StringUtils::join(",", schema_.identifier) + "' is expected to contain string.");
+    throw std::invalid_argument("getOrGenerateId: idField '" + utils::string::join(",", schema_.identifier) + "' is expected to contain string.");
   }
 
   auto id = id_generator_->generate().to_string();
@@ -878,7 +878,7 @@ std::string StructuredConfiguration::getOptionalField(const Node& node, const st
   if (!result) {
     if (infoMessage.empty()) {
       // Build a helpful info message for the user to inform them that a default is being used
-      infoMessage = "Using default value for optional field '" + utils::StringUtils::join(",", field_name) + "'";
+      infoMessage = "Using default value for optional field '" + utils::string::join(",", field_name) + "'";
       if (auto name = node["name"]) {
         infoMessage += "' in component named '" + name.getString().value() + "'";
       }

--- a/libminifi/src/core/flow/StructuredConnectionParser.cpp
+++ b/libminifi/src/core/flow/StructuredConnectionParser.cpp
@@ -69,7 +69,7 @@ void StructuredConnectionParser::configureConnectionSourceRelationships(minifi::
 uint64_t StructuredConnectionParser::getWorkQueueSize() const {
   if (auto max_work_queue_data_size_node = connectionNode_[schema_.max_queue_size]) {
     std::string max_work_queue_str = max_work_queue_data_size_node.getIntegerAsString().value();
-    uint64_t max_work_queue_size;
+    uint64_t max_work_queue_size = 0;
     if (core::Property::StringToInt(max_work_queue_str, max_work_queue_size)) {
       logger_->log_debug("Setting {} as the max queue size.", max_work_queue_size);
       return max_work_queue_size;
@@ -97,7 +97,7 @@ uint64_t StructuredConnectionParser::getSwapThreshold() const {
   const flow::Node swap_threshold_node = connectionNode_[schema_.swap_threshold];
   if (swap_threshold_node) {
     auto swap_threshold_str = swap_threshold_node.getString().value();
-    uint64_t swap_threshold;
+    uint64_t swap_threshold = 0;
     if (core::Property::StringToInt(swap_threshold_str, swap_threshold)) {
       logger_->log_debug("Setting {} as the swap threshold.", swap_threshold);
       return swap_threshold;

--- a/libminifi/src/core/flow/StructuredConnectionParser.cpp
+++ b/libminifi/src/core/flow/StructuredConnectionParser.cpp
@@ -197,7 +197,7 @@ std::chrono::milliseconds StructuredConnectionParser::getFlowFileExpiration() co
 bool StructuredConnectionParser::getDropEmpty() const {
   const flow::Node drop_empty_node = connectionNode_[schema_.drop_empty];
   if (drop_empty_node) {
-    return utils::StringUtils::toBool(drop_empty_node.getString().value()).value_or(false);
+    return utils::string::toBool(drop_empty_node.getString().value()).value_or(false);
   }
   return false;
 }

--- a/libminifi/src/core/logging/LoggerConfiguration.cpp
+++ b/libminifi/src/core/logging/LoggerConfiguration.cpp
@@ -125,11 +125,11 @@ void LoggerConfiguration::initialize(const std::shared_ptr<LoggerProperties> &lo
    * There is no need to shorten names per spdlog sink as this is a per log instance.
    */
   if (const auto shorten_names_str = logger_properties->getString("spdlog.shorten_names")) {
-    shorten_names_ = utils::StringUtils::toBool(*shorten_names_str).value_or(false);
+    shorten_names_ = utils::string::toBool(*shorten_names_str).value_or(false);
   }
 
   if (const auto include_uuid_str = logger_properties->getString("logger.include.uuid")) {
-    include_uuid_ = utils::StringUtils::toBool(*include_uuid_str).value_or(true);
+    include_uuid_ = utils::string::toBool(*include_uuid_str).value_or(true);
   }
 
   if (const auto max_log_entry_length_str = logger_properties->getString("max.log.entry.length")) {
@@ -230,8 +230,8 @@ std::shared_ptr<internal::LoggerNamespace> LoggerConfiguration::initialize_names
     bool first = true;
     spdlog::level::level_enum level = spdlog::level::info;
     std::vector<std::shared_ptr<spdlog::sinks::sink>> sinks;
-    for (auto const & segment : utils::StringUtils::split(logger_def, ",")) {
-      std::string level_name = utils::StringUtils::trim(segment);
+    for (auto const & segment : utils::string::split(logger_def, ",")) {
+      std::string level_name = utils::string::trim(segment);
       if (first) {
         first = false;
         auto opt_level = utils::parse_log_level(level_name);
@@ -248,7 +248,7 @@ std::shared_ptr<internal::LoggerNamespace> LoggerConfiguration::initialize_names
     }
     std::shared_ptr<internal::LoggerNamespace> current_namespace = root_namespace;
     if (logger_key != "logger.root") {
-      for (auto const & name : utils::StringUtils::split(logger_key.substr(logger_type.length() + 1, logger_key.length() - logger_type.length()), "::")) {
+      for (auto const & name : utils::string::split(logger_key.substr(logger_type.length() + 1, logger_key.length() - logger_type.length()), "::")) {
         auto child_pair = current_namespace->children.find(name);
         std::shared_ptr<internal::LoggerNamespace> child;
         if (child_pair == current_namespace->children.end()) {
@@ -285,7 +285,7 @@ std::shared_ptr<spdlog::logger> LoggerConfiguration::get_logger(const std::share
   std::string current_namespace_str;
   std::string sink_namespace_str = "root";
   std::string level_namespace_str = "root";
-  for (auto const & name_segment : utils::StringUtils::split(name, "::")) {
+  for (auto const & name_segment : utils::string::split(name, "::")) {
     current_namespace_str += name_segment;
     auto child_pair = current_namespace->children.find(name_segment);
     if (child_pair == current_namespace->children.end()) {

--- a/libminifi/src/core/logging/Utils.cpp
+++ b/libminifi/src/core/logging/Utils.cpp
@@ -21,19 +21,19 @@
 namespace org::apache::nifi::minifi::utils {
 
 std::optional<spdlog::level::level_enum> parse_log_level(const std::string& level_name) {
-  if (utils::StringUtils::equalsIgnoreCase(level_name, "trace")) {
+  if (utils::string::equalsIgnoreCase(level_name, "trace")) {
     return spdlog::level::trace;
-  } else if (utils::StringUtils::equalsIgnoreCase(level_name, "debug")) {
+  } else if (utils::string::equalsIgnoreCase(level_name, "debug")) {
     return spdlog::level::debug;
-  } else if (utils::StringUtils::equalsIgnoreCase(level_name, "info")) {
+  } else if (utils::string::equalsIgnoreCase(level_name, "info")) {
     return spdlog::level::info;
-  } else if (utils::StringUtils::equalsIgnoreCase(level_name, "warn")) {
+  } else if (utils::string::equalsIgnoreCase(level_name, "warn")) {
     return spdlog::level::warn;
-  } else if (utils::StringUtils::equalsIgnoreCase(level_name, "error")) {
+  } else if (utils::string::equalsIgnoreCase(level_name, "error")) {
     return spdlog::level::err;
-  } else if (utils::StringUtils::equalsIgnoreCase(level_name, "critical")) {
+  } else if (utils::string::equalsIgnoreCase(level_name, "critical")) {
     return spdlog::level::critical;
-  } else if (utils::StringUtils::equalsIgnoreCase(level_name, "off")) {
+  } else if (utils::string::equalsIgnoreCase(level_name, "off")) {
     return spdlog::level::off;
   }
   return std::nullopt;

--- a/libminifi/src/core/repository/VolatileContentRepository.cpp
+++ b/libminifi/src/core/repository/VolatileContentRepository.cpp
@@ -44,7 +44,7 @@ bool VolatileContentRepository::initialize(const std::shared_ptr<Configure> &con
     std::stringstream strstream;
     strstream << Configure::nifi_volatile_repository_options << getName() << "." << minimal_locking;
     if (configure->get(strstream.str(), value)) {
-      minimize_locking_ =  utils::StringUtils::toBool(value).value_or(true);
+      minimize_locking_ =  utils::string::toBool(value).value_or(true);
     }
   }
   if (!minimize_locking_) {

--- a/libminifi/src/core/state/LogMetricsPublisher.cpp
+++ b/libminifi/src/core/state/LogMetricsPublisher.cpp
@@ -99,7 +99,7 @@ void LogMetricsPublisher::loadMetricNodes() {
     metric_classes_str = configuration_->get(minifi::Configuration::nifi_metrics_publisher_metrics);
   }
   if (metric_classes_str && !metric_classes_str->empty()) {
-    auto metric_classes = utils::StringUtils::split(*metric_classes_str, ",");
+    auto metric_classes = utils::string::split(*metric_classes_str, ",");
     std::lock_guard<std::mutex> lock(response_nodes_mutex_);
     for (const std::string& clazz : metric_classes) {
       auto loaded_response_nodes = response_node_loader_->loadResponseNodes(clazz);

--- a/libminifi/src/core/state/MetricsPublisherFactory.cpp
+++ b/libminifi/src/core/state/MetricsPublisherFactory.cpp
@@ -41,7 +41,7 @@ std::vector<gsl::not_null<std::unique_ptr<MetricsPublisher>>> createMetricsPubli
     const std::shared_ptr<Configure>& configuration, const std::shared_ptr<state::response::ResponseNodeLoader>& response_node_loader) {
   if (auto metrics_publisher_class_str = configuration->get(minifi::Configure::nifi_metrics_publisher_class)) {
     std::vector<gsl::not_null<std::unique_ptr<MetricsPublisher>>> publishers;
-    auto publisher_classes = minifi::utils::StringUtils::split(*metrics_publisher_class_str, ",");
+    auto publisher_classes = minifi::utils::string::split(*metrics_publisher_class_str, ",");
     publishers.reserve(publisher_classes.size());
     for (const auto& publisher_class : publisher_classes) {
       publishers.push_back(createMetricsPublisher(publisher_class, configuration, response_node_loader));

--- a/libminifi/src/core/state/Value.cpp
+++ b/libminifi/src/core/state/Value.cpp
@@ -54,7 +54,7 @@ std::string hashResponseNodes(const std::vector<SerializedResponseNode>& nodes) 
   }
   std::array<std::byte, EVP_MAX_MD_SIZE> digest{};
   EVP_DigestFinal_ex(ctx, reinterpret_cast<unsigned char*>(digest.data()), nullptr);
-  return utils::StringUtils::to_hex(digest, true /*uppercase*/);
+  return utils::string::to_hex(digest, true /*uppercase*/);
 }
 
 rapidjson::Value SerializedResponseNode::nodeToJson(const SerializedResponseNode& node, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>& alloc) {

--- a/libminifi/src/core/state/nodes/AgentInformation.cpp
+++ b/libminifi/src/core/state/nodes/AgentInformation.cpp
@@ -71,9 +71,9 @@ void ComponentManifest::serializeClassDescription(const std::vector<ClassDescrip
           SerializedResponseNode allowed_type;
           allowed_type.name = "typeProvidedByValue";
           for (const auto &type : allowed_types) {
-            std::string class_name = utils::StringUtils::split(type, "::").back();
+            std::string class_name = utils::string::split(type, "::").back();
             std::string typeClazz = type;
-            utils::StringUtils::replaceAll(typeClazz, "::", ".");
+            utils::string::replaceAll(typeClazz, "::", ".");
             allowed_type.children.push_back({.name = "type", .value = typeClazz});
             allowed_type.children.push_back({.name = "group", .value = GROUP_STR});
             allowed_type.children.push_back({.name = "artifact", .value = core::ClassLoader::getDefaultClassLoader().getGroupForClass(class_name).value_or("")});

--- a/libminifi/src/core/state/nodes/ResponseNodeLoader.cpp
+++ b/libminifi/src/core/state/nodes/ResponseNodeLoader.cpp
@@ -252,7 +252,7 @@ std::vector<SharedResponseNode> ResponseNodeLoader::getComponentMetricsNodes(con
   }
   std::lock_guard<std::mutex> lock(component_metrics_mutex_);
   static const std::string PROCESSOR_FILTER_PREFIX = "processorMetrics/";
-  if (utils::StringUtils::startsWith(metrics_class, PROCESSOR_FILTER_PREFIX)) {
+  if (utils::string::startsWith(metrics_class, PROCESSOR_FILTER_PREFIX)) {
     auto regex_str = metrics_class.substr(PROCESSOR_FILTER_PREFIX.size());
     return getMatchingComponentMetricsNodes(regex_str);
   } else {

--- a/libminifi/src/properties/Properties.cpp
+++ b/libminifi/src/properties/Properties.cpp
@@ -100,7 +100,7 @@ bool integerValidatedProperty(const core::PropertyValidator* const validator) {
 std::optional<int64_t> stringToDataSize(std::string_view input) {
   int64_t value = 0;
   std::string unit_str;
-  if (!utils::StringUtils::splitToValueAndUnit(input, value, unit_str)) {
+  if (!utils::string::splitToValueAndUnit(input, value, unit_str)) {
     return std::nullopt;
   }
 
@@ -201,7 +201,7 @@ void Properties::loadConfigureFile(const std::filesystem::path& configuration_fi
   for (const auto& line : PropertiesFile{file}) {
     auto key = line.getKey();
     auto persisted_value = line.getValue();
-    auto value = utils::StringUtils::replaceEnvironmentVariables(persisted_value);
+    auto value = utils::string::replaceEnvironmentVariables(persisted_value);
     bool need_to_persist_new_value = false;
     fixValidatedProperty(std::string(prefix) + key, persisted_value, value, need_to_persist_new_value, *logger_);
     dirty_ = dirty_ || need_to_persist_new_value;

--- a/libminifi/src/properties/PropertiesFile.cpp
+++ b/libminifi/src/properties/PropertiesFile.cpp
@@ -25,21 +25,21 @@
 namespace org::apache::nifi::minifi {
 
 PropertiesFile::Line::Line(std::string line) : line_(line) {
-  line = utils::StringUtils::trim(line);
+  line = utils::string::trim(line);
   if (line.empty() || line[0] == '#') { return; }
 
   size_t index_of_first_equals_sign = line.find('=');
   if (index_of_first_equals_sign == std::string::npos) { return; }
 
-  std::string key = utils::StringUtils::trim(line.substr(0, index_of_first_equals_sign));
+  std::string key = utils::string::trim(line.substr(0, index_of_first_equals_sign));
   if (key.empty()) { return; }
 
   key_ = key;
-  value_ = utils::StringUtils::trim(line.substr(index_of_first_equals_sign + 1));
+  value_ = utils::string::trim(line.substr(index_of_first_equals_sign + 1));
 }
 
 PropertiesFile::Line::Line(std::string key, std::string value)
-  : line_{utils::StringUtils::join_pack(key, "=", value)}, key_{std::move(key)}, value_{std::move(value)} {
+  : line_{utils::string::join_pack(key, "=", value)}, key_{std::move(key)}, value_{std::move(value)} {
 }
 
 bool PropertiesFile::Line::isValidKey(const std::string &key) {

--- a/libminifi/src/utils/BaseHTTPClient.cpp
+++ b/libminifi/src/utils/BaseHTTPClient.cpp
@@ -30,9 +30,9 @@ constexpr const char* HTTPS = "https://";
 
 
 std::optional<std::string> parseProtocol(const std::string& url_input) {
-  if (minifi::utils::StringUtils::startsWith(url_input, HTTP)) {
+  if (minifi::utils::string::startsWith(url_input, HTTP)) {
     return HTTP;
-  } else if (minifi::utils::StringUtils::startsWith(url_input, HTTPS)) {
+  } else if (minifi::utils::string::startsWith(url_input, HTTPS)) {
     return HTTPS;
   } else {
     return std::nullopt;

--- a/libminifi/src/utils/ClassUtils.cpp
+++ b/libminifi/src/utils/ClassUtils.cpp
@@ -27,12 +27,12 @@ namespace org::apache::nifi::minifi::utils {
 
 bool ClassUtils::shortenClassName(std::string_view class_name, std::string &out) {
   std::string class_delim = "::";
-  auto class_split = utils::StringUtils::split(class_name, class_delim);
+  auto class_split = utils::string::split(class_name, class_delim);
   // support . and ::
   if (class_split.size() <= 1) {
     if (class_name.find('.') != std::string::npos) {
       class_delim = ".";
-      class_split = utils::StringUtils::split(class_name, class_delim);
+      class_split = utils::string::split(class_name, class_delim);
     } else {
       // if no update can be performed, return false to let the developer know
       // this. Out will have no updates
@@ -45,7 +45,7 @@ bool ClassUtils::shortenClassName(std::string_view class_name, std::string &out)
     }
   }
 
-  out = utils::StringUtils::join(class_delim, class_split);
+  out = utils::string::join(class_delim, class_split);
   return true;
 }
 

--- a/libminifi/src/utils/Cron.cpp
+++ b/libminifi/src/utils/Cron.cpp
@@ -51,7 +51,7 @@ namespace {
 // This has been fixed in gcc12.2
 std::stringstream getCaseInsensitiveCStream(const std::string& str) {
 #if defined(__GNUC__) && (__GNUC__ < 12 || (__GNUC__ == 12 && __GNUC_MINOR__ < 2))
-  auto patched_str = StringUtils::toLower(str);
+  auto patched_str = string::toLower(str);
   if (!patched_str.empty())
     patched_str[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(patched_str[0])));
   auto stream = std::stringstream{patched_str};
@@ -390,7 +390,7 @@ std::unique_ptr<CronField> parseCronField(const std::string& field_str) {
     if (field_str.find('#') != std::string::npos) {
       if constexpr (!std::is_same<weekday, FieldType>())
         throw BadCronExpression("# can only be used in the Day of week field");
-      auto operands = StringUtils::split(field_str, "#");
+      auto operands = string::split(field_str, "#");
       if (operands.size() != 2)
         throw BadCronExpression("Invalid field " + field_str);
 
@@ -399,7 +399,7 @@ std::unique_ptr<CronField> parseCronField(const std::string& field_str) {
     }
 
     if (field_str.find('-') != std::string::npos) {
-      auto operands = StringUtils::split(field_str, "-");
+      auto operands = string::split(field_str, "-");
       if (operands.size() != 2)
         throw BadCronExpression("Invalid field " + field_str);
       if (operands[0] == "L") {
@@ -417,7 +417,7 @@ std::unique_ptr<CronField> parseCronField(const std::string& field_str) {
     }
 
     if (field_str.find('/') != std::string::npos) {
-      auto operands = StringUtils::split(field_str, "/");
+      auto operands = string::split(field_str, "/");
       if (operands.size() != 2)
         throw BadCronExpression("Invalid field " + field_str);
       if (operands[0] == "*")
@@ -427,7 +427,7 @@ std::unique_ptr<CronField> parseCronField(const std::string& field_str) {
     }
 
     if (field_str.find(',') != std::string::npos) {
-      auto operands_str = StringUtils::split(field_str, ",");
+      auto operands_str = string::split(field_str, ",");
       std::vector<FieldType> operands;
       std::transform(operands_str.begin(), operands_str.end(), std::back_inserter(operands), parse<FieldType>);
       return std::make_unique<ListField<FieldType>>(std::move(operands));
@@ -436,7 +436,7 @@ std::unique_ptr<CronField> parseCronField(const std::string& field_str) {
     if (field_str.ends_with('W')) {
       if constexpr (!std::is_same<day, FieldType>())
         throw BadCronExpression("W can only be used in the Day of month field");
-      auto operands_str = StringUtils::split(field_str, "W");
+      auto operands_str = string::split(field_str, "W");
       if (operands_str.size() != 2)
         throw BadCronExpression("Invalid field " + field_str);
       return std::make_unique<ClosestWeekdayToTheNthDayOfTheMonth>(parse<day>(operands_str[0]));
@@ -450,7 +450,7 @@ std::unique_ptr<CronField> parseCronField(const std::string& field_str) {
 }  // namespace
 
 Cron::Cron(const std::string& expression) {
-  auto tokens = StringUtils::split(expression, " ");
+  auto tokens = string::split(expression, " ");
 
   if (tokens.size() != 6 && tokens.size() != 7)
     throw BadCronExpression("malformed cron string (must be 6 or 7 fields): " + expression);

--- a/libminifi/src/utils/Id.cpp
+++ b/libminifi/src/utils/Id.cpp
@@ -170,8 +170,8 @@ std::optional<Identifier> Identifier::parse(const std::string &str) {
 bool Identifier::parseByte(Data &data, const uint8_t *input, int &charIdx, int &byteIdx) {
   uint8_t upper = 0;
   uint8_t lower = 0;
-  if (!StringUtils::from_hex(input[charIdx++], upper)
-      || !StringUtils::from_hex(input[charIdx++], lower)) {
+  if (!string::from_hex(input[charIdx++], upper)
+      || !string::from_hex(input[charIdx++], lower)) {
     return false;
   }
   data[byteIdx++] = (upper << 4) | lower;

--- a/libminifi/src/utils/ProcessorConfigUtils.cpp
+++ b/libminifi/src/utils/ProcessorConfigUtils.cpp
@@ -28,16 +28,16 @@ namespace org::apache::nifi::minifi::utils {
 std::vector<std::string> listFromCommaSeparatedProperty(const core::ProcessContext& context, std::string_view property_name) {
   std::string property_string;
   context.getProperty(property_name, property_string);
-  return utils::StringUtils::splitAndTrim(property_string, ",");
+  return utils::string::splitAndTrim(property_string, ",");
 }
 
 std::vector<std::string> listFromRequiredCommaSeparatedProperty(const core::ProcessContext& context, std::string_view property_name) {
-  return utils::StringUtils::splitAndTrim(getRequiredPropertyOrThrow(context, property_name), ",");
+  return utils::string::splitAndTrim(getRequiredPropertyOrThrow(context, property_name), ",");
 }
 
 bool parseBooleanPropertyOrThrow(const core::ProcessContext& context, std::string_view property_name) {
   const std::string value_str = getRequiredPropertyOrThrow(context, property_name);
-  const auto maybe_value = utils::StringUtils::toBool(value_str);
+  const auto maybe_value = utils::string::toBool(value_str);
   if (!maybe_value) {
     throw std::runtime_error(std::string(property_name) + " property is invalid: value is " + value_str);
   }

--- a/libminifi/src/utils/crypto/EncryptionManager.cpp
+++ b/libminifi/src/utils/crypto/EncryptionManager.cpp
@@ -61,14 +61,14 @@ std::optional<Bytes> EncryptionManager::readKey(const std::string& key_name) con
   bootstrap_conf.setHome(key_dir_);
   bootstrap_conf.loadConfigureFile(DEFAULT_NIFI_BOOTSTRAP_FILE);
   return bootstrap_conf.getString(key_name)
-         | utils::transform([](const std::string &encryption_key_hex) { return utils::StringUtils::from_hex(encryption_key_hex); });
+         | utils::transform([](const std::string &encryption_key_hex) { return utils::string::from_hex(encryption_key_hex); });
 }
 
 bool EncryptionManager::writeKey(const std::string &key_name, const Bytes& key) const {
   minifi::Properties bootstrap_conf;
   bootstrap_conf.setHome(key_dir_);
   bootstrap_conf.loadConfigureFile(DEFAULT_NIFI_BOOTSTRAP_FILE);
-  bootstrap_conf.set(key_name, utils::StringUtils::to_hex(key));
+  bootstrap_conf.set(key_name, utils::string::to_hex(key));
   return bootstrap_conf.commitChanges();
 }
 

--- a/libminifi/src/utils/crypto/EncryptionUtils.cpp
+++ b/libminifi/src/utils/crypto/EncryptionUtils.cpp
@@ -77,8 +77,8 @@ std::string encrypt(const std::string& plaintext, const Bytes& key) {
   Bytes nonce = randomBytes(EncryptionType::nonceLength());
   Bytes ciphertext_plus_mac = encryptRaw(stringToBytes(plaintext), key, nonce);
 
-  std::string nonce_base64 = utils::StringUtils::to_base64(nonce);
-  std::string ciphertext_plus_mac_base64 = utils::StringUtils::to_base64(ciphertext_plus_mac);
+  std::string nonce_base64 = utils::string::to_base64(nonce);
+  std::string ciphertext_plus_mac_base64 = utils::string::to_base64(ciphertext_plus_mac);
   return nonce_base64 + EncryptionType::separator() + ciphertext_plus_mac_base64;
 }
 
@@ -111,13 +111,13 @@ std::string decrypt(const std::string& input, const Bytes& key) {
 }
 
 EncryptedData parseEncrypted(const std::string& input) {
-  std::vector<std::string> nonce_and_rest = utils::StringUtils::split(input, EncryptionType::separator());
+  std::vector<std::string> nonce_and_rest = utils::string::split(input, EncryptionType::separator());
   if (nonce_and_rest.size() != 2) {
     throw std::invalid_argument{"Incorrect input; expected '<nonce>" + EncryptionType::separator() + "<ciphertext_plus_mac>'"};
   }
 
-  Bytes nonce = utils::StringUtils::from_base64(nonce_and_rest[0]);
-  Bytes ciphertext_plus_mac = utils::StringUtils::from_base64(nonce_and_rest[1]);
+  Bytes nonce = utils::string::from_base64(nonce_and_rest[0]);
+  Bytes ciphertext_plus_mac = utils::string::from_base64(nonce_and_rest[1]);
 
   return EncryptedData{nonce, ciphertext_plus_mac};
 }

--- a/libminifi/src/utils/file/FilePattern.cpp
+++ b/libminifi/src/utils/file/FilePattern.cpp
@@ -27,10 +27,10 @@ static bool isGlobPattern(const std::string& pattern) {
 }
 
 FilePattern::FilePatternSegment::FilePatternSegment(std::string pattern) {
-  pattern = utils::StringUtils::trim(pattern);
+  pattern = utils::string::trim(pattern);
   if (!pattern.empty() && pattern[0] == '!') {
     excluding_ = true;
-    pattern = utils::StringUtils::trim(pattern.substr(1));
+    pattern = utils::string::trim(pattern.substr(1));
   }
   if (pattern.empty()) {
     throw FilePatternSegmentError("Empty pattern");
@@ -79,7 +79,7 @@ std::filesystem::path FilePattern::FilePatternSegment::getBaseDirectory() const 
 }
 
 FilePattern::FilePattern(const std::string &pattern, const ErrorHandler& error_handler) {
-  for (const auto& segment : StringUtils::split(pattern, ",")) {
+  for (const auto& segment : string::split(pattern, ",")) {
     try {
       segments_.emplace_back(segment);
     } catch (const FilePatternSegmentError& segment_error) {

--- a/libminifi/src/utils/file/FileReaderCallback.cpp
+++ b/libminifi/src/utils/file/FileReaderCallback.cpp
@@ -42,13 +42,13 @@ int64_t FileReaderCallback::operator()(const std::shared_ptr<io::OutputStream>& 
 
   std::ifstream input_stream{file_path_, std::ifstream::in | std::ifstream::binary};
   if (!input_stream.is_open()) {
-    throw FileReaderCallbackIOError(StringUtils::join_pack("Error opening file: ", std::strerror(errno)), errno);
+    throw FileReaderCallbackIOError(string::join_pack("Error opening file: ", std::strerror(errno)), errno);
   }
   logger_->log_debug("Opening {}", file_path_);
   while (input_stream.good()) {
     input_stream.read(buffer.data(), buffer.size());
     if (input_stream.bad()) {
-      throw FileReaderCallbackIOError(StringUtils::join_pack("Error reading file: ", std::strerror(errno)), errno);
+      throw FileReaderCallbackIOError(string::join_pack("Error reading file: ", std::strerror(errno)), errno);
     }
     const auto num_bytes_read = input_stream.gcount();
     logger_->log_trace("Read {} bytes of input", std::intmax_t{num_bytes_read});

--- a/libminifi/src/utils/file/FileReaderCallback.cpp
+++ b/libminifi/src/utils/file/FileReaderCallback.cpp
@@ -59,7 +59,7 @@ int64_t FileReaderCallback::operator()(const std::shared_ptr<io::OutputStream>& 
   input_stream.close();
 
   logger_->log_debug("Finished reading {} bytes from the file", num_bytes_written);
-  return num_bytes_written;
+  return gsl::narrow<int64_t>(num_bytes_written);
 }
 
 }  // namespace org::apache::nifi::minifi::utils

--- a/libminifi/src/utils/file/PathUtils.cpp
+++ b/libminifi/src/utils/file/PathUtils.cpp
@@ -33,9 +33,9 @@
 namespace org::apache::nifi::minifi::utils::file {
 
 std::string globToRegex(std::string glob) {
-  utils::StringUtils::replaceAll(glob, ".", "\\.");
-  utils::StringUtils::replaceAll(glob, "*", ".*");
-  utils::StringUtils::replaceAll(glob, "?", ".");
+  utils::string::replaceAll(glob, ".", "\\.");
+  utils::string::replaceAll(glob, "*", ".*");
+  utils::string::replaceAll(glob, "?", ".");
   return glob;
 }
 

--- a/libminifi/src/utils/tls/DistinguishedName.cpp
+++ b/libminifi/src/utils/tls/DistinguishedName.cpp
@@ -21,12 +21,7 @@
 
 #include "utils/StringUtils.h"
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
-namespace utils {
-namespace tls {
+namespace org::apache::nifi::minifi::utils::tls {
 
 DistinguishedName::DistinguishedName(const std::vector<std::string>& components) {
   std::transform(components.begin(), components.end(), std::back_inserter(components_),
@@ -56,9 +51,4 @@ std::string DistinguishedName::toString() const {
   return utils::string::join(", ", components_);
 }
 
-}  // namespace tls
-}  // namespace utils
-}  // namespace minifi
-}  // namespace nifi
-}  // namespace apache
-}  // namespace org
+}  // namespace org::apache::nifi::minifi::utils::tls

--- a/libminifi/src/utils/tls/DistinguishedName.cpp
+++ b/libminifi/src/utils/tls/DistinguishedName.cpp
@@ -30,16 +30,16 @@ namespace tls {
 
 DistinguishedName::DistinguishedName(const std::vector<std::string>& components) {
   std::transform(components.begin(), components.end(), std::back_inserter(components_),
-      [](const std::string& component) { return utils::StringUtils::trim(component); });
+      [](const std::string& component) { return utils::string::trim(component); });
   std::sort(components_.begin(), components_.end());
 }
 
 DistinguishedName DistinguishedName::fromCommaSeparated(const std::string& comma_separated_components) {
-  return DistinguishedName{utils::StringUtils::splitRemovingEmpty(comma_separated_components, ",")};
+  return DistinguishedName{utils::string::splitRemovingEmpty(comma_separated_components, ",")};
 }
 
 DistinguishedName DistinguishedName::fromSlashSeparated(const std::string &slash_separated_components) {
-  return DistinguishedName{utils::StringUtils::splitRemovingEmpty(slash_separated_components, "/")};
+  return DistinguishedName{utils::string::splitRemovingEmpty(slash_separated_components, "/")};
 }
 
 std::optional<std::string> DistinguishedName::getCN() const {
@@ -53,7 +53,7 @@ std::optional<std::string> DistinguishedName::getCN() const {
 }
 
 std::string DistinguishedName::toString() const {
-  return utils::StringUtils::join(", ", components_);
+  return utils::string::join(", ", components_);
 }
 
 }  // namespace tls

--- a/libminifi/src/utils/tls/ExtendedKeyUsage.cpp
+++ b/libminifi/src/utils/tls/ExtendedKeyUsage.cpp
@@ -67,9 +67,9 @@ ExtendedKeyUsage::ExtendedKeyUsage(const EXTENDED_KEY_USAGE& key_usage_asn1) : E
 }
 
 ExtendedKeyUsage::ExtendedKeyUsage(const std::string& key_usage_str) : ExtendedKeyUsage{} {
-  const std::vector<std::string> key_usages = utils::StringUtils::split(key_usage_str, ",");
+  const std::vector<std::string> key_usages = utils::string::split(key_usage_str, ",");
   for (const auto& key_usage : key_usages) {
-    const std::string key_usage_trimmed = utils::StringUtils::trim(key_usage);
+    const std::string key_usage_trimmed = utils::string::trim(key_usage);
     const auto it = std::find_if(EXT_KEY_USAGE_NAME_TO_BIT_POS.begin(), EXT_KEY_USAGE_NAME_TO_BIT_POS.end(),
                                  [key_usage_trimmed](const KeyValuePair& kv){ return kv.key == key_usage_trimmed; });
     if (it != EXT_KEY_USAGE_NAME_TO_BIT_POS.end()) {

--- a/libminifi/src/utils/tls/TLSUtils.cpp
+++ b/libminifi/src/utils/tls/TLSUtils.cpp
@@ -33,7 +33,7 @@ namespace tls {
 int pemPassWordCb(char *buf, int size, int /*rwflag*/, void *userdata) {
   const std::string * const origPass = reinterpret_cast<std::string*>(userdata);
   // make copy the password, trimming it
-  const auto pass = utils::StringUtils::trimRight(*origPass);
+  const auto pass = utils::string::trimRight(*origPass);
   /**
    * 1) Ensure that password is trimmed.
    * 2) Don't attempt a larger copy than the buffer we are allowed.

--- a/libminifi/src/utils/tls/TLSUtils.cpp
+++ b/libminifi/src/utils/tls/TLSUtils.cpp
@@ -23,12 +23,7 @@
 #include "utils/gsl.h"
 #include "utils/StringUtils.h"
 
-namespace org {
-namespace apache {
-namespace nifi {
-namespace minifi {
-namespace utils {
-namespace tls {
+namespace org::apache::nifi::minifi::utils::tls {
 
 int pemPassWordCb(char *buf, int size, int /*rwflag*/, void *userdata) {
   const std::string * const origPass = reinterpret_cast<std::string*>(userdata);
@@ -51,9 +46,4 @@ int pemPassWordCb(char *buf, int size, int /*rwflag*/, void *userdata) {
   return -1;
 }
 
-}  // namespace tls
-}  // namespace utils
-}  // namespace minifi
-}  // namespace nifi
-}  // namespace apache
-}  // namespace org
+}  // namespace org::apache::nifi::minifi::utils::tls

--- a/libminifi/test/TestBase.cpp
+++ b/libminifi/test/TestBase.cpp
@@ -144,7 +144,7 @@ std::optional<std::smatch> LogTestController::matchesRegex(const std::string& re
 }
 
 int LogTestController::countOccurrences(const std::string& pattern) const {
-  return minifi::utils::StringUtils::countOccurrences(getLogs(), pattern).second;
+  return minifi::utils::string::countOccurrences(getLogs(), pattern).second;
 }
 
 void LogTestController::reset() {

--- a/libminifi/test/integration/IntegrationBase.h
+++ b/libminifi/test/integration/IntegrationBase.h
@@ -166,7 +166,7 @@ void IntegrationBase::run(const std::optional<std::filesystem::path>& test_file_
     running = false;  // Stop running after this iteration, unless restart is explicitly requested
 
     bool should_encrypt_flow_config = (configuration->get(minifi::Configure::nifi_flow_configuration_encrypt)
-        | utils::andThen(utils::StringUtils::toBool)).value_or(false);
+        | utils::andThen(utils::string::toBool)).value_or(false);
 
     std::shared_ptr<utils::file::FileSystem> filesystem;
     if (home_path) {

--- a/libminifi/test/integration/OnScheduleErrorHandlingTests.cpp
+++ b/libminifi/test/integration/OnScheduleErrorHandlingTests.cpp
@@ -35,7 +35,7 @@ class KamikazeErrorHandlingTests : public IntegrationBase {
     using org::apache::nifi::minifi::utils::verifyEventHappenedInPollTime;
     assert(verifyEventHappenedInPollTime(wait_time_, [&] {
       const std::string logs = LogTestController::getInstance().getLogs();
-      const auto result = utils::StringUtils::countOccurrences(logs, minifi::processors::KamikazeProcessor::OnScheduleExceptionStr);
+      const auto result = utils::string::countOccurrences(logs, minifi::processors::KamikazeProcessor::OnScheduleExceptionStr);
       const int occurrences = result.second;
       return 1 < occurrences;
     }));
@@ -48,7 +48,7 @@ class KamikazeErrorHandlingTests : public IntegrationBase {
 
     const bool test_success = verifyEventHappenedInPollTime(std::chrono::milliseconds(wait_time_), [&] {
       const std::string logs = LogTestController::getInstance().getLogs();
-      const auto result = utils::StringUtils::countOccurrences(logs, minifi::processors::KamikazeProcessor::OnScheduleExceptionStr);
+      const auto result = utils::string::countOccurrences(logs, minifi::processors::KamikazeProcessor::OnScheduleExceptionStr);
       size_t last_pos = result.first;
       for (const std::string& msg : must_appear_byorder_msgs) {
         last_pos = logs.find(msg, last_pos);

--- a/libminifi/test/integration/StateTransactionalityTests.cpp
+++ b/libminifi/test/integration/StateTransactionalityTests.cpp
@@ -104,16 +104,16 @@ const std::unordered_map<std::string, std::string> exampleState2{{"key3", "value
 
 auto standardLogChecker = [] {
   const std::string logs = LogTestController::getInstance().getLogs();
-  const auto errorResult = utils::StringUtils::countOccurrences(logs, "[error]");
-  const auto warningResult = utils::StringUtils::countOccurrences(logs, "[warning]");
+  const auto errorResult = utils::string::countOccurrences(logs, "[error]");
+  const auto warningResult = utils::string::countOccurrences(logs, "[warning]");
   return errorResult.second == 0 && warningResult.second == 0;
 };
 
 auto exceptionRollbackWarnings = [] {
   const std::string logs = LogTestController::getInstance().getLogs();
-  const auto errorResult = utils::StringUtils::countOccurrences(logs, "[error]");
-  const auto exceptionWarningResult = utils::StringUtils::countOccurrences(logs, "[warning] Caught \"Triggering rollback\"");
-  const auto rollbackWarningResult = utils::StringUtils::countOccurrences(logs, "[warning] ProcessSession rollback for statefulProcessor executed");
+  const auto errorResult = utils::string::countOccurrences(logs, "[error]");
+  const auto exceptionWarningResult = utils::string::countOccurrences(logs, "[warning] Caught \"Triggering rollback\"");
+  const auto rollbackWarningResult = utils::string::countOccurrences(logs, "[warning] ProcessSession rollback for statefulProcessor executed");
   return errorResult.second == 0 && exceptionWarningResult.second == 1 && rollbackWarningResult.second == 1;
 };
 

--- a/libminifi/test/schema-tests/SchemaTests.cpp
+++ b/libminifi/test/schema-tests/SchemaTests.cpp
@@ -49,7 +49,7 @@ void extractExpectedErrors(nlohmann::json& node, const std::string& path, std::u
   }
   if (node.is_object() || node.is_array()) {
     for (auto& [key, val] : node.items()) {
-      extractExpectedErrors(val, utils::StringUtils::join_pack(path, "/", key), errors);
+      extractExpectedErrors(val, utils::string::join_pack(path, "/", key), errors);
     }
   }
 }

--- a/libminifi/test/unit/CertificateUtilsTests.cpp
+++ b/libminifi/test/unit/CertificateUtilsTests.cpp
@@ -106,7 +106,7 @@ constexpr std::string_view expected_iqmp =
     "31FE9F07A8CCF56D820E6A3F4E620A9B40EC64805EF935F0A2CC608C";
 
 TEST_CASE("convertWindowsRsaKeyPair() works correctly") {
-  std::vector<std::byte> windows_private_key_blob = utils::StringUtils::from_hex(BCRYPT_RSAFULLPRIVATE_BLOB_example);
+  std::vector<std::byte> windows_private_key_blob = utils::string::from_hex(BCRYPT_RSAFULLPRIVATE_BLOB_example);
   utils::tls::EVP_PKEY_unique_ptr openssl_private_key = utils::tls::convertWindowsRsaKeyPair(utils::as_span<BYTE>(std::span{windows_private_key_blob}));
   REQUIRE(openssl_private_key);
 

--- a/libminifi/test/unit/CertificateUtilsTests.cpp
+++ b/libminifi/test/unit/CertificateUtilsTests.cpp
@@ -26,7 +26,7 @@
 namespace utils = org::apache::nifi::minifi::utils;
 
 TEST_CASE("getCertificateExpiration() works correctly") {
-  using namespace date::literals;
+  using namespace date::literals;  // NOLINT(google-build-using-namespace)
   using namespace std::literals::chrono_literals;
 
   const auto executable_dir = utils::file::get_executable_dir();

--- a/libminifi/test/unit/DecryptorTests.cpp
+++ b/libminifi/test/unit/DecryptorTests.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Decryptor can decide whether a property is encrypted", "[isValidEncry
 }
 
 TEST_CASE("Decryptor can decrypt a property", "[decrypt]") {
-  utils::crypto::Bytes encryption_key = utils::StringUtils::from_hex("4024b327fdc987ce3eb43dd1f690b9987e4072e0020e3edf4349ce1ad91a4e38");
+  utils::crypto::Bytes encryption_key = utils::string::from_hex("4024b327fdc987ce3eb43dd1f690b9987e4072e0020e3edf4349ce1ad91a4e38");
   minifi::Decryptor decryptor{utils::crypto::EncryptionProvider{encryption_key}};
 
   std::string encrypted_value = "l3WY1V27knTiPa6jVX0jrq4qjmKsySOu||ErntqZpHP1M+6OkA14p5sdnqJhuNHWHDVUU5EyMloTtSytKk9a5xNKo=";
@@ -43,7 +43,7 @@ TEST_CASE("Decryptor can decrypt a property", "[decrypt]") {
 }
 
 TEST_CASE("Decryptor will throw if the value is incorrect", "[decrypt]") {
-  utils::crypto::Bytes encryption_key = utils::StringUtils::from_hex("4024b327fdc987ce3eb43dd1f690b9987e4072e0020e3edf4349ce1ad91a4e38");
+  utils::crypto::Bytes encryption_key = utils::string::from_hex("4024b327fdc987ce3eb43dd1f690b9987e4072e0020e3edf4349ce1ad91a4e38");
   minifi::Decryptor decryptor{utils::crypto::EncryptionProvider{encryption_key}};
 
   // correct nonce + ciphertext and mac: "l3WY1V27knTiPa6jVX0jrq4qjmKsySOu||ErntqZpHP1M+6OkA14p5sdnqJhuNHWHDVUU5EyMloTtSytKk9a5xNKo="
@@ -84,7 +84,7 @@ TEST_CASE("Decryptor will throw if the value is incorrect", "[decrypt]") {
 }
 
 TEST_CASE("Decryptor can decrypt a configuration file", "[decryptSensitiveProperties]") {
-  utils::crypto::Bytes encryption_key = utils::StringUtils::from_hex("5506c28d0fe265299e294a4c766b723a48986764953e93d38b3c627176fd10ed");
+  utils::crypto::Bytes encryption_key = utils::string::from_hex("5506c28d0fe265299e294a4c766b723a48986764953e93d38b3c627176fd10ed");
   minifi::Decryptor decryptor{utils::crypto::EncryptionProvider{encryption_key}};
 
   minifi::Configure configuration{decryptor};

--- a/libminifi/test/unit/DecryptorTests.cpp
+++ b/libminifi/test/unit/DecryptorTests.cpp
@@ -90,7 +90,7 @@ TEST_CASE("Decryptor can decrypt a configuration file", "[decryptSensitiveProper
   minifi::Configure configuration{decryptor};
   configuration.setHome("resources");
   configuration.loadConfigureFile("encrypted.minifi.properties");
-  REQUIRE(configuration.getConfiguredKeys().size() > 0);
+  REQUIRE_FALSE(configuration.getConfiguredKeys().empty());
 
   const auto passphrase = configuration.get(minifi::Configure::nifi_security_client_pass_phrase);
   REQUIRE(passphrase);

--- a/libminifi/test/unit/EncryptionUtilsTests.cpp
+++ b/libminifi/test/unit/EncryptionUtilsTests.cpp
@@ -23,9 +23,9 @@
 namespace utils = org::apache::nifi::minifi::utils;
 
 namespace {
-const utils::crypto::Bytes SECRET_KEY = utils::StringUtils::from_hex("aa411f289c91685ef9d5a9e5a4fad9393ff4c7a78ab978484323488caed7a9ab");
+const utils::crypto::Bytes SECRET_KEY = utils::string::from_hex("aa411f289c91685ef9d5a9e5a4fad9393ff4c7a78ab978484323488caed7a9ab");
 
-const utils::crypto::Bytes NONCE = utils::StringUtils::from_base64("RBrWo9lv7xNA6JJWHCa9avnT42CCr1bn");
+const utils::crypto::Bytes NONCE = utils::string::from_base64("RBrWo9lv7xNA6JJWHCa9avnT42CCr1bn");
 }  // namespace
 
 TEST_CASE("EncryptionUtils can do a simple encryption", "[encryptRaw]") {
@@ -34,11 +34,11 @@ TEST_CASE("EncryptionUtils can do a simple encryption", "[encryptRaw]") {
   utils::crypto::Bytes output = utils::crypto::encryptRaw(plaintext, SECRET_KEY, NONCE);
 
   REQUIRE(output.size() == plaintext.size() + utils::crypto::EncryptionType::macLength());
-  REQUIRE(utils::StringUtils::to_base64(output) == "x3WIHJGb+7hGlfIQd3gz8zw11EP0uFh9Ml1XBEAPCX5OTKqWcY+o+Q==");
+  REQUIRE(utils::string::to_base64(output) == "x3WIHJGb+7hGlfIQd3gz8zw11EP0uFh9Ml1XBEAPCX5OTKqWcY+o+Q==");
 }
 
 TEST_CASE("EncryptionUtils can do a simple decryption", "[decryptRaw]") {
-  utils::crypto::Bytes ciphertext_plus_mac = utils::StringUtils::from_base64("x3WIHJGb+7hGlfIQd3gz8zw11EP0uFh9Ml1XBEAPCX5OTKqWcY+o+Q==");
+  utils::crypto::Bytes ciphertext_plus_mac = utils::string::from_base64("x3WIHJGb+7hGlfIQd3gz8zw11EP0uFh9Ml1XBEAPCX5OTKqWcY+o+Q==");
 
   utils::crypto::Bytes output = utils::crypto::decryptRaw(ciphertext_plus_mac, SECRET_KEY, NONCE);
 

--- a/libminifi/test/unit/FileSystemTests.cpp
+++ b/libminifi/test/unit/FileSystemTests.cpp
@@ -27,7 +27,7 @@
 using utils::crypto::EncryptionProvider;
 using utils::file::FileSystem;
 
-utils::crypto::Bytes encryption_key = utils::StringUtils::from_hex("4024b327fdc987ce3eb43dd1f690b9987e4072e0020e3edf4349ce1ad91a4e38");
+utils::crypto::Bytes encryption_key = utils::string::from_hex("4024b327fdc987ce3eb43dd1f690b9987e4072e0020e3edf4349ce1ad91a4e38");
 
 struct FileSystemTest : TestController {
   FileSystemTest() {

--- a/libminifi/test/unit/IdTests.cpp
+++ b/libminifi/test/unit/IdTests.cpp
@@ -150,7 +150,7 @@ TEST_CASE("Test parse", "[id]") {
   for (const auto& test_case : test_cases) {
     utils::Identifier id = utils::Identifier::parse(test_case.first).value();
     REQUIRE(memcmp(IdentifierTestAccessor::get_data_(id).data(), test_case.second.data(), 16U) == 0);
-    REQUIRE(utils::StringUtils::equalsIgnoreCase(test_case.first, id.to_string().view()));
+    REQUIRE(utils::string::equalsIgnoreCase(test_case.first, id.to_string().view()));
   }
 
   LogTestController::getInstance().reset();

--- a/libminifi/test/unit/MinifiConcurrentQueueTests.cpp
+++ b/libminifi/test/unit/MinifiConcurrentQueueTests.cpp
@@ -250,7 +250,7 @@ TEST_CASE("TestConcurrentQueue: test simple producer and consumer", "[ProducerCo
     consumer.join();
   }
 
-  REQUIRE(utils::StringUtils::join("-", results) == "ba-dum-tss");
+  REQUIRE(utils::string::join("-", results) == "ba-dum-tss");
 }
 
 TEST_CASE("TestConcurrentQueue: test timed waiting consumers", "[ProducerConsumer]") {
@@ -273,7 +273,7 @@ TEST_CASE("TestConcurrentQueue: test timed waiting consumers", "[ProducerConsume
   producer.join();
   consumer.join();
 
-  REQUIRE(utils::StringUtils::join("-", results) == "ba-dum-tss");
+  REQUIRE(utils::string::join("-", results) == "ba-dum-tss");
 }
 
 TEST_CASE("TestConcurrentQueue: test untimed waiting consumers", "[ProducerConsumer]") {
@@ -298,7 +298,7 @@ TEST_CASE("TestConcurrentQueue: test untimed waiting consumers", "[ProducerConsu
   queue.stop();
   consumer.join();
 
-  REQUIRE(utils::StringUtils::join("-", results) == "ba-dum-tss");
+  REQUIRE(utils::string::join("-", results) == "ba-dum-tss");
 }
 
 TEST_CASE("TestConcurrentQueue: test the readding dequeue consumer", "[ProducerConsumer]") {
@@ -317,7 +317,7 @@ TEST_CASE("TestConcurrentQueue: test the readding dequeue consumer", "[ProducerC
   producer.join();
   consumer.join();
 
-  REQUIRE(utils::StringUtils::join("-", results) == "ba-dum-tss");
+  REQUIRE(utils::string::join("-", results) == "ba-dum-tss");
 }
 
 TEST_CASE("TestConcurrentQueue: test waiting consumers with blocked producer", "[ProducerConsumer]") {

--- a/libminifi/test/unit/PropertyTests.cpp
+++ b/libminifi/test/unit/PropertyTests.cpp
@@ -31,7 +31,7 @@ TEST_CASE("Test Trimmer Right", "[testTrims]") {
 
   REQUIRE(test.c_str()[test.length() - 1] == '\n');
   REQUIRE(test.c_str()[test.length() - 2] == '\t');
-  test = org::apache::nifi::minifi::utils::StringUtils::trimRight(test);
+  test = org::apache::nifi::minifi::utils::string::trimRight(test);
 
   REQUIRE(test.c_str()[test.length() - 1] == 'd');
   REQUIRE(test.c_str()[test.length() - 2] == 'a');
@@ -41,7 +41,7 @@ TEST_CASE("Test Trimmer Right", "[testTrims]") {
   REQUIRE(test.c_str()[test.length() - 1] == '\t');
   REQUIRE(test.c_str()[test.length() - 2] == '\v');
 
-  test = org::apache::nifi::minifi::utils::StringUtils::trimRight(test);
+  test = org::apache::nifi::minifi::utils::string::trimRight(test);
 
   REQUIRE(test.c_str()[test.length() - 1] == 'd');
   REQUIRE(test.c_str()[test.length() - 2] == 'a');
@@ -51,7 +51,7 @@ TEST_CASE("Test Trimmer Right", "[testTrims]") {
   REQUIRE(test.c_str()[test.length() - 1] == '\f');
   REQUIRE(test.c_str()[test.length() - 2] == ' ');
 
-  test = org::apache::nifi::minifi::utils::StringUtils::trimRight(test);
+  test = org::apache::nifi::minifi::utils::string::trimRight(test);
 
   REQUIRE(test.c_str()[test.length() - 1] == 'd');
 }
@@ -62,7 +62,7 @@ TEST_CASE("Test Trimmer Left", "[testTrims]") {
   REQUIRE(test.c_str()[0] == '\t');
   REQUIRE(test.c_str()[1] == '\n');
 
-  test = org::apache::nifi::minifi::utils::StringUtils::trimLeft(test);
+  test = org::apache::nifi::minifi::utils::string::trimLeft(test);
 
   REQUIRE(test.c_str()[0] == 'a');
   REQUIRE(test.c_str()[1] == ' ');
@@ -72,7 +72,7 @@ TEST_CASE("Test Trimmer Left", "[testTrims]") {
   REQUIRE(test.c_str()[0] == '\v');
   REQUIRE(test.c_str()[1] == '\t');
 
-  test = org::apache::nifi::minifi::utils::StringUtils::trimLeft(test);
+  test = org::apache::nifi::minifi::utils::string::trimLeft(test);
 
   REQUIRE(test.c_str()[0] == 'a');
   REQUIRE(test.c_str()[1] == ' ');
@@ -82,7 +82,7 @@ TEST_CASE("Test Trimmer Left", "[testTrims]") {
   REQUIRE(test.c_str()[0] == ' ');
   REQUIRE(test.c_str()[1] == '\f');
 
-  test = org::apache::nifi::minifi::utils::StringUtils::trimLeft(test);
+  test = org::apache::nifi::minifi::utils::string::trimLeft(test);
 
   REQUIRE(test.c_str()[0] == 'a');
   REQUIRE(test.c_str()[1] == ' ');

--- a/libminifi/test/unit/Site2SiteTests.cpp
+++ b/libminifi/test/unit/Site2SiteTests.cpp
@@ -95,7 +95,7 @@ TEST_CASE("TestSiteToSiteVerifySend", "[S2S3]") {
   collector_ptr->get_next_client_response();
   REQUIRE(collector_ptr->get_next_client_response() == "PORT_IDENTIFIER");
   collector_ptr->get_next_client_response();
-  REQUIRE(utils::StringUtils::equalsIgnoreCase(collector_ptr->get_next_client_response(), "c56a4180-65aa-42ec-a945-5fd21dec0538"));
+  REQUIRE(utils::string::equalsIgnoreCase(collector_ptr->get_next_client_response(), "c56a4180-65aa-42ec-a945-5fd21dec0538"));
   collector_ptr->get_next_client_response();
   REQUIRE(collector_ptr->get_next_client_response() == "REQUEST_EXPIRATION_MILLIS");
   collector_ptr->get_next_client_response();

--- a/libminifi/test/unit/StagingQueueTests.cpp
+++ b/libminifi/test/unit/StagingQueueTests.cpp
@@ -92,7 +92,7 @@ TEST_CASE("Modify and overflow triggered automatic commit", "[TestStagingQueue4]
   }
   queue.modify([] (MockItem& item) {
     // a new item has been allocated
-    REQUIRE(item.data_ == "");
+    REQUIRE(item.data_.empty());
   });
   REQUIRE(queue.size() == 11);
   MockItem out;

--- a/libminifi/test/unit/StagingQueueTests.cpp
+++ b/libminifi/test/unit/StagingQueueTests.cpp
@@ -105,7 +105,7 @@ TEST_CASE("Discard overflow", "[TestStagingQueue5]") {
   StagingQueue<MockItem> queue(30, 10);
   for (size_t idx = 0; idx < 5; ++idx) {
     queue.modify([&] (MockItem& item) {
-      item.data_ = utils::StringUtils::repeat(std::to_string(idx), 10);
+      item.data_ = utils::string::repeat(std::to_string(idx), 10);
     });
     queue.commit();
   }
@@ -116,7 +116,7 @@ TEST_CASE("Discard overflow", "[TestStagingQueue5]") {
   // idx 0 and 1 have been discarded
   for (size_t idx = 2; idx < 5; ++idx) {
     REQUIRE(queue.tryDequeue(out));
-    REQUIRE(out.data_ == utils::StringUtils::repeat(std::to_string(idx), 10));
+    REQUIRE(out.data_ == utils::string::repeat(std::to_string(idx), 10));
   }
   REQUIRE(queue.size() == 0);
 }

--- a/libminifi/test/unit/StringUtilsTests.cpp
+++ b/libminifi/test/unit/StringUtilsTests.cpp
@@ -36,7 +36,7 @@ namespace org::apache::nifi::minifi::utils {
 
 // NOLINTBEGIN(readability-container-size-empty)
 
-TEST_CASE("string::chomp works correctly", "[StringUtils][chomp]") {
+TEST_CASE("string::chomp works correctly", "[chomp]") {
   using pair_of = std::pair<std::string, std::string>;
   CHECK(string::chomp("foobar") == pair_of{"foobar", ""});
   CHECK(string::chomp("foobar\n") == pair_of{"foobar", "\n"});

--- a/libminifi/test/unit/ZlibStreamTests.cpp
+++ b/libminifi/test/unit/ZlibStreamTests.cpp
@@ -66,7 +66,7 @@ TEST_CASE("gzip compression and decompression", "[basic]") {
   REQUIRE(0U < compressBuffer.size());
 
   if (compressBuffer.size() < 64U) {
-    std::cerr << utils::StringUtils::to_hex(compressBuffer.getBuffer()) << std::endl;
+    std::cerr << utils::string::to_hex(compressBuffer.getBuffer()) << std::endl;
   }
 
   /* Decompression */

--- a/minifi_main/AgentDocs.cpp
+++ b/minifi_main/AgentDocs.cpp
@@ -65,12 +65,12 @@ std::string formatAllowedValues(const minifi::core::Property& property) {
 
 std::string formatDescription(std::string_view description_view, bool supports_expression_language = false) {
   std::string description{description_view};
-  minifi::utils::StringUtils::replaceAll(description, "\n", "<br/>");
+  minifi::utils::string::replaceAll(description, "\n", "<br/>");
   return supports_expression_language ? description + "<br/>**Supports Expression Language: true**" : description;
 }
 
 std::string formatListOfRelationships(std::span<const minifi::core::RelationshipDefinition> relationships) {
-  return minifi::utils::StringUtils::join(", ", relationships, [](const auto& relationship) { return relationship.name; });
+  return minifi::utils::string::join(", ", relationships, [](const auto& relationship) { return relationship.name; });
 }
 
 inline constexpr std::string_view APACHE_LICENSE = R"license(<!--
@@ -161,11 +161,11 @@ void writeOutputAttributes(std::ostream& docs, const minifi::ClassDescription& d
 }
 
 std::string extractClassName(const std::string& full_class_name) {
-  return minifi::utils::StringUtils::split(full_class_name, ".").back();
+  return minifi::utils::string::split(full_class_name, ".").back();
 }
 
 std::string lowercaseFirst(const std::pair<std::string, minifi::ClassDescription>& key_value) {
-  return minifi::utils::StringUtils::toLower(key_value.first);
+  return minifi::utils::string::toLower(key_value.first);
 };
 
 }  // namespace

--- a/minifi_main/MiNiFiMain.cpp
+++ b/minifi_main/MiNiFiMain.cpp
@@ -139,7 +139,7 @@ void writeJsonSchema(const std::shared_ptr<minifi::Configure> &configuration, st
 void overridePropertiesFromCommandLine(const argparse::ArgumentParser& parser, const std::shared_ptr<minifi::Configure>& configure) {
   const auto& properties = parser.get<std::vector<std::string>>("--property");
   for (const auto& property : properties) {
-    auto property_key_and_value = utils::StringUtils::splitAndTrimRemovingEmpty(property, "=");
+    auto property_key_and_value = utils::string::splitAndTrimRemovingEmpty(property, "=");
     if (property_key_and_value.size() != 2) {
       std::cerr << "Command line property must be defined in <key>=<value> format, invalid property: " << property << std::endl;
       std::cerr << parser;
@@ -384,7 +384,7 @@ int main(int argc, char **argv) {
     configure->get(minifi::Configure::nifi_configuration_class_name, nifi_configuration_class_name);
 
     bool should_encrypt_flow_config = (configure->get(minifi::Configure::nifi_flow_configuration_encrypt)
-        | utils::andThen(utils::StringUtils::toBool)).value_or(false);
+        | utils::andThen(utils::string::toBool)).value_or(false);
 
     auto filesystem = std::make_shared<utils::file::FileSystem>(
         should_encrypt_flow_config,
@@ -405,7 +405,7 @@ int main(int argc, char **argv) {
       prov_repo, flow_repo, configure, std::move(flow_configuration), content_repo, std::move(metrics_publisher_store), filesystem, request_restart);
 
     const bool disk_space_watchdog_enable = configure->get(minifi::Configure::minifi_disk_space_watchdog_enable)
-        | utils::andThen(utils::StringUtils::toBool)
+        | utils::andThen(utils::string::toBool)
         | utils::valueOrElse([] { return true; });
 
     std::unique_ptr<utils::CallBackTimer> disk_space_watchdog;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-2275

It is probably easier to review the two original commits separately:
794916124ad5f3c69ab3451e4d96124b54d009e1 is, or should be, only `StringUtils` -> `string` replacements;
3afefe3438d1fbb2fc0f74e236fa22c7b4c48066 is clang-tidy fixes; this is where bugs (or solutions which could be improved) are more likely

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
