### PR TITLE
MINIFICPP-2375 Do not throw in lua ExecuteScript if onTrigger is missing

### DIFF
--- a/extensions/lua/LuaScriptEngine.h
+++ b/extensions/lua/LuaScriptEngine.h
@@ -52,8 +52,9 @@ class LuaScriptEngine {
   void call(const std::string& fn_name, Args&& ...args) {
     sol::protected_function_result function_result{};
     try {
-      sol::protected_function fn = lua_[fn_name.c_str()];
-      function_result = fn(convert(args)...);
+      if (sol::protected_function fn = lua_[fn_name.c_str()]) {
+        function_result = fn(convert(args)...);
+      }
     } catch (const std::exception& e) {
       throw LuaScriptException(e.what());
     }

--- a/extensions/lua/tests/TestExecuteScriptProcessorWithLuaScript.cpp
+++ b/extensions/lua/tests/TestExecuteScriptProcessorWithLuaScript.cpp
@@ -30,6 +30,16 @@
 
 namespace org::apache::nifi::minifi::processors::test {
 
+TEST_CASE("Lua: hello world") {
+  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
+  minifi::test::SingleProcessorTestController controller{execute_script};
+
+  execute_script->setProperty(ExecuteScript::ScriptEngine, "lua");
+  execute_script->setProperty(ExecuteScript::ScriptBody, R"(print("Hello world!"))");
+
+  CHECK_NOTHROW(controller.trigger());
+}
+
 TEST_CASE("Script engine is not set", "[executescriptMisconfiguration]") {
   TestController test_controller;
   auto plan = test_controller.createPlan();

--- a/extensions/python/tests/TestExecuteScriptProcessorWithPythonScript.cpp
+++ b/extensions/python/tests/TestExecuteScriptProcessorWithPythonScript.cpp
@@ -29,6 +29,16 @@
 
 namespace org::apache::nifi::minifi::processors::test {
 
+TEST_CASE("Python: hello world") {
+  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
+  minifi::test::SingleProcessorTestController controller{execute_script};
+
+  execute_script->setProperty(ExecuteScript::ScriptEngine, "python");
+  execute_script->setProperty(ExecuteScript::ScriptBody, R"(print("Hello world!"))");
+
+  CHECK_NOTHROW(controller.trigger());
+}
+
 TEST_CASE("Script engine is not set", "[executescriptMisconfiguration]") {
   TestController test_controller;
   auto plan = test_controller.createPlan();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-2375

In the Python script engine, we allow simple scripts without an onTrigger function, which runs the code without processing any flow files. In Lua, such scripts used to throw an "attempt to call a nil value" exception. After this change, the Lua script engine also allows simple scripts without an onTrigger function.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
