### PR TITLE
MINIFICPP-2307 Fix libsodium url parameter passing for CMake 3.29

### DIFF
--- a/cmake/BundledLibSodium.cmake
+++ b/cmake/BundledLibSodium.cmake
@@ -48,7 +48,7 @@ function(use_bundled_libsodium SOURCE_DIR BINARY_DIR)
     if (WIN32)
         ExternalProject_Add(
                 libsodium-external
-                URL "${LIBSODIUM_OFFICIAL_MIRROR_URL} ${LIBSODIUM_GITHUB_MIRROR_URL} ${LIBSODIUM_GENTOO_MIRROR_URL}"
+                URL "${LIBSODIUM_OFFICIAL_MIRROR_URL}" "${LIBSODIUM_GITHUB_MIRROR_URL}" "${LIBSODIUM_GENTOO_MIRROR_URL}"
                 URL_HASH ${LIBSODIUM_URL_HASH}
                 SOURCE_DIR "${BINARY_DIR}/thirdparty/libsodium-src"
                 LIST_SEPARATOR % # This is needed for passing semicolon-separated lists
@@ -62,7 +62,7 @@ function(use_bundled_libsodium SOURCE_DIR BINARY_DIR)
 
         ExternalProject_Add(
                 libsodium-external
-                URL "${LIBSODIUM_OFFICIAL_MIRROR_URL} ${LIBSODIUM_GITHUB_MIRROR_URL} ${LIBSODIUM_GENTOO_MIRROR_URL}"
+                URL "${LIBSODIUM_OFFICIAL_MIRROR_URL}" "${LIBSODIUM_GITHUB_MIRROR_URL}" "${LIBSODIUM_GENTOO_MIRROR_URL}"
                 URL_HASH ${LIBSODIUM_URL_HASH}
                 BUILD_IN_SOURCE true
                 SOURCE_DIR "${BINARY_DIR}/thirdparty/libsodium-src"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-2307

------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
