### PR TITLE
MINIFICPP-2426 Update the URL for librdkafka on github

### DIFF
--- a/cmake/BundledLibRdKafka.cmake
+++ b/cmake/BundledLibRdKafka.cmake
@@ -43,7 +43,7 @@ function(use_bundled_librdkafka SOURCE_DIR BINARY_DIR)
     # Build project
     ExternalProject_Add(
             kafka-external
-            URL "https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz"
+            URL "https://github.com/confluentinc/librdkafka/archive/v1.6.0.tar.gz"
             URL_HASH "SHA256=3130cbd391ef683dc9acf9f83fe82ff93b8730a1a34d0518e93c250929be9f6b"
             LIST_SEPARATOR % # This is needed for passing semicolon-separated lists
             CMAKE_ARGS ${LIBRDKAFKA_CMAKE_ARGS}


### PR DESCRIPTION
Librdkafka has been moved from user edenhill to user confluentinc on github.  At the moment, the edenhill URL still works and gets forwarded to confluentinc, but the forwarding may stop working at some point.

https://issues.apache.org/jira/browse/MINIFICPP-2426

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
