### PR TITLE
MINIFICPP-2392 Remove duplicate controller properties from encrypt-config

### DIFF
--- a/encrypt-config/FlowConfigEncryptor.cpp
+++ b/encrypt-config/FlowConfigEncryptor.cpp
@@ -77,10 +77,15 @@ std::vector<SensitiveProperty> listSensitiveProperties(const minifi::core::Proce
     }
   }
 
+  std::unordered_set<minifi::utils::Identifier> processed_controller_services;
   for (const auto* controller_service_node : process_group.getAllControllerServices()) {
     gsl_Expects(controller_service_node);
     const auto* controller_service = controller_service_node->getControllerServiceImplementation();
     gsl_Expects(controller_service);
+    if (processed_controller_services.contains(controller_service->getUUID())) {
+      continue;
+    }
+    processed_controller_services.insert(controller_service->getUUID());
     for (const auto& [_, property] : controller_service->getProperties()) {
       if (property.isSensitive()) {
         sensitive_properties.push_back(SensitiveProperty{


### PR DESCRIPTION
This removes the duplicate controller properties when using encrypt-config in interactive mode for flow-config encryption.

https://issues.apache.org/jira/browse/MINIFICPP-2392

-----------------------------

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
