### PR TITLE
MINIFICPP-2351 Fix flakiness in MultipartUploadStateStorageTest

### DIFF
--- a/extensions/aws/s3/MultipartUploadStateStorage.cpp
+++ b/extensions/aws/s3/MultipartUploadStateStorage.cpp
@@ -26,7 +26,7 @@ void MultipartUploadStateStorage::storeState(const std::string& bucket, const st
   state_manager_->get(stored_state);
   std::string state_key = bucket + "/" + key;
   stored_state[state_key + ".upload_id"] = state.upload_id;
-  stored_state[state_key + ".upload_time"] = std::to_string(state.upload_time);
+  stored_state[state_key + ".upload_time"] = std::to_string(state.upload_time_ms_since_epoch);
   stored_state[state_key + ".uploaded_parts"] = std::to_string(state.uploaded_parts);
   stored_state[state_key + ".uploaded_size"] = std::to_string(state.uploaded_size);
   stored_state[state_key + ".part_size"] = std::to_string(state.part_size);
@@ -56,7 +56,7 @@ std::optional<MultipartUploadState> MultipartUploadStateStorage::getState(const 
   MultipartUploadState state;
   state.upload_id = state_map[state_key + ".upload_id"];
 
-  core::Property::StringToInt(state_map[state_key + ".upload_time"], state.upload_time);
+  core::Property::StringToInt(state_map[state_key + ".upload_time"], state.upload_time_ms_since_epoch);
   core::Property::StringToInt(state_map[state_key + ".uploaded_parts"], state.uploaded_parts);
   core::Property::StringToInt(state_map[state_key + ".uploaded_size"], state.uploaded_size);
   core::Property::StringToInt(state_map[state_key + ".part_size"], state.part_size);
@@ -105,7 +105,7 @@ void MultipartUploadStateStorage::removeAgedStates(std::chrono::milliseconds mul
 
   std::vector<std::string> keys_to_remove;
   for (const auto& [property_key, value] : state_map) {
-    std::string upload_time_suffix = ".upload_time";
+    static constexpr std::string_view upload_time_suffix = ".upload_time";
     if (!minifi::utils::string::endsWith(property_key, upload_time_suffix)) {
       continue;
     }

--- a/extensions/aws/s3/MultipartUploadStateStorage.cpp
+++ b/extensions/aws/s3/MultipartUploadStateStorage.cpp
@@ -26,7 +26,7 @@ void MultipartUploadStateStorage::storeState(const std::string& bucket, const st
   state_manager_->get(stored_state);
   std::string state_key = bucket + "/" + key;
   stored_state[state_key + ".upload_id"] = state.upload_id;
-  stored_state[state_key + ".upload_time"] = std::to_string(state.upload_time.Millis());
+  stored_state[state_key + ".upload_time"] = std::to_string(state.upload_time);
   stored_state[state_key + ".uploaded_parts"] = std::to_string(state.uploaded_parts);
   stored_state[state_key + ".uploaded_size"] = std::to_string(state.uploaded_size);
   stored_state[state_key + ".part_size"] = std::to_string(state.part_size);
@@ -56,10 +56,7 @@ std::optional<MultipartUploadState> MultipartUploadStateStorage::getState(const 
   MultipartUploadState state;
   state.upload_id = state_map[state_key + ".upload_id"];
 
-  int64_t stored_upload_time = 0;
-  core::Property::StringToInt(state_map[state_key + ".upload_time"], stored_upload_time);
-  state.upload_time = Aws::Utils::DateTime(stored_upload_time);
-
+  core::Property::StringToInt(state_map[state_key + ".upload_time"], state.upload_time);
   core::Property::StringToInt(state_map[state_key + ".uploaded_parts"], state.uploaded_parts);
   core::Property::StringToInt(state_map[state_key + ".uploaded_size"], state.uploaded_size);
   core::Property::StringToInt(state_map[state_key + ".part_size"], state.part_size);

--- a/extensions/aws/s3/MultipartUploadStateStorage.h
+++ b/extensions/aws/s3/MultipartUploadStateStorage.h
@@ -41,13 +41,13 @@ struct MultipartUploadState {
     : upload_id(upload_id),
       part_size(part_size),
       full_size(full_size),
-      upload_time(upload_time.Millis()) {}
+      upload_time_ms_since_epoch(upload_time.Millis()) {}
   std::string upload_id;
   size_t uploaded_parts{};
   uint64_t uploaded_size{};
   uint64_t part_size{};
   uint64_t full_size{};
-  int64_t upload_time;
+  int64_t upload_time_ms_since_epoch;
   std::vector<std::string> uploaded_etags;
 
   bool operator==(const MultipartUploadState&) const = default;

--- a/extensions/aws/s3/MultipartUploadStateStorage.h
+++ b/extensions/aws/s3/MultipartUploadStateStorage.h
@@ -41,13 +41,13 @@ struct MultipartUploadState {
     : upload_id(upload_id),
       part_size(part_size),
       full_size(full_size),
-      upload_time(upload_time) {}
+      upload_time(upload_time.Millis()) {}
   std::string upload_id;
   size_t uploaded_parts{};
   uint64_t uploaded_size{};
   uint64_t part_size{};
   uint64_t full_size{};
-  Aws::Utils::DateTime upload_time;
+  int64_t upload_time;
   std::vector<std::string> uploaded_etags;
 
   bool operator==(const MultipartUploadState&) const = default;

--- a/extensions/aws/tests/MultipartUploadStateStorageTest.cpp
+++ b/extensions/aws/tests/MultipartUploadStateStorageTest.cpp
@@ -142,7 +142,7 @@ TEST_CASE_METHOD(MultipartUploadStateStorageTestFixture, "Remove aged off state"
   state1.uploaded_size = 150_MiB;
   state1.part_size = 50_MiB;
   state1.full_size = 200_MiB;
-  state1.upload_time = Aws::Utils::DateTime(Aws::Utils::DateTime::CurrentTimeMillis()) - std::chrono::minutes(10);
+  state1.upload_time = (Aws::Utils::DateTime::Now() - std::chrono::minutes(10)).Millis();
   state1.uploaded_etags = {"etag1", "etag2", "etag3"};
   upload_storage_->storeState("test_bucket", "key1", state1);
   minifi::aws::s3::MultipartUploadState state2;

--- a/extensions/aws/tests/MultipartUploadStateStorageTest.cpp
+++ b/extensions/aws/tests/MultipartUploadStateStorageTest.cpp
@@ -44,53 +44,33 @@ class MultipartUploadStateStorageTestFixture {
 
 TEST_CASE_METHOD(MultipartUploadStateStorageTestFixture, "Store and get current key state", "[s3StateStorage]") {
   REQUIRE(upload_storage_->getState("test_bucket", "key") == std::nullopt);
-  minifi::aws::s3::MultipartUploadState state;
-  state.upload_id = "id1";
+  minifi::aws::s3::MultipartUploadState state("id1", 50_MiB, 200_MiB, Aws::Utils::DateTime::Now());
   state.uploaded_parts = 2;
   state.uploaded_size = 100_MiB;
-  state.part_size = 50_MiB;
-  state.full_size = 200_MiB;
-  state.upload_time = Aws::Utils::DateTime::CurrentTimeMillis();
   state.uploaded_etags = {"etag1", "etag2"};
   upload_storage_->storeState("test_bucket", "key", state);
   REQUIRE(*upload_storage_->getState("test_bucket", "key") == state);
 }
 
 TEST_CASE_METHOD(MultipartUploadStateStorageTestFixture, "Get key upload state from multiple keys and buckets", "[s3StateStorage]") {
-  minifi::aws::s3::MultipartUploadState state1;
-  state1.upload_id = "id1";
+  minifi::aws::s3::MultipartUploadState state1("id1", 50_MiB, 200_MiB, Aws::Utils::DateTime::Now());
   state1.uploaded_parts = 3;
   state1.uploaded_size = 150_MiB;
-  state1.part_size = 50_MiB;
-  state1.full_size = 200_MiB;
-  state1.upload_time = Aws::Utils::DateTime::CurrentTimeMillis();
   state1.uploaded_etags = {"etag1", "etag2", "etag3"};
   upload_storage_->storeState("old_bucket", "key1", state1);
-  minifi::aws::s3::MultipartUploadState state2;
-  state2.upload_id = "id2";
+  minifi::aws::s3::MultipartUploadState state2("id2", 50_MiB, 200_MiB, Aws::Utils::DateTime::Now());
   state2.uploaded_parts = 2;
   state2.uploaded_size = 100_MiB;
-  state2.part_size = 50_MiB;
-  state2.full_size = 200_MiB;
-  state2.upload_time = Aws::Utils::DateTime::CurrentTimeMillis();
   state2.uploaded_etags = {"etag4", "etag5"};
   upload_storage_->storeState("test_bucket", "key1", state2);
-  minifi::aws::s3::MultipartUploadState state3;
-  state3.upload_id = "id3";
+  minifi::aws::s3::MultipartUploadState state3("id3", 50_MiB, 400_MiB, Aws::Utils::DateTime::Now());
   state3.uploaded_parts = 4;
   state3.uploaded_size = 200_MiB;
-  state3.part_size = 50_MiB;
-  state3.full_size = 400_MiB;
-  state3.upload_time = Aws::Utils::DateTime::CurrentTimeMillis();
   state3.uploaded_etags = {"etag6", "etag7", "etag9", "etag8"};
   upload_storage_->storeState("test_bucket", "key2", state3);
-  minifi::aws::s3::MultipartUploadState state4;
-  state2.upload_id = "id2";
+  minifi::aws::s3::MultipartUploadState state4("id2", 50_MiB, 200_MiB, Aws::Utils::DateTime::Now());
   state2.uploaded_parts = 3;
   state2.uploaded_size = 150_MiB;
-  state2.part_size = 50_MiB;
-  state2.full_size = 200_MiB;
-  state2.upload_time = Aws::Utils::DateTime::CurrentTimeMillis();
   state2.uploaded_etags = {"etag4", "etag5", "etag10"};
   upload_storage_->storeState("test_bucket", "key1", state4);
   REQUIRE(*upload_storage_->getState("test_bucket", "key1") == state4);
@@ -99,31 +79,19 @@ TEST_CASE_METHOD(MultipartUploadStateStorageTestFixture, "Get key upload state f
 }
 
 TEST_CASE_METHOD(MultipartUploadStateStorageTestFixture, "Remove state", "[s3StateStorage]") {
-  minifi::aws::s3::MultipartUploadState state1;
-  state1.upload_id = "id1";
+  minifi::aws::s3::MultipartUploadState state1("id1", 50_MiB, 200_MiB, Aws::Utils::DateTime::Now());
   state1.uploaded_parts = 3;
   state1.uploaded_size = 150_MiB;
-  state1.part_size = 50_MiB;
-  state1.full_size = 200_MiB;
-  state1.upload_time = Aws::Utils::DateTime::CurrentTimeMillis();
   state1.uploaded_etags = {"etag1", "etag2", "etag3"};
   upload_storage_->storeState("old_bucket", "key1", state1);
-  minifi::aws::s3::MultipartUploadState state2;
-  state2.upload_id = "id2";
+  minifi::aws::s3::MultipartUploadState state2("id2", 50_MiB, 200_MiB, Aws::Utils::DateTime::Now());
   state2.uploaded_parts = 2;
   state2.uploaded_size = 100_MiB;
-  state2.part_size = 50_MiB;
-  state2.full_size = 200_MiB;
-  state2.upload_time = Aws::Utils::DateTime::CurrentTimeMillis();
   state2.uploaded_etags = {"etag4", "etag5"};
   upload_storage_->storeState("test_bucket", "key1", state2);
-  minifi::aws::s3::MultipartUploadState state3;
-  state3.upload_id = "id3";
+  minifi::aws::s3::MultipartUploadState state3("id3", 50_MiB, 400_MiB, Aws::Utils::DateTime::Now());
   state3.uploaded_parts = 4;
   state3.uploaded_size = 200_MiB;
-  state3.part_size = 50_MiB;
-  state3.full_size = 400_MiB;
-  state3.upload_time = Aws::Utils::DateTime::CurrentTimeMillis();
   state3.uploaded_etags = {"etag6", "etag7", "etag9", "etag8"};
   upload_storage_->storeState("test_bucket", "key2", state3);
   REQUIRE(*upload_storage_->getState("old_bucket", "key1") == state1);
@@ -136,25 +104,18 @@ TEST_CASE_METHOD(MultipartUploadStateStorageTestFixture, "Remove state", "[s3Sta
 }
 
 TEST_CASE_METHOD(MultipartUploadStateStorageTestFixture, "Remove aged off state", "[s3StateStorage]") {
-  minifi::aws::s3::MultipartUploadState state1;
-  state1.upload_id = "id1";
+  using namespace std::literals::chrono_literals;
+  minifi::aws::s3::MultipartUploadState state1("id1", 50_MiB, 200_MiB, Aws::Utils::DateTime::Now() - 10min);
   state1.uploaded_parts = 3;
   state1.uploaded_size = 150_MiB;
-  state1.part_size = 50_MiB;
-  state1.full_size = 200_MiB;
-  state1.upload_time = (Aws::Utils::DateTime::Now() - std::chrono::minutes(10)).Millis();
   state1.uploaded_etags = {"etag1", "etag2", "etag3"};
   upload_storage_->storeState("test_bucket", "key1", state1);
-  minifi::aws::s3::MultipartUploadState state2;
-  state2.upload_id = "id2";
+  minifi::aws::s3::MultipartUploadState state2("id2", 50_MiB, 200_MiB, Aws::Utils::DateTime::Now());
   state2.uploaded_parts = 2;
   state2.uploaded_size = 100_MiB;
-  state2.part_size = 50_MiB;
-  state2.full_size = 200_MiB;
-  state2.upload_time = Aws::Utils::DateTime::CurrentTimeMillis();
   state2.uploaded_etags = {"etag4", "etag5"};
   upload_storage_->storeState("test_bucket", "key2", state2);
-  upload_storage_->removeAgedStates(std::chrono::minutes(10));
+  upload_storage_->removeAgedStates(10min);
   REQUIRE(upload_storage_->getState("test_bucket", "key1") == std::nullopt);
   REQUIRE(upload_storage_->getState("test_bucket", "key2") == state2);
 }

--- a/extensions/aws/tests/MultipartUploadStateStorageTest.cpp
+++ b/extensions/aws/tests/MultipartUploadStateStorageTest.cpp
@@ -154,7 +154,7 @@ TEST_CASE_METHOD(MultipartUploadStateStorageTestFixture, "Remove aged off state"
   state2.upload_time = Aws::Utils::DateTime::CurrentTimeMillis();
   state2.uploaded_etags = {"etag4", "etag5"};
   upload_storage_->storeState("test_bucket", "key2", state2);
-  upload_storage_->removeAgedStates(std::chrono::milliseconds(10));
+  upload_storage_->removeAgedStates(std::chrono::minutes(10));
   REQUIRE(upload_storage_->getState("test_bucket", "key1") == std::nullopt);
   REQUIRE(upload_storage_->getState("test_bucket", "key2") == state2);
 }


### PR DESCRIPTION
Fix a typo (10 ms -> 10 minutes) in MultipartUploadStateStorageTest which caused occasional test failures on underpowered or overloaded machines.

Also added some refactoring: 165078c93a68418922aa09c85a1b39293f4f9df1 and ceae032225dd342d1d3bffb5c7b378ba587daf2f.

https://issues.apache.org/jira/browse/MINIFICPP-2351

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
