### PR TITLE
MINIFICPP-2317 Fix openssl flag flipped in MINIFICPP-1797

### DIFF
--- a/cmake/BundledLibArchive.cmake
+++ b/cmake/BundledLibArchive.cmake
@@ -50,9 +50,9 @@ function(use_bundled_libarchive SOURCE_DIR BINARY_DIR)
             -DENABLE_WERROR=OFF)
 
     if (MINIFI_OPENSSL)
-        list(APPEND LIBARCHIVE_CMAKE_ARGS -DENABLE_OPENSSL=OFF)
-    else()
         list(APPEND LIBARCHIVE_CMAKE_ARGS -DENABLE_OPENSSL=ON)
+    else()
+        list(APPEND LIBARCHIVE_CMAKE_ARGS -DENABLE_OPENSSL=OFF)
     endif()
 
     if (NOT ENABLE_LZMA)


### PR DESCRIPTION
Credits to Gabor Gyimesi for finding the issue

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
