### PR TITLE
MINIFICPP-2366 various OSSP-uuid fixes

### DIFF
--- a/cmake/BundledOSSPUUID.cmake
+++ b/cmake/BundledOSSPUUID.cmake
@@ -39,15 +39,16 @@ function(use_bundled_osspuuid SOURCE_DIR BINARY_DIR)
     ENDFOREACH(BYPRODUCT)
 
     # Build project
-    if(WIN32)
-        set(ADDITIONAL_COMPILER_FLAGS "")
-    else()
-        set(ADDITIONAL_COMPILER_FLAGS "-fPIC")
+    if(NOT WIN32)
+        string(APPEND ADDITIONAL_COMPILER_FLAGS "-fPIC ")
+    endif()
+    if(APPLE)
+        string(APPEND ADDITIONAL_COMPILER_FLAGS "-isysroot ${CMAKE_OSX_SYSROOT} ")
     endif()
     set(CONFIGURE_COMMAND ./configure "CC=${CMAKE_C_COMPILER}" "CXX=${CMAKE_CXX_COMPILER}" "CFLAGS=${PASSTHROUGH_CMAKE_C_FLAGS} ${ADDITIONAL_COMPILER_FLAGS}" "CXXFLAGS=${PASSTHROUGH_CMAKE_CXX_FLAGS} ${ADDITIONAL_COMPILER_FLAGS}" --enable-shared=no --with-cxx --without-perl --without-php --without-pgsql "--prefix=${BINARY_DIR}/thirdparty/ossp-uuid-install")
 
     string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type)
-    if(NOT build_type MATCHES debug)
+    if(build_type MATCHES debug)
         list(APPEND CONFIGURE_COMMAND --enable-debug=yes)
     endif()
 
@@ -62,8 +63,8 @@ function(use_bundled_osspuuid SOURCE_DIR BINARY_DIR)
             UPDATE_COMMAND ""
             INSTALL_COMMAND make install
             BUILD_BYPRODUCTS ${OSSPUUID_LIBRARIES_LIST}
-            CONFIGURE_COMMAND ""
-            PATCH_COMMAND ${PC} && ${CONFIGURE_COMMAND}
+            CONFIGURE_COMMAND ${CONFIGURE_COMMAND}
+            PATCH_COMMAND ${PC}
             STEP_TARGETS build
             EXCLUDE_FROM_ALL TRUE
     )


### PR DESCRIPTION
- inverted debug flag: The ossp-uuid lib was built in debug in non-debug minifi builds, and in release mode in debug minifi builds
- pass along isysroot to the autotools build on Mac OS: On my Mac, the isysroot flag needed to be passed to autotools, it didn't autodetect it from the SDKROOT env var.
- separate patch and configure to different steps

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
