### PR TITLE
MINIFICPP-1757 remove problematic linker flags on macos/gcc

### DIFF
--- a/cmake/Extensions.cmake
+++ b/cmake/Extensions.cmake
@@ -70,7 +70,7 @@ macro(register_extension extension-name extension-display-name extension-guard d
         if(WIN32)
             install(TARGETS ${extension-name} RUNTIME DESTINATION extensions COMPONENT ${component-name})
         else()
-            if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+            if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND NOT APPLE)
                 target_link_options(${extension-name} PRIVATE "-Wl,--disable-new-dtags")
             endif()
             if (APPLE)

--- a/controller/CMakeLists.txt
+++ b/controller/CMakeLists.txt
@@ -48,7 +48,7 @@ set_target_properties(minificontroller PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
 if (NOT WIN32)
-    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND NOT APPLE)
         target_link_options(minificontroller PRIVATE "-Wl,--disable-new-dtags")
     endif()
     if (APPLE)

--- a/encrypt-config/CMakeLists.txt
+++ b/encrypt-config/CMakeLists.txt
@@ -31,7 +31,7 @@ set_target_properties(encrypt-config PROPERTIES OUTPUT_NAME encrypt-config)
 set_target_properties(encrypt-config PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
 if (NOT WIN32)
-    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND NOT APPLE)
         target_link_options(encrypt-config PRIVATE "-Wl,--disable-new-dtags")
     endif()
     if (APPLE)

--- a/minifi_main/CMakeLists.txt
+++ b/minifi_main/CMakeLists.txt
@@ -83,7 +83,7 @@ else()
 endif()
 
 if (NOT WIN32)
-    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND NOT APPLE)
         target_link_options(minifiexe PRIVATE "-Wl,--disable-new-dtags")
     endif()
     if (APPLE)


### PR DESCRIPTION
This doesn't fix the GCC build on macos, just resolves a single issue I ran into a while back

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
