### PR TITLE
MINIFICPP-2389 Fix auto-terminated relationships in python processors

### DIFF
--- a/extensions/python/ExecutePythonProcessor.cpp
+++ b/extensions/python/ExecutePythonProcessor.cpp
@@ -70,7 +70,7 @@ void ExecutePythonProcessor::initalizeThroughScriptEngine() {
 }
 
 void ExecutePythonProcessor::onScheduleSharedPtr(const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSessionFactory>& /*sessionFactory*/) {
-  setAutoTerminatedRelationships(std::vector<core::Relationship>{Original});
+  addAutoTerminatedRelationship(Original);
   if (!processor_initialized_) {
     loadScript();
     python_script_engine_ = createScriptEngine();

--- a/libminifi/include/core/Connectable.h
+++ b/libminifi/include/core/Connectable.h
@@ -62,6 +62,7 @@ class Connectable : public CoreComponent {
 
   std::vector<Relationship> getSupportedRelationships() const;
 
+  void addAutoTerminatedRelationship(const core::Relationship& relationship);
   void setAutoTerminatedRelationships(std::span<const core::Relationship> relationships);
 
   bool isAutoTerminated(const Relationship &relationship);

--- a/libminifi/src/core/Connectable.cpp
+++ b/libminifi/src/core/Connectable.cpp
@@ -75,6 +75,17 @@ bool Connectable::isSupportedRelationship(const core::Relationship &relationship
   return relationships_.contains(relationship.getName());
 }
 
+void Connectable::addAutoTerminatedRelationship(const core::Relationship& relationship) {
+  if (isRunning()) {
+    logger_->log_warn("Can not add processor auto terminated relationship while the process {} is running", name_);
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(relationship_mutex_);
+
+  auto_terminated_relationships_[relationship.getName()] = relationship;
+}
+
 void Connectable::setAutoTerminatedRelationships(std::span<const core::Relationship> relationships) {
   if (isRunning()) {
     logger_->log_warn("Can not set processor auto terminated relationship while the process {} is running", name_);

--- a/libminifi/src/core/Connectable.cpp
+++ b/libminifi/src/core/Connectable.cpp
@@ -59,6 +59,7 @@ void Connectable::setSupportedRelationships(std::span<const core::RelationshipDe
 
 std::vector<Relationship> Connectable::getSupportedRelationships() const {
   std::vector<Relationship> relationships;
+  relationships.reserve(relationships_.size());
   for (auto const &item : relationships_) {
     relationships.push_back(item.second);
   }


### PR DESCRIPTION
The original relationship in python processors was added with the NiFi python processor support and was set to be auto terminated by default to be in sync with NiFi's implementation. Unfortunately setting the relationship to be auto-terminated clears every previously auto-terminated relationship, so the auto-terminated relationships set in the flow configuration are removed from the list.

https://issues.apache.org/jira/browse/MINIFICPP-2389

------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
