### PR TITLE
MINIFICPP-2408 change Lua mirror to GitHub

### DIFF
--- a/cmake/Lua.cmake
+++ b/cmake/Lua.cmake
@@ -18,20 +18,26 @@
 include(FetchContent)
 
 FetchContent_Declare(lua
-    URL         "https://www.lua.org/ftp/lua-5.4.6.tar.gz"
-    URL_HASH    "SHA256=7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88"
+    URL         "https://github.com/lua/lua/archive/refs/tags/v5.4.6.tar.gz"
+    URL_HASH    "SHA256=11c228cf9b9564d880b394f8069ad829d01e39756567f79c347a6b89fed44771"
 )
 
 FetchContent_GetProperties(lua)
 if(NOT lua_POPULATED)
     FetchContent_Populate(lua)
+    # lua.org tarball:
+    #set(lua_tarball_src_path "src/")
+    # github.com tarball:
+    set(lua_tarball_src_path "")
 
-    file(GLOB LUA_SOURCES "${lua_SOURCE_DIR}/src/*.c")
+    file(GLOB LUA_SOURCES "${lua_SOURCE_DIR}/${lua_tarball_src_path}*.c")
+    # the github tarball contains onelua.c, which is a concatenated version of all source files, we don't need it
+    list(REMOVE_ITEM LUA_SOURCES "${lua_SOURCE_DIR}/${lua_tarball_src_path}onelua.c")
     add_library(lua STATIC ${LUA_SOURCES})
 
     file(MAKE_DIRECTORY "${lua_BINARY_DIR}/include")
-    foreach(HEADER lua.h luaconf.h lualib.h lauxlib.h lua.hpp)
-        file(COPY "${lua_SOURCE_DIR}/src/${HEADER}" DESTINATION "${lua_BINARY_DIR}/include")
+    foreach(HEADER lua.h luaconf.h lualib.h lauxlib.h)
+        file(COPY "${lua_SOURCE_DIR}/${lua_tarball_src_path}${HEADER}" DESTINATION "${lua_BINARY_DIR}/include")
     endforeach()
     set(LUA_INCLUDE_DIR "${lua_BINARY_DIR}/include" CACHE STRING "" FORCE)
 endif()


### PR DESCRIPTION
Lua.org is down, and we might as well change to the GitHub release tarball, because other packages already depend on GitHub being available.

I removed lua.hpp, because it's not present in the GitHub release tarball, but it seems to be unused.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
