### PR TITLE
MINIFICPP-2324 Make start after install optional

### DIFF
--- a/msi/WixWin.wsi.in
+++ b/msi/WixWin.wsi.in
@@ -49,9 +49,8 @@ ${WIX_EXTRA_FEATURES}
 
     <Feature Id="InstallService" Title="Apache NiFi MiNiFi C++ Service" AllowAdvertise="no" Display="hidden" Level="1">
       <ComponentRef Id="minifiService"/>
-      <ComponentRef Id="minifiService_autostart"/>
       <ComponentRef Id="minifiServiceNotLocal"/>
-      <ComponentRef Id="minifiServiceNotLocal_autostart"/>
+      <ComponentRef Id="minifiService_autostart"/>
     </Feature>
 
     <Feature Id="InstallConf" Title="Apache NiFi MiNiFi C++ Configuration" AllowAdvertise="yes"  Level="1">
@@ -366,15 +365,6 @@ ${WIX_EXTRA_FEATURES}
                 <Condition><![CDATA[SERVICEACCOUNT="LocalSystem"]]></Condition>
               </Component>
 
-              <Component Id="minifiService_autostart" Guid="17e2be83-e375-4b54-95da-f26fbf20b2ca">
-                <File Id="MiNiFiExe_autostart" Name="minifi.exe" KeyPath="yes" Source="minifi_main\minifi.exe"/>
-                <ServiceControl Id="ServiceControl_Start"
-                      Name="Apache NiFi MiNiFi"
-                      Start="install"
-                      Wait="no" />
-                <Condition><![CDATA[SERVICEACCOUNT="LocalSystem" AND AUTOSTART="1"]]></Condition>
-              </Component>
-
               <Component Id="minifiServiceNotLocal" Guid="87658309-0339-425c-8633-f54ffaaa4922">
                 <File Id="MiNiFiExeWithPassword" Name="minifi.exe" KeyPath="yes" Source="minifi_main\minifi.exe"/>
                 <ServiceInstall Id="MiNiFiExeServiceWithPassword"
@@ -400,13 +390,13 @@ ${WIX_EXTRA_FEATURES}
                 <Condition><![CDATA[SERVICEACCOUNT<>"LocalSystem"]]></Condition>
               </Component>
 
-              <Component Id="minifiServiceNotLocal_autostart" Guid="e347bedd-3c94-49c4-bc78-7b011811c4e6">
-                <File Id="MiNiFiExe_NotLocal_autostart" Name="minifi.exe" KeyPath="yes" Source="minifi_main\minifi.exe"/>
-                <ServiceControl Id="ServiceControl_NotLocal_Start"
+              <Component Id="minifiService_autostart" Guid="17e2be83-e375-4b54-95da-f26fbf20b2ca">
+                <File Id="MiNiFiExe_autostart" Name="minifi.exe" KeyPath="yes" Source="minifi_main\minifi.exe"/>
+                <ServiceControl Id="ServiceControl_Start"
                       Name="Apache NiFi MiNiFi"
                       Start="install"
                       Wait="no" />
-                <Condition><![CDATA[SERVICEACCOUNT<>"LocalSystem" AND AUTOSTART="1"]]></Condition>
+                <Condition><![CDATA[AUTOSTART="1"]]></Condition>
               </Component>
 
 ${WIX_EXTRA_COMPONENTS}

--- a/msi/WixWin.wsi.in
+++ b/msi/WixWin.wsi.in
@@ -49,7 +49,9 @@ ${WIX_EXTRA_FEATURES}
 
     <Feature Id="InstallService" Title="Apache NiFi MiNiFi C++ Service" AllowAdvertise="no" Display="hidden" Level="1">
       <ComponentRef Id="minifiService"/>
+      <ComponentRef Id="minifiService_autostart"/>
       <ComponentRef Id="minifiServiceNotLocal"/>
+      <ComponentRef Id="minifiServiceNotLocal_autostart"/>
     </Feature>
 
     <Feature Id="InstallConf" Title="Apache NiFi MiNiFi C++ Configuration" AllowAdvertise="yes"  Level="1">
@@ -181,10 +183,10 @@ ${WIX_EXTRA_FEATURES}
       </Dialog>
 
 
-      <Dialog Id="PropertiesDialog" Width="370" Height="320" Title="Agent Properties">
-        <Control Id="Next" Type="PushButton" X="236" Y="290" Width="56" Height="17" Default="yes" Text="Next" />
-        <Control Id="Back" Type="PushButton" X="180" Y="290" Width="56" Height="17" Text="Back" />
-        <Control Id="Cancel" Type="PushButton" X="304" Y="290" Width="56" Height="17" Cancel="yes" Text="Cancel">
+      <Dialog Id="PropertiesDialog" Width="370" Height="340" Title="Agent Properties">
+        <Control Id="Next" Type="PushButton" X="236" Y="310" Width="56" Height="17" Default="yes" Text="Next" />
+        <Control Id="Back" Type="PushButton" X="180" Y="310" Width="56" Height="17" Text="Back" />
+        <Control Id="Cancel" Type="PushButton" X="304" Y="310" Width="56" Height="17" Cancel="yes" Text="Cancel">
           <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
         </Control>
 
@@ -192,40 +194,44 @@ ${WIX_EXTRA_FEATURES}
         <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="Apache NiFi MiNiFi Properties" />
         <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.InstallDirDlgBannerBitmap)" />
         <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
-        <Control Id="BottomLine" Type="Line" X="0" Y="283" Width="370" Height="0" />
+        <Control Id="BottomLine" Type="Line" X="0" Y="303" Width="370" Height="0" />
 
+        <Control Id="AutoStartMiNiFi" Type="CheckBox" X="20" Y="55"
+                         Width="200" Height="17" Property="AUTOSTART"
+                         CheckBoxValue="1"
+                         Text="Start MiNiFi service at the end of the installation." Default="no" />
 
-        <Control Id="EnableC2" Type="CheckBox" X="20" Y="60"
+        <Control Id="EnableC2" Type="CheckBox" X="20" Y="80"
                          Width="200" Height="17" Property="ENABLEC2"
                          CheckBoxValue="1"
                          Text="Enable interactive Command and Control." Default="no" />
 
-        <Control Id="AgentClassLabel" Type="Text" X="20" Y="80" Width="290" Height="20" NoPrefix="yes" Text="Agent Class" />
-        <Control Id="AgentClass" Type="Edit" X="20" Y="100" Width="320" Height="18" Property="AGENT_CLASS" Indirect="no" >
+        <Control Id="AgentClassLabel" Type="Text" X="20" Y="100" Width="290" Height="20" NoPrefix="yes" Text="Agent Class" />
+        <Control Id="AgentClass" Type="Edit" X="20" Y="120" Width="320" Height="18" Property="AGENT_CLASS" Indirect="no" >
           <Condition Action="disable"><![CDATA[ENABLEC2<>1]]></Condition>
           <Condition Action="enable">ENABLEC2="1"</Condition>
         </Control>
 
-        <Control Id="AgentIdentifierLabel" Type="Text" X="20" Y="120" Width="60" Height="20" NoPrefix="yes" Text="Agent Identifier" />
-        <Control Id="AgentIdentifier" Type="Edit" X="20" Y="140" Width="320" Height="18" Property="AGENT_IDENTIFIER"  Indirect="no"  >
+        <Control Id="AgentIdentifierLabel" Type="Text" X="20" Y="140" Width="60" Height="20" NoPrefix="yes" Text="Agent Identifier" />
+        <Control Id="AgentIdentifier" Type="Edit" X="20" Y="160" Width="320" Height="18" Property="AGENT_IDENTIFIER"  Indirect="no"  >
           <Condition Action="disable"><![CDATA[ENABLEC2<>1]]></Condition>
           <Condition Action="enable">ENABLEC2="1"</Condition>
         </Control>
 
-        <Control Id="ServertHeartbeatIdentifierLabel" Type="Text" X="20" Y="160" Width="80" Height="20" NoPrefix="yes" Text="Server Heartbeat URL" />
-        <Control Id="ServerHeartbeatIdentifier" Type="Edit" X="20" Y="180" Width="320" Height="18" Property="SERVER_HEARTBEAT" Indirect="no"  >
+        <Control Id="ServertHeartbeatIdentifierLabel" Type="Text" X="20" Y="180" Width="80" Height="20" NoPrefix="yes" Text="Server Heartbeat URL" />
+        <Control Id="ServerHeartbeatIdentifier" Type="Edit" X="20" Y="200" Width="320" Height="18" Property="SERVER_HEARTBEAT" Indirect="no"  >
           <Condition Action="disable"><![CDATA[ENABLEC2<>1]]></Condition>
           <Condition Action="enable">ENABLEC2="1"</Condition>
         </Control>
 
-        <Control Id="ServerAckIdentifierLabel" Type="Text" X="20" Y="200" Width="60" Height="20" NoPrefix="yes" Text="Server Ack URL" />
-        <Control Id="ServeAckrIdentifier" Type="Edit" X="20" Y="220" Width="320" Height="18" Property="SERVER_ACK" Indirect="no"  >
+        <Control Id="ServerAckIdentifierLabel" Type="Text" X="20" Y="220" Width="60" Height="20" NoPrefix="yes" Text="Server Ack URL" />
+        <Control Id="ServeAckrIdentifier" Type="Edit" X="20" Y="240" Width="320" Height="18" Property="SERVER_ACK" Indirect="no"  >
           <Condition Action="disable"><![CDATA[ENABLEC2<>1]]></Condition>
           <Condition Action="enable">ENABLEC2="1"</Condition>
         </Control>
 
-        <Control Id="AgentHeartbeatLabel" Type="Text" X="20" Y="240" Width="80" Height="20" NoPrefix="yes" Text="Agent Heartbeat" />
-        <Control Id="AgentHeartbeat" Type="ComboBox" X="20" Y="260" Width="300" Height="17" Property="AGENT_HEARTBEAT" Sorted="yes" >
+        <Control Id="AgentHeartbeatLabel" Type="Text" X="20" Y="260" Width="80" Height="20" NoPrefix="yes" Text="Agent Heartbeat" />
+        <Control Id="AgentHeartbeat" Type="ComboBox" X="20" Y="280" Width="300" Height="17" Property="AGENT_HEARTBEAT" Sorted="yes" >
           <ComboBox Property="AGENT_HEARTBEAT">
             <ListItem Value="250 msec" />
             <ListItem Value="1 sec" />
@@ -268,12 +274,11 @@ ${WIX_EXTRA_FEATURES}
     <Property Id="SERVER_HEARTBEAT"  Value="http://localhost:8181/heartbeat" />
     <Property Id="SERVER_ACK"  Value="http://localhost:8181/acknowledge" />
     <Property Id="ENABLEC2" />
-
+    <Property Id="AUTOSTART" Value="1" />
     <Property Id="SERVICEACCOUNT" Value="LocalSystem" />
     <Property Id="SERVICEACCOUNTPASSWORD" />
 
     <SetProperty Id="AGENT_IDENTIFIER" After="AppSearch" Value="[ComputerName]" Sequence="first" />
-
     <SetProperty Id="ENABLEC2" After="AppSearch" Value="0" Sequence="first" >
       <![CDATA[ENABLEC2 = 0]]>
     </SetProperty>
@@ -350,10 +355,6 @@ ${WIX_EXTRA_FEATURES}
                         RestartServiceDelayInSeconds="60"/>
                 </ServiceInstall>
                 <RegistryValue Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\Apache NiFi MiNiFi" Type="integer" Name="DelayedAutostart" Value="1"/>
-                <ServiceControl Id="ServiceControl_Start"
-                      Name="Apache NiFi MiNiFi"
-                      Start="install"
-                      Wait="no" />
                 <ServiceControl Id="ServiceControl_Stop"
                                 Name="Apache NiFi MiNiFi"
                                 Stop="both"
@@ -364,6 +365,16 @@ ${WIX_EXTRA_FEATURES}
                                   EventMessageFile="[#MiNiFiExe]" />
                 <Condition><![CDATA[SERVICEACCOUNT="LocalSystem"]]></Condition>
               </Component>
+
+              <Component Id="minifiService_autostart" Guid="17e2be83-e375-4b54-95da-f26fbf20b2ca">
+                <File Id="MiNiFiExe_autostart" Name="minifi.exe" KeyPath="yes" Source="minifi_main\minifi.exe"/>
+                <ServiceControl Id="ServiceControl_Start"
+                      Name="Apache NiFi MiNiFi"
+                      Start="install"
+                      Wait="no" />
+                <Condition><![CDATA[SERVICEACCOUNT="LocalSystem" AND AUTOSTART="1"]]></Condition>
+              </Component>
+
               <Component Id="minifiServiceNotLocal" Guid="87658309-0339-425c-8633-f54ffaaa4922">
                 <File Id="MiNiFiExeWithPassword" Name="minifi.exe" KeyPath="yes" Source="minifi_main\minifi.exe"/>
                 <ServiceInstall Id="MiNiFiExeServiceWithPassword"
@@ -378,10 +389,6 @@ ${WIX_EXTRA_FEATURES}
                                 Start="auto"
                                 Interactive="no" />
                 <RegistryValue Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\Apache NiFi MiNiFi" Type="integer" Name="DelayedAutostart" Value="1"/>
-                <ServiceControl Id="ServiceControl_Start_WithPassword"
-                      Name="Apache NiFi MiNiFi"
-                      Start="install"
-                      Wait="no" />
                 <ServiceControl Id="ServiceControl_Stop_WithPassword"
                                 Name="Apache NiFi MiNiFi"
                                 Stop="both"
@@ -391,6 +398,15 @@ ${WIX_EXTRA_FEATURES}
                                   Name="ApacheNiFiMiNiFi"
                                   EventMessageFile="[#MiNiFiExeWithPassword]" />
                 <Condition><![CDATA[SERVICEACCOUNT<>"LocalSystem"]]></Condition>
+              </Component>
+
+              <Component Id="minifiServiceNotLocal_autostart" Guid="e347bedd-3c94-49c4-bc78-7b011811c4e6">
+                <File Id="MiNiFiExe_NotLocal_autostart" Name="minifi.exe" KeyPath="yes" Source="minifi_main\minifi.exe"/>
+                <ServiceControl Id="ServiceControl_NotLocal_Start"
+                      Name="Apache NiFi MiNiFi"
+                      Start="install"
+                      Wait="no" />
+                <Condition><![CDATA[SERVICEACCOUNT<>"LocalSystem" AND AUTOSTART="1"]]></Condition>
               </Component>
 
 ${WIX_EXTRA_COMPONENTS}


### PR DESCRIPTION
In the Windows installer (msi), add a new checkbox, enabled by default, to control whether the service will be started at the end of the installation. To disable auto-start from the command line, use the `AUTOSTART=""` property in the `msiexec.exe` command.

https://issues.apache.org/jira/browse/MINIFICPP-2324

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
