### PR TITLE
MINIFICPP-2405 Fix test failure due to too low memory usage

### DIFF
--- a/libminifi/test/unit/MemoryUsageTest.cpp
+++ b/libminifi/test/unit/MemoryUsageTest.cpp
@@ -36,7 +36,9 @@ TEST_CASE("Test Physical memory usage", "[testphysicalmemoryusage]") {
   std::mt19937 gen(std::random_device{}());
   std::uniform_int_distribution dist(0, 255);
   std::vector<uint8_t> large_random_vector(30'000'000);
-  std::generate(begin(large_random_vector), end(large_random_vector), [&]() { return dist(gen); });
+  for (size_t i = 0; i < 10; ++i) {
+    large_random_vector[dist(gen) * 100'000 + dist(gen) * 1000 + dist(gen)] = dist(gen);
+  }
 
   const auto ram_usage_by_process = utils::OsUtils::getCurrentProcessPhysicalMemoryUsage();
   const auto ram_usage_by_system = utils::OsUtils::getSystemPhysicalMemoryUsage();

--- a/libminifi/test/unit/MemoryUsageTest.cpp
+++ b/libminifi/test/unit/MemoryUsageTest.cpp
@@ -20,7 +20,8 @@
 // as we measure the absolute memory usage that would fail this test
 #define EXTENSION_LIST ""  // NOLINT(cppcoreguidelines-macro-usage)
 
-#include <cstring>
+#include <iostream>
+#include <numeric>
 #include <random>
 
 #include "utils/gsl.h"


### PR DESCRIPTION
`MemoryUsageTest` has started failing on MacOS CI (AppleClang 15.0.0.15000040) because a vector containing 30,000,000 zero chars occupies less than 30,000,000 bytes in memory. Filling the vector with random numbers seems to solve the "issue".

https://issues.apache.org/jira/browse/MINIFICPP-2405

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
