### PR TITLE
MINIFICPP-2419 Fix splunk docker tests

### DIFF
--- a/docker/test/integration/cluster/DockerTestCluster.py
+++ b/docker/test/integration/cluster/DockerTestCluster.py
@@ -228,10 +228,6 @@ class DockerTestCluster:
         container_name = self.container_store.get_container_name_with_postfix(container_name)
         return self.splunk_checker.enable_splunk_hec_ssl(container_name, splunk_cert_pem, splunk_key_pem, root_ca_cert_pem)
 
-    def get_splunk_token(self, container_name, hec_name):
-        container_name = self.container_store.get_container_name_with_postfix(container_name)
-        return self.splunk_checker.get_splunk_token(container_name, hec_name)
-
     def check_google_cloud_storage(self, gcs_container_name, content):
         gcs_container_name = self.container_store.get_container_name_with_postfix(gcs_container_name)
         return self.gcs_checker.check_google_cloud_storage(gcs_container_name, content)

--- a/docker/test/integration/cluster/checkers/SplunkChecker.py
+++ b/docker/test/integration/cluster/checkers/SplunkChecker.py
@@ -58,7 +58,7 @@ class SplunkChecker:
     def enable_splunk_hec_indexer(self, container_name, hec_name):
         (code, _) = self.container_communicator.execute_command(container_name, ["sudo",
                                                                                  "/opt/splunk/bin/splunk", "http-event-collector",
-                                                                                 "create", hec_name,
+                                                                                 "update", hec_name,
                                                                                  "-uri", "https://localhost:8089",
                                                                                  "-use-ack", "1",
                                                                                  "-disabled", "0",
@@ -78,22 +78,3 @@ class SplunkChecker:
                                                                                  "-require-client-cert", "1",
                                                                                  "-auth", "admin:splunkadmin"])
         return code == 0
-
-    def get_splunk_token(self, container_name, hec_name):
-        (code, output) = self.container_communicator.execute_command(container_name, ["sudo",
-                                                                                      "/opt/splunk/bin/splunk", "http-event-collector",
-                                                                                      "list",
-                                                                                      "-uri", "https://localhost:8089",
-                                                                                      "-auth", "admin:splunkadmin"])
-        if code != 0:
-            return None
-        output_lines = output.splitlines()
-        hec_name_found = False
-        for output_line in output_lines:
-            if hec_name_found:
-                if "token=" in output_line:
-                    return "Splunk " + output_line.split("=")[1].strip()
-            else:
-                if hec_name in output_line:
-                    hec_name_found = True
-        return None

--- a/docker/test/integration/features/MiNiFi_integration_test_driver.py
+++ b/docker/test/integration/features/MiNiFi_integration_test_driver.py
@@ -116,12 +116,6 @@ class MiNiFi_integration_test:
         assert self.cluster.wait_for_container_startup_to_finish('splunk')
         assert self.cluster.enable_splunk_hec_indexer('splunk', 'splunk_hec_token')
 
-    def get_splunk_token(self):
-        token = self.cluster.get_splunk_token('splunk', 'splunk_hec_token')
-        if token is None:
-            raise Exception("Failed to get Splunk token")
-        return token
-
     def start_elasticsearch(self, context):
         self.cluster.acquire_container(context=context, name='elasticsearch', engine='elasticsearch')
         self.cluster.deploy_container('elasticsearch')

--- a/docker/test/integration/features/splunk.feature
+++ b/docker/test/integration/features/splunk.feature
@@ -25,9 +25,7 @@ Feature: Sending data to Splunk HEC using PutSplunkHTTP
     And a GetFile processor with the "Input Directory" property set to "/tmp/input"
     And a file with the content "foobar" is present in "/tmp/input"
     And a PutSplunkHTTP processor set up to communicate with the Splunk HEC instance
-    And the Splunk token property is set for the PutSplunkHTTP processor
     And a QuerySplunkIndexingStatus processor set up to communicate with the Splunk HEC Instance
-    And the Splunk token property is set for the QuerySplunkIndexingStatus processor
     And the "Splunk Request Channel" properties of the PutSplunkHTTP and QuerySplunkIndexingStatus processors are set to the same random guid
     And the "Source" property of the PutSplunkHTTP processor is set to "my-source"
     And the "Source Type" property of the PutSplunkHTTP processor is set to "my-source-type"
@@ -50,9 +48,7 @@ Feature: Sending data to Splunk HEC using PutSplunkHTTP
     And a GetFile processor with the "Input Directory" property set to "/tmp/input"
     And a file with the content "foobar" is present in "/tmp/input"
     And a PutSplunkHTTP processor set up to communicate with the Splunk HEC instance
-    And the Splunk token property is set for the PutSplunkHTTP processor
     And a QuerySplunkIndexingStatus processor set up to communicate with the Splunk HEC Instance
-    And the Splunk token property is set for the QuerySplunkIndexingStatus processor
     And the "Splunk Request Channel" properties of the PutSplunkHTTP and QuerySplunkIndexingStatus processors are set to the same random guid
     And the "Source" property of the PutSplunkHTTP processor is set to "my-source"
     And the "Source Type" property of the PutSplunkHTTP processor is set to "my-source-type"

--- a/docker/test/integration/features/steps/steps.py
+++ b/docker/test/integration/features/steps/steps.py
@@ -527,12 +527,6 @@ def step_impl(context):
     context.test.start_splunk(context)
 
 
-@given("the Splunk token property is set for the {processor_name} processor")
-def step_impl(context, processor_name):
-    token = context.test.get_splunk_token()
-    context.execute_steps(f"given the \"Token\" property of the {processor_name} processor is set to \"{token}\"")
-
-
 # TCP client
 @given('a TCP client is set up to send a test TCP message to minifi')
 def step_impl(context):

--- a/docker/test/integration/minifi/processors/PutSplunkHTTP.py
+++ b/docker/test/integration/minifi/processors/PutSplunkHTTP.py
@@ -25,7 +25,7 @@ class PutSplunkHTTP(Processor):
             properties={
                 'Hostname': 'splunk',
                 'Port': '8088',
-                'Token': 'Splunk 176fae97-f59d-4f08-939a-aa6a543f2485'
+                'Token': 'Splunk 176fae97-f59d-4f08-939a-aa6a543f2485'  # Token of the default splunk_hec_token HTTP Event Collector in the Splunk container image
             },
             auto_terminate=['success', 'failure'],
             schedule=schedule)

--- a/docker/test/integration/minifi/processors/PutSplunkHTTP.py
+++ b/docker/test/integration/minifi/processors/PutSplunkHTTP.py
@@ -24,7 +24,8 @@ class PutSplunkHTTP(Processor):
             clazz='PutSplunkHTTP',
             properties={
                 'Hostname': 'splunk',
-                'Port': '8088'
+                'Port': '8088',
+                'Token': 'Splunk 176fae97-f59d-4f08-939a-aa6a543f2485'
             },
             auto_terminate=['success', 'failure'],
             schedule=schedule)

--- a/docker/test/integration/minifi/processors/QuerySplunkIndexingStatus.py
+++ b/docker/test/integration/minifi/processors/QuerySplunkIndexingStatus.py
@@ -25,7 +25,7 @@ class QuerySplunkIndexingStatus(Processor):
             properties={
                 'Hostname': 'splunk',
                 'Port': '8088',
-                'Token': 'Splunk 176fae97-f59d-4f08-939a-aa6a543f2485'
+                'Token': 'Splunk 176fae97-f59d-4f08-939a-aa6a543f2485'  # Token of the default splunk_hec_token HTTP Event Collector in the Splunk container image
             },
             auto_terminate=['acknowledged', 'unacknowledged', 'undetermined', 'failure'],
             schedule=schedule)

--- a/docker/test/integration/minifi/processors/QuerySplunkIndexingStatus.py
+++ b/docker/test/integration/minifi/processors/QuerySplunkIndexingStatus.py
@@ -24,7 +24,8 @@ class QuerySplunkIndexingStatus(Processor):
             clazz='QuerySplunkIndexingStatus',
             properties={
                 'Hostname': 'splunk',
-                'Port': '8088'
+                'Port': '8088',
+                'Token': 'Splunk 176fae97-f59d-4f08-939a-aa6a543f2485'
             },
             auto_terminate=['acknowledged', 'unacknowledged', 'undetermined', 'failure'],
             schedule=schedule)

--- a/docker/test/integration/resources/splunk-hec/Dockerfile
+++ b/docker/test/integration/resources/splunk-hec/Dockerfile
@@ -1,2 +1,2 @@
-FROM splunk/splunk:9.0
+FROM splunk/splunk:9.2.1-patch2
 ADD conf/default.yml /tmp/defaults/default.yml


### PR DESCRIPTION
The `splunk_hec_token` was readded in the new image update, which made the previous fix of creating our own hec token fail. The previous change was reverted and the splunk image version updated to the current specific version which should not change in the future.

https://issues.apache.org/jira/browse/MINIFICPP-2419

-----------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
