### PR TITLE
MINIFICPP-2377 Support process group level controller services

### DIFF
--- a/extensions/aws/processors/DeleteS3Object.h
+++ b/extensions/aws/processors/DeleteS3Object.h
@@ -31,7 +31,7 @@
 
 
 template<typename T>
-class S3TestsFixture;
+class FlowProcessorS3TestsFixture;
 
 namespace org::apache::nifi::minifi::aws::processors {
 
@@ -74,7 +74,7 @@ class DeleteS3Object : public S3Processor {
   void onTrigger(core::ProcessContext& context, core::ProcessSession& session) override;
 
  private:
-  friend class ::S3TestsFixture<DeleteS3Object>;
+  friend class ::FlowProcessorS3TestsFixture<DeleteS3Object>;
 
   explicit DeleteS3Object(std::string_view name, const minifi::utils::Identifier& uuid, std::unique_ptr<aws::s3::S3RequestSender> s3_request_sender)
     : S3Processor(name, uuid, core::logging::LoggerFactory<DeleteS3Object>::getLogger(uuid), std::move(s3_request_sender)) {

--- a/extensions/aws/processors/FetchS3Object.h
+++ b/extensions/aws/processors/FetchS3Object.h
@@ -33,7 +33,7 @@
 #include "utils/GeneralUtils.h"
 
 template<typename T>
-class S3TestsFixture;
+class FlowProcessorS3TestsFixture;
 
 namespace org::apache::nifi::minifi::aws::processors {
 
@@ -85,7 +85,7 @@ class FetchS3Object : public S3Processor {
   void onTrigger(core::ProcessContext& context, core::ProcessSession& session) override;
 
  private:
-  friend class ::S3TestsFixture<FetchS3Object>;
+  friend class ::FlowProcessorS3TestsFixture<FetchS3Object>;
 
   explicit FetchS3Object(const std::string& name, const minifi::utils::Identifier& uuid, std::unique_ptr<aws::s3::S3RequestSender> s3_request_sender)
     : S3Processor(name, uuid, core::logging::LoggerFactory<FetchS3Object>::getLogger(uuid), std::move(s3_request_sender)) {

--- a/extensions/aws/processors/PutS3Object.h
+++ b/extensions/aws/processors/PutS3Object.h
@@ -38,7 +38,7 @@
 #include "utils/Id.h"
 
 template<typename T>
-class S3TestsFixture;
+class FlowProcessorS3TestsFixture;
 
 namespace org::apache::nifi::minifi::aws::processors {
 
@@ -181,7 +181,7 @@ class PutS3Object : public S3Processor {
   static constexpr uint64_t MIN_PART_SIZE = 5_MiB;
   static constexpr uint64_t MAX_UPLOAD_SIZE = 5_GiB;
 
-  friend class ::S3TestsFixture<PutS3Object>;
+  friend class ::FlowProcessorS3TestsFixture<PutS3Object>;
 
   explicit PutS3Object(const std::string& name, const minifi::utils::Identifier& uuid, std::unique_ptr<aws::s3::S3RequestSender> s3_request_sender)
     : S3Processor(name, uuid, core::logging::LoggerFactory<PutS3Object>::getLogger(uuid), std::move(s3_request_sender)) {

--- a/extensions/aws/processors/S3Processor.cpp
+++ b/extensions/aws/processors/S3Processor.cpp
@@ -48,7 +48,7 @@ std::optional<Aws::Auth::AWSCredentials> S3Processor::getAWSCredentialsFromContr
     return std::nullopt;
   }
 
-  std::shared_ptr<core::controller::ControllerService> service = context.getControllerService(service_name);
+  std::shared_ptr<core::controller::ControllerService> service = context.getControllerService(service_name, getUUID());
   if (!service) {
     logger_->log_error("AWS credentials service with name: '{}' could not be found", service_name);
     return std::nullopt;
@@ -121,7 +121,7 @@ void S3Processor::onSchedule(core::ProcessContext& context, core::ProcessSession
 
   if (auto communications_timeout = context.getProperty<core::TimePeriodValue>(CommunicationsTimeout)) {
     logger_->log_debug("S3Processor: Communications Timeout {}", communications_timeout->getMilliseconds());
-    client_config_->connectTimeoutMs = gsl::narrow<long>(communications_timeout->getMilliseconds().count());  // NOLINT(runtime/int)
+    client_config_->connectTimeoutMs = gsl::narrow<long>(communications_timeout->getMilliseconds().count());  // NOLINT(runtime/int,google-runtime-int)
   } else {
     throw Exception(PROCESS_SCHEDULE_EXCEPTION, "Communications Timeout missing or invalid");
   }

--- a/extensions/aws/tests/PutS3ObjectTests.cpp
+++ b/extensions/aws/tests/PutS3ObjectTests.cpp
@@ -43,7 +43,7 @@ class PutS3ObjectTestsFixture : public FlowProcessorS3TestsFixture<minifi::aws::
 
 class PutS3ObjectLimitChanged : public minifi::aws::processors::PutS3Object {
  protected:
-  friend class ::S3TestsFixture<PutS3ObjectLimitChanged>;
+  friend class ::FlowProcessorS3TestsFixture<PutS3ObjectLimitChanged>;
 
   explicit PutS3ObjectLimitChanged(const std::string& name, const minifi::utils::Identifier& uuid, std::unique_ptr<minifi::aws::s3::S3RequestSender> s3_request_sender)
     : PutS3Object(name, uuid, std::move(s3_request_sender)) {

--- a/extensions/aws/tests/S3TestsFixture.h
+++ b/extensions/aws/tests/S3TestsFixture.h
@@ -133,8 +133,8 @@ class FlowProcessorS3TestsFixture : public S3TestsFixture<T> {
     LogTestController::getInstance().setTrace<minifi::processors::GetFile>();
     LogTestController::getInstance().setDebug<minifi::processors::UpdateAttribute>();
 
-    this->mock_s3_request_sender_ptr = new MockS3RequestSender();
-    std::unique_ptr<minifi::aws::s3::S3RequestSender> mock_s3_request_sender(this->mock_s3_request_sender_ptr);
+    auto mock_s3_request_sender = std::make_unique<MockS3RequestSender>();
+    this->mock_s3_request_sender_ptr = mock_s3_request_sender.get();
     auto s3_processor_unique_ptr = std::unique_ptr<T>(new T("S3Processor", utils::Identifier(), std::move(mock_s3_request_sender)));
     this->s3_processor = s3_processor_unique_ptr.get();
 
@@ -195,8 +195,8 @@ template<typename T>
 class FlowProducerS3TestsFixture : public S3TestsFixture<T> {
  public:
   FlowProducerS3TestsFixture() {
-    this->mock_s3_request_sender_ptr = new MockS3RequestSender();
-    std::unique_ptr<minifi::aws::s3::S3RequestSender> mock_s3_request_sender(this->mock_s3_request_sender_ptr);
+    auto mock_s3_request_sender = std::make_unique<MockS3RequestSender>();
+    this->mock_s3_request_sender_ptr = mock_s3_request_sender.get();
     auto s3_processor_unique_ptr = std::unique_ptr<T>(new T("S3Processor", utils::Identifier(), std::move(mock_s3_request_sender)));
     this->s3_processor = s3_processor_unique_ptr.get();
 

--- a/extensions/azure/processors/AzureStorageProcessorBase.cpp
+++ b/extensions/azure/processors/AzureStorageProcessorBase.cpp
@@ -35,7 +35,7 @@ std::tuple<AzureStorageProcessorBase::GetCredentialsFromControllerResult, std::o
     return std::make_tuple(GetCredentialsFromControllerResult::CONTROLLER_NAME_EMPTY, std::nullopt);
   }
 
-  std::shared_ptr<core::controller::ControllerService> service = context.getControllerService(service_name);
+  std::shared_ptr<core::controller::ControllerService> service = context.getControllerService(service_name, getUUID());
   if (nullptr == service) {
     logger_->log_error("Azure Storage credentials service with name: '{}' could not be found", service_name);
     return std::make_tuple(GetCredentialsFromControllerResult::CONTROLLER_NAME_INVALID, std::nullopt);

--- a/extensions/azure/tests/ListAzureBlobStorageTests.cpp
+++ b/extensions/azure/tests/ListAzureBlobStorageTests.cpp
@@ -45,9 +45,10 @@ class ListAzureBlobStorageTestsFixture {
     plan_ = test_controller_.createPlan();
     auto mock_blob_storage = std::make_unique<MockBlobStorage>();
     mock_blob_storage_ptr_ = mock_blob_storage.get();
-    list_azure_blob_storage_ = std::make_shared<minifi::azure::processors::ListAzureBlobStorage>("ListAzureBlobStorage", std::move(mock_blob_storage));
+    auto list_azure_blob_storage_unique_ptr = std::make_unique<minifi::azure::processors::ListAzureBlobStorage>("ListAzureBlobStorage", std::move(mock_blob_storage));
+    list_azure_blob_storage_ = list_azure_blob_storage_unique_ptr.get();
 
-    plan_->addProcessor(list_azure_blob_storage_, "ListAzureBlobStorage", { {"success", "d"} });
+    plan_->addProcessor(std::move(list_azure_blob_storage_unique_ptr), "ListAzureBlobStorage", { {"success", "d"} });
     auto logattribute = plan_->addProcessor("LogAttribute", "LogAttribute", { {"success", "d"} }, true);
     plan_->setProperty(logattribute, minifi::processors::LogAttribute::FlowFilesToLog, "0");
 
@@ -72,7 +73,7 @@ class ListAzureBlobStorageTestsFixture {
   TestController test_controller_;
   std::shared_ptr<TestPlan> plan_;
   MockBlobStorage* mock_blob_storage_ptr_;
-  std::shared_ptr<core::Processor> list_azure_blob_storage_;
+  core::Processor* list_azure_blob_storage_;
   std::shared_ptr<core::controller::ControllerServiceNode> azure_storage_cred_service_;
 };
 

--- a/extensions/azure/tests/ListAzureDataLakeStorageTests.cpp
+++ b/extensions/azure/tests/ListAzureDataLakeStorageTests.cpp
@@ -42,10 +42,11 @@ class ListAzureDataLakeStorageTestsFixture {
     plan_ = test_controller_.createPlan();
     auto mock_data_lake_storage_client = std::make_unique<MockDataLakeStorageClient>();
     mock_data_lake_storage_client_ptr_ = mock_data_lake_storage_client.get();
-    list_azure_data_lake_storage_ = std::shared_ptr<minifi::azure::processors::ListAzureDataLakeStorage>(
+    auto list_azure_data_lake_storage_unique_ptr = std::unique_ptr<minifi::azure::processors::ListAzureDataLakeStorage>(
       new minifi::azure::processors::ListAzureDataLakeStorage("ListAzureDataLakeStorage", utils::Identifier(), std::move(mock_data_lake_storage_client)));
+    list_azure_data_lake_storage_ = list_azure_data_lake_storage_unique_ptr.get();
 
-    plan_->addProcessor(list_azure_data_lake_storage_, "ListAzureDataLakeStorage", { {"success", "d"} });
+    plan_->addProcessor(std::move(list_azure_data_lake_storage_unique_ptr), "ListAzureDataLakeStorage", { {"success", "d"} });
     auto logattribute = plan_->addProcessor("LogAttribute", "LogAttribute", { {"success", "d"} }, true);
     plan_->setProperty(logattribute, minifi::processors::LogAttribute::FlowFilesToLog, "0");
 
@@ -73,7 +74,7 @@ class ListAzureDataLakeStorageTestsFixture {
   TestController test_controller_;
   std::shared_ptr<TestPlan> plan_;
   MockDataLakeStorageClient* mock_data_lake_storage_client_ptr_;
-  std::shared_ptr<core::Processor> list_azure_data_lake_storage_;
+  core::Processor* list_azure_data_lake_storage_;
   std::shared_ptr<core::controller::ControllerServiceNode> azure_storage_cred_service_;
 };
 

--- a/extensions/bustache/tests/ApplyTemplateTests.cpp
+++ b/extensions/bustache/tests/ApplyTemplateTests.cpp
@@ -75,16 +75,16 @@ TEST_CASE("Test usage of ApplyTemplate", "[ApplyTemplateTest]") {
   REQUIRE_FALSE(template_source_dir.empty());
   REQUIRE_FALSE(put_file_destination_dir.empty());
 
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getFile");
+  auto getfile = plan->addProcessor("GetFile", "getFile");
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory, get_file_source_dir.string());
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::KeepSourceFile, "true");
 
-  std::shared_ptr<core::Processor> extract_text = plan->addProcessor("ExtractText", "testExtractText", core::Relationship("success", "description"), true);
+  auto extract_text = plan->addProcessor("ExtractText", "testExtractText", core::Relationship("success", "description"), true);
   plan->setProperty(extract_text, org::apache::nifi::minifi::processors::ExtractText::Attribute, TEST_ATTR);
 
-  std::shared_ptr<core::Processor> apply_template = plan->addProcessor("ApplyTemplate", "testApplyTemplate", core::Relationship("success", "description"), true);
+  auto apply_template = plan->addProcessor("ApplyTemplate", "testApplyTemplate", core::Relationship("success", "description"), true);
 
-  std::shared_ptr<core::Processor> put_file = plan->addProcessor("PutFile", "put_file", core::Relationship("success", "description"), true);
+  auto put_file = plan->addProcessor("PutFile", "put_file", core::Relationship("success", "description"), true);
   plan->setProperty(put_file, org::apache::nifi::minifi::processors::PutFile::Directory, put_file_destination_dir.string());
   plan->setProperty(put_file, org::apache::nifi::minifi::processors::PutFile::ConflictResolution, magic_enum::enum_name(minifi::processors::PutFile::FileExistsResolutionStrategy::replace));
 

--- a/extensions/civetweb/tests/ListenHTTPTests.cpp
+++ b/extensions/civetweb/tests/ListenHTTPTests.cpp
@@ -141,7 +141,7 @@ class ListenHTTPTestsFixture {
     plan->runNextProcessor();  // UpdateAttribute
     plan->runNextProcessor();  // ListenHTTP
 
-    auto raw_ptr = dynamic_cast<org::apache::nifi::minifi::processors::ListenHTTP*>(listen_http.get());
+    auto raw_ptr = dynamic_cast<org::apache::nifi::minifi::processors::ListenHTTP*>(listen_http);
     std::string protocol = std::string("http") + (raw_ptr->isSecure() ? "s" : "");
     std::string portstr = raw_ptr->getPort();
     REQUIRE(LogTestController::getInstance().contains("Listening on port " + portstr));
@@ -228,10 +228,10 @@ class ListenHTTPTestsFixture {
   std::filesystem::path tmp_dir;
   TestController testController;
   std::shared_ptr<TestPlan> plan;
-  std::shared_ptr<core::Processor> get_file;
-  std::shared_ptr<core::Processor> update_attribute;
-  std::shared_ptr<core::Processor> listen_http;
-  std::shared_ptr<core::Processor> log_attribute;
+  core::Processor* get_file = nullptr;
+  core::Processor* update_attribute = nullptr;
+  core::Processor* listen_http = nullptr;
+  core::Processor* log_attribute = nullptr;
 
   std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service;
   HttpRequestMethod method = HttpRequestMethod::GET;
@@ -672,8 +672,8 @@ TEST_CASE_METHOD(ListenHTTPTestsFixture, "HTTPS minimum SSL version", "[https]")
 
 TEST_CASE("ListenHTTP bored yield", "[listenhttp][bored][yield]") {
   using processors::ListenHTTP;
-  const auto listen_http = std::make_shared<ListenHTTP>("listenhttp");
-  SingleProcessorTestController controller{listen_http};
+  SingleProcessorTestController controller{std::make_unique<ListenHTTP>("listenhttp")};
+  auto listen_http = controller.getProcessor();
   listen_http->setProperty(ListenHTTP::Port, "0");
 
   REQUIRE(!listen_http->isYield());

--- a/extensions/elasticsearch/PostElasticsearch.cpp
+++ b/extensions/elasticsearch/PostElasticsearch.cpp
@@ -37,19 +37,17 @@ void PostElasticsearch::initialize() {
   setSupportedRelationships(Relationships);
 }
 
-namespace {
-auto getSSLContextService(core::ProcessContext& context) {
+auto PostElasticsearch::getSSLContextService(core::ProcessContext& context) const {
   if (auto ssl_context = context.getProperty(PostElasticsearch::SSLContext))
-    return std::dynamic_pointer_cast<minifi::controllers::SSLContextService>(context.getControllerService(*ssl_context));
+    return std::dynamic_pointer_cast<minifi::controllers::SSLContextService>(context.getControllerService(*ssl_context, getUUID()));
   return std::shared_ptr<minifi::controllers::SSLContextService>{};
 }
 
-auto getCredentialsService(core::ProcessContext& context) {
+auto PostElasticsearch::getCredentialsService(core::ProcessContext& context) const {
   if (auto credentials = context.getProperty(PostElasticsearch::ElasticCredentials))
-    return std::dynamic_pointer_cast<ElasticsearchCredentialsControllerService>(context.getControllerService(*credentials));
+    return std::dynamic_pointer_cast<ElasticsearchCredentialsControllerService>(context.getControllerService(*credentials, getUUID()));
   return std::shared_ptr<ElasticsearchCredentialsControllerService>{};
 }
-}  // namespace
 
 void PostElasticsearch::onSchedule(core::ProcessContext& context, core::ProcessSessionFactory&) {
   context.getProperty(MaxBatchSize, max_batch_size_);

--- a/extensions/elasticsearch/PostElasticsearch.h
+++ b/extensions/elasticsearch/PostElasticsearch.h
@@ -108,6 +108,8 @@ class PostElasticsearch : public core::Processor {
 
  private:
   std::string collectPayload(core::ProcessContext&, core::ProcessSession&, std::vector<std::shared_ptr<core::FlowFile>>&) const;
+  auto getSSLContextService(core::ProcessContext& context) const;
+  auto getCredentialsService(core::ProcessContext& context) const;
 
   uint64_t max_batch_size_ = 100;
   std::string host_url_;

--- a/extensions/elasticsearch/tests/PostElasticsearchTests.cpp
+++ b/extensions/elasticsearch/tests/PostElasticsearchTests.cpp
@@ -25,9 +25,8 @@ namespace org::apache::nifi::minifi::extensions::elasticsearch::test {
 
 TEST_CASE("PostElasticsearch", "[elastic]") {
   MockElastic mock_elastic("10433");
-
-  auto post_elasticsearch_json = std::make_shared<PostElasticsearch>("PostElasticsearch");
-  minifi::test::SingleProcessorTestController test_controller{post_elasticsearch_json};
+  minifi::test::SingleProcessorTestController test_controller{std::make_unique<PostElasticsearch>("PostElasticsearch")};
+  auto post_elasticsearch_json = test_controller.getProcessor();
   auto elasticsearch_credentials_controller_service = test_controller.plan->addController("ElasticsearchCredentialsControllerService", "elasticsearch_credentials_controller_service");
   CHECK(test_controller.plan->setProperty(post_elasticsearch_json,
                                      PostElasticsearch::ElasticCredentials,

--- a/extensions/execute-process/test/ExecuteProcessTests.cpp
+++ b/extensions/execute-process/test/ExecuteProcessTests.cpp
@@ -28,13 +28,13 @@ namespace org::apache::nifi::minifi::test {
 class ExecuteProcessTestsFixture {
  public:
   ExecuteProcessTestsFixture()
-      : execute_process_(std::make_shared<processors::ExecuteProcess>("ExecuteProcess")),
-        controller_(execute_process_) {
+      : controller_(std::make_unique<processors::ExecuteProcess>("ExecuteProcess")),
+        execute_process_(controller_.getProcessor<processors::ExecuteProcess>()) {
     LogTestController::getInstance().setTrace<processors::ExecuteProcess>();
   }
  protected:
-  std::shared_ptr<processors::ExecuteProcess> execute_process_;
   test::SingleProcessorTestController controller_;
+  processors::ExecuteProcess* execute_process_;
 };
 
 TEST_CASE_METHOD(ExecuteProcessTestsFixture, "ExecuteProcess can run a single command", "[ExecuteProcess]") {

--- a/extensions/expression-language/tests/ProcessContextExprTests.cpp
+++ b/extensions/expression-language/tests/ProcessContextExprTests.cpp
@@ -60,7 +60,7 @@ REGISTER_RESOURCE(DummyProcessor, Processor);
 TEST_CASE("ProcessContextExpr can update existing processor properties", "[setProperty][getProperty]") {
   TestController test_controller;
   std::shared_ptr<TestPlan> test_plan = test_controller.createPlan();
-  std::shared_ptr<minifi::core::Processor> dummy_processor = test_plan->addProcessor("DummyProcessor", "dummy_processor");
+  [[maybe_unused]] minifi::core::Processor* dummy_processor = test_plan->addProcessor("DummyProcessor", "dummy_processor");
   std::shared_ptr<minifi::core::ProcessContext> context = [test_plan] { test_plan->runNextProcessor(); return test_plan->getCurrentContext(); }();
   REQUIRE(dynamic_pointer_cast<minifi::core::ProcessContextExpr>(context) != nullptr);
 

--- a/extensions/gcp/processors/GCSProcessor.cpp
+++ b/extensions/gcp/processors/GCSProcessor.cpp
@@ -24,18 +24,16 @@ namespace gcs = ::google::cloud::storage;
 
 namespace org::apache::nifi::minifi::extensions::gcp {
 
-namespace {
-std::shared_ptr<google::cloud::storage::oauth2::Credentials> getCredentials(core::ProcessContext& context) {
+std::shared_ptr<google::cloud::storage::oauth2::Credentials> GCSProcessor::getCredentials(core::ProcessContext& context) const {
   std::string service_name;
   if (context.getProperty(GCSProcessor::GCPCredentials, service_name) && !IsNullOrEmpty(service_name)) {
-    auto gcp_credentials_controller_service = std::dynamic_pointer_cast<const GCPCredentialsControllerService>(context.getControllerService(service_name));
+    auto gcp_credentials_controller_service = std::dynamic_pointer_cast<const GCPCredentialsControllerService>(context.getControllerService(service_name, getUUID()));
     if (!gcp_credentials_controller_service)
       return nullptr;
     return gcp_credentials_controller_service->getCredentials();
   }
   return nullptr;
 }
-}  // namespace
 
 void GCSProcessor::onSchedule(core::ProcessContext& context, core::ProcessSessionFactory&) {
   if (auto number_of_retries = context.getProperty<uint64_t>(NumberOfRetries)) {

--- a/extensions/gcp/processors/GCSProcessor.h
+++ b/extensions/gcp/processors/GCSProcessor.h
@@ -67,6 +67,7 @@ class GCSProcessor : public core::Processor {
 
  protected:
   virtual google::cloud::storage::Client getClient() const;
+  std::shared_ptr<google::cloud::storage::oauth2::Credentials> getCredentials(core::ProcessContext& context) const;
 
   std::optional<std::string> endpoint_url_;
   std::shared_ptr<google::cloud::storage::oauth2::Credentials> gcp_credentials_;

--- a/extensions/gcp/tests/DeleteGCSObjectTests.cpp
+++ b/extensions/gcp/tests/DeleteGCSObjectTests.cpp
@@ -49,6 +49,7 @@ REGISTER_RESOURCE(DeleteGCSObjectMocked, Processor);
 class DeleteGCSObjectTests : public ::testing::Test {
  public:
   void SetUp() override {
+    delete_gcs_object_ = test_controller_.getProcessor<DeleteGCSObjectMocked>();
     gcp_credentials_node_ = test_controller_.plan->addController("GCPCredentialsControllerService", "gcp_credentials_controller_service");
     test_controller_.plan->setProperty(gcp_credentials_node_,
                                        GCPCredentialsControllerService::CredentialsLoc,
@@ -57,9 +58,10 @@ class DeleteGCSObjectTests : public ::testing::Test {
                                        DeleteGCSObject::GCPCredentials,
                                        "gcp_credentials_controller_service");
   }
-  std::shared_ptr<DeleteGCSObjectMocked> delete_gcs_object_ = std::make_shared<DeleteGCSObjectMocked>("DeleteGCSObjectMocked");
-  org::apache::nifi::minifi::test::SingleProcessorTestController test_controller_{delete_gcs_object_};
+
+  org::apache::nifi::minifi::test::SingleProcessorTestController test_controller_{std::make_unique<DeleteGCSObjectMocked>("DeleteGCSObjectMocked")};
   std::shared_ptr<minifi::core::controller::ControllerServiceNode>  gcp_credentials_node_;
+  DeleteGCSObjectMocked* delete_gcs_object_ = nullptr;
 };
 
 TEST_F(DeleteGCSObjectTests, MissingBucket) {

--- a/extensions/gcp/tests/FetchGCSObjectTests.cpp
+++ b/extensions/gcp/tests/FetchGCSObjectTests.cpp
@@ -46,6 +46,7 @@ REGISTER_RESOURCE(FetchGCSObjectMocked, Processor);
 class FetchGCSObjectTests : public ::testing::Test {
  public:
   void SetUp() override {
+    fetch_gcs_object_ = test_controller_.getProcessor<FetchGCSObjectMocked>();
     gcp_credentials_node_ = test_controller_.plan->addController("GCPCredentialsControllerService", "gcp_credentials_controller_service");
     test_controller_.plan->setProperty(gcp_credentials_node_,
                                        GCPCredentialsControllerService::CredentialsLoc,
@@ -54,8 +55,8 @@ class FetchGCSObjectTests : public ::testing::Test {
                                        FetchGCSObject::GCPCredentials,
                                        "gcp_credentials_controller_service");
   }
-  std::shared_ptr<FetchGCSObjectMocked> fetch_gcs_object_ = std::make_shared<FetchGCSObjectMocked>("FetchGCSObjectMocked");
-  org::apache::nifi::minifi::test::SingleProcessorTestController test_controller_{fetch_gcs_object_};
+  FetchGCSObjectMocked* fetch_gcs_object_ = nullptr;
+  org::apache::nifi::minifi::test::SingleProcessorTestController test_controller_{std::make_unique<FetchGCSObjectMocked>("FetchGCSObjectMocked")};
   std::shared_ptr<minifi::core::controller::ControllerServiceNode>  gcp_credentials_node_;
 };
 

--- a/extensions/gcp/tests/ListGCSBucketTests.cpp
+++ b/extensions/gcp/tests/ListGCSBucketTests.cpp
@@ -65,6 +65,7 @@ auto CreateObject(int index, int generation = 1) {
 class ListGCSBucketTests : public ::testing::Test {
  public:
   void SetUp() override {
+    list_gcs_bucket_ = test_controller_.getProcessor<ListGCSBucketMocked>();
     gcp_credentials_node_ = test_controller_.plan->addController("GCPCredentialsControllerService", "gcp_credentials_controller_service");
     test_controller_.plan->setProperty(gcp_credentials_node_,
                                        GCPCredentialsControllerService::CredentialsLoc,
@@ -73,8 +74,8 @@ class ListGCSBucketTests : public ::testing::Test {
                                        ListGCSBucket::GCPCredentials,
                                        "gcp_credentials_controller_service");
   }
-  std::shared_ptr<ListGCSBucketMocked> list_gcs_bucket_ = std::make_shared<ListGCSBucketMocked>("ListGCSBucketMocked");
-  org::apache::nifi::minifi::test::SingleProcessorTestController test_controller_{list_gcs_bucket_};
+  org::apache::nifi::minifi::test::SingleProcessorTestController test_controller_{std::make_unique<ListGCSBucketMocked>("ListGCSBucketMocked")};
+  ListGCSBucketMocked* list_gcs_bucket_ = nullptr;
   std::shared_ptr<minifi::core::controller::ControllerServiceNode>  gcp_credentials_node_;
 };
 

--- a/extensions/gcp/tests/PutGCSObjectTests.cpp
+++ b/extensions/gcp/tests/PutGCSObjectTests.cpp
@@ -52,6 +52,7 @@ REGISTER_RESOURCE(PutGCSObjectMocked, Processor);
 class PutGCSObjectTests : public ::testing::Test {
  public:
   void SetUp() override {
+    put_gcs_object_ = test_controller_.getProcessor<PutGCSObjectMocked>();
     gcp_credentials_node_ = test_controller_.plan->addController("GCPCredentialsControllerService", "gcp_credentials_controller_service");
     test_controller_.plan->setProperty(gcp_credentials_node_,
                                        GCPCredentialsControllerService::CredentialsLoc,
@@ -60,8 +61,8 @@ class PutGCSObjectTests : public ::testing::Test {
                                        PutGCSObject::GCPCredentials,
                                        "gcp_credentials_controller_service");
   }
-  std::shared_ptr<PutGCSObjectMocked> put_gcs_object_ = std::make_shared<PutGCSObjectMocked>("PutGCSObjectMocked");
-  org::apache::nifi::minifi::test::SingleProcessorTestController test_controller_{put_gcs_object_};
+  PutGCSObjectMocked* put_gcs_object_ = nullptr;
+  org::apache::nifi::minifi::test::SingleProcessorTestController test_controller_{std::make_unique<PutGCSObjectMocked>("PutGCSObjectMocked")};
   std::shared_ptr<minifi::core::controller::ControllerServiceNode>  gcp_credentials_node_;
 
   static auto return_upload_done(const ResumableUploadRequest& request) {

--- a/extensions/grafana-loki/PushGrafanaLoki.cpp
+++ b/extensions/grafana-loki/PushGrafanaLoki.cpp
@@ -77,9 +77,9 @@ void PushGrafanaLoki::LogBatch::setStartPushTime(std::chrono::system_clock::time
 
 const core::Relationship PushGrafanaLoki::Self("__self__", "Marks the FlowFile to be owned by this processor");
 
-std::shared_ptr<minifi::controllers::SSLContextService> PushGrafanaLoki::getSSLContextService(core::ProcessContext& context) {
+std::shared_ptr<minifi::controllers::SSLContextService> PushGrafanaLoki::getSSLContextService(core::ProcessContext& context) const {
   if (auto ssl_context = context.getProperty(PushGrafanaLoki::SSLContextService)) {
-    return std::dynamic_pointer_cast<minifi::controllers::SSLContextService>(context.getControllerService(*ssl_context));
+    return std::dynamic_pointer_cast<minifi::controllers::SSLContextService>(context.getControllerService(*ssl_context, getUUID()));
   }
   return std::shared_ptr<minifi::controllers::SSLContextService>{};
 }

--- a/extensions/grafana-loki/PushGrafanaLoki.h
+++ b/extensions/grafana-loki/PushGrafanaLoki.h
@@ -132,9 +132,9 @@ class PushGrafanaLoki : public core::Processor {
     std::shared_ptr<core::logging::Logger> logger_;
   };
 
-  static std::shared_ptr<minifi::controllers::SSLContextService> getSSLContextService(core::ProcessContext& context);
   static std::map<std::string, std::string> buildStreamLabelMap(core::ProcessContext& context);
 
+  std::shared_ptr<minifi::controllers::SSLContextService> getSSLContextService(core::ProcessContext& context) const;
   void processBatch(const std::vector<std::shared_ptr<core::FlowFile>>& batched_flow_files, core::ProcessSession& session);
   virtual nonstd::expected<void, std::string> submitRequest(const std::vector<std::shared_ptr<core::FlowFile>>& batched_flow_files, core::ProcessSession& session) = 0;
   void initializeHttpClient(core::ProcessContext& context);

--- a/extensions/grafana-loki/tests/PushGrafanaLokiGrpcTest.cpp
+++ b/extensions/grafana-loki/tests/PushGrafanaLokiGrpcTest.cpp
@@ -25,8 +25,8 @@
 namespace org::apache::nifi::minifi::extensions::grafana::loki::test {
 
 TEST_CASE("Url property is required", "[PushGrafanaLokiGrpc]") {
-  auto push_grafana_loki_grpc = std::make_shared<PushGrafanaLokiGrpc>("PushGrafanaLokiGrpc");
-  minifi::test::SingleProcessorTestController test_controller(push_grafana_loki_grpc);
+  minifi::test::SingleProcessorTestController test_controller(std::make_unique<PushGrafanaLokiGrpc>("PushGrafanaLokiGrpc"));
+  auto push_grafana_loki_grpc = test_controller.getProcessor();
   test_controller.plan->setProperty(push_grafana_loki_grpc, PushGrafanaLokiGrpc::Url, "");
   test_controller.plan->setProperty(push_grafana_loki_grpc, PushGrafanaLokiGrpc::StreamLabels, "job=minifi,directory=/opt/minifi/logs/");
   test_controller.plan->setProperty(push_grafana_loki_grpc, PushGrafanaLokiGrpc::LogLineBatchSize, "1");
@@ -34,8 +34,8 @@ TEST_CASE("Url property is required", "[PushGrafanaLokiGrpc]") {
 }
 
 TEST_CASE("Valid stream labels need to be set", "[PushGrafanaLokiGrpc]") {
-  auto push_grafana_loki_grpc = std::make_shared<PushGrafanaLokiGrpc>("PushGrafanaLokiGrpc");
-  minifi::test::SingleProcessorTestController test_controller(push_grafana_loki_grpc);
+  minifi::test::SingleProcessorTestController test_controller(std::make_unique<PushGrafanaLokiGrpc>("PushGrafanaLokiGrpc"));
+  auto push_grafana_loki_grpc = test_controller.getProcessor();
   test_controller.plan->setProperty(push_grafana_loki_grpc, PushGrafanaLokiGrpc::Url, "localhost:10991");
   test_controller.plan->setProperty(push_grafana_loki_grpc, PushGrafanaLokiGrpc::LogLineBatchSize, "1");
   SECTION("Stream labels cannot be empty") {
@@ -48,8 +48,8 @@ TEST_CASE("Valid stream labels need to be set", "[PushGrafanaLokiGrpc]") {
 }
 
 TEST_CASE("Log Line Batch Size cannot be 0", "[PushGrafanaLokiGrpc]") {
-  auto push_grafana_loki_grpc = std::make_shared<PushGrafanaLokiGrpc>("PushGrafanaLokiGrpc");
-  minifi::test::SingleProcessorTestController test_controller(push_grafana_loki_grpc);
+  minifi::test::SingleProcessorTestController test_controller(std::make_unique<PushGrafanaLokiGrpc>("PushGrafanaLokiGrpc"));
+  auto push_grafana_loki_grpc = test_controller.getProcessor();
   CHECK(test_controller.plan->setProperty(push_grafana_loki_grpc, PushGrafanaLokiGrpc::Url, "localhost:10991"));
   CHECK(test_controller.plan->setProperty(push_grafana_loki_grpc, PushGrafanaLokiGrpc::StreamLabels, "job=minifi,directory=/opt/minifi/logs/"));
   test_controller.plan->setProperty(push_grafana_loki_grpc, PushGrafanaLokiGrpc::LogLineBatchSize, "0");
@@ -60,8 +60,8 @@ class PushGrafanaLokiGrpcTestFixture {
  public:
   PushGrafanaLokiGrpcTestFixture()
       : mock_loki_("10991"),
-        push_grafana_loki_grpc_(std::make_shared<PushGrafanaLokiGrpc>("PushGrafanaLokiGrpc")),
-        test_controller_(push_grafana_loki_grpc_) {
+        test_controller_(std::make_unique<PushGrafanaLokiGrpc>("PushGrafanaLokiGrpc")),
+        push_grafana_loki_grpc_(test_controller_.getProcessor<PushGrafanaLokiGrpc>()) {
     LogTestController::getInstance().setDebug<TestPlan>();
     LogTestController::getInstance().setDebug<minifi::core::Processor>();
     LogTestController::getInstance().setTrace<minifi::core::ProcessSession>();
@@ -110,8 +110,8 @@ class PushGrafanaLokiGrpcTestFixture {
 
  protected:
   MockGrafanaLokiGrpc mock_loki_;
-  std::shared_ptr<PushGrafanaLokiGrpc> push_grafana_loki_grpc_;
   minifi::test::SingleProcessorTestController test_controller_;
+  PushGrafanaLokiGrpc* push_grafana_loki_grpc_;
 };
 
 TEST_CASE_METHOD(PushGrafanaLokiGrpcTestFixture, "PushGrafanaLokiGrpc should send 1 log line to Grafana Loki in a trigger", "[PushGrafanaLokiGrpc]") {

--- a/extensions/grafana-loki/tests/PushGrafanaLokiRESTTest.cpp
+++ b/extensions/grafana-loki/tests/PushGrafanaLokiRESTTest.cpp
@@ -30,8 +30,9 @@
 namespace org::apache::nifi::minifi::extensions::grafana::loki::test {
 
 TEST_CASE("Url property is required", "[PushGrafanaLokiREST]") {
-  auto push_grafana_loki_rest = std::make_shared<PushGrafanaLokiREST>("PushGrafanaLokiREST");
-  minifi::test::SingleProcessorTestController test_controller(push_grafana_loki_rest);
+  minifi::test::SingleProcessorTestController test_controller(std::make_unique<PushGrafanaLokiREST>("PushGrafanaLokiREST"));
+  auto push_grafana_loki_rest = test_controller.getProcessor();
+
   test_controller.plan->setProperty(push_grafana_loki_rest, PushGrafanaLokiREST::Url, "");
   test_controller.plan->setProperty(push_grafana_loki_rest, PushGrafanaLokiREST::StreamLabels, "job=minifi,directory=/opt/minifi/logs/");
   test_controller.plan->setProperty(push_grafana_loki_rest, PushGrafanaLokiREST::LogLineBatchSize, "1");
@@ -39,8 +40,8 @@ TEST_CASE("Url property is required", "[PushGrafanaLokiREST]") {
 }
 
 TEST_CASE("Valid stream labels need to be set", "[PushGrafanaLokiREST]") {
-  auto push_grafana_loki_rest = std::make_shared<PushGrafanaLokiREST>("PushGrafanaLokiREST");
-  minifi::test::SingleProcessorTestController test_controller(push_grafana_loki_rest);
+  minifi::test::SingleProcessorTestController test_controller(std::make_unique<PushGrafanaLokiREST>("PushGrafanaLokiREST"));
+  auto push_grafana_loki_rest = test_controller.getProcessor();
   test_controller.plan->setProperty(push_grafana_loki_rest, PushGrafanaLokiREST::Url, "localhost:10990");
   test_controller.plan->setProperty(push_grafana_loki_rest, PushGrafanaLokiREST::LogLineBatchSize, "1");
   SECTION("Stream labels cannot be empty") {
@@ -53,8 +54,8 @@ TEST_CASE("Valid stream labels need to be set", "[PushGrafanaLokiREST]") {
 }
 
 TEST_CASE("Log Line Batch Size cannot be 0", "[PushGrafanaLokiREST]") {
-  auto push_grafana_loki_rest = std::make_shared<PushGrafanaLokiREST>("PushGrafanaLokiREST");
-  minifi::test::SingleProcessorTestController test_controller(push_grafana_loki_rest);
+  minifi::test::SingleProcessorTestController test_controller(std::make_unique<PushGrafanaLokiREST>("PushGrafanaLokiREST"));
+  auto push_grafana_loki_rest = test_controller.getProcessor();
   test_controller.plan->setProperty(push_grafana_loki_rest, PushGrafanaLokiREST::Url, "localhost:10990");
   test_controller.plan->setProperty(push_grafana_loki_rest, PushGrafanaLokiREST::StreamLabels, "job=minifi,directory=/opt/minifi/logs/");
   test_controller.plan->setProperty(push_grafana_loki_rest, PushGrafanaLokiREST::LogLineBatchSize, "0");
@@ -65,8 +66,8 @@ class PushGrafanaLokiRESTTestFixture {
  public:
   PushGrafanaLokiRESTTestFixture()
       : mock_loki_("10990"),
-        push_grafana_loki_rest_(std::make_shared<PushGrafanaLokiREST>("PushGrafanaLokiREST")),
-        test_controller_(push_grafana_loki_rest_) {
+        test_controller_(std::make_unique<PushGrafanaLokiREST>("PushGrafanaLokiREST")),
+        push_grafana_loki_rest_(test_controller_.getProcessor<PushGrafanaLokiREST>()) {
     LogTestController::getInstance().setDebug<TestPlan>();
     LogTestController::getInstance().setDebug<minifi::core::Processor>();
     LogTestController::getInstance().setTrace<minifi::core::ProcessSession>();
@@ -159,8 +160,8 @@ class PushGrafanaLokiRESTTestFixture {
 
  protected:
   MockGrafanaLokiREST mock_loki_;
-  std::shared_ptr<PushGrafanaLokiREST> push_grafana_loki_rest_;
   minifi::test::SingleProcessorTestController test_controller_;
+  PushGrafanaLokiREST* push_grafana_loki_rest_;
 };
 
 TEST_CASE_METHOD(PushGrafanaLokiRESTTestFixture, "PushGrafanaLokiREST should send 1 log line to Grafana Loki in a trigger", "[PushGrafanaLokiREST]") {
@@ -272,8 +273,8 @@ TEST_CASE_METHOD(PushGrafanaLokiRESTTestFixture, "PushGrafanaLokiREST should wai
 }
 
 TEST_CASE("If username is set, password is also required to be set", "[PushGrafanaLokiREST]") {
-  auto push_grafana_loki_rest = std::make_shared<PushGrafanaLokiREST>("PushGrafanaLokiREST");
-  minifi::test::SingleProcessorTestController test_controller(push_grafana_loki_rest);
+  minifi::test::SingleProcessorTestController test_controller(std::make_unique<PushGrafanaLokiREST>("PushGrafanaLokiREST"));
+  auto push_grafana_loki_rest = test_controller.getProcessor();
   test_controller.plan->setProperty(push_grafana_loki_rest, PushGrafanaLokiREST::Url, "localhost:10990");
   test_controller.plan->setProperty(push_grafana_loki_rest, PushGrafanaLokiREST::StreamLabels, "job=minifi,directory=/opt/minifi/logs/");
   test_controller.plan->setProperty(push_grafana_loki_rest, PushGrafanaLokiREST::LogLineBatchSize, "1");

--- a/extensions/kubernetes/processors/CollectKubernetesPodMetrics.cpp
+++ b/extensions/kubernetes/processors/CollectKubernetesPodMetrics.cpp
@@ -36,7 +36,7 @@ void CollectKubernetesPodMetrics::onSchedule(core::ProcessContext& context, core
     throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, utils::string::join_pack("Missing '", KubernetesControllerService.name, "' property")};
   }
 
-  std::shared_ptr<core::controller::ControllerService> controller_service = context.getControllerService(*controller_service_name);
+  std::shared_ptr<core::controller::ControllerService> controller_service = context.getControllerService(*controller_service_name, getUUID());
   if (!controller_service) {
     throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, utils::string::join_pack("Controller service '", *controller_service_name, "' not found")};
   }

--- a/extensions/libarchive/tests/FocusArchiveTests.cpp
+++ b/extensions/libarchive/tests/FocusArchiveTests.cpp
@@ -49,13 +49,13 @@ const char* FOCUSED_CONTENT = FILE_CONTENT[0];
 
 TEST_CASE("Test Creation of FocusArchiveEntry", "[getfileCreate]") {
   TestController testController;
-  std::shared_ptr<core::Processor> processor = std::make_shared<FocusArchiveEntry>("processorname");
+  auto processor = std::make_shared<FocusArchiveEntry>("processorname");
   REQUIRE(processor->getName() == "processorname");
 }
 
 TEST_CASE("Test Creation of UnfocusArchiveEntry", "[getfileCreate]") {
   TestController testController;
-  std::shared_ptr<core::Processor> processor = std::make_shared<UnfocusArchiveEntry>("processorname");
+  auto processor = std::make_shared<UnfocusArchiveEntry>("processorname");
   REQUIRE(processor->getName() == "processorname");
   REQUIRE(processor->getUUID());
 }
@@ -83,20 +83,20 @@ TEST_CASE("FocusArchive", "[testFocusArchive]") {
   REQUIRE(!dir1.empty());
   REQUIRE(!dir2.empty());
   REQUIRE(!dir3.empty());
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
+  auto getfile = plan->addProcessor("GetFile", "getfileCreate2");
   plan->setProperty(getfile, GetFile::Directory, dir1.string());
   plan->setProperty(getfile, GetFile::KeepSourceFile, "true");
 
-  std::shared_ptr<core::Processor> fprocessor = plan->addProcessor("FocusArchiveEntry", "focusarchiveCreate", core::Relationship("success", "description"), true);
+  auto fprocessor = plan->addProcessor("FocusArchiveEntry", "focusarchiveCreate", core::Relationship("success", "description"), true);
   plan->setProperty(fprocessor, FocusArchiveEntry::Path, FOCUSED_FILE);
 
-  std::shared_ptr<core::Processor> putfile1 = plan->addProcessor("PutFile", "PutFile1", core::Relationship("success", "description"), true);
+  auto putfile1 = plan->addProcessor("PutFile", "PutFile1", core::Relationship("success", "description"), true);
   plan->setProperty(putfile1, PutFile::Directory, dir2.string());
   plan->setProperty(putfile1, PutFile::ConflictResolution, magic_enum::enum_name(PutFile::FileExistsResolutionStrategy::replace));
 
-  std::shared_ptr<core::Processor> ufprocessor = plan->addProcessor("UnfocusArchiveEntry", "unfocusarchiveCreate", core::Relationship("success", "description"), true);
+  plan->addProcessor("UnfocusArchiveEntry", "unfocusarchiveCreate", core::Relationship("success", "description"), true);
 
-  std::shared_ptr<core::Processor> putfile2 = plan->addProcessor("PutFile", "PutFile2", core::Relationship("success", "description"), true);
+  auto putfile2 = plan->addProcessor("PutFile", "PutFile2", core::Relationship("success", "description"), true);
   plan->setProperty(putfile2, PutFile::Directory, dir3.string());
   plan->setProperty(putfile2, PutFile::ConflictResolution, magic_enum::enum_name(PutFile::FileExistsResolutionStrategy::replace));
 

--- a/extensions/libarchive/tests/ManipulateArchiveTests.cpp
+++ b/extensions/libarchive/tests/ManipulateArchiveTests.cpp
@@ -70,17 +70,17 @@ bool run_archive_test(OrderedTestArchive& input_archive, const OrderedTestArchiv
   REQUIRE(!dir1.empty());
   REQUIRE(!dir2.empty());
 
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
+  auto getfile = plan->addProcessor("GetFile", "getfileCreate2");
   plan->setProperty(getfile, GetFile::Directory, dir1.string());
   plan->setProperty(getfile, GetFile::KeepSourceFile, "true");
 
-  std::shared_ptr<core::Processor> maprocessor = plan->addProcessor("ManipulateArchive", "testManipulateArchive", core::Relationship("success", "description"), true);
+  auto maprocessor = plan->addProcessor("ManipulateArchive", "testManipulateArchive", core::Relationship("success", "description"), true);
 
   for (const auto& [name, value] : properties) {
     plan->setProperty(maprocessor, name, value);
   }
 
-  std::shared_ptr<core::Processor> putfile2 = plan->addProcessor("PutFile", "PutFile2", core::Relationship("success", "description"), true);
+  auto putfile2 = plan->addProcessor("PutFile", "PutFile2", core::Relationship("success", "description"), true);
   plan->setProperty(putfile2, PutFile::Directory, dir2.string());
   plan->setProperty(putfile2, PutFile::ConflictResolution, magic_enum::enum_name(PutFile::FileExistsResolutionStrategy::replace));
 
@@ -110,7 +110,7 @@ bool run_archive_test(TAE_MAP_T input_map, TAE_MAP_T output_map, const PROP_MAP_
 
 TEST_CASE("Test creation of ManipulateArchive", "[manipulatearchiveCreate]") {
   TestController testController;
-  std::shared_ptr<core::Processor> processor = std::make_shared<ManipulateArchive>("processorname");
+  auto processor = std::make_shared<ManipulateArchive>("processorname");
   REQUIRE(processor->getName() == "processorname");
   REQUIRE(processor->getUUID());
 }

--- a/extensions/libarchive/tests/MergeFileTests.cpp
+++ b/extensions/libarchive/tests/MergeFileTests.cpp
@@ -904,18 +904,16 @@ TEST_CASE_METHOD(MergeTestController, "Maximum Group Size is respected", "[testM
 }
 
 TEST_CASE("Empty MergeContent yields") {
-  const auto merge_content = std::make_shared<minifi::processors::MergeContent>("mergeContent");
-
-  minifi::test::SingleProcessorTestController controller{merge_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<minifi::processors::MergeContent>("mergeContent")};
   controller.trigger();
 
+  auto merge_content = controller.getProcessor();
   CHECK(merge_content->isYield());
 }
 
 TEST_CASE("Empty MergeContent doesnt yield when processing readybins") {
-  const auto merge_content = std::make_shared<minifi::processors::MergeContent>("mergeContent");
-
-  minifi::test::SingleProcessorTestController controller{merge_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<minifi::processors::MergeContent>("mergeContent")};
+  const auto merge_content = controller.getProcessor();
   controller.plan->setProperty(merge_content, minifi::processors::MergeContent::MaxBinAge, "100ms");
   controller.plan->setProperty(merge_content, minifi::processors::MergeContent::MinEntries, "2");
 

--- a/extensions/librdkafka/tests/PublishKafkaTests.cpp
+++ b/extensions/librdkafka/tests/PublishKafkaTests.cpp
@@ -25,8 +25,8 @@ namespace org::apache::nifi::minifi::test {
 TEST_CASE("Scheduling should fail when batch size is larger than the max queue message count", "[testPublishKafka]") {
   LogTestController::getInstance().setTrace<TestPlan>();
   LogTestController::getInstance().setTrace<processors::PublishKafka>();
-  const auto publish_kafka = std::make_shared<processors::PublishKafka>("PublishKafka");
-  SingleProcessorTestController test_controller(publish_kafka);
+  SingleProcessorTestController test_controller(std::make_unique<processors::PublishKafka>("PublishKafka"));
+  const auto publish_kafka = test_controller.getProcessor();
   publish_kafka->setProperty(processors::PublishKafka::ClientName, "test_client");
   publish_kafka->setProperty(processors::PublishKafka::SeedBrokers, "test_seedbroker");
   publish_kafka->setProperty(processors::PublishKafka::QueueBufferMaxMessage, "1000");

--- a/extensions/lua/tests/TestExecuteScriptProcessorWithLuaScript.cpp
+++ b/extensions/lua/tests/TestExecuteScriptProcessorWithLuaScript.cpp
@@ -31,8 +31,8 @@
 namespace org::apache::nifi::minifi::processors::test {
 
 TEST_CASE("Lua: hello world") {
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "lua");
   execute_script->setProperty(ExecuteScript::ScriptBody, R"(print("Hello world!"))");
@@ -81,9 +81,8 @@ end
 }
 
 TEST_CASE("Lua: Test session get should return None if there are no flowfiles in the incoming connections") {
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "lua");
@@ -104,9 +103,8 @@ end
 
 TEST_CASE("Lua: Test Log", "[executescriptLuaLog]") {
   LogTestController::getInstance().reset();
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "lua");
@@ -124,9 +122,8 @@ end
 }
 
 TEST_CASE("Lua: Test Read File", "[executescriptLuaRead]") {
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "lua");
@@ -156,9 +153,8 @@ end
 }
 
 TEST_CASE("Lua: Test Write File", "[executescriptLuaWrite]") {
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "lua");
@@ -190,9 +186,8 @@ TEST_CASE("Lua: Test Write File", "[executescriptLuaWrite]") {
 
 TEST_CASE("Lua: Test Create", "[executescriptLuaCreate]") {
   LogTestController::getInstance().reset();
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "lua");
@@ -216,9 +211,8 @@ end
 
 TEST_CASE("Lua: Test Update Attribute", "[executescriptLuaUpdateAttribute]") {
   LogTestController::getInstance().reset();
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "lua");
@@ -280,9 +274,8 @@ TEST_CASE("Lua: Test Require", "[executescriptLuaRequire]") {
 TEST_CASE("Lua: Test Module Directory property", "[executescriptLuaModuleDirectoryProperty]") {
   using org::apache::nifi::minifi::utils::file::get_executable_dir;
 
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
   const auto script_files_directory =  minifi::utils::file::FileUtils::get_executable_dir() / "resources" / "test_lua_scripts";
@@ -299,9 +292,8 @@ TEST_CASE("Lua: Test Module Directory property", "[executescriptLuaModuleDirecto
 }
 
 TEST_CASE("Lua: Non existent script file should throw", "[executescriptLuaNonExistentScriptFile]") {
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "lua");
@@ -311,9 +303,8 @@ TEST_CASE("Lua: Non existent script file should throw", "[executescriptLuaNonExi
 }
 
 TEST_CASE("Lua can remove flowfiles", "[ExecuteScript]") {
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
   execute_script->setProperty(ExecuteScript::ScriptEngine, "lua");
   execute_script->setProperty(ExecuteScript::ScriptBody,
@@ -329,9 +320,8 @@ TEST_CASE("Lua can remove flowfiles", "[ExecuteScript]") {
 }
 
 TEST_CASE("Lua can store states in StateManager", "[ExecuteScript]") {
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<minifi::processors::ExecuteScript>();
   execute_script->setProperty(ExecuteScript::ScriptEngine, "lua");
   execute_script->setProperty(ExecuteScript::ScriptBody,

--- a/extensions/mqtt/tests/ConsumeMQTTTests.cpp
+++ b/extensions/mqtt/tests/ConsumeMQTTTests.cpp
@@ -40,7 +40,7 @@ struct Fixture {
 
   TestController testController_;
   std::shared_ptr<TestPlan> plan_;
-  std::shared_ptr<core::Processor> consumeMqttProcessor_;
+  core::Processor* consumeMqttProcessor_ = nullptr;
 };
 }  // namespace
 

--- a/extensions/mqtt/tests/PublishMQTTTests.cpp
+++ b/extensions/mqtt/tests/PublishMQTTTests.cpp
@@ -44,7 +44,7 @@ struct Fixture {
 
   TestController testController_;
   std::shared_ptr<TestPlan> plan_;
-  std::shared_ptr<core::Processor> publishMqttProcessor_;
+  core::Processor* publishMqttProcessor_ = nullptr;
 };
 }  // namespace
 

--- a/extensions/opencv/tests/CaptureRTSPFrameTest.cpp
+++ b/extensions/opencv/tests/CaptureRTSPFrameTest.cpp
@@ -46,7 +46,7 @@ TEST_CASE("CaptureRTSPFrame::ValidCapture", "[!mayfail]") {
     LogTestController::getInstance().setDebug<core::ProcessSession>();
 
     std::shared_ptr<TestPlan> plan = testController.createPlan();
-    std::shared_ptr<core::Processor> captureRTSP = plan->addProcessor("CaptureRTSPFrame", "CaptureRTSPFrame");
+    auto captureRTSP = plan->addProcessor("CaptureRTSPFrame", "CaptureRTSPFrame");
     // the RTSP url below comes from a public RTSP stream (hopefully still alive by the time you read this)
     // alternatively, we can set our own server using vlc.
     // vlc -vvv --loop <input video> --sout '#rtp{port=1234,sdp=rtsp://127.0.0.1:port/test}' --sout-keep
@@ -69,7 +69,7 @@ TEST_CASE("CaptureRTSPFrame::InvalidURI", "[opencvtest2]") {
   LogTestController::getInstance().setDebug<core::ProcessSession>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> captureRTSP = plan->addProcessor("CaptureRTSPFrame", "CaptureRTSPFrame");
+  auto captureRTSP = plan->addProcessor("CaptureRTSPFrame", "CaptureRTSPFrame");
 
   plan->setProperty(captureRTSP, minifi::processors::CaptureRTSPFrame::RTSPHostname, "170.93.143.139");
   plan->setProperty(captureRTSP, minifi::processors::CaptureRTSPFrame::RTSPURI, "abcd");

--- a/extensions/pdh/tests/PerformanceDataMonitorTests.cpp
+++ b/extensions/pdh/tests/PerformanceDataMonitorTests.cpp
@@ -65,8 +65,8 @@ class PerformanceDataMonitorTester {
   TestController test_controller_;
   std::filesystem::path dir_;
   std::shared_ptr<TestPlan> plan_;
-  std::shared_ptr<core::Processor> performance_monitor_;
-  std::shared_ptr<core::Processor> putfile_;
+  core::Processor* performance_monitor_;
+  core::Processor* putfile_;
 };
 
 

--- a/extensions/procfs/tests/ProcFsMonitorTests.cpp
+++ b/extensions/procfs/tests/ProcFsMonitorTests.cpp
@@ -23,8 +23,8 @@
 namespace org::apache::nifi::minifi::extensions::procfs::tests {
 
 TEST_CASE("ProcFsMonitorTests", "[procfsmonitortests]") {
-  std::shared_ptr<ProcFsMonitor> proc_fs_monitor = std::make_shared<ProcFsMonitor>("ProcFsMonitor");
-  org::apache::nifi::minifi::test::SingleProcessorTestController test_controller_{proc_fs_monitor};
+  org::apache::nifi::minifi::test::SingleProcessorTestController test_controller_{std::make_unique<ProcFsMonitor>("ProcFsMonitor")};
+  auto proc_fs_monitor = test_controller_.getProcessor();
 
   SECTION("Absolute JSON") {
     test_controller_.plan->setProperty(proc_fs_monitor, ProcFsMonitor::ResultRelativenessProperty, "Absolute");

--- a/extensions/python/tests/ExecutePythonProcessorTests.cpp
+++ b/extensions/python/tests/ExecutePythonProcessorTests.cpp
@@ -134,14 +134,14 @@ class SimplePythonFlowFileTransferTest : public ExecutePythonProcessorTestBase {
     }
   }
 
-  std::shared_ptr<core::Processor> addGetFileProcessorToPlan(const std::filesystem::path& dir_path) {
-    std::shared_ptr<core::Processor> getfile = plan_->addProcessor("GetFile", "getfileCreate2");
+  core::Processor* addGetFileProcessorToPlan(const std::filesystem::path& dir_path) {
+    auto getfile = plan_->addProcessor("GetFile", "getfileCreate2");
     plan_->setProperty(getfile, minifi::processors::GetFile::Directory, dir_path.string());
     plan_->setProperty(getfile, minifi::processors::GetFile::KeepSourceFile, "true");
     return getfile;
   }
 
-  std::shared_ptr<core::Processor> addExecutePythonProcessorToPlan(const std::filesystem::path& used_as_script_file, const std::string& used_as_script_body) {
+  core::Processor* addExecutePythonProcessorToPlan(const std::filesystem::path& used_as_script_file, const std::string& used_as_script_body) {
     auto executePythonProcessor = plan_->addProcessor("ExecutePythonProcessor", "executePythonProcessor", core::Relationship("success", "description"), true);
     if (!used_as_script_file.empty()) {
       plan_->setProperty(executePythonProcessor, minifi::extensions::python::processors::ExecutePythonProcessor::ScriptFile, getScriptFullPath(used_as_script_file).string());
@@ -152,8 +152,8 @@ class SimplePythonFlowFileTransferTest : public ExecutePythonProcessorTestBase {
     return executePythonProcessor;
   }
 
-  std::shared_ptr<core::Processor> addPutFileProcessorToPlan(const core::Relationship& execute_python_outbound_connection, const std::filesystem::path& dir_path) {
-    std::shared_ptr<core::Processor> putfile = plan_->addProcessor("PutFile", "putfile", execute_python_outbound_connection, true);
+  core::Processor* addPutFileProcessorToPlan(const core::Relationship& execute_python_outbound_connection, const std::filesystem::path& dir_path) {
+    auto putfile = plan_->addProcessor("PutFile", "putfile", execute_python_outbound_connection, true);
     plan_->setProperty(putfile, minifi::processors::PutFile::Directory, dir_path.string());
     return putfile;
   }

--- a/extensions/python/tests/TestExecuteScriptProcessorWithPythonScript.cpp
+++ b/extensions/python/tests/TestExecuteScriptProcessorWithPythonScript.cpp
@@ -30,8 +30,8 @@
 namespace org::apache::nifi::minifi::processors::test {
 
 TEST_CASE("Python: hello world") {
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "python");
   execute_script->setProperty(ExecuteScript::ScriptBody, R"(print("Hello world!"))");
@@ -79,9 +79,8 @@ TEST_CASE("Test both script body and script file set", "[executescriptMisconfigu
 }
 
 TEST_CASE("Python: Test session get should return None if there are no flowfiles in the incoming connections") {
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "python");
@@ -98,9 +97,8 @@ def onTrigger(context, session):
 }
 
 TEST_CASE("Python: Test Read File", "[executescriptPythonRead]") {
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "python");
@@ -128,9 +126,8 @@ def onTrigger(context, session):
 }
 
 TEST_CASE("Python: Test Write File", "[executescriptPythonWrite]") {
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "python");
@@ -155,9 +152,8 @@ def onTrigger(context, session):
 }
 
 TEST_CASE("Python: Test Create", "[executescriptPythonCreate]") {
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "python");
@@ -178,9 +174,8 @@ def onTrigger(context, session):
 }
 
 TEST_CASE("Python: Test Update Attribute", "[executescriptPythonUpdateAttribute]") {
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "python");
@@ -204,9 +199,8 @@ def onTrigger(context, session):
 }
 
 TEST_CASE("Python: Test Get Context Property", "[executescriptPythonGetContextProperty]") {
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "python");
@@ -226,9 +220,8 @@ def onTrigger(context, session):
 TEST_CASE("Python: Test Module Directory property", "[executescriptPythonModuleDirectoryProperty]") {
   using org::apache::nifi::minifi::utils::file::get_executable_dir;
 
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
   const auto script_files_directory =  minifi::utils::file::FileUtils::get_executable_dir() / "resources" / "test_python_scripts";
@@ -245,9 +238,8 @@ TEST_CASE("Python: Test Module Directory property", "[executescriptPythonModuleD
 }
 
 TEST_CASE("Python: Non existent script file should throw", "[executescriptPythonNonExistentScriptFile]") {
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
 
   execute_script->setProperty(ExecuteScript::ScriptEngine, "python");
@@ -257,9 +249,8 @@ TEST_CASE("Python: Non existent script file should throw", "[executescriptPython
 }
 
 TEST_CASE("Python can remove flowfiles", "[ExecuteScript]") {
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<ExecuteScript>();
   execute_script->setProperty(ExecuteScript::ScriptEngine, "python");
   execute_script->setProperty(ExecuteScript::ScriptBody, R"(
@@ -272,9 +263,8 @@ def onTrigger(context, session):
 }
 
 TEST_CASE("Python can store states in StateManager", "[ExecuteScript]") {
-  const auto execute_script = std::make_shared<ExecuteScript>("ExecuteScript");
-
-  minifi::test::SingleProcessorTestController controller{execute_script};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ExecuteScript>("ExecuteScript")};
+  const auto execute_script = controller.getProcessor();
   LogTestController::getInstance().setTrace<minifi::processors::ExecuteScript>();
   execute_script->setProperty(ExecuteScript::ScriptEngine, "python");
   execute_script->setProperty(ExecuteScript::ScriptBody,

--- a/extensions/python/types/PyProcessContext.cpp
+++ b/extensions/python/types/PyProcessContext.cpp
@@ -123,7 +123,7 @@ PyObject* PyProcessContext::getControllerService(PyProcessContext* self, PyObjec
     return nullptr;
   }
 
-  if (auto controller_service = context->getControllerService(controller_service_name)) {
+  if (auto controller_service = context->getControllerService(controller_service_name, context->getProcessorNode()->getUUID())) {
     std::string controller_service_type_str = controller_service_type;
     if (controller_service_type_str == "SSLContextService") {
       auto ssl_ctx_service = std::dynamic_pointer_cast<controllers::SSLContextService>(controller_service);

--- a/extensions/sftp/tests/FetchSFTPTests.cpp
+++ b/extensions/sftp/tests/FetchSFTPTests.cpp
@@ -156,10 +156,10 @@ class FetchSFTPTestsFixture {
   std::filesystem::path dst_dir{testController.createTempDirectory()};
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::unique_ptr<SFTPTestServer> sftp_server;
-  std::shared_ptr<core::Processor> generate_flow_file;
-  std::shared_ptr<core::Processor> update_attribute;
-  std::shared_ptr<core::Processor> fetch_sftp;
-  std::shared_ptr<core::Processor> put_file;
+  core::Processor* generate_flow_file;
+  core::Processor* update_attribute;
+  core::Processor* fetch_sftp;
+  core::Processor* put_file;
 };
 
 TEST_CASE_METHOD(FetchSFTPTestsFixture, "FetchSFTP fetch one file", "[FetchSFTP][basic]") {

--- a/extensions/sftp/tests/ListSFTPTests.cpp
+++ b/extensions/sftp/tests/ListSFTPTests.cpp
@@ -91,8 +91,8 @@ class ListSFTPTestsFixture {
   void createPlan(const utils::Identifier* list_sftp_uuid = nullptr, const std::shared_ptr<minifi::Configure>& configuration = nullptr) {
     const auto state_dir = plan == nullptr ? testController.createTempDirectory() : plan->getStateDir();
 
-    log_attribute.reset();
-    list_sftp.reset();
+    log_attribute = nullptr;
+    list_sftp = nullptr;
     plan.reset();
 
     if (configuration) {
@@ -160,8 +160,8 @@ class ListSFTPTestsFixture {
   std::filesystem::path working_directory = testController.createTempDirectory();
   std::shared_ptr<TestPlan> plan;
   std::unique_ptr<SFTPTestServer> sftp_server;
-  std::shared_ptr<core::Processor> list_sftp;
-  std::shared_ptr<core::Processor> log_attribute;
+  core::Processor* list_sftp = nullptr;
+  core::Processor* log_attribute = nullptr;
 };
 
 class PersistentListSFTPTestsFixture : public ListSFTPTestsFixture {

--- a/extensions/sftp/tests/ListThenFetchSFTPTests.cpp
+++ b/extensions/sftp/tests/ListThenFetchSFTPTests.cpp
@@ -188,10 +188,10 @@ class ListThenFetchSFTPTestsFixture {
   std::filesystem::path dst_dir = testController.createTempDirectory();
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::unique_ptr<SFTPTestServer> sftp_server;
-  std::shared_ptr<core::Processor> list_sftp;
-  std::shared_ptr<core::Processor> fetch_sftp;
-  std::shared_ptr<core::Processor> log_attribute;
-  std::shared_ptr<core::Processor> put_file;
+  core::Processor* list_sftp;
+  core::Processor* fetch_sftp;
+  core::Processor* log_attribute;
+  core::Processor* put_file;
 };
 
 TEST_CASE_METHOD(ListThenFetchSFTPTestsFixture, "ListSFTP then FetchSFTP one file", "[ListThenFetchSFTP][basic]") {

--- a/extensions/sftp/tests/PutSFTPTests.cpp
+++ b/extensions/sftp/tests/PutSFTPTests.cpp
@@ -190,8 +190,8 @@ class PutSFTPTestsFixture {
   std::filesystem::path dst_dir = testController.createTempDirectory();
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   std::unique_ptr<SFTPTestServer> sftp_server;
-  std::shared_ptr<core::Processor> get_file;
-  std::shared_ptr<core::Processor> put;
+  core::Processor* get_file;
+  core::Processor* put;
 };
 
 namespace {

--- a/extensions/smb/SmbConnectionControllerService.cpp
+++ b/extensions/smb/SmbConnectionControllerService.cpp
@@ -67,7 +67,7 @@ void SmbConnectionControllerService::notifyStop() {
 gsl::not_null<std::shared_ptr<SmbConnectionControllerService>> SmbConnectionControllerService::getFromProperty(const core::ProcessContext& context, const core::PropertyReference& property) {
   std::shared_ptr<SmbConnectionControllerService> smb_connection_controller_service;
   if (auto connection_controller_name = context.getProperty(property)) {
-    smb_connection_controller_service = std::dynamic_pointer_cast<SmbConnectionControllerService>(context.getControllerService(*connection_controller_name));
+    smb_connection_controller_service = std::dynamic_pointer_cast<SmbConnectionControllerService>(context.getControllerService(*connection_controller_name, context.getProcessorNode()->getUUID()));
   }
   if (!smb_connection_controller_service) {
     throw minifi::Exception(ExceptionType::PROCESS_SCHEDULE_EXCEPTION, "Missing SMB Connection Controller Service");

--- a/extensions/smb/tests/FetchSmbTests.cpp
+++ b/extensions/smb/tests/FetchSmbTests.cpp
@@ -30,8 +30,8 @@ namespace org::apache::nifi::minifi::extensions::smb::test {
 REGISTER_RESOURCE(MockSmbConnectionControllerService, ControllerService);
 
 TEST_CASE("FetchSmb invalid network path") {
-  const auto fetch_smb = std::make_shared<FetchSmb>("FetchSmb");
-  minifi::test::SingleProcessorTestController controller{fetch_smb};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<FetchSmb>("FetchSmb")};
+  const auto fetch_smb = controller.getProcessor();
   auto smb_connection_node = controller.plan->addController("MockSmbConnectionControllerService", "smb_connection_controller_service");
   REQUIRE(controller.plan->setProperty(smb_connection_node, SmbConnectionControllerService::Hostname, utils::OsUtils::getHostName().value_or("localhost")));
   REQUIRE(controller.plan->setProperty(smb_connection_node, SmbConnectionControllerService::Share, "some_share_that_does_not_exist"));
@@ -43,8 +43,8 @@ TEST_CASE("FetchSmb invalid network path") {
 }
 
 TEST_CASE("FetchSmb tests") {
-  const auto fetch_smb = std::make_shared<FetchSmb>("FetchSmb");
-  minifi::test::SingleProcessorTestController controller{fetch_smb};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<FetchSmb>("FetchSmb")};
+  const auto fetch_smb = controller.getProcessor();
 
   auto smb_connection_node = controller.plan->addController("MockSmbConnectionControllerService", "smb_connection_controller_service");
   auto mock_smb_connection_controller_service = std::dynamic_pointer_cast<MockSmbConnectionControllerService>(smb_connection_node->getControllerServiceImplementation());

--- a/extensions/smb/tests/ListAndFetchSmbTests.cpp
+++ b/extensions/smb/tests/ListAndFetchSmbTests.cpp
@@ -33,10 +33,10 @@ using minifi::processors::ReadFromFlowFileTestProcessor;
 TEST_CASE("ListSmb and FetchSmb work together") {
   TestController controller;
   auto plan = controller.createPlan();
-  auto list_smb = std::dynamic_pointer_cast<ListSmb>(plan->addProcessor("ListSmb", "list_smb"));
-  auto fetch_smb = std::dynamic_pointer_cast<FetchSmb>(plan->addProcessor("FetchSmb", "fetch_smb"));
-  auto read_from_success_relationship = std::dynamic_pointer_cast<ReadFromFlowFileTestProcessor>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_success_relationship"));
-  auto read_from_failure_relationship = std::dynamic_pointer_cast<ReadFromFlowFileTestProcessor>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_failure_relationship"));
+  auto list_smb = dynamic_cast<ListSmb*>(plan->addProcessor("ListSmb", "list_smb"));
+  auto fetch_smb = dynamic_cast<FetchSmb*>(plan->addProcessor("FetchSmb", "fetch_smb"));
+  auto read_from_success_relationship = dynamic_cast<ReadFromFlowFileTestProcessor*>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_success_relationship"));
+  auto read_from_failure_relationship = dynamic_cast<ReadFromFlowFileTestProcessor*>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_failure_relationship"));
 
   plan->addConnection(list_smb, ListSmb::Success, fetch_smb);
 

--- a/extensions/smb/tests/ListSmbTests.cpp
+++ b/extensions/smb/tests/ListSmbTests.cpp
@@ -31,8 +31,8 @@ namespace org::apache::nifi::minifi::extensions::smb::test {
 REGISTER_RESOURCE(MockSmbConnectionControllerService, ControllerService);
 
 TEST_CASE("ListSmb invalid network path") {
-  const auto list_smb = std::make_shared<ListSmb>("ListSmb");
-  minifi::test::SingleProcessorTestController controller{list_smb};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ListSmb>("ListSmb")};
+  const auto list_smb = controller.getProcessor();
   auto smb_connection_node = controller.plan->addController("MockSmbConnectionControllerService", "smb_connection_controller_service");
   REQUIRE(controller.plan->setProperty(smb_connection_node, SmbConnectionControllerService::Hostname, utils::OsUtils::getHostName().value_or("localhost")));
   REQUIRE(controller.plan->setProperty(smb_connection_node, SmbConnectionControllerService::Share, "some_share_that_does_not_exists"));
@@ -52,8 +52,8 @@ bool checkForFlowFileWithAttributes(const std::vector<std::shared_ptr<core::Flow
 }
 
 TEST_CASE("ListSmb tests") {
-  const auto list_smb = std::make_shared<ListSmb>("ListSmb");
-  minifi::test::SingleProcessorTestController controller{list_smb};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<ListSmb>("ListSmb")};
+  const auto list_smb = controller.getProcessor();
 
   auto smb_connection_node = controller.plan->addController("MockSmbConnectionControllerService", "smb_connection_controller_service");
   auto mock_smb_connection_controller_service = std::dynamic_pointer_cast<MockSmbConnectionControllerService>(smb_connection_node->getControllerServiceImplementation());

--- a/extensions/smb/tests/PutSmbTests.cpp
+++ b/extensions/smb/tests/PutSmbTests.cpp
@@ -35,8 +35,8 @@ std::string checkFileContent(const std::filesystem::path& path) {
 }
 
 TEST_CASE("PutSmb invalid network path") {
-  const auto put_smb = std::make_shared<PutSmb>("PutSmb");
-  minifi::test::SingleProcessorTestController controller{put_smb};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<PutSmb>("PutSmb")};
+  const auto put_smb = controller.getProcessor();
   auto smb_connection_node = controller.plan->addController("MockSmbConnectionControllerService", "smb_connection_controller_service");
   REQUIRE(controller.plan->setProperty(smb_connection_node, SmbConnectionControllerService::Hostname, utils::OsUtils::getHostName().value_or("localhost")));
   REQUIRE(controller.plan->setProperty(smb_connection_node, SmbConnectionControllerService::Share, "some_share_that_does_not_exists"));
@@ -48,8 +48,8 @@ TEST_CASE("PutSmb invalid network path") {
 }
 
 TEST_CASE("PutSmb conflict resolution test") {
-  const auto put_smb = std::make_shared<PutSmb>("PutSmb");
-  minifi::test::SingleProcessorTestController controller{put_smb};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<PutSmb>("PutSmb")};
+  const auto put_smb = controller.getProcessor();
 
   auto temp_directory = controller.createTempDirectory();
   auto smb_connection_node = controller.plan->addController("MockSmbConnectionControllerService", "smb_connection_controller_service");
@@ -133,8 +133,8 @@ TEST_CASE("PutSmb conflict resolution test") {
 }
 
 TEST_CASE("PutSmb create missing dirs test") {
-  const auto put_smb = std::make_shared<PutSmb>("PutSmb");
-  minifi::test::SingleProcessorTestController controller{put_smb};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<PutSmb>("PutSmb")};
+  const auto put_smb = controller.getProcessor();
 
   auto temp_directory = controller.createTempDirectory();
   auto smb_connection_node = controller.plan->addController("MockSmbConnectionControllerService", "smb_connection_controller_service");

--- a/extensions/splunk/SplunkHECProcessor.cpp
+++ b/extensions/splunk/SplunkHECProcessor.cpp
@@ -44,10 +44,10 @@ std::string SplunkHECProcessor::getNetworkLocation() const {
   return hostname_ + ":" + port_;
 }
 
-std::shared_ptr<minifi::controllers::SSLContextService> SplunkHECProcessor::getSSLContextService(core::ProcessContext& context) {
+std::shared_ptr<minifi::controllers::SSLContextService> SplunkHECProcessor::getSSLContextService(core::ProcessContext& context) const {
   std::string context_name;
   if (context.getProperty(SSLContext, context_name) && !IsNullOrEmpty(context_name))
-    return std::dynamic_pointer_cast<minifi::controllers::SSLContextService>(context.getControllerService(context_name));
+    return std::dynamic_pointer_cast<minifi::controllers::SSLContextService>(context.getControllerService(context_name, getUUID()));
   return nullptr;
 }
 

--- a/extensions/splunk/SplunkHECProcessor.h
+++ b/extensions/splunk/SplunkHECProcessor.h
@@ -80,7 +80,7 @@ class SplunkHECProcessor : public core::Processor {
 
  protected:
   std::string getNetworkLocation() const;
-  static std::shared_ptr<minifi::controllers::SSLContextService> getSSLContextService(core::ProcessContext& context);
+  std::shared_ptr<minifi::controllers::SSLContextService> getSSLContextService(core::ProcessContext& context) const;
   void initializeClient(http::HTTPClient& client, const std::string &url, std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service) const;
 
   std::string token_;

--- a/extensions/splunk/tests/PutSplunkHTTPTests.cpp
+++ b/extensions/splunk/tests/PutSplunkHTTPTests.cpp
@@ -36,10 +36,10 @@ TEST_CASE("PutSplunkHTTP tests", "[putsplunkhttp]") {
 
   TestController test_controller;
   auto plan = test_controller.createPlan();
-  auto write_to_flow_file = std::dynamic_pointer_cast<WriteToFlowFileTestProcessor>(plan->addProcessor("WriteToFlowFileTestProcessor", "write_to_flow_file"));
-  auto put_splunk_http = std::dynamic_pointer_cast<PutSplunkHTTP>(plan->addProcessor("PutSplunkHTTP", "put_splunk_http"));
-  auto read_from_success = std::dynamic_pointer_cast<ReadFromFlowFileTestProcessor>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_success"));
-  auto read_from_failure = std::dynamic_pointer_cast<ReadFromFlowFileTestProcessor>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_failure"));
+  auto write_to_flow_file = dynamic_cast<WriteToFlowFileTestProcessor*>(plan->addProcessor("WriteToFlowFileTestProcessor", "write_to_flow_file"));
+  auto put_splunk_http = dynamic_cast<PutSplunkHTTP*>(plan->addProcessor("PutSplunkHTTP", "put_splunk_http"));
+  auto read_from_success = dynamic_cast<ReadFromFlowFileTestProcessor*>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_success"));
+  auto read_from_failure = dynamic_cast<ReadFromFlowFileTestProcessor*>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_failure"));
 
   plan->addConnection(write_to_flow_file, WriteToFlowFileTestProcessor::Success, put_splunk_http);
   plan->addConnection(put_splunk_http, PutSplunkHTTP::Success, read_from_success);
@@ -128,9 +128,9 @@ TEST_CASE("PutSplunkHTTP content type tests", "[putsplunkhttpcontenttype]") {
 
   TestController test_controller;
   auto plan = test_controller.createPlan();
-  auto write_to_flow_file = std::dynamic_pointer_cast<WriteToFlowFileTestProcessor>(plan->addProcessor("WriteToFlowFileTestProcessor", "write_to_flow_file"));
-  auto update_attribute = std::dynamic_pointer_cast<UpdateAttribute>(plan->addProcessor("UpdateAttribute", "update_attribute"));
-  auto put_splunk_http = std::dynamic_pointer_cast<PutSplunkHTTP>(plan->addProcessor("PutSplunkHTTP", "put_splunk_http"));
+  auto write_to_flow_file = dynamic_cast<WriteToFlowFileTestProcessor*>(plan->addProcessor("WriteToFlowFileTestProcessor", "write_to_flow_file"));
+  auto update_attribute = dynamic_cast<UpdateAttribute*>(plan->addProcessor("UpdateAttribute", "update_attribute"));
+  auto put_splunk_http = dynamic_cast<PutSplunkHTTP*>(plan->addProcessor("PutSplunkHTTP", "put_splunk_http"));
 
   plan->addConnection(write_to_flow_file, WriteToFlowFileTestProcessor::Success, update_attribute);
   plan->addConnection(update_attribute, UpdateAttribute::Success, put_splunk_http);

--- a/extensions/splunk/tests/QuerySplunkIndexingStatusTests.cpp
+++ b/extensions/splunk/tests/QuerySplunkIndexingStatusTests.cpp
@@ -37,13 +37,13 @@ TEST_CASE("QuerySplunkIndexingStatus tests", "[querysplunkindexingstatus]") {
 
   TestController test_controller;
   auto plan = test_controller.createPlan();
-  auto write_to_flow_file = std::dynamic_pointer_cast<WriteToFlowFileTestProcessor>(plan->addProcessor("WriteToFlowFileTestProcessor", "write_to_flow_file"));
-  auto update_attribute = std::dynamic_pointer_cast<UpdateAttribute>(plan->addProcessor("UpdateAttribute", "update_attribute"));
-  auto query_splunk_indexing_status = std::dynamic_pointer_cast<QuerySplunkIndexingStatus>(plan->addProcessor("QuerySplunkIndexingStatus", "query_splunk_indexing_status"));
-  auto read_from_acknowledged = std::dynamic_pointer_cast<ReadFromFlowFileTestProcessor>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_acknowledged"));
-  auto read_from_undetermined = std::dynamic_pointer_cast<ReadFromFlowFileTestProcessor>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_undetermined"));
-  auto read_from_unacknowledged = std::dynamic_pointer_cast<ReadFromFlowFileTestProcessor>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_unacknowledged"));
-  auto read_from_failure = std::dynamic_pointer_cast<ReadFromFlowFileTestProcessor>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_failure"));
+  auto write_to_flow_file = dynamic_cast<WriteToFlowFileTestProcessor*>(plan->addProcessor("WriteToFlowFileTestProcessor", "write_to_flow_file"));
+  auto update_attribute = dynamic_cast<UpdateAttribute*>(plan->addProcessor("UpdateAttribute", "update_attribute"));
+  auto query_splunk_indexing_status = dynamic_cast<QuerySplunkIndexingStatus*>(plan->addProcessor("QuerySplunkIndexingStatus", "query_splunk_indexing_status"));
+  auto read_from_acknowledged = dynamic_cast<ReadFromFlowFileTestProcessor*>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_acknowledged"));
+  auto read_from_undetermined = dynamic_cast<ReadFromFlowFileTestProcessor*>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_undetermined"));
+  auto read_from_unacknowledged = dynamic_cast<ReadFromFlowFileTestProcessor*>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_unacknowledged"));
+  auto read_from_failure = dynamic_cast<ReadFromFlowFileTestProcessor*>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_failure"));
 
   plan->addConnection(write_to_flow_file, WriteToFlowFileTestProcessor::Success, update_attribute);
   plan->addConnection(update_attribute, UpdateAttribute ::Success, query_splunk_indexing_status);

--- a/extensions/sql/processors/SQLProcessor.cpp
+++ b/extensions/sql/processors/SQLProcessor.cpp
@@ -31,7 +31,7 @@ void SQLProcessor::onSchedule(core::ProcessContext& context, core::ProcessSessio
   std::string controllerService;
   context.getProperty(DBControllerService, controllerService);
 
-  if (auto service = context.getControllerService(controllerService)) {
+  if (auto service = context.getControllerService(controllerService, getUUID())) {
     db_service_ = std::dynamic_pointer_cast<sql::controllers::DatabaseService>(service);
     if (!db_service_) {
       throw minifi::Exception(PROCESSOR_EXCEPTION, "'" + controllerService + "' is not a DatabaseService");

--- a/extensions/sql/tests/PutSQLTests.cpp
+++ b/extensions/sql/tests/PutSQLTests.cpp
@@ -114,7 +114,6 @@ TEST_CASE("PutSQL routes to failure on malformed content statement") {
   SQLTestController testController;
 
   auto plan = testController.createSQLPlan("PutSQL", {{"success", "d"}, {"failure", "d"}});
-  auto sql_proc = plan->getSQLProcessor();
 
   std::shared_ptr<core::FlowFile> input_file;
   SECTION("No parameters") {

--- a/extensions/sql/tests/SQLTestPlan.h
+++ b/extensions/sql/tests/SQLTestPlan.h
@@ -75,7 +75,7 @@ class SQLTestPlan {
     return flow_file;
   }
 
-  std::shared_ptr<core::Processor> getSQLProcessor() {
+  core::Processor* getSQLProcessor() {
     return processor_;
   }
 
@@ -83,7 +83,7 @@ class SQLTestPlan {
     if (reschedule) {
       plan_->reset(reschedule);
     }
-    plan_->runProcessor(0);  // run the one and only sql processor
+    plan_->runProcessor(static_cast<size_t>(0));  // run the one and only sql processor
   }
 
   std::vector<std::shared_ptr<core::FlowFile>> getOutputs(const core::Relationship& relationship) {
@@ -101,7 +101,7 @@ class SQLTestPlan {
 
  private:
   std::shared_ptr<TestPlan> plan_;
-  std::shared_ptr<core::Processor> processor_;
+  core::Processor* processor_;
   minifi::Connection* input_;
   std::map<core::Relationship, minifi::Connection*> outputs_;
 };

--- a/extensions/standard-processors/modbus/FetchModbusTcp.cpp
+++ b/extensions/standard-processors/modbus/FetchModbusTcp.cpp
@@ -34,7 +34,7 @@ namespace org::apache::nifi::minifi::modbus {
 
 void FetchModbusTcp::onSchedule(core::ProcessContext& context, core::ProcessSessionFactory&) {
   const auto record_set_writer_name = context.getProperty(RecordSetWriter);
-  record_set_writer_ = std::dynamic_pointer_cast<core::RecordSetWriter>(context.getControllerService(record_set_writer_name.value_or("")));
+  record_set_writer_ = std::dynamic_pointer_cast<core::RecordSetWriter>(context.getControllerService(record_set_writer_name.value_or(""), getUUID()));
   if (!record_set_writer_) {
     throw Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, "Invalid or missing RecordSetWriter"};
   }
@@ -66,7 +66,7 @@ void FetchModbusTcp::onSchedule(core::ProcessContext& context, core::ProcessSess
 
   ssl_context_.reset();
   if (const auto controller_service_name = context.getProperty(SSLContextService); controller_service_name && !IsNullOrEmpty(*controller_service_name)) {
-    if (auto controller_service = context.getControllerService(*controller_service_name)) {
+    if (auto controller_service = context.getControllerService(*controller_service_name, getUUID())) {
       if (const auto ssl_context_service = std::dynamic_pointer_cast<minifi::controllers::SSLContextService>(controller_service)) {
         ssl_context_ = utils::net::getSslContext(*ssl_context_service);
       } else {

--- a/extensions/standard-processors/processors/GetTCP.cpp
+++ b/extensions/standard-processors/processors/GetTCP.cpp
@@ -70,11 +70,11 @@ char GetTCP::parseDelimiter(core::ProcessContext& context) {
   return delimiter;
 }
 
-std::optional<asio::ssl::context> GetTCP::parseSSLContext(core::ProcessContext& context) {
+std::optional<asio::ssl::context> GetTCP::parseSSLContext(core::ProcessContext& context) const {
   std::optional<asio::ssl::context> ssl_context;
   if (auto context_name = context.getProperty(SSLContextService)) {
-    if (auto controller_service = context.getControllerService(*context_name)) {
-      if (auto ssl_context_service = std::dynamic_pointer_cast<minifi::controllers::SSLContextService>(context.getControllerService(*context_name))) {
+    if (auto controller_service = context.getControllerService(*context_name, getUUID())) {
+      if (auto ssl_context_service = std::dynamic_pointer_cast<minifi::controllers::SSLContextService>(context.getControllerService(*context_name, getUUID()))) {
         ssl_context = utils::net::getSslContext(*ssl_context_service);
       } else {
         throw Exception(PROCESS_SCHEDULE_EXCEPTION, *context_name + " is not an SSL Context Service");

--- a/extensions/standard-processors/processors/GetTCP.h
+++ b/extensions/standard-processors/processors/GetTCP.h
@@ -141,7 +141,7 @@ class GetTCP : public core::Processor {
 
   std::vector<utils::net::ConnectionId> parseEndpointList(core::ProcessContext& context);
   static char parseDelimiter(core::ProcessContext& context);
-  static std::optional<asio::ssl::context> parseSSLContext(core::ProcessContext& context);
+  std::optional<asio::ssl::context> parseSSLContext(core::ProcessContext& context) const;
   static uint64_t parseMaxBatchSize(core::ProcessContext& context);
 
   class TcpClient {

--- a/extensions/standard-processors/processors/InvokeHTTP.cpp
+++ b/extensions/standard-processors/processors/InvokeHTTP.cpp
@@ -111,7 +111,7 @@ void InvokeHTTP::setupMembersFromProperties(const core::ProcessContext& context)
   content_type_ = context.getProperty(InvokeHTTP::ContentType);
 
   if (auto ssl_context_name = context.getProperty(SSLContext)) {
-    if (auto service = context.getControllerService(*ssl_context_name)) {
+    if (auto service = context.getControllerService(*ssl_context_name, getUUID())) {
       ssl_context_service_ = std::dynamic_pointer_cast<minifi::controllers::SSLContextService>(service);
       if (!ssl_context_service_)
         logger_->log_error("Controller service '{}' is not an SSLContextService", *ssl_context_name);

--- a/extensions/standard-processors/processors/PutTCP.cpp
+++ b/extensions/standard-processors/processors/PutTCP.cpp
@@ -75,8 +75,8 @@ void PutTCP::onSchedule(core::ProcessContext& context, core::ProcessSessionFacto
   std::string context_name;
   ssl_context_.reset();
   if (context.getProperty(SSLContextService, context_name) && !IsNullOrEmpty(context_name)) {
-    if (auto controller_service = context.getControllerService(context_name)) {
-      if (const auto ssl_context_service = std::dynamic_pointer_cast<minifi::controllers::SSLContextService>(context.getControllerService(context_name))) {
+    if (auto controller_service = context.getControllerService(context_name, getUUID())) {
+      if (const auto ssl_context_service = std::dynamic_pointer_cast<minifi::controllers::SSLContextService>(context.getControllerService(context_name, getUUID()))) {
         ssl_context_ = utils::net::getSslContext(*ssl_context_service);
       } else {
         throw Exception(PROCESS_SCHEDULE_EXCEPTION, context_name + " is not an SSL Context Service");

--- a/extensions/standard-processors/processors/TailFile.cpp
+++ b/extensions/standard-processors/processors/TailFile.cpp
@@ -315,7 +315,7 @@ void TailFile::parseAttributeProviderServiceProperty(core::ProcessContext& conte
     return;
   }
 
-  std::shared_ptr<core::controller::ControllerService> controller_service = context.getControllerService(*attribute_provider_service_name);
+  std::shared_ptr<core::controller::ControllerService> controller_service = context.getControllerService(*attribute_provider_service_name, getUUID());
   if (!controller_service) {
     throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, utils::string::join_pack("Controller service '", *attribute_provider_service_name, "' not found")};
   }

--- a/extensions/standard-processors/tests/unit/AppendHostInfoTests.cpp
+++ b/extensions/standard-processors/tests/unit/AppendHostInfoTests.cpp
@@ -29,9 +29,9 @@ TEST_CASE("AppendHostInfoTest", "[appendhostinfotest]") {
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   LogTestController::getInstance().setTrace<minifi::processors::AppendHostInfo>();
   LogTestController::getInstance().setTrace<minifi::processors::LogAttribute>();
-  std::shared_ptr<core::Processor> generate_flow_file = plan->addProcessor("GenerateFlowFile", "generate_flow_file");
-  std::shared_ptr<core::Processor> append_host_info = plan->addProcessor("AppendHostInfo", "append_host_info", core::Relationship("success", "description"), true);
-  std::shared_ptr<core::Processor> log_attribute = plan->addProcessor("LogAttribute", "log_attributes", core::Relationship("success", "description"), true);
+  plan->addProcessor("GenerateFlowFile", "generate_flow_file");
+  plan->addProcessor("AppendHostInfo", "append_host_info", core::Relationship("success", "description"), true);
+  plan->addProcessor("LogAttribute", "log_attributes", core::Relationship("success", "description"), true);
 
   testController.runSession(plan);
 
@@ -44,9 +44,9 @@ TEST_CASE("AppendHostInfoTestWithUnmatchableRegex", "[appendhostinfotestunmatcha
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   LogTestController::getInstance().setTrace<minifi::processors::AppendHostInfo>();
   LogTestController::getInstance().setTrace<minifi::processors::LogAttribute>();
-  std::shared_ptr<core::Processor> generate_flow_file = plan->addProcessor("GenerateFlowFile", "generate_flow_file");
-  std::shared_ptr<core::Processor> append_host_info = plan->addProcessor("AppendHostInfo", "append_host_info", core::Relationship("success", "description"), true);
-  std::shared_ptr<core::Processor> log_attribute = plan->addProcessor("LogAttribute", "log_attributes", core::Relationship("success", "description"), true);
+  plan->addProcessor("GenerateFlowFile", "generate_flow_file");
+  auto append_host_info = plan->addProcessor("AppendHostInfo", "append_host_info", core::Relationship("success", "description"), true);
+  plan->addProcessor("LogAttribute", "log_attributes", core::Relationship("success", "description"), true);
 
   plan->setProperty(append_host_info, AppendHostInfo::InterfaceNameFilter, "\b");
 
@@ -62,9 +62,9 @@ TEST_CASE("AppendHostInfoTestCanFilterOutLoopbackInterfacesWithRegex", "[appendh
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   LogTestController::getInstance().setTrace<minifi::processors::AppendHostInfo>();
   LogTestController::getInstance().setTrace<minifi::processors::LogAttribute>();
-  std::shared_ptr<core::Processor> generate_flow_file = plan->addProcessor("GenerateFlowFile", "generate_flow_file");
-  std::shared_ptr<core::Processor> append_host_info = plan->addProcessor("AppendHostInfo", "append_host_info", core::Relationship("success", "description"), true);
-  std::shared_ptr<core::Processor> log_attribute = plan->addProcessor("LogAttribute", "log_attributes", core::Relationship("success", "description"), true);
+  plan->addProcessor("GenerateFlowFile", "generate_flow_file");
+  auto append_host_info = plan->addProcessor("AppendHostInfo", "append_host_info", core::Relationship("success", "description"), true);
+  plan->addProcessor("LogAttribute", "log_attributes", core::Relationship("success", "description"), true);
 
   plan->setProperty(append_host_info, AppendHostInfo::InterfaceNameFilter, "(?!Loopback|lo).*?");  // set up the regex to accept everything except interfaces starting with Loopback or lo
 

--- a/extensions/standard-processors/tests/unit/AttributeRollingWindowTests.cpp
+++ b/extensions/standard-processors/tests/unit/AttributeRollingWindowTests.cpp
@@ -36,8 +36,8 @@ bool checkAttributes(const std::map<std::string, std::string>& expected, const s
 }
 
 TEST_CASE("AttributeRollingWindow properly forwards properties to RollingWindow and sets attributes", "[attributerollingwindow]") {
-  const auto proc = std::make_shared<AttributeRollingWindow>("AttributeRollingWindow");
-  SingleProcessorTestController controller{proc};
+  SingleProcessorTestController controller{std::make_unique<AttributeRollingWindow>("AttributeRollingWindow")};
+  const auto proc = controller.getProcessor();
   proc->setProperty(AttributeRollingWindow::ValueToTrack, "${value}");
   proc->setProperty(AttributeRollingWindow::WindowLength, "3");
   const auto trigger_with_value_and_check_attributes = [&controller](const std::string& value, const std::map<std::string, std::string>& expected_out_attributes) {

--- a/extensions/standard-processors/tests/unit/AttributesToJSONTests.cpp
+++ b/extensions/standard-processors/tests/unit/AttributesToJSONTests.cpp
@@ -109,11 +109,11 @@ class AttributesToJSONTestFixture {
   TestController test_controller_;
   std::shared_ptr<TestPlan> plan_;
   std::filesystem::path dir_;
-  std::shared_ptr<core::Processor> getfile_;
-  std::shared_ptr<core::Processor> update_attribute_;
-  std::shared_ptr<core::Processor> attribute_to_json_;
-  std::shared_ptr<core::Processor> logattribute_;
-  std::shared_ptr<core::Processor> putfile_;
+  core::Processor* getfile_ = nullptr;
+  core::Processor* update_attribute_ = nullptr;
+  core::Processor* attribute_to_json_ = nullptr;
+  core::Processor* logattribute_ = nullptr;
+  core::Processor* putfile_ = nullptr;
 };
 
 TEST_CASE_METHOD(AttributesToJSONTestFixture, "Move all attributes to a flowfile attribute", "[AttributesToJSONTests]") {

--- a/extensions/standard-processors/tests/unit/DefragmentTextTests.cpp
+++ b/extensions/standard-processors/tests/unit/DefragmentTextTests.cpp
@@ -37,10 +37,10 @@ namespace defragment_text = org::apache::nifi::minifi::processors::defragment_te
 TEST_CASE("DefragmentText Single source tests", "[defragmenttextsinglesource]") {
   TestController testController;
   auto plan = testController.createPlan();
-  auto write_to_flow_file = std::dynamic_pointer_cast<WriteToFlowFileTestProcessor>(plan->addProcessor("WriteToFlowFileTestProcessor", "write_to_flow_file"));
-  auto defrag_text_flow_files = std::dynamic_pointer_cast<DefragmentText>(plan->addProcessor("DefragmentText", "defrag_text_flow_files"));
-  auto read_from_success_relationship = std::dynamic_pointer_cast<ReadFromFlowFileTestProcessor>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_success_relationship"));
-  auto read_from_failure_relationship = std::dynamic_pointer_cast<ReadFromFlowFileTestProcessor>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_failure_relationship"));
+  auto write_to_flow_file = dynamic_cast<WriteToFlowFileTestProcessor*>(plan->addProcessor("WriteToFlowFileTestProcessor", "write_to_flow_file"));
+  auto defrag_text_flow_files = dynamic_cast<DefragmentText*>(plan->addProcessor("DefragmentText", "defrag_text_flow_files"));
+  auto read_from_success_relationship = dynamic_cast<ReadFromFlowFileTestProcessor*>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_success_relationship"));
+  auto read_from_failure_relationship = dynamic_cast<ReadFromFlowFileTestProcessor*>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_failure_relationship"));
 
   plan->addConnection(write_to_flow_file, WriteToFlowFileTestProcessor::Success, defrag_text_flow_files);
 
@@ -222,13 +222,13 @@ TEST_CASE("DefragmentText Single source tests", "[defragmenttextsinglesource]") 
 TEST_CASE("DefragmentTextMultipleSources", "[defragmenttextinvalidsources]") {
   TestController testController;
   auto plan = testController.createPlan();
-  auto input_1 = std::dynamic_pointer_cast<WriteToFlowFileTestProcessor>(plan->addProcessor("WriteToFlowFileTestProcessor", "input_1"));
-  auto input_2 = std::dynamic_pointer_cast<WriteToFlowFileTestProcessor>(plan->addProcessor("WriteToFlowFileTestProcessor", "input_2"));
-  auto update_ff_1 = std::dynamic_pointer_cast<UpdateAttribute>(plan->addProcessor("UpdateAttribute", "update_attribute_1"));
-  auto update_ff_2 = std::dynamic_pointer_cast<UpdateAttribute>(plan->addProcessor("UpdateAttribute", "update_attribute_2"));
-  auto defrag_text_flow_files = std::dynamic_pointer_cast<DefragmentText>(plan->addProcessor("DefragmentText", "defrag_text_flow_files"));
-  auto read_from_failure_relationship = std::dynamic_pointer_cast<ReadFromFlowFileTestProcessor>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_failure_relationship"));
-  auto read_from_success_relationship = std::dynamic_pointer_cast<ReadFromFlowFileTestProcessor>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_success_relationship"));
+  auto input_1 = dynamic_cast<WriteToFlowFileTestProcessor*>(plan->addProcessor("WriteToFlowFileTestProcessor", "input_1"));
+  auto input_2 = dynamic_cast<WriteToFlowFileTestProcessor*>(plan->addProcessor("WriteToFlowFileTestProcessor", "input_2"));
+  auto update_ff_1 = dynamic_cast<UpdateAttribute*>(plan->addProcessor("UpdateAttribute", "update_attribute_1"));
+  auto update_ff_2 = dynamic_cast<UpdateAttribute*>(plan->addProcessor("UpdateAttribute", "update_attribute_2"));
+  auto defrag_text_flow_files = dynamic_cast<DefragmentText*>(plan->addProcessor("DefragmentText", "defrag_text_flow_files"));
+  auto read_from_failure_relationship = dynamic_cast<ReadFromFlowFileTestProcessor*>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_failure_relationship"));
+  auto read_from_success_relationship = dynamic_cast<ReadFromFlowFileTestProcessor*>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_success_relationship"));
 
   plan->addConnection(input_1, WriteToFlowFileTestProcessor::Success, update_ff_1);
   plan->addConnection(input_2, WriteToFlowFileTestProcessor::Success, update_ff_2);
@@ -370,12 +370,12 @@ REGISTER_RESOURCE(FragmentGenerator, Processor);
 TEST_CASE("DefragmentText with offset attributes", "[defragmenttextoffsetattributes]") {
   TestController testController;
   auto plan = testController.createPlan();
-  auto input_1 = std::dynamic_pointer_cast<FragmentGenerator>(plan->addProcessor("FragmentGenerator", "input_1"));
-  auto input_2 = std::dynamic_pointer_cast<FragmentGenerator>(plan->addProcessor("FragmentGenerator", "input_2"));
+  auto input_1 = dynamic_cast<FragmentGenerator*>(plan->addProcessor("FragmentGenerator", "input_1"));
+  auto input_2 = dynamic_cast<FragmentGenerator*>(plan->addProcessor("FragmentGenerator", "input_2"));
 
-  auto defrag_text_flow_files = std::dynamic_pointer_cast<DefragmentText>(plan->addProcessor("DefragmentText", "defrag_text_flow_files"));
-  auto read_from_failure_relationship = std::dynamic_pointer_cast<ReadFromFlowFileTestProcessor>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_failure_relationship"));
-  auto read_from_success_relationship = std::dynamic_pointer_cast<ReadFromFlowFileTestProcessor>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_success_relationship"));
+  auto defrag_text_flow_files = dynamic_cast<DefragmentText*>(plan->addProcessor("DefragmentText", "defrag_text_flow_files"));
+  auto read_from_failure_relationship = dynamic_cast<ReadFromFlowFileTestProcessor*>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_failure_relationship"));
+  auto read_from_success_relationship = dynamic_cast<ReadFromFlowFileTestProcessor*>(plan->addProcessor("ReadFromFlowFileTestProcessor", "read_from_success_relationship"));
 
   plan->addConnection(input_1, FragmentGenerator::Success, defrag_text_flow_files);
   plan->addConnection(input_2, FragmentGenerator::Success, defrag_text_flow_files);

--- a/extensions/standard-processors/tests/unit/ExtractTextTests.cpp
+++ b/extensions/standard-processors/tests/unit/ExtractTextTests.cpp
@@ -47,7 +47,7 @@ const char* TEST_ATTR = "ExtractedText";
 
 TEST_CASE("Test creation of ExtractText", "[extracttextCreate]") {
   TestController testController;
-  auto processor = std::make_shared<org::apache::nifi::minifi::processors::ExtractText>("processorname");
+  auto processor = std::make_unique<org::apache::nifi::minifi::processors::ExtractText>("processorname");
   REQUIRE(processor->getName() == "processorname");
   utils::Identifier processoruuid = processor->getUUID();
   REQUIRE(processoruuid);

--- a/extensions/standard-processors/tests/unit/ExtractTextTests.cpp
+++ b/extensions/standard-processors/tests/unit/ExtractTextTests.cpp
@@ -47,7 +47,7 @@ const char* TEST_ATTR = "ExtractedText";
 
 TEST_CASE("Test creation of ExtractText", "[extracttextCreate]") {
   TestController testController;
-  std::shared_ptr<core::Processor> processor = std::make_shared<org::apache::nifi::minifi::processors::ExtractText>("processorname");
+  auto processor = std::make_shared<org::apache::nifi::minifi::processors::ExtractText>("processorname");
   REQUIRE(processor->getName() == "processorname");
   utils::Identifier processoruuid = processor->getUUID();
   REQUIRE(processoruuid);
@@ -69,14 +69,14 @@ TEST_CASE("Test usage of ExtractText", "[extracttextTest]") {
 
   auto temp_dir = testController.createTempDirectory();
   REQUIRE(!temp_dir.empty());
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
+  auto getfile = plan->addProcessor("GetFile", "getfileCreate2");
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory, temp_dir.string());
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::KeepSourceFile, "true");
 
-  std::shared_ptr<core::Processor> maprocessor = plan->addProcessor("ExtractText", "testExtractText", core::Relationship("success", "description"), true);
+  auto maprocessor = plan->addProcessor("ExtractText", "testExtractText", core::Relationship("success", "description"), true);
   plan->setProperty(maprocessor, org::apache::nifi::minifi::processors::ExtractText::Attribute, TEST_ATTR);
 
-  std::shared_ptr<core::Processor> laprocessor = plan->addProcessor("LogAttribute", "outputLogAttribute", core::Relationship("success", "description"), true);
+  plan->addProcessor("LogAttribute", "outputLogAttribute", core::Relationship("success", "description"), true);
 
   auto test_file_path = temp_dir / TEST_FILE;
 
@@ -134,17 +134,17 @@ TEST_CASE("Test usage of ExtractText in regex mode", "[extracttextRegexTest]") {
 
   auto dir = testController.createTempDirectory();
   REQUIRE(!dir.empty());
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
+  auto getfile = plan->addProcessor("GetFile", "getfileCreate2");
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory, dir.string());
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::KeepSourceFile, "true");
 
-  std::shared_ptr<core::Processor> maprocessor = plan->addProcessor("ExtractText", "testExtractText", core::Relationship("success", "description"), true);
+  auto maprocessor = plan->addProcessor("ExtractText", "testExtractText", core::Relationship("success", "description"), true);
   plan->setProperty(maprocessor, org::apache::nifi::minifi::processors::ExtractText::RegexMode, "true");
   plan->setProperty(maprocessor, org::apache::nifi::minifi::processors::ExtractText::EnableRepeatingCaptureGroup, "true");
   plan->setDynamicProperty(maprocessor, "RegexAttr", "Speed limit ([0-9]+)");
   plan->setDynamicProperty(maprocessor, "InvalidRegex", "[Invalid)A(F)");
 
-  std::shared_ptr<core::Processor> laprocessor = plan->addProcessor("LogAttribute", "outputLogAttribute", core::Relationship("success", "description"), true);
+  plan->addProcessor("LogAttribute", "outputLogAttribute", core::Relationship("success", "description"), true);
 
   auto test_file_path = dir / TEST_FILE;
 
@@ -211,7 +211,7 @@ TEST_CASE("Test usage of ExtractText in regex mode with large regex matches", "[
   plan->setProperty(extract_text_processor, org::apache::nifi::minifi::processors::ExtractText::IncludeCaptureGroupZero, "false");
   plan->setDynamicProperty(extract_text_processor, "RegexAttr", "Speed limit (.*)");
 
-  auto log_attribute_processor = plan->addProcessor("LogAttribute", "outputLogAttribute", core::Relationship("success", "description"), true);
+  plan->addProcessor("LogAttribute", "outputLogAttribute", core::Relationship("success", "description"), true);
 
   std::string additional_long_string(100'000, '.');
   minifi::test::utils::putFileToDir(dir, TEST_FILE, "Speed limit 80" + additional_long_string);

--- a/extensions/standard-processors/tests/unit/FetchFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/FetchFileTests.cpp
@@ -45,8 +45,8 @@ class FetchFileTestFixture {
  protected:
   [[nodiscard]] std::unordered_multiset<std::string> getDirContents(const std::filesystem::path& dir_path) const;
 
-  std::shared_ptr<minifi::processors::FetchFile> fetch_file_processor_;
   std::shared_ptr<minifi::test::SingleProcessorTestController> test_controller_;
+  minifi::processors::FetchFile* fetch_file_processor_ = nullptr;
   const std::filesystem::path input_dir_;
   const std::filesystem::path permission_denied_file_name_;
   const std::filesystem::path input_file_name_;
@@ -55,8 +55,8 @@ class FetchFileTestFixture {
 };
 
 FetchFileTestFixture::FetchFileTestFixture()
-  : fetch_file_processor_(std::make_shared<minifi::processors::FetchFile>("FetchFile")),
-    test_controller_(std::make_shared<minifi::test::SingleProcessorTestController>(fetch_file_processor_)),
+  : test_controller_(std::make_shared<minifi::test::SingleProcessorTestController>(std::make_unique<minifi::processors::FetchFile>("FetchFile"))),
+    fetch_file_processor_(test_controller_->getProcessor<minifi::processors::FetchFile>()),
     input_dir_(test_controller_->createTempDirectory()),
     permission_denied_file_name_("permission_denied.txt"),
     input_file_name_("test.txt"),

--- a/extensions/standard-processors/tests/unit/GenerateFlowFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/GenerateFlowFileTests.cpp
@@ -37,8 +37,9 @@ TEST_CASE("GenerateFlowFileWithBinaryData") {
     is_unique = true;
   }
 
-  std::shared_ptr<GenerateFlowFile> generate_flow_file = std::make_shared<GenerateFlowFile>("GenerateFlowFile");
-  minifi::test::SingleProcessorTestController test_controller{generate_flow_file};
+
+  minifi::test::SingleProcessorTestController test_controller{std::make_unique<GenerateFlowFile>("GenerateFlowFile")};
+  auto generate_flow_file = test_controller.getProcessor();
   LogTestController::getInstance().setWarn<GenerateFlowFile>();
 
   test_controller.plan->setProperty(generate_flow_file, GenerateFlowFile::FileSize, "10");
@@ -66,8 +67,8 @@ TEST_CASE("GenerateFlowFileWithBinaryData") {
 }
 
 TEST_CASE("GenerateFlowFileTestEmpty") {
-  std::shared_ptr<GenerateFlowFile> generate_flow_file = std::make_shared<GenerateFlowFile>("GenerateFlowFile");
-  minifi::test::SingleProcessorTestController test_controller{generate_flow_file};
+  minifi::test::SingleProcessorTestController test_controller{std::make_unique<GenerateFlowFile>("GenerateFlowFile")};
+  auto generate_flow_file = test_controller.getProcessor();
 
   test_controller.plan->setProperty(generate_flow_file, GenerateFlowFile::FileSize, "0");
   test_controller.plan->setProperty(generate_flow_file, GenerateFlowFile::UniqueFlowFiles, "false");
@@ -80,8 +81,8 @@ TEST_CASE("GenerateFlowFileTestEmpty") {
 }
 
 TEST_CASE("GenerateFlowFileCustomTextTest") {
-  std::shared_ptr<GenerateFlowFile> generate_flow_file = std::make_shared<GenerateFlowFile>("GenerateFlowFile");
-  minifi::test::SingleProcessorTestController test_controller{generate_flow_file};
+  minifi::test::SingleProcessorTestController test_controller{std::make_unique<GenerateFlowFile>("GenerateFlowFile")};
+  auto generate_flow_file = test_controller.getProcessor();
 
   constexpr auto uuid_string_length = 36;
 
@@ -96,8 +97,8 @@ TEST_CASE("GenerateFlowFileCustomTextTest") {
 }
 
 TEST_CASE("GenerateFlowFileCustomTextEmptyTest") {
-  std::shared_ptr<GenerateFlowFile> generate_flow_file = std::make_shared<GenerateFlowFile>("GenerateFlowFile");
-  minifi::test::SingleProcessorTestController test_controller{generate_flow_file};
+  minifi::test::SingleProcessorTestController test_controller{std::make_unique<GenerateFlowFile>("GenerateFlowFile")};
+  auto generate_flow_file = test_controller.getProcessor();
 
   constexpr int32_t file_size = 10;
 
@@ -118,8 +119,8 @@ TEST_CASE("GenerateFlowFileCustomTextEmptyTest") {
 }
 
 TEST_CASE("GenerateFlowFile reevaluating CustomText") {
-  std::shared_ptr<GenerateFlowFile> generate_flow_file = std::make_shared<GenerateFlowFile>("GenerateFlowFile");
-  minifi::test::SingleProcessorTestController test_controller{generate_flow_file};
+  minifi::test::SingleProcessorTestController test_controller{std::make_unique<GenerateFlowFile>("GenerateFlowFile")};
+  auto generate_flow_file = test_controller.getProcessor();
   test_controller.plan->setProperty(generate_flow_file, GenerateFlowFile::DataFormat, "Text");
   test_controller.plan->setProperty(generate_flow_file, GenerateFlowFile::UniqueFlowFiles, "false");
   test_controller.plan->setProperty(generate_flow_file, GenerateFlowFile::CustomText, "${nextInt()}");
@@ -135,8 +136,8 @@ TEST_CASE("GenerateFlowFile reevaluating CustomText") {
 }
 
 TEST_CASE("GenerateFlowFile CustomText evaluates to empty string") {
-  std::shared_ptr<GenerateFlowFile> generate_flow_file = std::make_shared<GenerateFlowFile>("GenerateFlowFile");
-  minifi::test::SingleProcessorTestController test_controller{generate_flow_file};
+  minifi::test::SingleProcessorTestController test_controller{std::make_unique<GenerateFlowFile>("GenerateFlowFile")};
+  auto generate_flow_file = test_controller.getProcessor();
   test_controller.plan->setProperty(generate_flow_file, GenerateFlowFile::DataFormat, "Text");
   test_controller.plan->setProperty(generate_flow_file, GenerateFlowFile::UniqueFlowFiles, "false");
   test_controller.plan->setProperty(generate_flow_file, GenerateFlowFile::CustomText, "${invalid_variable}");

--- a/extensions/standard-processors/tests/unit/GetFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/GetFileTests.cpp
@@ -52,7 +52,7 @@ class GetFileTestController {
   std::filesystem::path input_file_name_;
   std::filesystem::path large_input_file_name_;
   std::filesystem::path hidden_input_file_name_;
-  std::shared_ptr<core::Processor> get_file_processor_;
+  core::Processor* get_file_processor_ = nullptr;
 };
 
 GetFileTestController::GetFileTestController()
@@ -270,9 +270,9 @@ TEST_CASE("Test if GetFile honors PollInterval property when triggered multiple 
 TEST_CASE("GetFile sets attributes correctly") {
   using minifi::processors::GetFile;
 
-  const auto get_file = std::make_shared<GetFile>("GetFile");
   LogTestController::getInstance().setTrace<GetFile>();
-  minifi::test::SingleProcessorTestController test_controller(get_file);
+  minifi::test::SingleProcessorTestController test_controller(std::make_unique<GetFile>("GetFile"));
+  const auto get_file = test_controller.getProcessor();
   std::filesystem::path dir = test_controller.createTempDirectory();
   get_file->setProperty(GetFile::Directory, dir.string());
   SECTION("File in subdirectory of input directory") {
@@ -303,8 +303,8 @@ TEST_CASE("GetFile can use expression language in Directory property") {
   using minifi::processors::GetFile;
   LogTestController::getInstance().setTrace<GetFile>();
 
-  const auto get_file = std::make_shared<GetFile>("GetFile");
-  minifi::test::SingleProcessorTestController test_controller(get_file);
+  minifi::test::SingleProcessorTestController test_controller(std::make_unique<GetFile>("GetFile"));
+  const auto get_file = test_controller.getProcessor();
 
   std::filesystem::path base_dir = test_controller.createTempDirectory();
   auto date_str = date::format("%Y-%m-%d", std::chrono::system_clock::now());

--- a/extensions/standard-processors/tests/unit/GetTCPTests.cpp
+++ b/extensions/standard-processors/tests/unit/GetTCPTests.cpp
@@ -152,8 +152,8 @@ class TcpTestServer {
 };
 
 TEST_CASE("GetTCP test with delimiter", "[GetTCP]") {
-  const auto get_tcp = std::make_shared<GetTCP>("GetTCP");
-  SingleProcessorTestController controller{get_tcp};
+  SingleProcessorTestController controller{std::make_unique<GetTCP>("GetTCP")};
+  const auto get_tcp = controller.getProcessor();
   LogTestController::getInstance().setTrace<GetTCP>();
   REQUIRE(get_tcp->setProperty(GetTCP::MaxBatchSize, "2"));
 
@@ -183,8 +183,8 @@ TEST_CASE("GetTCP test with delimiter", "[GetTCP]") {
 }
 
 TEST_CASE("GetTCP test with too large message", "[GetTCP]") {
-  const auto get_tcp = std::make_shared<GetTCP>("GetTCP");
-  SingleProcessorTestController controller{get_tcp};
+  SingleProcessorTestController controller{std::make_unique<GetTCP>("GetTCP")};
+  const auto get_tcp = controller.getProcessor();
   LogTestController::getInstance().setTrace<GetTCP>();
   REQUIRE(get_tcp->setProperty(GetTCP::MaxBatchSize, "2"));
   REQUIRE(get_tcp->setProperty(GetTCP::MaxMessageSize, "10"));
@@ -224,8 +224,8 @@ TEST_CASE("GetTCP test with too large message", "[GetTCP]") {
 }
 
 TEST_CASE("GetTCP test multiple endpoints", "[GetTCP]") {
-  const auto get_tcp = std::make_shared<GetTCP>("GetTCP");
-  SingleProcessorTestController controller{get_tcp};
+  SingleProcessorTestController controller{std::make_unique<GetTCP>("GetTCP")};
+  const auto get_tcp = controller.getProcessor();
   LogTestController::getInstance().setTrace<GetTCP>();
   REQUIRE(get_tcp->setProperty(GetTCP::MaxBatchSize, "2"));
 
@@ -268,8 +268,8 @@ TEST_CASE("GetTCP test multiple endpoints", "[GetTCP]") {
 }
 
 TEST_CASE("GetTCP max queue and max batch size test", "[GetTCP]") {
-  const auto get_tcp = std::make_shared<GetTCP>("GetTCP");
-  SingleProcessorTestController controller{get_tcp};
+  SingleProcessorTestController controller{std::make_unique<GetTCP>("GetTCP")};
+  const auto get_tcp = controller.getProcessor();
   LogTestController::getInstance().setTrace<GetTCP>();
   REQUIRE(get_tcp->setProperty(GetTCP::MaxBatchSize, "10"));
   REQUIRE(get_tcp->setProperty(GetTCP::MaxQueueSize, "50"));

--- a/extensions/standard-processors/tests/unit/HashContentTest.cpp
+++ b/extensions/standard-processors/tests/unit/HashContentTest.cpp
@@ -50,7 +50,7 @@ namespace org::apache::nifi::minifi::processors::test {
 
 TEST_CASE("Test Creation of HashContent", "[HashContentCreate]") {
   TestController testController;
-  std::shared_ptr<core::Processor> processor = std::make_shared<org::apache::nifi::minifi::processors::HashContent>("processorname");
+  auto processor = std::make_shared<org::apache::nifi::minifi::processors::HashContent>("processorname");
   REQUIRE(processor->getName() == "processorname");
   REQUIRE(processor->getUUID());
 }
@@ -68,27 +68,26 @@ TEST_CASE("Test usage of ExtractText", "[extracttextTest]") {
   auto tempdir = testController.createTempDirectory();
   REQUIRE(!tempdir.empty());
 
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
+  auto getfile = plan->addProcessor("GetFile", "getfileCreate2");
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory, tempdir.string());
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::KeepSourceFile, "true");
 
-  std::shared_ptr<core::Processor> md5processor = plan->addProcessor("HashContent", "HashContentMD5",
+  auto md5processor = plan->addProcessor("HashContent", "HashContentMD5",
       core::Relationship("success", "description"), true);
   plan->setProperty(md5processor, org::apache::nifi::minifi::processors::HashContent::HashAttribute, MD5_ATTR);
   plan->setProperty(md5processor, org::apache::nifi::minifi::processors::HashContent::HashAlgorithm, "MD5");
 
-  std::shared_ptr<core::Processor> shaprocessor = plan->addProcessor("HashContent", "HashContentSHA1",
+  auto shaprocessor = plan->addProcessor("HashContent", "HashContentSHA1",
       core::Relationship("success", "description"), true);
   plan->setProperty(shaprocessor, org::apache::nifi::minifi::processors::HashContent::HashAttribute, SHA1_ATTR);
   plan->setProperty(shaprocessor, org::apache::nifi::minifi::processors::HashContent::HashAlgorithm, "sha1");
 
-  std::shared_ptr<core::Processor> sha2processor = plan->addProcessor("HashContent", "HashContentSHA256",
+  auto sha2processor = plan->addProcessor("HashContent", "HashContentSHA256",
       core::Relationship("success", "description"), true);
   plan->setProperty(sha2processor, org::apache::nifi::minifi::processors::HashContent::HashAttribute, SHA256_ATTR);
   plan->setProperty(sha2processor, org::apache::nifi::minifi::processors::HashContent::HashAlgorithm, "sha-256");
 
-  std::shared_ptr<core::Processor> laprocessor = plan->addProcessor("LogAttribute", "outputLogAttribute",
-      core::Relationship("success", "description"), true);
+  plan->addProcessor("LogAttribute", "outputLogAttribute", core::Relationship("success", "description"), true);
 
   auto test_file_path = tempdir / TEST_FILE;
 
@@ -135,11 +134,11 @@ TEST_CASE("TestingFailOnEmptyProperty", "[HashContentPropertiesCheck]") {
   std::shared_ptr<TestPlan> plan = testController.createPlan();
 
   auto tempdir = testController.createTempDirectory();
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
+  auto getfile = plan->addProcessor("GetFile", "getfileCreate2");
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory, tempdir.string());
   plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::KeepSourceFile, "true");
 
-  std::shared_ptr<core::Processor> md5processor = plan->addProcessor("HashContent", "HashContentMD5",
+  auto md5processor = plan->addProcessor("HashContent", "HashContentMD5",
                                                                      core::Relationship("success", "description"), true);
   plan->setProperty(md5processor, HashContent::HashAttribute, MD5_ATTR);
   plan->setProperty(md5processor, HashContent::HashAlgorithm, "MD5");
@@ -168,8 +167,8 @@ TEST_CASE("TestingFailOnEmptyProperty", "[HashContentPropertiesCheck]") {
 }
 
 TEST_CASE("Invalid hash algorithm throws in onSchedule", "[HashContent]") {
-  auto hash_content = std::make_shared<HashContent>("HashContent");
-  minifi::test::SingleProcessorTestController controller{hash_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<HashContent>("HashContent")};
+  auto hash_content = controller.getProcessor();
   hash_content->setProperty(HashContent::HashAlgorithm, "My-Algo");
   REQUIRE_THROWS_WITH(controller.plan->scheduleProcessor(hash_content), "Process Schedule Operation: MYALGO is not supported, supported algorithms are: MD5, SHA1, SHA256");
 }

--- a/extensions/standard-processors/tests/unit/JoltTransformJSONTests.cpp
+++ b/extensions/standard-processors/tests/unit/JoltTransformJSONTests.cpp
@@ -28,8 +28,8 @@ namespace org::apache::nifi::minifi::test {
 // NOLINTBEGIN(readability-container-size-empty)
 
 TEST_CASE("Shiftr successful case") {
-  auto proc = std::make_shared<minifi::processors::JoltTransformJSON>("JoltProc");
-  SingleProcessorTestController controller{proc};
+  SingleProcessorTestController controller{std::make_unique<minifi::processors::JoltTransformJSON>("JoltProc")};
+  auto proc = controller.getProcessor();
   proc->setProperty(processors::JoltTransformJSON::JoltTransform, magic_enum::enum_name(processors::jolt_transform_json::JoltTransform::Shift));
   proc->setProperty(processors::JoltTransformJSON::JoltSpecification, R"json(
     {
@@ -76,8 +76,8 @@ TEST_CASE("Shiftr successful case") {
 }
 
 TEST_CASE("Shiftr multiple destination") {
-  auto proc = std::make_shared<minifi::processors::JoltTransformJSON>("JoltProc");
-  SingleProcessorTestController controller{proc};
+  SingleProcessorTestController controller{std::make_unique<minifi::processors::JoltTransformJSON>("JoltProc")};
+  auto proc = controller.getProcessor();
   proc->setProperty(processors::JoltTransformJSON::JoltTransform, magic_enum::enum_name(processors::jolt_transform_json::JoltTransform::Shift));
   proc->setProperty(processors::JoltTransformJSON::JoltSpecification, R"json(
     {
@@ -128,8 +128,8 @@ TEST_CASE("Shiftr invalid reference") {
 }
 
 TEST_CASE("Shiftr matches are correctly ordered") {
-  auto proc = std::make_shared<minifi::processors::JoltTransformJSON>("JoltProc");
-  SingleProcessorTestController controller{proc};
+  SingleProcessorTestController controller{std::make_unique<minifi::processors::JoltTransformJSON>("JoltProc")};
+  auto proc = controller.getProcessor();
   proc->setProperty(processors::JoltTransformJSON::JoltTransform, magic_enum::enum_name(processors::jolt_transform_json::JoltTransform::Shift));
   proc->setProperty(processors::JoltTransformJSON::JoltSpecification, R"json(
     {
@@ -172,8 +172,8 @@ TEST_CASE("Shiftr matches are correctly ordered") {
 }
 
 TEST_CASE("Shiftr arrays are maps with numeric keys") {
-  auto proc = std::make_shared<minifi::processors::JoltTransformJSON>("JoltProc");
-  SingleProcessorTestController controller{proc};
+  SingleProcessorTestController controller{std::make_unique<minifi::processors::JoltTransformJSON>("JoltProc")};
+  auto proc = controller.getProcessor();
   proc->setProperty(processors::JoltTransformJSON::JoltTransform, magic_enum::enum_name(processors::jolt_transform_json::JoltTransform::Shift));
   proc->setProperty(processors::JoltTransformJSON::JoltSpecification, R"json(
     {
@@ -204,8 +204,8 @@ TEST_CASE("Shiftr arrays are maps with numeric keys") {
 }
 
 TEST_CASE("Shiftr put into array at index") {
-  auto proc = std::make_shared<minifi::processors::JoltTransformJSON>("JoltProc");
-  SingleProcessorTestController controller{proc};
+  SingleProcessorTestController controller{std::make_unique<minifi::processors::JoltTransformJSON>("JoltProc")};
+  auto proc = controller.getProcessor();
   proc->setProperty(processors::JoltTransformJSON::JoltTransform, magic_enum::enum_name(processors::jolt_transform_json::JoltTransform::Shift));
   proc->setProperty(processors::JoltTransformJSON::JoltSpecification, R"json(
     {
@@ -238,8 +238,8 @@ TEST_CASE("Shiftr put into array at index") {
 
 TEST_CASE("Shiftr multiple patterns") {
   // this is an extension, so we can escape and match on a '|' character
-  auto proc = std::make_shared<minifi::processors::JoltTransformJSON>("JoltProc");
-  SingleProcessorTestController controller{proc};
+  SingleProcessorTestController controller{std::make_unique<minifi::processors::JoltTransformJSON>("JoltProc")};
+  auto proc = controller.getProcessor();
   proc->setProperty(processors::JoltTransformJSON::JoltTransform, magic_enum::enum_name(processors::jolt_transform_json::JoltTransform::Shift));
   proc->setProperty(processors::JoltTransformJSON::JoltSpecification, R"json(
     {
@@ -305,8 +305,8 @@ TEST_CASE("Run tests from https://github.com/bazaarvoice/jolt") {
       throw std::logic_error(fmt::format("Error in test json '{}' at {}:{} : {}", entry.string(), cursor.first, cursor.second, rapidjson::GetParseError_En(parse_res.Code())));
     }
 
-    auto proc = std::make_shared<minifi::processors::JoltTransformJSON>("JoltProc");
-    SingleProcessorTestController controller{proc};
+    SingleProcessorTestController controller{std::make_unique<minifi::processors::JoltTransformJSON>("JoltProc")};
+    auto proc = controller.getProcessor();
     LogTestController::getInstance().setTrace<minifi::processors::JoltTransformJSON>();
     proc->setProperty(processors::JoltTransformJSON::JoltTransform, magic_enum::enum_name(processors::jolt_transform_json::JoltTransform::Shift));
     proc->setProperty(processors::JoltTransformJSON::JoltSpecification, to_string(doc["spec"]));

--- a/extensions/standard-processors/tests/unit/ListFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/ListFileTests.cpp
@@ -52,7 +52,7 @@ class ListFileTestFixture {
   TestController test_controller_;
   std::shared_ptr<TestPlan> plan_;
   const std::filesystem::path input_dir_;
-  std::shared_ptr<core::Processor> list_file_processor_;
+  core::Processor* list_file_processor_;
   std::filesystem::path hidden_file_path_;
   std::filesystem::path empty_file_abs_path_;
   std::filesystem::path standard_file_abs_path_;
@@ -227,9 +227,9 @@ TEST_CASE_METHOD(ListFileTestFixture, "Test listing hidden files", "[testListFil
 TEST_CASE("ListFile sets attributes correctly") {
   using minifi::processors::ListFile;
 
-  const auto list_file = std::make_shared<ListFile>("ListFile");
   LogTestController::getInstance().setTrace<ListFile>();
-  minifi::test::SingleProcessorTestController test_controller(list_file);
+  minifi::test::SingleProcessorTestController test_controller(std::make_unique<ListFile>("ListFile"));
+  const auto list_file = test_controller.getProcessor();
   std::filesystem::path dir = test_controller.createTempDirectory();
   list_file->setProperty(ListFile::InputDirectory, dir.string());
   SECTION("File in subdirectory of input directory") {
@@ -256,8 +256,8 @@ TEST_CASE("ListFile sets attributes correctly") {
 TEST_CASE("If a second file with the same modification time shows up later, then it will get listed") {
   using minifi::processors::ListFile;
 
-  const auto list_file = std::make_shared<ListFile>("ListFile");
-  minifi::test::SingleProcessorTestController test_controller(list_file);
+  minifi::test::SingleProcessorTestController test_controller(std::make_unique<ListFile>("ListFile"));
+  const auto list_file = test_controller.getProcessor();
 
   const auto input_dir = test_controller.createTempDirectory();
   list_file->setProperty(ListFile::InputDirectory, input_dir.string());

--- a/extensions/standard-processors/tests/unit/ListenSyslogTests.cpp
+++ b/extensions/standard-processors/tests/unit/ListenSyslogTests.cpp
@@ -249,9 +249,8 @@ void check_parsed_attributes(const core::FlowFile& flow_file, const ValidRFC3164
 }
 
 TEST_CASE("ListenSyslog without parsing test", "[ListenSyslog]") {
-  const auto listen_syslog = std::make_shared<ListenSyslog>("ListenSyslog");
-
-  SingleProcessorTestController controller{listen_syslog};
+  SingleProcessorTestController controller{std::make_unique<ListenSyslog>("ListenSyslog")};
+  const auto listen_syslog = controller.getProcessor<ListenSyslog>();
   LogTestController::getInstance().setTrace<ListenSyslog>();
   REQUIRE(listen_syslog->setProperty(ListenSyslog::MaxBatchSize, "2"));
   REQUIRE(listen_syslog->setProperty(ListenSyslog::ParseMessages, "false"));
@@ -306,9 +305,8 @@ TEST_CASE("ListenSyslog without parsing test", "[ListenSyslog]") {
 }
 
 TEST_CASE("ListenSyslog with parsing test", "[ListenSyslog][NetworkListenerProcessor]") {
-  const auto listen_syslog = std::make_shared<ListenSyslog>("ListenSyslog");
-
-  SingleProcessorTestController controller{listen_syslog};
+  SingleProcessorTestController controller{std::make_unique<ListenSyslog>("ListenSyslog")};
+  const auto listen_syslog = controller.getProcessor<ListenSyslog>();
   LogTestController::getInstance().setTrace<ListenSyslog>();
   REQUIRE(listen_syslog->setProperty(ListenSyslog::MaxBatchSize, "100"));
   REQUIRE(listen_syslog->setProperty(ListenSyslog::ParseMessages, "true"));
@@ -412,8 +410,8 @@ TEST_CASE("ListenSyslog with parsing test", "[ListenSyslog][NetworkListenerProce
 }
 
 TEST_CASE("ListenSyslog can be rescheduled", "[ListenSyslog][NetworkListenerProcessor]") {
-  const auto listen_syslog = std::make_shared<ListenSyslog>("ListenSyslog");
-  SingleProcessorTestController controller{listen_syslog};
+  SingleProcessorTestController controller{std::make_unique<ListenSyslog>("ListenSyslog")};
+  const auto listen_syslog = controller.getProcessor<ListenSyslog>();
   LogTestController::getInstance().setTrace<ListenSyslog>();
   REQUIRE(listen_syslog->setProperty(ListenSyslog::Port, "0"));
   REQUIRE(listen_syslog->setProperty(ListenSyslog::MaxBatchSize, "100"));
@@ -434,9 +432,8 @@ TEST_CASE("ListenSyslog can be rescheduled", "[ListenSyslog][NetworkListenerProc
 }
 
 TEST_CASE("ListenSyslog max queue and max batch size test", "[ListenSyslog][NetworkListenerProcessor]") {
-  const auto listen_syslog = std::make_shared<ListenSyslog>("ListenSyslog");
-
-  SingleProcessorTestController controller{listen_syslog};
+  SingleProcessorTestController controller{std::make_unique<ListenSyslog>("ListenSyslog")};
+  const auto listen_syslog = controller.getProcessor<ListenSyslog>();
   REQUIRE(listen_syslog->setProperty(ListenSyslog::MaxBatchSize, "10"));
   REQUIRE(listen_syslog->setProperty(ListenSyslog::ParseMessages, "false"));
   REQUIRE(listen_syslog->setProperty(ListenSyslog::MaxQueueSize, "50"));
@@ -493,8 +490,8 @@ TEST_CASE("ListenSyslog max queue and max batch size test", "[ListenSyslog][Netw
 }
 
 TEST_CASE("Test ListenSyslog via TCP with SSL connection", "[ListenSyslog][NetworkListenerProcessor]") {
-  const auto listen_syslog = std::make_shared<ListenSyslog>("ListenSyslog");
-  SingleProcessorTestController controller{listen_syslog};
+  SingleProcessorTestController controller{std::make_unique<ListenSyslog>("ListenSyslog")};
+  const auto listen_syslog = controller.getProcessor<ListenSyslog>();
 
   auto ssl_context_service = controller.plan->addController("SSLContextService", "SSLContextService");
   const auto executable_dir = minifi::utils::file::FileUtils::get_executable_dir();

--- a/extensions/standard-processors/tests/unit/ListenTcpTests.cpp
+++ b/extensions/standard-processors/tests/unit/ListenTcpTests.cpp
@@ -38,8 +38,8 @@ void check_for_attributes(core::FlowFile& flow_file, uint16_t port) {
 }
 
 TEST_CASE("ListenTCP test multiple messages", "[ListenTCP][NetworkListenerProcessor]") {
-  const auto listen_tcp = std::make_shared<ListenTCP>("ListenTCP");
-  SingleProcessorTestController controller{listen_tcp};
+  SingleProcessorTestController controller{std::make_unique<ListenTCP>("ListenTCP")};
+  const auto listen_tcp = controller.getProcessor<ListenTCP>();
   LogTestController::getInstance().setTrace<ListenTCP>();
   REQUIRE(listen_tcp->setProperty(ListenTCP::MaxBatchSize, "2"));
   auto port = utils::scheduleProcessorOnRandomPort(controller.plan, listen_tcp);
@@ -66,8 +66,8 @@ TEST_CASE("ListenTCP test multiple messages", "[ListenTCP][NetworkListenerProces
 }
 
 TEST_CASE("ListenTCP can be rescheduled", "[ListenTCP][NetworkListenerProcessor]") {
-  const auto listen_tcp = std::make_shared<ListenTCP>("ListenTCP");
-  SingleProcessorTestController controller{listen_tcp};
+  SingleProcessorTestController controller{std::make_unique<ListenTCP>("ListenTCP")};
+  const auto listen_tcp = controller.getProcessor<ListenTCP>();
   LogTestController::getInstance().setTrace<ListenTCP>();
   REQUIRE(listen_tcp->setProperty(ListenTCP::Port, "0"));
   REQUIRE(listen_tcp->setProperty(ListenTCP::MaxBatchSize, "100"));
@@ -78,8 +78,8 @@ TEST_CASE("ListenTCP can be rescheduled", "[ListenTCP][NetworkListenerProcessor]
 }
 
 TEST_CASE("ListenTCP max queue and max batch size test", "[ListenTCP][NetworkListenerProcessor]") {
-  const auto listen_tcp = std::make_shared<ListenTCP>("ListenTCP");
-  SingleProcessorTestController controller{listen_tcp};
+  SingleProcessorTestController controller{std::make_unique<ListenTCP>("ListenTCP")};
+  const auto listen_tcp = controller.getProcessor<ListenTCP>();
   LogTestController::getInstance().setTrace<ListenTCP>();
   REQUIRE(listen_tcp->setProperty(ListenTCP::MaxBatchSize, "10"));
   REQUIRE(listen_tcp->setProperty(ListenTCP::MaxQueueSize, "50"));
@@ -111,9 +111,9 @@ TEST_CASE("ListenTCP max queue and max batch size test", "[ListenTCP][NetworkLis
 }
 
 TEST_CASE("Test ListenTCP with SSL connection", "[ListenTCP][NetworkListenerProcessor]") {
-  const auto listen_tcp = std::make_shared<ListenTCP>("ListenTCP");
   uint16_t port = 0;
-  SingleProcessorTestController controller{listen_tcp};
+  SingleProcessorTestController controller{std::make_unique<ListenTCP>("ListenTCP")};
+  const auto listen_tcp = controller.getProcessor<ListenTCP>();
   auto ssl_context_service = controller.plan->addController("SSLContextService", "SSLContextService");
   LogTestController::getInstance().setTrace<ListenTCP>();
   const auto executable_dir = minifi::utils::file::FileUtils::get_executable_dir();
@@ -241,8 +241,8 @@ bool isSslMethodAvailable(asio::ssl::context::method method) {
 }  // namespace
 
 TEST_CASE("Test ListenTCP SSL/TLS compatibility", "[ListenTCP][NetworkListenerProcessor]") {
-  const auto listen_tcp = std::make_shared<ListenTCP>("ListenTCP");
-  SingleProcessorTestController controller{listen_tcp};
+  SingleProcessorTestController controller{std::make_unique<ListenTCP>("ListenTCP")};
+  const auto listen_tcp = controller.getProcessor<ListenTCP>();
   auto ssl_context_service = controller.plan->addController("SSLContextService", "SSLContextService");
   LogTestController::getInstance().setTrace<ListenTCP>();
   const auto executable_dir = minifi::utils::file::FileUtils::get_executable_dir();
@@ -288,8 +288,8 @@ TEST_CASE("Test ListenTCP SSL/TLS compatibility", "[ListenTCP][NetworkListenerPr
 }
 
 TEST_CASE("Custom delimiter", "[ListenTCP][NetworkListenerProcessor]") {
-  const auto listen_tcp = std::make_shared<ListenTCP>("ListenTCP");
-  SingleProcessorTestController controller{listen_tcp};
+  SingleProcessorTestController controller{std::make_unique<ListenTCP>("ListenTCP")};
+  const auto listen_tcp = controller.getProcessor<ListenTCP>();
   LogTestController::getInstance().setTrace<ListenTCP>();
 
   std::string delimiter = GENERATE("\n", "\\n", "foo", "💩", "foo\\nbar");

--- a/extensions/standard-processors/tests/unit/ListenUDPTests.cpp
+++ b/extensions/standard-processors/tests/unit/ListenUDPTests.cpp
@@ -36,8 +36,8 @@ void check_for_attributes(core::FlowFile& flow_file, uint16_t port) {
 }
 
 TEST_CASE("ListenUDP test multiple messages", "[ListenUDP][NetworkListenerProcessor]") {
-  const auto listen_udp = std::make_shared<ListenUDP>("ListenUDP");
-  SingleProcessorTestController controller{listen_udp};
+  SingleProcessorTestController controller{std::make_unique<ListenUDP>("ListenUDP")};
+  const auto listen_udp = controller.getProcessor<ListenUDP>();
   LogTestController::getInstance().setTrace<ListenUDP>();
 
   REQUIRE(listen_udp->setProperty(ListenUDP::MaxBatchSize, "2"));
@@ -68,8 +68,8 @@ TEST_CASE("ListenUDP test multiple messages", "[ListenUDP][NetworkListenerProces
 }
 
 TEST_CASE("ListenUDP can be rescheduled", "[ListenUDP][NetworkListenerProcessor]") {
-  const auto listen_udp = std::make_shared<ListenUDP>("ListenUDP");
-  SingleProcessorTestController controller{listen_udp};
+  SingleProcessorTestController controller{std::make_unique<ListenUDP>("ListenUDP")};
+  const auto listen_udp = controller.getProcessor<ListenUDP>();
   LogTestController::getInstance().setTrace<ListenUDP>();
   REQUIRE(listen_udp->setProperty(ListenUDP::Port, "0"));
   REQUIRE(listen_udp->setProperty(ListenUDP::MaxBatchSize, "100"));
@@ -80,8 +80,8 @@ TEST_CASE("ListenUDP can be rescheduled", "[ListenUDP][NetworkListenerProcessor]
 }
 
 TEST_CASE("ListenUDP max queue and max batch size test", "[ListenUDP][NetworkListenerProcessor]") {
-  const auto listen_udp = std::make_shared<ListenUDP>("ListenUDP");
-  SingleProcessorTestController controller{listen_udp};
+  SingleProcessorTestController controller{std::make_unique<ListenUDP>("ListenUDP")};
+  const auto listen_udp = controller.getProcessor<ListenUDP>();
   REQUIRE(listen_udp->setProperty(ListenUDP::MaxBatchSize, "10"));
   REQUIRE(listen_udp->setProperty(ListenUDP::MaxQueueSize, "50"));
 

--- a/extensions/standard-processors/tests/unit/LogAttributeTests.cpp
+++ b/extensions/standard-processors/tests/unit/LogAttributeTests.cpp
@@ -29,8 +29,8 @@ using namespace std::literals::chrono_literals;
 namespace org::apache::nifi::minifi::test {
 
 TEST_CASE("LogAttribute logs payload", "[LogAttribute]") {
-  const auto log_attribute = std::make_shared<LogAttribute>("log_attribute");
-  SingleProcessorTestController controller{log_attribute};
+  SingleProcessorTestController controller{std::make_unique<LogAttribute>("log_attribute")};
+  const auto log_attribute = controller.getProcessor();
   LogTestController::getInstance().setTrace<LogAttribute>();
 
   const auto [hexencode_payload, expected_payload] = GENERATE(
@@ -54,8 +54,8 @@ TEST_CASE("LogAttribute logs payload", "[LogAttribute]") {
 }
 
 TEST_CASE("LogAttribute LogLevel and LogPrefix", "[LogAttribute]") {
-  const auto log_attribute = std::make_shared<LogAttribute>("log_attribute");
-  SingleProcessorTestController controller{log_attribute};
+  SingleProcessorTestController controller{std::make_unique<LogAttribute>("log_attribute")};
+  const auto log_attribute = controller.getProcessor();
   LogTestController::getInstance().setTrace<LogAttribute>();
 
   const auto [log_level, log_prefix, expected_dash] = GENERATE(
@@ -81,8 +81,8 @@ TEST_CASE("LogAttribute LogLevel and LogPrefix", "[LogAttribute]") {
 }
 
 TEST_CASE("LogAttribute filtering attributes", "[LogAttribute]") {
-  const auto log_attribute = std::make_shared<LogAttribute>("log_attribute");
-  SingleProcessorTestController controller{log_attribute};
+  SingleProcessorTestController controller{std::make_unique<LogAttribute>("log_attribute")};
+  const auto log_attribute = controller.getProcessor();
   LogTestController::getInstance().setTrace<LogAttribute>();
 
   auto attrs_to_log = "";
@@ -128,8 +128,8 @@ TEST_CASE("LogAttribute filtering attributes", "[LogAttribute]") {
 }
 
 TEST_CASE("LogAttribute batch test", "[LogAttribute]") {
-  const auto log_attribute = std::make_shared<LogAttribute>("log_attribute");
-  SingleProcessorTestController controller{log_attribute};
+  SingleProcessorTestController controller{std::make_unique<LogAttribute>("log_attribute")};
+  const auto log_attribute = controller.getProcessor();
 
   const auto [flow_files_to_log, expected_success_flow_files] = GENERATE(
     std::make_tuple("0", 3U),

--- a/extensions/standard-processors/tests/unit/ProcessorTests.cpp
+++ b/extensions/standard-processors/tests/unit/ProcessorTests.cpp
@@ -53,7 +53,7 @@
 
 TEST_CASE("Test Creation of GetFile", "[getfileCreate]") {
   TestController testController;
-  std::shared_ptr<core::Processor> processor = std::make_shared<org::apache::nifi::minifi::processors::GetFile>("processorname");
+  auto processor = std::make_shared<org::apache::nifi::minifi::processors::GetFile>("processorname");
   REQUIRE(processor->getName() == "processorname");
 }
 
@@ -66,7 +66,7 @@ TEST_CASE("Test GetFileMultiple", "[getfileCreate3]") {
   auto config = std::make_shared<minifi::Configure>();
   std::shared_ptr<core::ContentRepository> content_repo = std::make_shared<core::repository::VolatileContentRepository>();
   content_repo->initialize(config);
-  std::shared_ptr<core::Processor> processor = std::make_shared<org::apache::nifi::minifi::processors::GetFile>("getfileCreate2");
+  auto processor = std::make_shared<org::apache::nifi::minifi::processors::GetFile>("getfileCreate2");
   processor->initialize();
   std::shared_ptr<core::Repository> test_repo = std::make_shared<TestRepository>();
   std::shared_ptr<TestRepository> repo = std::static_pointer_cast<TestRepository>(test_repo);
@@ -147,7 +147,7 @@ TEST_CASE("Test GetFile Ignore", "[getfileCreate3]") {
   TestController testController;
   LogTestController::getInstance().setDebug<minifi::processors::GetFile>();
   std::shared_ptr<core::ContentRepository> content_repo = std::make_shared<core::repository::VolatileContentRepository>();
-  std::shared_ptr<core::Processor> processor = std::make_shared<org::apache::nifi::minifi::processors::GetFile>("getfileCreate2");
+  auto processor = std::make_shared<org::apache::nifi::minifi::processors::GetFile>("getfileCreate2");
   processor->initialize();
 
   std::shared_ptr<core::Repository> test_repo = std::make_shared<TestRepository>();
@@ -234,7 +234,7 @@ TEST_CASE("TestConnectionFull", "[ConnectionFull]") {
   LogTestController::getInstance().setDebug<minifi::processors::GenerateFlowFile>();
   std::shared_ptr<core::ContentRepository> content_repo = std::make_shared<core::repository::VolatileContentRepository>();
   content_repo->initialize(std::make_shared<minifi::Configure>());
-  std::shared_ptr<core::Processor> processor = std::make_shared<org::apache::nifi::minifi::processors::GenerateFlowFile>("GFF");
+  auto processor = std::make_shared<org::apache::nifi::minifi::processors::GenerateFlowFile>("GFF");
   processor->initialize();
   processor->setProperty(minifi::processors::GenerateFlowFile::BatchSize, "10");
   processor->setProperty(minifi::processors::GenerateFlowFile::FileSize, "0");
@@ -285,7 +285,7 @@ TEST_CASE("LogAttributeTest", "[getfileCreate3]") {
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
+  auto getfile = plan->addProcessor("GetFile", "getfileCreate2");
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
@@ -327,7 +327,7 @@ TEST_CASE("LogAttributeTestInvalid", "[TestLogAttribute]") {
   LogTestController::getInstance().setDebug<minifi::processors::GetFile>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
+  auto getfile = plan->addProcessor("GetFile", "getfileCreate2");
 
   auto loggattr = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
@@ -345,7 +345,7 @@ void testMultiplesLogAttribute(int fileCount, int flowsToLog, std::string verify
   LogTestController::getInstance().setDebug<minifi::processors::GetFile>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
+  auto getfile = plan->addProcessor("GetFile", "getfileCreate2");
 
   auto loggattr = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
@@ -411,10 +411,9 @@ TEST_CASE("Test Find file", "[getfileCreate3]") {
   TestController testController;
   LogTestController::getInstance().setDebug<minifi::provenance::ProvenanceReporter>();
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> processor = plan->addProcessor("GetFile", "getfileCreate2");
-  std::shared_ptr<core::Processor> processorReport = std::make_shared<org::apache::nifi::minifi::core::reporting::SiteToSiteProvenanceReportingTask>(
-      std::make_shared<org::apache::nifi::minifi::Configure>());
-  plan->addProcessor(processorReport, "reporter", core::Relationship("success", "description"), false);
+  auto processor = plan->addProcessor("GetFile", "getfileCreate2");
+  auto processorReport = plan->addProcessor(std::make_unique<org::apache::nifi::minifi::core::reporting::SiteToSiteProvenanceReportingTask>(
+      std::make_shared<org::apache::nifi::minifi::Configure>()), "reporter", core::Relationship("success", "description"), false);
 
   auto dir = testController.createTempDirectory();
   plan->setProperty(processor, org::apache::nifi::minifi::processors::GetFile::Directory, dir.string());
@@ -464,8 +463,7 @@ TEST_CASE("Test Find file", "[getfileCreate3]") {
       throw std::runtime_error("Did not find record");
     }
   }
-  std::shared_ptr<org::apache::nifi::minifi::core::reporting::SiteToSiteProvenanceReportingTask> taskReport = std::static_pointer_cast<
-      org::apache::nifi::minifi::core::reporting::SiteToSiteProvenanceReportingTask>(processorReport);
+  auto taskReport = static_cast<org::apache::nifi::minifi::core::reporting::SiteToSiteProvenanceReportingTask*>(processorReport);
   taskReport->setBatchSize(1);
   std::vector<std::shared_ptr<core::SerializableComponent>> recordsReport;
   recordsReport.push_back(std::make_shared<minifi::provenance::ProvenanceEventRecord>());
@@ -519,7 +517,7 @@ TEST_CASE("TestEmptyContent", "[emptyContent]") {
   LogTestController::getInstance().setDebug<TestPlan>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("TestProcessorNoContent", "TestProcessorNoContent");
+  plan->addProcessor("TestProcessorNoContent", "TestProcessorNoContent");
 
   plan->runNextProcessor();
 
@@ -599,7 +597,7 @@ class ProcessorWithIncomingConnectionTest {
   ~ProcessorWithIncomingConnectionTest();
 
  protected:
-  std::shared_ptr<core::Processor> processor_;
+  std::shared_ptr<minifi::processors::LogAttribute> processor_;
   std::shared_ptr<minifi::Connection> incoming_connection_;
   std::shared_ptr<core::ProcessSession> session_;
 };

--- a/extensions/standard-processors/tests/unit/ProcessorTests.cpp
+++ b/extensions/standard-processors/tests/unit/ProcessorTests.cpp
@@ -53,7 +53,7 @@
 
 TEST_CASE("Test Creation of GetFile", "[getfileCreate]") {
   TestController testController;
-  auto processor = std::make_shared<org::apache::nifi::minifi::processors::GetFile>("processorname");
+  auto processor = std::make_shared<minifi::processors::GetFile>("processorname");
   REQUIRE(processor->getName() == "processorname");
 }
 
@@ -66,7 +66,7 @@ TEST_CASE("Test GetFileMultiple", "[getfileCreate3]") {
   auto config = std::make_shared<minifi::Configure>();
   std::shared_ptr<core::ContentRepository> content_repo = std::make_shared<core::repository::VolatileContentRepository>();
   content_repo->initialize(config);
-  auto processor = std::make_shared<org::apache::nifi::minifi::processors::GetFile>("getfileCreate2");
+  auto processor = std::make_shared<minifi::processors::GetFile>("getfileCreate2");
   processor->initialize();
   std::shared_ptr<core::Repository> test_repo = std::make_shared<TestRepository>();
   std::shared_ptr<TestRepository> repo = std::static_pointer_cast<TestRepository>(test_repo);
@@ -92,7 +92,7 @@ TEST_CASE("Test GetFileMultiple", "[getfileCreate3]") {
   auto node = std::make_shared<core::ProcessorNode>(processor.get());
   auto context = std::make_shared<core::ProcessContext>(node, nullptr, repo, repo, content_repo);
 
-  context->setProperty(org::apache::nifi::minifi::processors::GetFile::Directory, dir.string());
+  context->setProperty(minifi::processors::GetFile::Directory, dir.string());
   // replicate 10 threads
   processor->setScheduledState(core::ScheduledState::RUNNING);
 
@@ -147,7 +147,7 @@ TEST_CASE("Test GetFile Ignore", "[getfileCreate3]") {
   TestController testController;
   LogTestController::getInstance().setDebug<minifi::processors::GetFile>();
   std::shared_ptr<core::ContentRepository> content_repo = std::make_shared<core::repository::VolatileContentRepository>();
-  auto processor = std::make_shared<org::apache::nifi::minifi::processors::GetFile>("getfileCreate2");
+  auto processor = std::make_shared<minifi::processors::GetFile>("getfileCreate2");
   processor->initialize();
 
   std::shared_ptr<core::Repository> test_repo = std::make_shared<TestRepository>();
@@ -175,7 +175,7 @@ TEST_CASE("Test GetFile Ignore", "[getfileCreate3]") {
   auto node = std::make_shared<core::ProcessorNode>(processor.get());
   auto context = std::make_shared<core::ProcessContext>(node, nullptr, repo, repo, content_repo);
 
-  context->setProperty(org::apache::nifi::minifi::processors::GetFile::Directory, dir.string());
+  context->setProperty(minifi::processors::GetFile::Directory, dir.string());
   // replicate 10 threads
   processor->setScheduledState(core::ScheduledState::RUNNING);
 
@@ -234,7 +234,7 @@ TEST_CASE("TestConnectionFull", "[ConnectionFull]") {
   LogTestController::getInstance().setDebug<minifi::processors::GenerateFlowFile>();
   std::shared_ptr<core::ContentRepository> content_repo = std::make_shared<core::repository::VolatileContentRepository>();
   content_repo->initialize(std::make_shared<minifi::Configure>());
-  auto processor = std::make_shared<org::apache::nifi::minifi::processors::GenerateFlowFile>("GFF");
+  auto processor = std::make_shared<minifi::processors::GenerateFlowFile>("GFF");
   processor->initialize();
   processor->setProperty(minifi::processors::GenerateFlowFile::BatchSize, "10");
   processor->setProperty(minifi::processors::GenerateFlowFile::FileSize, "0");
@@ -291,7 +291,7 @@ TEST_CASE("LogAttributeTest", "[getfileCreate3]") {
 
   auto dir = testController.createTempDirectory();
 
-  plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory, dir.string());
+  plan->setProperty(getfile, minifi::processors::GetFile::Directory, dir.string());
   testController.runSession(plan, false);
   auto records = plan->getProvenanceRecords();
   std::shared_ptr<core::FlowFile> record = plan->getCurrentFlowFile();
@@ -333,9 +333,9 @@ TEST_CASE("LogAttributeTestInvalid", "[TestLogAttribute]") {
 
   auto dir = testController.createTempDirectory();
 
-  plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory, dir.string());
-  plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::BatchSize, "1");
-  REQUIRE_THROWS_AS(plan->setProperty(loggattr, org::apache::nifi::minifi::processors::LogAttribute::FlowFilesToLog, "-1"), utils::internal::ParseException);
+  plan->setProperty(getfile, minifi::processors::GetFile::Directory, dir.string());
+  plan->setProperty(getfile, minifi::processors::GetFile::BatchSize, "1");
+  REQUIRE_THROWS_AS(plan->setProperty(loggattr, minifi::processors::LogAttribute::FlowFilesToLog, "-1"), utils::internal::ParseException);
   LogTestController::getInstance().reset();
 }
 
@@ -354,9 +354,9 @@ void testMultiplesLogAttribute(int fileCount, int flowsToLog, std::string verify
   auto flowsToLogStr = std::to_string(flowsToLog);
   if (verifyStringFlowsLogged.empty())
     verifyStringFlowsLogged = std::to_string(flowsToLog);
-  plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::Directory, dir.string());
-  plan->setProperty(getfile, org::apache::nifi::minifi::processors::GetFile::BatchSize, std::to_string(fileCount));
-  plan->setProperty(loggattr, org::apache::nifi::minifi::processors::LogAttribute::FlowFilesToLog, flowsToLogStr);
+  plan->setProperty(getfile, minifi::processors::GetFile::Directory, dir.string());
+  plan->setProperty(getfile, minifi::processors::GetFile::BatchSize, std::to_string(fileCount));
+  plan->setProperty(loggattr, minifi::processors::LogAttribute::FlowFilesToLog, flowsToLogStr);
   testController.runSession(plan, false);
   auto records = plan->getProvenanceRecords();
   std::shared_ptr<core::FlowFile> record = plan->getCurrentFlowFile();
@@ -412,11 +412,11 @@ TEST_CASE("Test Find file", "[getfileCreate3]") {
   LogTestController::getInstance().setDebug<minifi::provenance::ProvenanceReporter>();
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   auto processor = plan->addProcessor("GetFile", "getfileCreate2");
-  auto processorReport = plan->addProcessor(std::make_unique<org::apache::nifi::minifi::core::reporting::SiteToSiteProvenanceReportingTask>(
-      std::make_shared<org::apache::nifi::minifi::Configure>()), "reporter", core::Relationship("success", "description"), false);
+  auto processorReport = plan->addProcessor(std::make_unique<minifi::core::reporting::SiteToSiteProvenanceReportingTask>(
+      std::make_shared<minifi::Configure>()), "reporter", core::Relationship("success", "description"), false);
 
   auto dir = testController.createTempDirectory();
-  plan->setProperty(processor, org::apache::nifi::minifi::processors::GetFile::Directory, dir.string());
+  plan->setProperty(processor, minifi::processors::GetFile::Directory, dir.string());
   testController.runSession(plan, false);
   auto records = plan->getProvenanceRecords();
   std::shared_ptr<core::FlowFile> record = plan->getCurrentFlowFile();
@@ -463,7 +463,7 @@ TEST_CASE("Test Find file", "[getfileCreate3]") {
       throw std::runtime_error("Did not find record");
     }
   }
-  auto taskReport = static_cast<org::apache::nifi::minifi::core::reporting::SiteToSiteProvenanceReportingTask*>(processorReport);
+  auto taskReport = static_cast<minifi::core::reporting::SiteToSiteProvenanceReportingTask*>(processorReport);
   taskReport->setBatchSize(1);
   std::vector<std::shared_ptr<core::SerializableComponent>> recordsReport;
   recordsReport.push_back(std::make_shared<minifi::provenance::ProvenanceEventRecord>());
@@ -476,7 +476,7 @@ TEST_CASE("Test Find file", "[getfileCreate3]") {
       [&](const std::shared_ptr<core::ProcessContext> &context, const std::shared_ptr<core::ProcessSession> &session) {
         taskReport->getJsonReport(*context, *session, recordsReport, jsonStr);
         REQUIRE(recordsReport.size() == 1);
-        REQUIRE(taskReport->getName() == std::string(org::apache::nifi::minifi::core::reporting::SiteToSiteProvenanceReportingTask::ReportTaskName));
+        REQUIRE(taskReport->getName() == std::string(minifi::core::reporting::SiteToSiteProvenanceReportingTask::ReportTaskName));
         REQUIRE(jsonStr.find("\"componentType\": \"getfileCreate2\"") != std::string::npos);
       };
 
@@ -539,7 +539,7 @@ void testRPGBypass(const std::string &host, const std::string &port, bool has_er
   LogTestController::getInstance().setTrace<minifi::core::ProcessSession>();
   LogTestController::getInstance().setTrace<TestPlan>();
 
-  auto configuration = std::make_shared<org::apache::nifi::minifi::Configure>();
+  auto configuration = std::make_shared<minifi::Configure>();
 
   std::shared_ptr<core::ContentRepository> content_repo = std::make_shared<core::repository::VolatileContentRepository>();
 

--- a/extensions/standard-processors/tests/unit/PutFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/PutFileTests.cpp
@@ -39,7 +39,7 @@
 
 TEST_CASE("Test Creation of PutFile", "[getfileCreate]") {
   TestController testController;
-  std::shared_ptr<core::Processor> processor = std::make_shared<org::apache::nifi::minifi::processors::PutFile>("processorname");
+  auto processor = std::make_shared<org::apache::nifi::minifi::processors::PutFile>("processorname");
   REQUIRE(processor->getName() == "processorname");
 }
 
@@ -53,9 +53,9 @@ TEST_CASE("PutFileTest", "[getfileputpfile]") {
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
 
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
+  auto getfile = plan->addProcessor("GetFile", "getfileCreate2");
 
-  std::shared_ptr<core::Processor> putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
+  auto putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
@@ -113,9 +113,9 @@ TEST_CASE("PutFileTestFileExists", "[getfileputpfile]") {
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
 
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
+  auto getfile = plan->addProcessor("GetFile", "getfileCreate2");
 
-  std::shared_ptr<core::Processor> putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
+  auto putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("failure", "description"), true);
 
@@ -172,9 +172,9 @@ TEST_CASE("PutFileTestFileExistsIgnore", "[getfileputpfile]") {
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
 
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
+  auto getfile = plan->addProcessor("GetFile", "getfileCreate2");
 
-  std::shared_ptr<core::Processor> putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
+  auto putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
@@ -234,9 +234,9 @@ TEST_CASE("PutFileTestFileExistsReplace", "[getfileputpfile]") {
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
 
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
+  auto getfile = plan->addProcessor("GetFile", "getfileCreate2");
 
-  std::shared_ptr<core::Processor> putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
+  auto putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
 
   plan->addProcessor("LogAttribute", "logattribute", { core::Relationship("success", "d"), core::Relationship("failure", "d") }, true);
 
@@ -298,9 +298,9 @@ TEST_CASE("PutFileMaxFileCountTest", "[getfileputpfilemaxcount]") {
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
 
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate");
+  auto getfile = plan->addProcessor("GetFile", "getfileCreate");
 
-  std::shared_ptr<core::Processor> putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
+  auto putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
 
   plan->addProcessor("LogAttribute", "logattribute", { core::Relationship("success", "d"), core::Relationship("failure", "d") }, true);
 
@@ -363,9 +363,9 @@ TEST_CASE("PutFileEmptyTest", "[EmptyFilePutTest]") {
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
 
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
+  auto getfile = plan->addProcessor("GetFile", "getfileCreate2");
 
-  std::shared_ptr<core::Processor> putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
+  auto putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
 
   const auto dir = testController.createTempDirectory();
   const auto putfiledir = testController.createTempDirectory();
@@ -396,9 +396,9 @@ TEST_CASE("TestPutFilePermissions", "[PutFilePermissions]") {
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
 
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
+  auto getfile = plan->addProcessor("GetFile", "getfileCreate2");
 
-  std::shared_ptr<core::Processor> putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
+  auto putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
 
   const auto dir = testController.createTempDirectory();
   const auto putfiledir = testController.createTempDirectory() / "test_dir";
@@ -432,8 +432,8 @@ TEST_CASE("PutFileCreateDirectoryTest", "[PutFileProperties]") {
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> getfile = plan->addProcessor("GetFile", "getfileCreate2");
-  std::shared_ptr<core::Processor> putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
+  auto getfile = plan->addProcessor("GetFile", "getfileCreate2");
+  auto putfile = plan->addProcessor("PutFile", "putfile", core::Relationship("success", "description"), true);
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
   // Define Directory

--- a/extensions/standard-processors/tests/unit/PutTCPTests.cpp
+++ b/extensions/standard-processors/tests/unit/PutTCPTests.cpp
@@ -97,7 +97,9 @@ utils::net::SslData createSslDataForServer() {
 
 class PutTCPTestFixture {
  public:
-  PutTCPTestFixture() {
+  PutTCPTestFixture() :
+      controller_(std::make_unique<PutTCP>("PutTCP")),
+      put_tcp_(controller_.getProcessor<PutTCP>()) {
     LogTestController::getInstance().setTrace<PutTCP>();
     LogTestController::getInstance().setInfo<core::ProcessSession>();
     LogTestController::getInstance().setTrace<utils::net::Server>();
@@ -227,8 +229,8 @@ class PutTCPTestFixture {
     return servers_.at(*port).cancellable_server.get();
   }
 
-  const std::shared_ptr<PutTCP> put_tcp_ = std::make_shared<PutTCP>("PutTCP");
-  test::SingleProcessorTestController controller_{put_tcp_};
+  test::SingleProcessorTestController controller_;
+  PutTCP* put_tcp_;
 
   class Server {
    public:

--- a/extensions/standard-processors/tests/unit/PutUDPTests.cpp
+++ b/extensions/standard-processors/tests/unit/PutUDPTests.cpp
@@ -46,9 +46,9 @@ std::optional<utils::net::Message> tryDequeueWithTimeout(utils::net::UdpServer& 
 }  // namespace
 
 TEST_CASE("PutUDP", "[putudp]") {
-  const auto put_udp = std::make_shared<PutUDP>("PutUDP");
+  test::SingleProcessorTestController controller{std::make_unique<PutUDP>("PutUDP")};
+  const auto put_udp = controller.getProcessor();
 
-  test::SingleProcessorTestController controller{put_udp};
   LogTestController::getInstance().setTrace<PutUDP>();
   LogTestController::getInstance().setTrace<core::ProcessContext>();
   put_udp->setProperty(PutUDP::Hostname, "${literal('localhost')}");

--- a/extensions/standard-processors/tests/unit/ReplaceTextTests.cpp
+++ b/extensions/standard-processors/tests/unit/ReplaceTextTests.cpp
@@ -45,12 +45,12 @@ TEST_CASE("ReplaceText can parse its properties", "[onSchedule]") {
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   LogTestController::getInstance().setDebug<minifi::processors::ReplaceText>();
 
-  std::shared_ptr<core::Processor> generate_flow_file = plan->addProcessor("GenerateFlowFile", "generate_flow_file");
+  auto generate_flow_file = plan->addProcessor("GenerateFlowFile", "generate_flow_file");
   plan->setProperty(generate_flow_file, minifi::processors::GenerateFlowFile::CustomText, "One green bottle is hanging on the wall");
   plan->setProperty(generate_flow_file, minifi::processors::GenerateFlowFile::DataFormat, "Text");
   plan->setProperty(generate_flow_file, minifi::processors::GenerateFlowFile::UniqueFlowFiles, "false");
 
-  std::shared_ptr<core::Processor> replace_text = plan->addProcessor("ReplaceText", "replace_text", minifi::processors::GenerateFlowFile::Success, true);
+  auto replace_text = plan->addProcessor("ReplaceText", "replace_text", minifi::processors::GenerateFlowFile::Success, true);
   plan->setProperty(replace_text, minifi::processors::ReplaceText::EvaluationMode, "Entire text");
   plan->setProperty(replace_text, minifi::processors::ReplaceText::LineByLineEvaluationMode, "Except-First-Line");
   plan->setProperty(replace_text, minifi::processors::ReplaceText::ReplacementStrategy, "Substitute Variables");
@@ -184,12 +184,12 @@ TEST_CASE("Regex Replace works correctly in ReplaceText in line by line mode", "
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
-  std::shared_ptr<core::Processor> generate_flow_file = plan->addProcessor("GenerateFlowFile", "generate_flow_file");
+  auto generate_flow_file = plan->addProcessor("GenerateFlowFile", "generate_flow_file");
   plan->setProperty(generate_flow_file, minifi::processors::GenerateFlowFile::CustomText, "apple\n pear\n orange\n banana\n");
   plan->setProperty(generate_flow_file, minifi::processors::GenerateFlowFile::DataFormat, "Text");
   plan->setProperty(generate_flow_file, minifi::processors::GenerateFlowFile::UniqueFlowFiles, "false");
 
-  std::shared_ptr<core::Processor> replace_text = plan->addProcessor("ReplaceText", "replace_text", minifi::processors::GenerateFlowFile::Success, true);
+  auto replace_text = plan->addProcessor("ReplaceText", "replace_text", minifi::processors::GenerateFlowFile::Success, true);
   plan->setProperty(replace_text, minifi::processors::ReplaceText::EvaluationMode, magic_enum::enum_name(minifi::processors::EvaluationModeType::LINE_BY_LINE));
   plan->setProperty(replace_text, minifi::processors::ReplaceText::ReplacementStrategy, magic_enum::enum_name(minifi::processors::ReplacementStrategyType::REGEX_REPLACE));
   plan->setProperty(replace_text, minifi::processors::ReplaceText::SearchValue, "[aeiou]");
@@ -275,7 +275,7 @@ TEST_CASE("Regex Replace works correctly in ReplaceText in line by line mode", "
     expected_output = "fruit\r\nfruit\r\nfruit\r\nfruit";
   }
 
-  std::shared_ptr<core::Processor> log_attribute = plan->addProcessor("LogAttribute", "log_attribute", minifi::processors::ReplaceText::Success, true);
+  auto log_attribute = plan->addProcessor("LogAttribute", "log_attribute", minifi::processors::ReplaceText::Success, true);
   plan->setProperty(log_attribute, minifi::processors::LogAttribute::LogPayload, "true");
 
   testController.runSession(plan);
@@ -293,15 +293,15 @@ class HandleEmptyIncomingFlowFile {
   void run() {
     LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
-    std::shared_ptr<core::Processor> generate_flow_file = plan->addProcessor("GenerateFlowFile", "generate_flow_file");
+    auto generate_flow_file = plan->addProcessor("GenerateFlowFile", "generate_flow_file");
     plan->setProperty(generate_flow_file, minifi::processors::GenerateFlowFile::FileSize, "0 B");
 
-    std::shared_ptr<core::Processor> replace_text = plan->addProcessor("ReplaceText", "replace_text", minifi::processors::GenerateFlowFile::Success, true);
+    auto replace_text = plan->addProcessor("ReplaceText", "replace_text", minifi::processors::GenerateFlowFile::Success, true);
     plan->setProperty(replace_text, minifi::processors::ReplaceText::EvaluationMode, magic_enum::enum_name(evaluation_mode_));
     plan->setProperty(replace_text, minifi::processors::ReplaceText::ReplacementStrategy, magic_enum::enum_name(replacement_strategy_));
     plan->setProperty(replace_text, minifi::processors::ReplaceText::ReplacementValue, "hippopotamus");
 
-    std::shared_ptr<core::Processor> log_attribute = plan->addProcessor("LogAttribute", "log_attribute", minifi::processors::ReplaceText::Success, true);
+    auto log_attribute = plan->addProcessor("LogAttribute", "log_attribute", minifi::processors::ReplaceText::Success, true);
     plan->setProperty(log_attribute, minifi::processors::LogAttribute::LogPayload, "true");
 
     testController.runSession(plan);
@@ -355,22 +355,22 @@ class UseExpressionLanguage {
   void run() {
     LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
-    std::shared_ptr<core::Processor> generate_flow_file = plan->addProcessor("GenerateFlowFile", "generate_flow_file");
+    auto generate_flow_file = plan->addProcessor("GenerateFlowFile", "generate_flow_file");
     plan->setProperty(generate_flow_file, minifi::processors::GenerateFlowFile::CustomText, "apple\n pear\n orange\n banana\n");
     plan->setProperty(generate_flow_file, minifi::processors::GenerateFlowFile::DataFormat, "Text");
     plan->setProperty(generate_flow_file, minifi::processors::GenerateFlowFile::UniqueFlowFiles, "false");
 
-    std::shared_ptr<core::Processor> update_attribute = plan->addProcessor("UpdateAttribute", "update_attribute", minifi::processors::GenerateFlowFile::Success, true);
+    auto update_attribute = plan->addProcessor("UpdateAttribute", "update_attribute", minifi::processors::GenerateFlowFile::Success, true);
     plan->setDynamicProperty(update_attribute, "substring", "an");
     plan->setDynamicProperty(update_attribute, "color", "blue");
 
-    std::shared_ptr<core::Processor> replace_text = plan->addProcessor("ReplaceText", "replace_text", minifi::processors::GenerateFlowFile::Success, true);
+    auto replace_text = plan->addProcessor("ReplaceText", "replace_text", minifi::processors::GenerateFlowFile::Success, true);
     plan->setProperty(replace_text, minifi::processors::ReplaceText::EvaluationMode, magic_enum::enum_name(minifi::processors::EvaluationModeType::ENTIRE_TEXT));
     plan->setProperty(replace_text, minifi::processors::ReplaceText::ReplacementStrategy, magic_enum::enum_name(minifi::processors::ReplacementStrategyType::LITERAL_REPLACE));
     plan->setProperty(replace_text, minifi::processors::ReplaceText::SearchValue, search_value_);
     plan->setProperty(replace_text, minifi::processors::ReplaceText::ReplacementValue, replacement_value_);
 
-    std::shared_ptr<core::Processor> log_attribute = plan->addProcessor("LogAttribute", "log_attribute", minifi::processors::ReplaceText::Success, true);
+    auto log_attribute = plan->addProcessor("LogAttribute", "log_attribute", minifi::processors::ReplaceText::Success, true);
     plan->setProperty(log_attribute, minifi::processors::LogAttribute::LogPayload, "true");
 
     testController.runSession(plan);

--- a/extensions/standard-processors/tests/unit/RetryFlowFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/RetryFlowFileTests.cpp
@@ -95,13 +95,13 @@ class RetryFlowFileTest {
     const core::Relationship failure         {RetryFlowFile::Failure};
 
     // Processors
-    std::shared_ptr<core::Processor> generate                    = plan_->addProcessor("GenerateFlowFile", "generate", {success}, false);
-    std::shared_ptr<core::Processor> update                      = plan_->addProcessor("UpdateAttribute", "update", {success}, false);
-    std::shared_ptr<core::Processor> retryflowfile               = plan_->addProcessor("RetryFlowFile", "retryflowfile", {retry, retries_exceeded, failure}, false);
-    std::shared_ptr<core::Processor> putfile_on_retry            = plan_->addProcessor("PutFile", "putfile_on_retry", {success}, false);
-    std::shared_ptr<core::Processor> putfile_on_retries_exceeded = plan_->addProcessor("PutFile", "putfile_on_retries_exceeded", {success}, false);
-    std::shared_ptr<core::Processor> putfile_on_failure          = plan_->addProcessor("PutFile", "putfile_on_failure", {success}, false);
-    std::shared_ptr<core::Processor> log_attribute               = plan_->addProcessor("LogAttribute", "log", {success}, false);
+    auto generate                    = plan_->addProcessor("GenerateFlowFile", "generate", {success}, false);
+    auto update                      = plan_->addProcessor("UpdateAttribute", "update", {success}, false);
+    auto retryflowfile               = plan_->addProcessor("RetryFlowFile", "retryflowfile", {retry, retries_exceeded, failure}, false);
+    auto putfile_on_retry            = plan_->addProcessor("PutFile", "putfile_on_retry", {success}, false);
+    auto putfile_on_retries_exceeded = plan_->addProcessor("PutFile", "putfile_on_retries_exceeded", {success}, false);
+    auto putfile_on_failure          = plan_->addProcessor("PutFile", "putfile_on_failure", {success}, false);
+    auto log_attribute               = plan_->addProcessor("LogAttribute", "log", {success}, false);
 
     retryflowfile->setPenalizationPeriod(std::chrono::milliseconds{0});
 

--- a/extensions/standard-processors/tests/unit/RouteTextTests.cpp
+++ b/extensions/standard-processors/tests/unit/RouteTextTests.cpp
@@ -54,7 +54,7 @@ struct RouteTextController : public TestController {
 
   RouteTextController() {
     plan_ = createPlan();
-    plan_->addProcessor(proc_, "RouteText");
+    proc_ = plan_->addProcessor(std::make_unique<processors::RouteText>("RouteText"), "RouteText");
     input_ = plan_->addConnection(nullptr, {"success", ""}, proc_);
     createOutput(processors::RouteText::Original);
     createOutput(processors::RouteText::Unmatched);
@@ -124,7 +124,7 @@ struct RouteTextController : public TestController {
   }
 
   std::shared_ptr<TestPlan> plan_ = createPlan();
-  std::shared_ptr<core::Processor> proc_ = std::make_shared<processors::RouteText>("RouteText");
+  core::Processor* proc_ = nullptr;
   std::map<std::string, minifi::Connection*> outputs_;
   minifi::Connection* input_;
 };

--- a/extensions/standard-processors/tests/unit/SegmentContentTests.cpp
+++ b/extensions/standard-processors/tests/unit/SegmentContentTests.cpp
@@ -56,8 +56,8 @@ std::vector<std::byte> createByteVector(Bytes... bytes) {
 }
 
 TEST_CASE("Invalid segmentSize tests") {
-  const auto segment_content = std::make_shared<SegmentContent>("SegmentContent");
-  minifi::test::SingleProcessorTestController controller{segment_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SegmentContent>("SegmentContent")};
+  const auto segment_content = controller.getProcessor();
 
   SECTION("foo") {
     REQUIRE_NOTHROW(segment_content->setProperty(SegmentContent::SegmentSize, "foo"), "General Operation: Segment Size value validation failed");
@@ -78,9 +78,10 @@ TEST_CASE("Invalid segmentSize tests") {
 }
 
 TEST_CASE("EmptyFlowFile") {
-  const auto split_content = std::make_shared<SegmentContent>("SegmentContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
-  split_content->setProperty(SegmentContent::SegmentSize, "10 B");
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SegmentContent>("SegmentContent")};
+  const auto segment_content = controller.getProcessor();
+
+  segment_content->setProperty(SegmentContent::SegmentSize, "10 B");
 
   auto trigger_results = controller.trigger("");
   auto original = trigger_results.at(processors::SegmentContent::Original);
@@ -93,8 +94,8 @@ TEST_CASE("EmptyFlowFile") {
 }
 
 TEST_CASE("SegmentContent with different sized text input") {
-  const auto segment_content = std::make_shared<SegmentContent>("SegmentContent");
-  minifi::test::SingleProcessorTestController controller{segment_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SegmentContent>("SegmentContent")};
+  const auto segment_content = controller.getProcessor();
 
   auto [original_size, segment_size] = GENERATE(
     std::make_tuple(size_t{1020}, size_t{30}),
@@ -130,8 +131,8 @@ TEST_CASE("SegmentContent with different sized text input") {
 }
 
 TEST_CASE("SegmentContent with different sized byte input") {
-  const auto segment_content = std::make_shared<SegmentContent>("SegmentContent");
-  minifi::test::SingleProcessorTestController controller{segment_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SegmentContent>("SegmentContent")};
+  const auto segment_content = controller.getProcessor();
 
   auto [original_size, segment_size] = GENERATE(
     std::make_tuple(size_t{1020}, size_t{30}),
@@ -168,8 +169,8 @@ TEST_CASE("SegmentContent with different sized byte input") {
 }
 
 TEST_CASE("SimpleTest", "[NiFi]") {
-  const auto segment_content = std::make_shared<SegmentContent>("SegmentContent");
-  minifi::test::SingleProcessorTestController controller{segment_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SegmentContent>("SegmentContent")};
+  const auto segment_content = controller.getProcessor();
 
   segment_content->setProperty(SegmentContent::SegmentSize, "4 B");
 
@@ -213,8 +214,8 @@ TEST_CASE("SimpleTest", "[NiFi]") {
 }
 
 TEST_CASE("TransferSmall", "[NiFi]") {
-  const auto segment_content = std::make_shared<SegmentContent>("SegmentContent");
-  minifi::test::SingleProcessorTestController controller{segment_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SegmentContent>("SegmentContent")};
+  const auto segment_content = controller.getProcessor();
 
   segment_content->setProperty(SegmentContent::SegmentSize, "4 KB");
 
@@ -234,8 +235,8 @@ TEST_CASE("TransferSmall", "[NiFi]") {
 }
 
 TEST_CASE("ExpressionLanguageSupport", "[NiFi]") {
-  const auto segment_content = std::make_shared<SegmentContent>("SegmentContent");
-  minifi::test::SingleProcessorTestController controller{segment_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SegmentContent>("SegmentContent")};
+  const auto segment_content = controller.getProcessor();
 
   segment_content->setProperty(SegmentContent::SegmentSize, "${segmentSize}");
 

--- a/extensions/standard-processors/tests/unit/SplitContentTests.cpp
+++ b/extensions/standard-processors/tests/unit/SplitContentTests.cpp
@@ -31,8 +31,8 @@ std::vector<std::byte> createByteVector(Bytes... bytes) {
 }
 
 TEST_CASE("WithoutByteSequence") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
   split_content->setProperty(SplitContent::ByteSequenceFormatProperty, magic_enum::enum_name(SplitContent::ByteSequenceFormat::Text));
   split_content->setProperty(SplitContent::KeepByteSequence, "true");
   split_content->setProperty(SplitContent::ByteSequenceLocationProperty, magic_enum::enum_name(SplitContent::ByteSequenceLocation::Leading));
@@ -41,8 +41,8 @@ TEST_CASE("WithoutByteSequence") {
 }
 
 TEST_CASE("EmptyFlowFile") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
   split_content->setProperty(SplitContent::ByteSequenceFormatProperty, magic_enum::enum_name(SplitContent::ByteSequenceFormat::Text));
   split_content->setProperty(SplitContent::ByteSequence, "ub");
   split_content->setProperty(SplitContent::KeepByteSequence, "true");
@@ -59,8 +59,8 @@ TEST_CASE("EmptyFlowFile") {
 }
 
 TEST_CASE("TextFormatLeadingPosition", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
   split_content->setProperty(SplitContent::ByteSequenceFormatProperty, magic_enum::enum_name(SplitContent::ByteSequenceFormat::Text));
   split_content->setProperty(SplitContent::ByteSequence, "ub");
   split_content->setProperty(SplitContent::KeepByteSequence, "true");
@@ -82,8 +82,8 @@ TEST_CASE("TextFormatLeadingPosition", "[NiFi]") {
 }
 
 TEST_CASE("TextFormatTrailingPosition", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
 
   split_content->setProperty(SplitContent::ByteSequenceFormatProperty, magic_enum::enum_name(SplitContent::ByteSequenceFormat::Text));
   split_content->setProperty(SplitContent::ByteSequence, "ub");
@@ -106,8 +106,8 @@ TEST_CASE("TextFormatTrailingPosition", "[NiFi]") {
 }
 
 TEST_CASE("TextFormatSplits", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
 
   split_content->setProperty(SplitContent::ByteSequenceFormatProperty, magic_enum::enum_name(SplitContent::ByteSequenceFormat::Text));
   split_content->setProperty(SplitContent::ByteSequence, "test");
@@ -144,8 +144,8 @@ TEST_CASE("TextFormatSplits", "[NiFi]") {
 }
 
 TEST_CASE("SmallSplits", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
 
   split_content->setProperty(SplitContent::KeepByteSequence, "false");
   split_content->setProperty(SplitContent::ByteSequence, "FFFF");
@@ -169,8 +169,8 @@ TEST_CASE("SmallSplits", "[NiFi]") {
 }
 
 TEST_CASE("WithSingleByteSplit", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
 
   split_content->setProperty(SplitContent::KeepByteSequence, "false");
   split_content->setProperty(SplitContent::ByteSequence, "FF");
@@ -194,8 +194,8 @@ TEST_CASE("WithSingleByteSplit", "[NiFi]") {
 }
 
 TEST_CASE("WithLargerSplit", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
 
   split_content->setProperty(SplitContent::KeepByteSequence, "false");
   split_content->setProperty(SplitContent::ByteSequence, "05050505");
@@ -219,8 +219,8 @@ TEST_CASE("WithLargerSplit", "[NiFi]") {
 }
 
 TEST_CASE("KeepingSequence", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
 
   split_content->setProperty(SplitContent::KeepByteSequence, "true");
   split_content->setProperty(SplitContent::ByteSequence, "05050505");
@@ -244,8 +244,8 @@ TEST_CASE("KeepingSequence", "[NiFi]") {
 }
 
 TEST_CASE("EndsWithSequence", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
 
   split_content->setProperty(SplitContent::KeepByteSequence, "false");
   split_content->setProperty(SplitContent::ByteSequence, "05050505");
@@ -267,8 +267,8 @@ TEST_CASE("EndsWithSequence", "[NiFi]") {
 }
 
 TEST_CASE("EndsWithSequenceAndKeepSequence", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
 
   split_content->setProperty(SplitContent::KeepByteSequence, "true");
   split_content->setProperty(SplitContent::ByteSequence, "05050505");
@@ -290,8 +290,8 @@ TEST_CASE("EndsWithSequenceAndKeepSequence", "[NiFi]") {
 }
 
 TEST_CASE("StartsWithSequence", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
 
   split_content->setProperty(SplitContent::KeepByteSequence, "false");
   split_content->setProperty(SplitContent::ByteSequence, "05050505");
@@ -313,8 +313,8 @@ TEST_CASE("StartsWithSequence", "[NiFi]") {
 }
 
 TEST_CASE("StartsWithSequenceAndKeepTrailingSequence", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
 
   split_content->setProperty(SplitContent::KeepByteSequence, "true");
   split_content->setProperty(SplitContent::ByteSequence, "05050505");
@@ -339,8 +339,8 @@ TEST_CASE("StartsWithSequenceAndKeepTrailingSequence", "[NiFi]") {
 }
 
 TEST_CASE("StartsWithSequenceAndKeepLeadingSequence") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
 
   split_content->setProperty(SplitContent::KeepByteSequence, "true");
   split_content->setProperty(SplitContent::ByteSequence, "05050505");
@@ -361,8 +361,8 @@ TEST_CASE("StartsWithSequenceAndKeepLeadingSequence") {
 }
 
 TEST_CASE("StartsWithDoubleSequenceAndKeepLeadingSequence") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
 
   split_content->setProperty(SplitContent::KeepByteSequence, "true");
   split_content->setProperty(SplitContent::ByteSequence, "05050505");
@@ -387,8 +387,8 @@ TEST_CASE("StartsWithDoubleSequenceAndKeepLeadingSequence") {
 }
 
 TEST_CASE("NoSplitterInString", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
 
   split_content->setProperty(SplitContent::ByteSequenceFormatProperty, magic_enum::enum_name(SplitContent::ByteSequenceFormat::Text));
   split_content->setProperty(SplitContent::ByteSequence, ",");
@@ -415,8 +415,8 @@ TEST_CASE("NoSplitterInString", "[NiFi]") {
 }
 
 TEST_CASE("ByteSequenceAtBufferTargetSize") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
 
   auto x = SplitContent::BUFFER_TARGET_SIZE-10;
 
@@ -456,8 +456,8 @@ TEST_CASE("ByteSequenceAtBufferTargetSize") {
 }
 
 TEST_CASE("TrickyWithLeading", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
   split_content->setProperty(SplitContent::ByteSequenceFormatProperty, magic_enum::enum_name(SplitContent::ByteSequenceFormat::Text));
   split_content->setProperty(SplitContent::ByteSequence, "aab");
   split_content->setProperty(SplitContent::KeepByteSequence, "true");
@@ -477,8 +477,8 @@ TEST_CASE("TrickyWithLeading", "[NiFi]") {
 }
 
 TEST_CASE("TrickyWithTrailing", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
   split_content->setProperty(SplitContent::ByteSequenceFormatProperty, magic_enum::enum_name(SplitContent::ByteSequenceFormat::Text));
   split_content->setProperty(SplitContent::ByteSequence, "aab");
   split_content->setProperty(SplitContent::KeepByteSequence, "true");
@@ -498,8 +498,8 @@ TEST_CASE("TrickyWithTrailing", "[NiFi]") {
 }
 
 TEST_CASE("TrickierWithLeading", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
   split_content->setProperty(SplitContent::ByteSequenceFormatProperty, magic_enum::enum_name(SplitContent::ByteSequenceFormat::Text));
   split_content->setProperty(SplitContent::ByteSequence, "abcd");
   split_content->setProperty(SplitContent::KeepByteSequence, "true");
@@ -519,8 +519,8 @@ TEST_CASE("TrickierWithLeading", "[NiFi]") {
 }
 
 TEST_CASE("TrickierWithTrailing", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
   split_content->setProperty(SplitContent::ByteSequenceFormatProperty, magic_enum::enum_name(SplitContent::ByteSequenceFormat::Text));
   split_content->setProperty(SplitContent::ByteSequence, "abcd");
   split_content->setProperty(SplitContent::KeepByteSequence, "true");
@@ -540,8 +540,8 @@ TEST_CASE("TrickierWithTrailing", "[NiFi]") {
 }
 
 TEST_CASE("OnlyByteSequencesNoKeep", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
   split_content->setProperty(SplitContent::ByteSequenceFormatProperty, magic_enum::enum_name(SplitContent::ByteSequenceFormat::Text));
   split_content->setProperty(SplitContent::ByteSequence, "ab");
   split_content->setProperty(SplitContent::KeepByteSequence, "false");
@@ -556,8 +556,8 @@ TEST_CASE("OnlyByteSequencesNoKeep", "[NiFi]") {
 }
 
 TEST_CASE("OnlyByteSequencesTrailing", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
   split_content->setProperty(SplitContent::ByteSequenceFormatProperty, magic_enum::enum_name(SplitContent::ByteSequenceFormat::Text));
   split_content->setProperty(SplitContent::ByteSequence, "ab");
   split_content->setProperty(SplitContent::KeepByteSequence, "true");
@@ -576,8 +576,8 @@ TEST_CASE("OnlyByteSequencesTrailing", "[NiFi]") {
 }
 
 TEST_CASE("OnlyByteSequencesLeading", "[NiFi]") {
-  const auto split_content = std::make_shared<SplitContent>("SplitContent");
-  minifi::test::SingleProcessorTestController controller{split_content};
+  minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
+  const auto split_content = controller.getProcessor();
   split_content->setProperty(SplitContent::ByteSequenceFormatProperty, magic_enum::enum_name(SplitContent::ByteSequenceFormat::Text));
   split_content->setProperty(SplitContent::ByteSequence, "ab");
   split_content->setProperty(SplitContent::KeepByteSequence, "true");

--- a/extensions/standard-processors/tests/unit/TailFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/TailFileTests.cpp
@@ -85,7 +85,7 @@ TEST_CASE("TailFile reads the file until the first delimiter", "[simple]") {
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
+  auto tailfile = plan->addProcessor("TailFile", "tailfileProc");
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
   auto dir = testController.createTempDirectory();
@@ -120,7 +120,7 @@ TEST_CASE("TailFile picks up the second line if a delimiter is written between r
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
+  auto tailfile = plan->addProcessor("TailFile", "tailfileProc");
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
@@ -162,7 +162,7 @@ TEST_CASE("TailFile re-reads the file if the state is deleted between runs", "[s
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
+  auto tailfile = plan->addProcessor("TailFile", "tailfileProc");
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
@@ -201,7 +201,7 @@ TEST_CASE("TailFile picks up the state correctly if it is rewritten between runs
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
+  auto tailfile = plan->addProcessor("TailFile", "tailfileProc");
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
@@ -375,10 +375,10 @@ TEST_CASE("TailFile picks up the new File to Tail if it is changed between runs"
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tail_file = plan->addProcessor("TailFile", "tail_file");
+  auto tail_file = plan->addProcessor("TailFile", "tail_file");
   plan->setProperty(tail_file, org::apache::nifi::minifi::processors::TailFile::Delimiter, "\n");
 
-  std::shared_ptr<core::Processor> log_attribute = plan->addProcessor("LogAttribute", "log_attribute", core::Relationship("success", "description"), true);
+  auto log_attribute = plan->addProcessor("LogAttribute", "log_attribute", core::Relationship("success", "description"), true);
   plan->setProperty(log_attribute, org::apache::nifi::minifi::processors::LogAttribute::FlowFilesToLog, "0");
 
   auto directory = testController.createTempDirectory();
@@ -417,14 +417,14 @@ TEST_CASE("TailFile picks up the new File to Tail if it is changed between runs 
   auto directory = testController.createTempDirectory();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tail_file = plan->addProcessor("TailFile", "tail_file");
+  auto tail_file = plan->addProcessor("TailFile", "tail_file");
   plan->setProperty(tail_file, org::apache::nifi::minifi::processors::TailFile::Delimiter, "\n");
   plan->setProperty(tail_file, org::apache::nifi::minifi::processors::TailFile::TailMode, "Multiple file");
   plan->setProperty(tail_file, org::apache::nifi::minifi::processors::TailFile::BaseDirectory, directory.string());
   plan->setProperty(tail_file, org::apache::nifi::minifi::processors::TailFile::LookupFrequency, "0 sec");
   plan->setProperty(tail_file, org::apache::nifi::minifi::processors::TailFile::FileName, "first\\..*\\.log");
 
-  std::shared_ptr<core::Processor> log_attribute = plan->addProcessor("LogAttribute", "log_attribute", core::Relationship("success", "description"), true);
+  auto log_attribute = plan->addProcessor("LogAttribute", "log_attribute", core::Relationship("success", "description"), true);
   plan->setProperty(log_attribute, org::apache::nifi::minifi::processors::LogAttribute::FlowFilesToLog, "0");
 
   createTempFile(directory, "first.fruit.log", "apple\n");
@@ -465,7 +465,7 @@ TEST_CASE("TailFile finds the single input file in both Single and Multiple mode
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
+  auto tailfile = plan->addProcessor("TailFile", "tailfileProc");
   plan->setProperty(tailfile, org::apache::nifi::minifi::processors::TailFile::Delimiter, "");
 
   plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
@@ -509,14 +509,14 @@ TEST_CASE("TailFile picks up new files created between runs", "[multiple_file]")
   auto dir = testController.createTempDirectory();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfile");
+  auto tailfile = plan->addProcessor("TailFile", "tailfile");
   plan->setProperty(tailfile, org::apache::nifi::minifi::processors::TailFile::TailMode, "Multiple file");
   plan->setProperty(tailfile, org::apache::nifi::minifi::processors::TailFile::BaseDirectory, dir.string());
   plan->setProperty(tailfile, org::apache::nifi::minifi::processors::TailFile::LookupFrequency, "0 sec");
   plan->setProperty(tailfile, org::apache::nifi::minifi::processors::TailFile::FileName, ".*\\.log");
   plan->setProperty(tailfile, org::apache::nifi::minifi::processors::TailFile::Delimiter, "\n");
 
-  std::shared_ptr<core::Processor> logattribute = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
+  auto logattribute = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
   plan->setProperty(logattribute, org::apache::nifi::minifi::processors::LogAttribute::FlowFilesToLog, "0");
 
   createTempFile(dir, "application.log", "line1\nline2\n");
@@ -544,14 +544,14 @@ TEST_CASE("TailFile can handle input files getting removed", "[multiple_file]") 
   auto dir = testController.createTempDirectory();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfile");
+  auto tailfile = plan->addProcessor("TailFile", "tailfile");
   plan->setProperty(tailfile, org::apache::nifi::minifi::processors::TailFile::TailMode, "Multiple file");
   plan->setProperty(tailfile, org::apache::nifi::minifi::processors::TailFile::BaseDirectory, dir.string());
   plan->setProperty(tailfile, org::apache::nifi::minifi::processors::TailFile::LookupFrequency, "0 sec");
   plan->setProperty(tailfile, org::apache::nifi::minifi::processors::TailFile::FileName, ".*\\.log");
   plan->setProperty(tailfile, org::apache::nifi::minifi::processors::TailFile::Delimiter, "\n");
 
-  std::shared_ptr<core::Processor> logattribute = plan->addProcessor("LogAttribute", "logattribute",
+  auto logattribute = plan->addProcessor("LogAttribute", "logattribute",
                                                                      core::Relationship("success", "description"),
                                                                      true);
   plan->setProperty(logattribute, org::apache::nifi::minifi::processors::LogAttribute::FlowFilesToLog, "0");
@@ -594,7 +594,7 @@ TEST_CASE("TailFile processes a very long line correctly", "[simple]") {
   LogTestController::getInstance().setTrace<core::ProcessSession>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
+  auto tailfile = plan->addProcessor("TailFile", "tailfileProc");
 
   auto dir = testController.createTempDirectory();
   auto temp_file_path = dir / TMP_FILE;
@@ -606,7 +606,7 @@ TEST_CASE("TailFile processes a very long line correctly", "[simple]") {
   plan->setProperty(tailfile, org::apache::nifi::minifi::processors::TailFile::FileName, temp_file_path.string());
   plan->setProperty(tailfile, org::apache::nifi::minifi::processors::TailFile::Delimiter, "\n");
 
-  std::shared_ptr<core::Processor> log_attr = plan->addProcessor("LogAttribute", "Log", core::Relationship("success", "description"), true);
+  auto log_attr = plan->addProcessor("LogAttribute", "Log", core::Relationship("success", "description"), true);
   plan->setProperty(log_attr, minifi::processors::LogAttribute::FlowFilesToLog, "0");
   plan->setProperty(log_attr, minifi::processors::LogAttribute::LogPayload, "true");
   plan->setProperty(log_attr, minifi::processors::LogAttribute::HexencodePayload, "true");
@@ -671,7 +671,7 @@ TEST_CASE("TailFile processes a long line followed by multiple newlines correctl
   LogTestController::getInstance().setTrace<core::ProcessSession>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
+  auto tailfile = plan->addProcessor("TailFile", "tailfileProc");
   auto dir = testController.createTempDirectory();
   auto temp_file_path = dir / TMP_FILE;
   std::ofstream tmpfile;
@@ -682,7 +682,7 @@ TEST_CASE("TailFile processes a long line followed by multiple newlines correctl
   plan->setProperty(tailfile, org::apache::nifi::minifi::processors::TailFile::FileName, temp_file_path.string());
   plan->setProperty(tailfile, org::apache::nifi::minifi::processors::TailFile::Delimiter, "\n");
 
-  std::shared_ptr<core::Processor> log_attr = plan->addProcessor("LogAttribute", "Log", core::Relationship("success", "description"), true);
+  auto log_attr = plan->addProcessor("LogAttribute", "Log", core::Relationship("success", "description"), true);
   plan->setProperty(log_attr, minifi::processors::LogAttribute::FlowFilesToLog, "0");
   plan->setProperty(log_attr, minifi::processors::LogAttribute::LogPayload, "true");
   plan->setProperty(log_attr, minifi::processors::LogAttribute::HexencodePayload, "true");
@@ -709,7 +709,7 @@ TEST_CASE("TailFile onSchedule throws if file(s) to tail cannot be determined", 
   LogTestController::getInstance().setDebug<minifi::processors::TailFile>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
+  auto tailfile = plan->addProcessor("TailFile", "tailfileProc");
 
   SECTION("Single file mode by default") {
     SECTION("No FileName") {
@@ -750,7 +750,7 @@ TEST_CASE("TailFile onSchedule throws in Multiple mode if the Base Directory doe
   LogTestController::getInstance().setDebug<minifi::processors::TailFile>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
+  auto tailfile = plan->addProcessor("TailFile", "tailfileProc");
   plan->setProperty(tailfile, minifi::processors::TailFile::TailMode, "Multiple file");
   plan->setProperty(tailfile, minifi::processors::TailFile::FileName, ".*\\.log");
 
@@ -912,11 +912,11 @@ TEST_CASE("TailFile ignores old rotated files", "[rotation]") {
   auto log_file_name = dir / "test.log";
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfile");
+  auto tailfile = plan->addProcessor("TailFile", "tailfile");
   plan->setProperty(tailfile, org::apache::nifi::minifi::processors::TailFile::FileName, log_file_name.string());
   plan->setProperty(tailfile, org::apache::nifi::minifi::processors::TailFile::Delimiter, "\n");
 
-  std::shared_ptr<core::Processor> logattribute = plan->addProcessor("LogAttribute", "logattribute",
+  auto logattribute = plan->addProcessor("LogAttribute", "logattribute",
                                                                      core::Relationship("success", "description"),
                                                                      true);
   plan->setProperty(logattribute, org::apache::nifi::minifi::processors::LogAttribute::FlowFilesToLog, "0");
@@ -1456,7 +1456,7 @@ TEST_CASE("TailFile interprets the lookup frequency property correctly", "[multi
   SECTION("Lookup frequency not set => defaults to 10 minutes") {
     testController.runSession(plan, true);
 
-    const auto tail_file_processor = std::dynamic_pointer_cast<minifi::processors::TailFile>(tail_file);
+    const auto tail_file_processor = dynamic_cast<minifi::processors::TailFile*>(tail_file);
     REQUIRE(tail_file_processor);
     REQUIRE(tail_file_processor->getLookupFrequency() == std::chrono::minutes{10});
   }
@@ -1512,8 +1512,8 @@ TEST_CASE("TailFile reads from a single file when Initial Start Position is set"
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
-  std::shared_ptr<core::Processor> logattribute = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
+  auto tailfile = plan->addProcessor("TailFile", "tailfileProc");
+  auto logattribute = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
   auto dir = testController.createTempDirectory();
   createTempFile(dir, ROLLED_OVER_TMP_FILE, ROLLED_OVER_TAIL_DATA);
@@ -1589,8 +1589,8 @@ TEST_CASE("TailFile reads from a single file when Initial Start Position is set 
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
-  std::shared_ptr<core::Processor> logattribute = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
+  auto tailfile = plan->addProcessor("TailFile", "tailfileProc");
+  auto logattribute = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
   auto dir = testController.createTempDirectory();
   auto temp_file_path = createTempFile(dir, TMP_FILE, NEWLINE_FILE);
@@ -1628,8 +1628,8 @@ TEST_CASE("TailFile reads multiple files when Initial Start Position is set", "[
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
-  std::shared_ptr<core::Processor> logattribute = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
+  auto tailfile = plan->addProcessor("TailFile", "tailfileProc");
+  auto logattribute = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
   auto dir = testController.createTempDirectory();
   createTempFile(dir, ROLLED_OVER_TMP_FILE, ROLLED_OVER_TAIL_DATA);
@@ -1717,8 +1717,8 @@ TEST_CASE("Initial Start Position is set to invalid or empty value", "[initialSt
   LogTestController::getInstance().setDebug<minifi::processors::LogAttribute>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tailfile = plan->addProcessor("TailFile", "tailfileProc");
-  std::shared_ptr<core::Processor> logattribute = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
+  auto tailfile = plan->addProcessor("TailFile", "tailfileProc");
+  auto logattribute = plan->addProcessor("LogAttribute", "logattribute", core::Relationship("success", "description"), true);
 
   auto dir = testController.createTempDirectory();
   createTempFile(dir, ROLLED_OVER_TMP_FILE, ROLLED_OVER_TAIL_DATA);
@@ -1744,7 +1744,7 @@ TEST_CASE("TailFile onSchedule throws if an invalid Attribute Provider Service i
   LogTestController::getInstance().setDebug<minifi::processors::TailFile>();
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
-  std::shared_ptr<core::Processor> tail_file = plan->addProcessor("TailFile", "tailfileProc");
+  auto tail_file = plan->addProcessor("TailFile", "tailfileProc");
   plan->setProperty(tail_file, minifi::processors::TailFile::TailMode, "Multiple file");
   plan->setProperty(tail_file, minifi::processors::TailFile::BaseDirectory, "/var/logs");
   plan->setProperty(tail_file, minifi::processors::TailFile::FileName, "minifi.log");
@@ -1786,13 +1786,13 @@ TEST_CASE("TailFile can use an AttributeProviderService", "[AttributeProviderSer
 
   std::shared_ptr<TestPlan> plan = testController.createPlan();
   plan->addController("TestAttributeProviderService", "attribute_provider_service");
-  std::shared_ptr<core::Processor> tail_file = plan->addProcessor("TailFile", "tail_file");
+  auto tail_file = plan->addProcessor("TailFile", "tail_file");
   plan->setProperty(tail_file, minifi::processors::TailFile::TailMode, "Multiple file");
   plan->setProperty(tail_file, minifi::processors::TailFile::BaseDirectory, (temp_directory / "my_${color}_${fruit}_${uid}" / "${animal}").string());
   plan->setProperty(tail_file, minifi::processors::TailFile::LookupFrequency, "0 sec");
   plan->setProperty(tail_file, minifi::processors::TailFile::FileName, ".*\\.log");
   plan->setProperty(tail_file, minifi::processors::TailFile::AttributeProviderService, "attribute_provider_service");
-  std::shared_ptr<core::Processor> log_attribute = plan->addProcessor("LogAttribute", "log_attribute", core::Relationship("success", ""), true);
+  auto log_attribute = plan->addProcessor("LogAttribute", "log_attribute", core::Relationship("success", ""), true);
   plan->setProperty(log_attribute, minifi::processors::LogAttribute::FlowFilesToLog, "0");
 
   createTempFile(temp_directory / "my_red_apple_001" / "dog", "0.log", "Idared\n");
@@ -1829,8 +1829,8 @@ TEST_CASE("TailFile can use an AttributeProviderService", "[AttributeProviderSer
 TEST_CASE("TailFile honors batch size for maximum lines processed", "[batchSize]") {
   LogTestController::getInstance().setTrace<minifi::processors::TailFile>();
 
-  auto tailfile = std::make_shared<minifi::processors::TailFile>("TailFile");
-  minifi::test::SingleProcessorTestController test_controller(tailfile);
+  minifi::test::SingleProcessorTestController test_controller(std::make_unique<minifi::processors::TailFile>("TailFile"));
+  auto tailfile = test_controller.getProcessor();
 
   auto temp_file_path  = test_controller.createTempDirectory() / TMP_FILE;
 

--- a/extensions/systemd/tests/ConsumeJournaldTest.cpp
+++ b/extensions/systemd/tests/ConsumeJournaldTest.cpp
@@ -160,7 +160,7 @@ TEST_CASE("ConsumeJournald", "[consumejournald]") {
       {"systemd", "Starting Rule-based Manager for Device Events and Files...", 1},
   }});
   auto* const libwrapper_observer = libwrapper.get();
-  const auto consume_journald = plan->addProcessor(std::make_shared<ConsumeJournald>("ConsumeJournald", utils::Identifier{},
+  const auto consume_journald = plan->addProcessor(std::make_unique<ConsumeJournald>("ConsumeJournald", utils::Identifier{},
       std::move(libwrapper)), "ConsumeJournald");
   REQUIRE(consume_journald->setProperty(ConsumeJournald::TimestampFormat, "ISO8601"));
   const auto get_cursor_position = [&consume_journald]() -> std::string {

--- a/libminifi/include/core/ProcessContext.h
+++ b/libminifi/include/core/ProcessContext.h
@@ -52,7 +52,7 @@ template<typename T>
 concept NotAFlowFile = !std::convertible_to<T &, const FlowFile &> && !std::convertible_to<T &, const std::shared_ptr<FlowFile> &>;
 }  // namespace detail
 
-class ProcessContext : public controller::ControllerServiceLookup, public core::VariableRegistry, public std::enable_shared_from_this<VariableRegistry> {
+class ProcessContext : public core::VariableRegistry, public std::enable_shared_from_this<VariableRegistry> {
  public:
   /*!
    * Create a new process context associated with the processor/controller service/state manager
@@ -193,46 +193,8 @@ class ProcessContext : public controller::ControllerServiceLookup, public core::
   ProcessContext(const ProcessContext &parent) = delete;
   ProcessContext &operator=(const ProcessContext &parent) = delete;
 
-  // controller services
-
-  /**
-   * @param identifier of controller service
-   * @return the ControllerService that is registered with the given
-   * identifier
-   */
-  std::shared_ptr<core::controller::ControllerService> getControllerService(const std::string &identifier) const override {
-    return controller_service_provider_ == nullptr ? nullptr : controller_service_provider_->getControllerService(identifier);
-  }
-
-  /**
-   * @param identifier identifier of service to check
-   * @return <code>true</code> if the Controller Service with the given
-   * identifier is enabled, <code>false</code> otherwise. If the given
-   * identifier is not known by this ControllerServiceLookup, returns
-   * <code>false</code>
-   */
-  bool isControllerServiceEnabled(const std::string &identifier) override {
-    return controller_service_provider_->isControllerServiceEnabled(identifier);
-  }
-
-  /**
-   * @param identifier identifier of service to check
-   * @return <code>true</code> if the Controller Service with the given
-   * identifier has been enabled but is still in the transitioning state,
-   * otherwise returns <code>false</code>. If the given identifier is not
-   * known by this ControllerServiceLookup, returns <code>false</code>
-   */
-  bool isControllerServiceEnabling(const std::string &identifier) override {
-    return controller_service_provider_->isControllerServiceEnabling(identifier);
-  }
-
-  /**
-   * @param identifier identifier to look up
-   * @return the name of the Controller service with the given identifier. If
-   * no service can be found with this identifier, returns {@code null}
-   */
-  const std::string getControllerServiceName(const std::string &identifier) const override {
-    return controller_service_provider_->getControllerServiceName(identifier);
+  std::shared_ptr<core::controller::ControllerService> getControllerService(const std::string &identifier, const utils::Identifier &processor_uuid) const {
+    return controller_service_provider_ == nullptr ? nullptr : controller_service_provider_->getControllerService(identifier, processor_uuid);
   }
 
   void initializeContentRepository(const std::string& home) {

--- a/libminifi/include/core/ProcessGroup.h
+++ b/libminifi/include/core/ProcessGroup.h
@@ -199,7 +199,7 @@ class ProcessGroup : public CoreComponent {
    */
   void addControllerService(const std::string &nodeId, const std::shared_ptr<core::controller::ControllerServiceNode> &node);
 
-  core::controller::ControllerServiceNode* findControllerService(const std::string &nodeId) const;
+  core::controller::ControllerServiceNode* findControllerService(const std::string &nodeId, Traverse traverse = Traverse::ExcludeChildren) const;
 
   std::vector<const core::controller::ControllerServiceNode*> getAllControllerServices() const;
 
@@ -220,6 +220,10 @@ class ProcessGroup : public CoreComponent {
 
   void setParameterContext(ParameterContext* parameter_context);
   ParameterContext* getParameterContext() const;
+
+  const std::set<std::unique_ptr<ProcessGroup>>& getChildProcessGroups() const {
+    return child_process_groups_;
+  }
 
  protected:
   void startProcessingProcessors(TimerDrivenSchedulingAgent& timeScheduler, EventDrivenSchedulingAgent& eventScheduler, CronDrivenSchedulingAgent& cronScheduler);

--- a/libminifi/include/core/controller/ControllerServiceLookup.h
+++ b/libminifi/include/core/controller/ControllerServiceLookup.h
@@ -53,6 +53,14 @@ class ControllerServiceLookup {
   virtual std::shared_ptr<ControllerService> getControllerService(const std::string &identifier) const = 0;
 
   /**
+   * Gets the controller service in the scope of the processor via the provided identifier.
+   * @param identifier reference string for controller service.
+   * @param processor_uuid uuid of the processor
+   * @return controller service reference.
+   */
+  virtual std::shared_ptr<ControllerService> getControllerService(const std::string &identifier, const utils::Identifier &processor_uuid) const = 0;
+
+  /**
    * Detects if controller service is enabled.
    * @param identifier reference string for controller service.
    * @return true if controller service is enabled.

--- a/libminifi/include/core/controller/ControllerServiceLookup.h
+++ b/libminifi/include/core/controller/ControllerServiceLookup.h
@@ -46,7 +46,8 @@ class ControllerServiceLookup {
   virtual ~ControllerServiceLookup() = default;
 
   /**
-   * Gets the controller service via the provided identifier.
+   * Gets the controller service via the provided identifier. This overload returns the controller service in a global scope from all
+   * available controller services in the flow.
    * @param identifier reference string for controller service.
    * @return controller service reference.
    */

--- a/libminifi/include/core/controller/ControllerServiceNodeMap.h
+++ b/libminifi/include/core/controller/ControllerServiceNodeMap.h
@@ -41,7 +41,7 @@ class ControllerServiceNodeMap {
   ControllerServiceNodeMap& operator=(ControllerServiceNodeMap&&) = delete;
 
   ControllerServiceNode* get(const std::string &id) const;
-  ControllerServiceNode* get(const std::string &id, const utils::Identifier &processor_uuid) const;
+  ControllerServiceNode* get(const std::string &id, const utils::Identifier &processor_or_controller_uuid) const;
 
   bool put(const std::string &id, const std::shared_ptr<ControllerServiceNode> &serviceNode);
   bool put(const std::string &id, ProcessGroup* process_group);
@@ -51,7 +51,9 @@ class ControllerServiceNodeMap {
 
  protected:
   mutable std::mutex mutex_;
+  // Map of controller service id to the controller service node
   std::map<std::string, std::shared_ptr<ControllerServiceNode>> controller_service_nodes_;
+  // Map of controller service id to the process group that contains it
   std::map<std::string, gsl::not_null<ProcessGroup*>> process_groups_;
 };
 

--- a/libminifi/include/core/controller/ControllerServiceProvider.h
+++ b/libminifi/include/core/controller/ControllerServiceProvider.h
@@ -66,6 +66,10 @@ class ControllerServiceProvider : public CoreComponent, public ConfigurableCompo
     return controller_map_->get(id);
   }
 
+  virtual ControllerServiceNode* getControllerServiceNode(const std::string &id, const utils::Identifier &controller_uuid) const {
+    return controller_map_->get(id, controller_uuid);
+  }
+
   virtual void clearControllerServices() = 0;
 
   virtual std::vector<std::shared_ptr<core::controller::ControllerServiceNode>> getAllControllerServices() {
@@ -73,8 +77,9 @@ class ControllerServiceProvider : public CoreComponent, public ConfigurableCompo
   }
 
   std::shared_ptr<ControllerService> getControllerService(const std::string &identifier) const override;
+  std::shared_ptr<ControllerService> getControllerService(const std::string &identifier, const utils::Identifier &processor_uuid) const override;
 
-  void putControllerServiceNode(const std::string& identifier, const std::shared_ptr<ControllerServiceNode>& controller_service_node);
+  void putControllerServiceNode(const std::string& identifier, const std::shared_ptr<ControllerServiceNode>& controller_service_node, ProcessGroup* process_group);
 
   bool isControllerServiceEnabled(const std::string &identifier) override {
     const ControllerServiceNode* const node = getControllerServiceNode(identifier);

--- a/libminifi/include/core/controller/ControllerServiceProvider.h
+++ b/libminifi/include/core/controller/ControllerServiceProvider.h
@@ -66,8 +66,8 @@ class ControllerServiceProvider : public CoreComponent, public ConfigurableCompo
     return controller_map_->get(id);
   }
 
-  virtual ControllerServiceNode* getControllerServiceNode(const std::string &id, const utils::Identifier &controller_uuid) const {
-    return controller_map_->get(id, controller_uuid);
+  virtual ControllerServiceNode* getControllerServiceNode(const std::string &id, const utils::Identifier &processor_or_controller_uuid) const {
+    return controller_map_->get(id, processor_or_controller_uuid);
   }
 
   virtual void clearControllerServices() = 0;

--- a/libminifi/include/core/controller/ForwardingControllerServiceProvider.h
+++ b/libminifi/include/core/controller/ForwardingControllerServiceProvider.h
@@ -39,12 +39,20 @@ class ForwardingControllerServiceProvider : public ControllerServiceProvider {
     return controller_service_provider_impl_->getControllerServiceNode(id);
   }
 
+  ControllerServiceNode* getControllerServiceNode(const std::string &id, const utils::Identifier &controller_uuid) const override {
+    return controller_service_provider_impl_->getControllerServiceNode(id, controller_uuid);
+  }
+
   void clearControllerServices() override {
     return controller_service_provider_impl_->clearControllerServices();
   }
 
   std::shared_ptr<ControllerService> getControllerService(const std::string &identifier) const override {
     return controller_service_provider_impl_->getControllerService(identifier);
+  }
+
+  std::shared_ptr<ControllerService> getControllerService(const std::string &identifier, const utils::Identifier &processor_uuid) const override {
+    return controller_service_provider_impl_->getControllerService(identifier, processor_uuid);
   }
 
   std::vector<std::shared_ptr<core::controller::ControllerServiceNode>> getAllControllerServices() override {

--- a/libminifi/include/core/flow/StructuredConfiguration.h
+++ b/libminifi/include/core/flow/StructuredConfiguration.h
@@ -109,7 +109,7 @@ class StructuredConfiguration : public FlowConfiguration {
   std::unique_ptr<core::ProcessGroup> parseRootProcessGroup(const Node& root_flow_node);
 
   void parseParameterContexts(const Node& parameter_contexts_node);
-  void parseControllerServices(const Node& controller_services_node);
+  void parseControllerServices(const Node& controller_services_node, core::ProcessGroup* parent_group);
 
   /**
    * Parses the Connections section of a configuration.

--- a/libminifi/src/RemoteProcessorGroupPort.cpp
+++ b/libminifi/src/RemoteProcessorGroupPort.cpp
@@ -118,7 +118,7 @@ void RemoteProcessorGroupPort::onSchedule(core::ProcessContext& context, core::P
   if (!context.getProperty(SSLContext, context_name) || IsNullOrEmpty(context_name)) {
     context_name = RPG_SSL_CONTEXT_SERVICE_NAME;
   }
-  std::shared_ptr<core::controller::ControllerService> service = context.getControllerService(context_name);
+  std::shared_ptr<core::controller::ControllerService> service = context.getControllerService(context_name, getUUID());
   if (nullptr != service) {
     ssl_service = std::static_pointer_cast<minifi::controllers::SSLContextService>(service);
   } else {

--- a/libminifi/src/core/ProcessGroup.cpp
+++ b/libminifi/src/core/ProcessGroup.cpp
@@ -116,11 +116,11 @@ void ProcessGroup::addProcessGroup(std::unique_ptr<ProcessGroup> child) {
 void ProcessGroup::startProcessingProcessors(TimerDrivenSchedulingAgent& timeScheduler,
     EventDrivenSchedulingAgent& eventScheduler, CronDrivenSchedulingAgent& cronScheduler) {
 
-  std::set<Processor*> processors_to_schedule;
+  std::vector<Processor*> processors_to_schedule;
   {
     std::unique_lock<std::recursive_mutex> lock(mutex_);
     for (const auto& processor : failed_processors_) {
-      processors_to_schedule.insert(processor);
+      processors_to_schedule.push_back(processor);
     }
   }
 

--- a/libminifi/src/core/controller/ControllerServiceNodeMap.cpp
+++ b/libminifi/src/core/controller/ControllerServiceNodeMap.cpp
@@ -30,7 +30,7 @@ ControllerServiceNode* ControllerServiceNodeMap::get(const std::string &id) cons
     return nullptr;
 }
 
-ControllerServiceNode* ControllerServiceNodeMap::get(const std::string &id, const utils::Identifier& processor_uuid) const {
+ControllerServiceNode* ControllerServiceNodeMap::get(const std::string &id, const utils::Identifier& processor_or_controller_uuid) const {
   std::lock_guard<std::mutex> lock(mutex_);
   ControllerServiceNode* controller = nullptr;
   auto exists = controller_service_nodes_.find(id);
@@ -48,11 +48,11 @@ ControllerServiceNode* ControllerServiceNodeMap::get(const std::string &id, cons
     return nullptr;
   }
 
-  if (process_group->findProcessorById(processor_uuid)) {
+  if (process_group->findProcessorById(processor_or_controller_uuid, ProcessGroup::Traverse::IncludeChildren)) {
     return controller;
   }
 
-  if (process_group->findControllerService(processor_uuid.to_string(), ProcessGroup::Traverse::IncludeChildren)) {
+  if (process_group->findControllerService(processor_or_controller_uuid.to_string(), ProcessGroup::Traverse::IncludeChildren)) {
     return controller;
   }
 

--- a/libminifi/src/core/controller/ControllerServiceNodeMap.cpp
+++ b/libminifi/src/core/controller/ControllerServiceNodeMap.cpp
@@ -1,0 +1,96 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "core/controller/ControllerServiceNodeMap.h"
+#include "core/ProcessGroup.h"
+
+namespace org::apache::nifi::minifi::core::controller {
+
+ControllerServiceNode* ControllerServiceNodeMap::get(const std::string &id) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto exists = controller_service_nodes_.find(id);
+  if (exists != controller_service_nodes_.end())
+    return exists->second.get();
+  else
+    return nullptr;
+}
+
+ControllerServiceNode* ControllerServiceNodeMap::get(const std::string &id, const utils::Identifier& processor_uuid) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  ControllerServiceNode* controller = nullptr;
+  auto exists = controller_service_nodes_.find(id);
+  if (exists != controller_service_nodes_.end()) {
+    controller = exists->second.get();
+  } else {
+    return nullptr;
+  }
+
+  auto process_group_of_controller_exists = process_groups_.find(id);
+  ProcessGroup* process_group = nullptr;
+  if (process_group_of_controller_exists != process_groups_.end()) {
+    process_group = process_group_of_controller_exists->second;
+  } else {
+    return nullptr;
+  }
+
+  if (process_group->findProcessorById(processor_uuid)) {
+    return controller;
+  }
+
+  if (process_group->findControllerService(processor_uuid.to_string(), ProcessGroup::Traverse::IncludeChildren)) {
+    return controller;
+  }
+
+  return nullptr;
+}
+
+bool ControllerServiceNodeMap::put(const std::string &id, const std::shared_ptr<ControllerServiceNode> &serviceNode) {
+  if (id.empty() || serviceNode == nullptr)
+    return false;
+  std::lock_guard<std::mutex> lock(mutex_);
+  controller_service_nodes_[id] = serviceNode;
+  return true;
+}
+
+bool ControllerServiceNodeMap::put(const std::string &id, ProcessGroup* process_group) {
+  if (id.empty() || process_group == nullptr)
+    return false;
+  std::lock_guard<std::mutex> lock(mutex_);
+  process_groups_.emplace(id, gsl::make_not_null(process_group));
+  return true;
+}
+
+void ControllerServiceNodeMap::clear() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (const auto& [id, node] : controller_service_nodes_) {
+    node->disable();
+  }
+  controller_service_nodes_.clear();
+}
+
+std::vector<std::shared_ptr<ControllerServiceNode>> ControllerServiceNodeMap::getAllControllerServices() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<std::shared_ptr<ControllerServiceNode>> services;
+  services.reserve(controller_service_nodes_.size());
+  for (const auto& [id, node] : controller_service_nodes_) {
+    services.push_back(node);
+  }
+  return services;
+}
+
+}  // namespace org::apache::nifi::minifi::core::controller

--- a/libminifi/src/core/controller/ControllerServiceProvider.cpp
+++ b/libminifi/src/core/controller/ControllerServiceProvider.cpp
@@ -34,9 +34,19 @@ std::shared_ptr<ControllerService> ControllerServiceProvider::getControllerServi
   }
 }
 
-void ControllerServiceProvider::putControllerServiceNode(const std::string& identifier, const std::shared_ptr<ControllerServiceNode>& controller_service_node) {
+std::shared_ptr<ControllerService> ControllerServiceProvider::getControllerService(const std::string &identifier, const utils::Identifier &processor_uuid) const {
+  auto service = controller_map_->get(identifier, processor_uuid);
+  if (service != nullptr) {
+    return service->getControllerServiceImplementation();
+  } else {
+    return nullptr;
+  }
+}
+
+void ControllerServiceProvider::putControllerServiceNode(const std::string& identifier, const std::shared_ptr<ControllerServiceNode>& controller_service_node, ProcessGroup* process_group) {
   gsl_Expects(controller_map_);
   controller_map_->put(identifier, controller_service_node);
+  controller_map_->put(identifier, process_group);
 }
 
 }  // namespace org::apache::nifi::minifi::core::controller

--- a/libminifi/src/core/controller/StandardControllerServiceNode.cpp
+++ b/libminifi/src/core/controller/StandardControllerServiceNode.cpp
@@ -29,7 +29,7 @@ bool StandardControllerServiceNode::enable() {
   if (getProperty(property.getName(), property)) {
     active = true;
     for (const auto& linked_service : property.getValues()) {
-      ControllerServiceNode* csNode = provider->getControllerServiceNode(linked_service);
+      ControllerServiceNode* csNode = provider->getControllerServiceNode(linked_service, controller_service_->getUUID());
       if (nullptr != csNode) {
         std::lock_guard<std::mutex> lock(mutex_);
         linked_controller_services_.push_back(csNode);

--- a/libminifi/src/core/flow/StructuredConfiguration.cpp
+++ b/libminifi/src/core/flow/StructuredConfiguration.cpp
@@ -97,8 +97,10 @@ std::unique_ptr<core::ProcessGroup> StructuredConfiguration::parseProcessGroup(c
   Node remoteProcessingGroupsNode = node[schema_.remote_process_group];
   Node childProcessGroupNodeSeq = node[schema_.process_groups];
   Node parameterContextNameNode = node[schema_.parameter_context_name];
+  Node controllerServiceNode = node[schema_.controller_services];
 
   parseParameterContext(parameterContextNameNode, *group);
+  parseControllerServices(controllerServiceNode, group.get());
   parseProcessorNode(processorsNode, group.get());
   parseRemoteProcessGroup(remoteProcessingGroupsNode, group.get());
   parseFunnels(funnelsNode, group.get());
@@ -121,20 +123,12 @@ std::unique_ptr<core::ProcessGroup> StructuredConfiguration::getRootFrom(const N
     schema_ = std::move(schema);
     uuids_.clear();
     Node parameterContextsNode = root_node[schema_.parameter_contexts];
-    Node controllerServiceNode = root_node[schema_.root_group][schema_.controller_services];
     Node provenanceReportNode = root_node[schema_.provenance_reporting];
 
     parseParameterContexts(parameterContextsNode);
-    parseControllerServices(controllerServiceNode);
     // Create the root process group
     std::unique_ptr<core::ProcessGroup> root = parseRootProcessGroup(root_node);
     parseProvenanceReporting(provenanceReportNode, root.get());
-
-    // set the controller services into the root group.
-    for (const auto& controller_service : service_provider_->getAllControllerServices()) {
-      root->addControllerService(controller_service->getName(), controller_service);
-      root->addControllerService(controller_service->getUUIDStr(), controller_service);
-    }
 
     root->verify();
 
@@ -518,7 +512,7 @@ void StructuredConfiguration::parseProvenanceReporting(const Node& node, core::P
   parent_group->addProcessor(std::move(reportTask));
 }
 
-void StructuredConfiguration::parseControllerServices(const Node& controller_services_node) {
+void StructuredConfiguration::parseControllerServices(const Node& controller_services_node, core::ProcessGroup* parent_group) {
   if (!controller_services_node || !controller_services_node.isSequence()) {
     return;
   }
@@ -551,11 +545,15 @@ void StructuredConfiguration::parseControllerServices(const Node& controller_ser
           parsePropertiesNode(propertiesNode, *controllerServiceImpl, name, nullptr);
         }
       }
+
+      service_provider_->putControllerServiceNode(id, controller_service_node, parent_group);
+      service_provider_->putControllerServiceNode(name, controller_service_node, parent_group);
+
+      parent_group->addControllerService(controller_service_node->getName(), controller_service_node);
+      parent_group->addControllerService(controller_service_node->getUUIDStr(), controller_service_node);
     } else {
       logger_->log_debug("Could not locate {}", type);
     }
-    service_provider_->putControllerServiceNode(id, controller_service_node);
-    service_provider_->putControllerServiceNode(name, controller_service_node);
   }
 }
 

--- a/libminifi/src/utils/net/Ssl.cpp
+++ b/libminifi/src/utils/net/Ssl.cpp
@@ -22,7 +22,7 @@ namespace org::apache::nifi::minifi::utils::net {
 std::optional<utils::net::SslData> getSslData(const core::ProcessContext& context, const core::PropertyReference& ssl_prop, const std::shared_ptr<core::logging::Logger>& logger) {
   auto getSslContextService = [&]() -> std::shared_ptr<minifi::controllers::SSLContextService> {
     if (auto ssl_service_name = context.getProperty(ssl_prop); ssl_service_name && !ssl_service_name->empty()) {
-      if (auto service = context.getControllerService(*ssl_service_name)) {
+      if (auto service = context.getControllerService(*ssl_service_name, context.getProcessorNode()->getUUID())) {
         if (auto ssl_service = std::dynamic_pointer_cast<org::apache::nifi::minifi::controllers::SSLContextService>(service)) {
           return ssl_service;
         } else {

--- a/libminifi/test/integration/ControllerServiceIntegrationTests.cpp
+++ b/libminifi/test/integration/ControllerServiceIntegrationTests.cpp
@@ -77,8 +77,6 @@ TEST_CASE("ControllerServiceIntegrationTests", "[controller]") {
   });
   const auto controller = std::make_shared<minifi::FlowController>(test_repo, test_flow_repo, configuration, std::move(yaml_ptr), content_repo);
 
-  disabled = false;
-
   core::YamlConfiguration yaml_config(core::ConfigurationContext{
       .flow_file_repo = test_repo,
       .content_repo = content_repo,
@@ -89,12 +87,21 @@ TEST_CASE("ControllerServiceIntegrationTests", "[controller]") {
   });
   auto pg = yaml_config.getRoot();
 
-  auto provider = std::make_shared<core::controller::StandardControllerServiceProvider>(std::make_unique<core::controller::ControllerServiceNodeMap>(), std::make_shared<minifi::Configure>());
   auto* mockNode = pg->findControllerService("MockItLikeIts1995");
   REQUIRE(mockNode != nullptr);
   mockNode->enable();
   std::vector<core::controller::ControllerServiceNode*> linkedNodes = mockNode->getLinkedControllerServices();
   REQUIRE(linkedNodes.size() == 1);
+
+  auto* notInProcessGroup = pg->findControllerService("SubMockController");
+  REQUIRE(notInProcessGroup == nullptr);
+  REQUIRE(pg->getChildProcessGroups().size() == 1);
+  auto* cpg = pg->getChildProcessGroups().begin()->get();
+  auto subMockController = cpg->findControllerService("SubMockController");
+  REQUIRE(subMockController != nullptr);
+  subMockController->enable();
+  std::vector<core::controller::ControllerServiceNode*> subMockControllerLinkedNodes = subMockController->getLinkedControllerServices();
+  REQUIRE(subMockControllerLinkedNodes.size() == 2);
 
   core::controller::ControllerServiceNode* notexistNode = pg->findControllerService("MockItLikeItsWrong");
   REQUIRE(notexistNode == nullptr);
@@ -136,6 +143,8 @@ TEST_CASE("ControllerServiceIntegrationTests", "[controller]") {
 //  }
 //  REQUIRE(verifyEventHappenedInPollTime(std::chrono::seconds(2), checkCsIdEnabledMatchesDisabledFlag));
 
+  REQUIRE(verifyEventHappenedInPollTime(10s, [&] { return subprocess_controller_service_not_found_correctly.load(); }));
+  REQUIRE(verifyEventHappenedInPollTime(10s, [&] { return subprocess_controller_service_found_correctly.load(); }));
   controller->waitUnload(60s);
 }
 

--- a/libminifi/test/libtest/unit/ContentRepositoryDependentTests.h
+++ b/libminifi/test/libtest/unit/ContentRepositoryDependentTests.h
@@ -89,7 +89,7 @@ class Fixture {
   TestController test_controller_;
 
   std::shared_ptr<TestPlan> test_plan_;
-  std::shared_ptr<core::Processor> dummy_processor_;
+  core::Processor* dummy_processor_;
   std::shared_ptr<core::ProcessContext> context_;
   std::unique_ptr<core::ProcessSession> process_session_;
 };

--- a/libminifi/test/libtest/unit/MockClasses.h
+++ b/libminifi/test/libtest/unit/MockClasses.h
@@ -31,8 +31,9 @@
 
 namespace minifi = org::apache::nifi::minifi;
 
-std::atomic<bool> disabled;
 std::mutex control_mutex;
+std::atomic<bool> subprocess_controller_service_found_correctly{false};
+std::atomic<bool> subprocess_controller_service_not_found_correctly{false};
 
 class MockControllerService : public minifi::core::controller::ControllerService {
  public:
@@ -96,8 +97,14 @@ class MockProcessor : public minifi::core::Processor {
 
   static constexpr const char* Description = "An example processor";
   static constexpr auto LinkedService = minifi::core::PropertyDefinitionBuilder<>::createProperty("linkedService").withDescription("Linked service").build();
-  static constexpr auto Properties = std::array<minifi::core::PropertyReference, 1>{LinkedService};
-  static constexpr auto Relationships = std::array<minifi::core::RelationshipDefinition, 0>{};
+  static constexpr auto InSubProcessGroup = minifi::core::PropertyDefinitionBuilder<>::createProperty("InSubProcessGroup")
+    .withPropertyType(minifi::core::StandardPropertyTypes::BOOLEAN_TYPE)
+    .withDefaultValue("false")
+    .withDescription("Is in sub process group")
+    .build();
+  static constexpr auto Properties = std::array<minifi::core::PropertyReference, 2>{LinkedService, InSubProcessGroup};
+  static constexpr auto Success = minifi::core::RelationshipDefinition{"success", "FlowFiles are routed to success relationship"};
+  static constexpr auto Relationships = std::array<minifi::core::RelationshipDefinition, 1>{Success};
   static constexpr bool SupportsDynamicProperties = false;
   static constexpr bool SupportsDynamicRelationships = false;
   static constexpr minifi::core::annotation::Input InputRequirement = minifi::core::annotation::Input::INPUT_ALLOWED;
@@ -108,22 +115,33 @@ class MockProcessor : public minifi::core::Processor {
     setSupportedProperties(Properties);
   }
 
-  void onTrigger(minifi::core::ProcessContext& context, minifi::core::ProcessSession&) override {
+  void onTrigger(minifi::core::ProcessContext& context, minifi::core::ProcessSession& session) override {
+    auto flow_file = session.get();
+    if (!flow_file) {
+      flow_file = session.create();
+    }
     std::string linked_service;
     getProperty("linkedService", linked_service);
     if (!IsNullOrEmpty(linked_service)) {
-      std::shared_ptr<minifi::core::controller::ControllerService> service = context.getControllerService(linked_service);
+      std::shared_ptr<minifi::core::controller::ControllerService> service = context.getControllerService(linked_service, getUUID());
       std::lock_guard<std::mutex> lock(control_mutex);
-      if (!disabled.load()) {
-        REQUIRE(context.isControllerServiceEnabled(linked_service));
-        REQUIRE(nullptr != service);
-        REQUIRE("pushitrealgood" == std::static_pointer_cast<MockControllerService>(service)->doSomething());
-      } else {
-        REQUIRE_FALSE(context.isControllerServiceEnabled(linked_service));
-      }
+      REQUIRE(nullptr != service);
+      REQUIRE("pushitrealgood" == std::static_pointer_cast<MockControllerService>(service)->doSomething());
       // verify we have access to the controller service
       // and verify that we can execute it.
     }
+
+    bool in_sub_process_group = false;
+    getProperty("InSubProcessGroup", in_sub_process_group);
+    auto sub_service = context.getControllerService("SubMockController", getUUID());
+    if (in_sub_process_group) {
+      REQUIRE(nullptr != sub_service);
+      subprocess_controller_service_found_correctly = true;
+    } else {
+      REQUIRE(nullptr == sub_service);
+      subprocess_controller_service_not_found_correctly = true;
+    }
+    session.transfer(flow_file, Success);
   }
 
   bool isYield() override {

--- a/libminifi/test/libtest/unit/RecordSetTesters.h
+++ b/libminifi/test/libtest/unit/RecordSetTesters.h
@@ -36,7 +36,7 @@ class RecordSetFixture {
   TestController test_controller_{};
   TestController::PlanConfig plan_config_{};
   std::shared_ptr<TestPlan> test_plan_ = test_controller_.createPlan(plan_config_);
-  std::shared_ptr<Processor> dummy_processor_ = test_plan_->addProcessor("DummyProcessor", "dummyProcessor");
+  Processor* dummy_processor_ = test_plan_->addProcessor("DummyProcessor", "dummyProcessor");
   std::shared_ptr<ProcessContext> context_ = [this] { test_plan_->runNextProcessor(); return test_plan_->getCurrentContext(); }();
   std::unique_ptr<ProcessSession> process_session_ = std::make_unique<ProcessSession>(context_);
 

--- a/libminifi/test/libtest/unit/TestBase.cpp
+++ b/libminifi/test/libtest/unit/TestBase.cpp
@@ -37,6 +37,7 @@
 #include "utils/StringUtils.h"
 #include "utils/span.h"
 #include "LogUtils.h"
+#include "utils/GeneralUtils.h"
 
 #include "fmt/format.h"
 #include "spdlog/sinks/stdout_sinks.h"
@@ -213,6 +214,7 @@ TestPlan::TestPlan(std::shared_ptr<minifi::core::ContentRepository> content_repo
       location(-1),
       current_flowfile_(nullptr),
       flow_version_(std::move(flow_version)),
+      root_process_group_(std::make_unique<minifi::core::ProcessGroup>(minifi::core::ROOT_PROCESS_GROUP, "root", minifi::utils::IdGenerator::getIdGenerator()->generate(), 0)),
       logger_(logging::LoggerFactory<TestPlan>::getLogger()) {
   /* Inject the default state storage ahead of ProcessContext to make sure we have a unique state directory */
   if (state_dir == nullptr) {
@@ -238,7 +240,7 @@ TestPlan::~TestPlan() {
   controller_services_provider_->clearControllerServices();
 }
 
-std::shared_ptr<minifi::core::Processor> TestPlan::addProcessor(const std::shared_ptr<minifi::core::Processor> &processor, const std::string& /*name*/,
+minifi::core::Processor* TestPlan::addProcessor(std::unique_ptr<minifi::core::Processor> processor, const std::string& /*name*/,
     const std::initializer_list<minifi::core::Relationship>& relationships, bool linkToPrevious) {
   if (finalized) {
     return nullptr;
@@ -247,15 +249,15 @@ std::shared_ptr<minifi::core::Processor> TestPlan::addProcessor(const std::share
   // initialize the processor
   processor->initialize();
   processor->setFlowIdentifier(flow_version_->getFlowIdentifier());
-  processor_mapping_[processor->getUUID()] = processor;
+  processor_mapping_[processor->getUUID()] = processor.get();
   if (!linkToPrevious) {
     if (!std::empty(relationships)) {
       termination_ = *(relationships.begin());
     }
   } else {
-    std::shared_ptr<minifi::core::Processor> last = processor_queue_.back();
+    auto last = processor_queue_.back();
     if (last == nullptr) {
-      last = processor;
+      last = processor.get();
       if (!std::empty(relationships)) {
         termination_ = *(relationships.begin());
       }
@@ -269,13 +271,13 @@ std::shared_ptr<minifi::core::Processor> TestPlan::addProcessor(const std::share
       connection->addRelationship(relationship);
     }
     // link the connections so that we can test results at the end for this
-    connection->setSource(last.get());
+    connection->setSource(last);
     connection->setDestination(processor.get());
 
     connection->setSourceUUID(last->getUUID());
     connection->setDestinationUUID(processor->getUUID());
     last->addConnection(connection.get());
-    if (last != processor) {
+    if (last != processor.get()) {
       processor->addConnection(connection.get());
     }
     relationships_.push_back(std::move(connection));
@@ -288,29 +290,34 @@ std::shared_ptr<minifi::core::Processor> TestPlan::addProcessor(const std::share
     ->withProvenanceRepository(prov_repo_)->withConfiguration(configuration_);
   auto context = contextBuilder->build(node);
   processor_contexts_.push_back(context);
-  processor_queue_.push_back(processor);
-  return processor;
+  processor_queue_.push_back(processor.get());
+  auto raw_ptr = processor.get();
+  root_process_group_->addProcessor(std::move(processor));
+  return raw_ptr;
 }
 
-std::shared_ptr<minifi::core::Processor> TestPlan::addProcessor(const std::string &processor_name, const minifi::utils::Identifier &uuid, const std::string &name,
+minifi::core::Processor* TestPlan::addProcessor(const std::string &processor_name, const minifi::utils::Identifier &uuid, const std::string &name,
     const std::initializer_list<minifi::core::Relationship> &relationships, bool linkToPrevious) {
   if (finalized) {
     return nullptr;
   }
   std::lock_guard<std::recursive_mutex> guard(mutex);
 
-  std::shared_ptr<core::CoreComponent> ptr = minifi::core::ClassLoader::getDefaultClassLoader().instantiate(processor_name, uuid);
+  std::unique_ptr<core::CoreComponent> ptr = minifi::core::ClassLoader::getDefaultClassLoader().instantiate(processor_name, uuid);
   if (nullptr == ptr) {
     throw std::runtime_error{fmt::format("Failed to instantiate processor name: {0} uuid: {1}", processor_name, uuid.to_string().c_str())};
   }
-  std::shared_ptr<minifi::core::Processor> processor = std::static_pointer_cast<minifi::core::Processor>(ptr);
+  std::unique_ptr<minifi::core::Processor> processor = minifi::utils::dynamic_unique_cast<minifi::core::Processor>(std::move(ptr));
+  if (nullptr == processor) {
+    throw std::runtime_error{fmt::format("Failed to cast to processor with name: {0} uuid: {1}", processor_name, uuid.to_string().c_str())};
+  }
 
   processor->setName(name);
 
-  return addProcessor(processor, name, relationships, linkToPrevious);
+  return addProcessor(std::move(processor), name, relationships, linkToPrevious);
 }
 
-std::shared_ptr<minifi::core::Processor> TestPlan::addProcessor(const std::string &processor_name, const std::string &name, const std::initializer_list<minifi::core::Relationship>& relationships,
+minifi::core::Processor* TestPlan::addProcessor(const std::string &processor_name, const std::string &name, const std::initializer_list<minifi::core::Relationship>& relationships,
     bool linkToPrevious) {
   if (finalized) {
     return nullptr;
@@ -319,8 +326,8 @@ std::shared_ptr<minifi::core::Processor> TestPlan::addProcessor(const std::strin
   return addProcessor(processor_name, minifi::utils::IdGenerator::getIdGenerator()->generate(), name, relationships, linkToPrevious);
 }
 
-minifi::Connection* TestPlan::addConnection(const std::shared_ptr<minifi::core::Processor>& source_proc, const minifi::core::Relationship& source_relationship,
-    const std::shared_ptr<minifi::core::Processor>& destination_proc) {
+minifi::Connection* TestPlan::addConnection(minifi::core::Processor* source_proc, const minifi::core::Relationship& source_relationship,
+    minifi::core::Processor* destination_proc) {
   std::stringstream connection_name;
   connection_name
     << (source_proc ? source_proc->getUUIDStr().c_str() : "none")
@@ -333,11 +340,11 @@ minifi::Connection* TestPlan::addConnection(const std::shared_ptr<minifi::core::
   // link the connections so that we can test results at the end for this
 
   if (source_proc) {
-    connection->setSource(source_proc.get());
+    connection->setSource(source_proc);
     connection->setSourceUUID(source_proc->getUUID());
   }
   if (destination_proc) {
-    connection->setDestination(destination_proc.get());
+    connection->setDestination(destination_proc);
     connection->setDestinationUUID(destination_proc->getUUID());
   }
   if (source_proc) {
@@ -372,10 +379,15 @@ std::shared_ptr<minifi::core::controller::ControllerServiceNode> TestPlan::addCo
   controller_service_node->setUUID(uuid);
   controller_service_node->setName(name);
 
+  controller_services_provider_->putControllerServiceNode(uuid.to_string(), controller_service_node, root_process_group_.get());
+  controller_services_provider_->putControllerServiceNode(name, controller_service_node, root_process_group_.get());
+
+  root_process_group_->addControllerService(uuid.to_string(), controller_service_node);
+
   return controller_service_node;
 }
 
-bool TestPlan::setProperty(const std::shared_ptr<minifi::core::Processor>& processor, const std::string& property, const std::string& value, bool dynamic) {
+bool TestPlan::setProperty(minifi::core::Processor* processor, const std::string& property, const std::string& value, bool dynamic) {
   std::lock_guard<std::recursive_mutex> guard(mutex);
 
   size_t i = 0;
@@ -397,15 +409,15 @@ bool TestPlan::setProperty(const std::shared_ptr<minifi::core::Processor>& proce
   }
 }
 
-bool TestPlan::setProperty(const std::shared_ptr<minifi::core::Processor>& processor, const core::PropertyReference& property, std::string_view value) {
+bool TestPlan::setProperty(minifi::core::Processor* processor, const core::PropertyReference& property, std::string_view value) {
   return setProperty(processor, std::string(property.name), std::string(value), false);
 }
 
-bool TestPlan::setProperty(const std::shared_ptr<minifi::core::Processor>& processor, std::string_view property, std::string_view value) {
+bool TestPlan::setProperty(minifi::core::Processor* processor, std::string_view property, std::string_view value) {
   return setProperty(processor, std::string(property), std::string(value), false);
 }
 
-bool TestPlan::setDynamicProperty(const std::shared_ptr<minifi::core::Processor>& processor, std::string_view property, std::string_view value) {
+bool TestPlan::setDynamicProperty(minifi::core::Processor* processor, std::string_view property, std::string_view value) {
   return setProperty(processor, std::string(property), std::string(value), true);
 }
 
@@ -447,8 +459,8 @@ void TestPlan::reset(bool reschedule) {
   }
 }
 
-std::vector<std::shared_ptr<minifi::core::Processor>>::iterator TestPlan::getProcessorItByUuid(const std::string& uuid) {
-  const auto processor_node_matches_processor = [&uuid] (const std::shared_ptr<minifi::core::Processor>& processor) {
+std::vector<minifi::core::Processor*>::iterator TestPlan::getProcessorItByUuid(const std::string& uuid) {
+  const auto processor_node_matches_processor = [&uuid] (minifi::core::Processor* processor) {
     return processor->getUUIDStr() == uuid;
   };
   auto processor_found_at = std::find_if(processor_queue_.begin(), processor_queue_.end(), processor_node_matches_processor);
@@ -458,7 +470,7 @@ std::vector<std::shared_ptr<minifi::core::Processor>>::iterator TestPlan::getPro
   return processor_found_at;
 }
 
-std::shared_ptr<minifi::core::ProcessContext> TestPlan::getProcessContextForProcessor(const std::shared_ptr<minifi::core::Processor>& processor) {
+std::shared_ptr<minifi::core::ProcessContext> TestPlan::getProcessContextForProcessor(minifi::core::Processor* processor) {
   const auto contextMatchesProcessor = [&processor] (const std::shared_ptr<minifi::core::ProcessContext>& context) {
     return context->getProcessorNode()->getUUIDStr() ==  processor->getUUIDStr();
   };
@@ -469,7 +481,7 @@ std::shared_ptr<minifi::core::ProcessContext> TestPlan::getProcessContextForProc
   return *context_found_at;
 }
 
-void TestPlan::scheduleProcessor(const std::shared_ptr<minifi::core::Processor>& processor, const std::shared_ptr<minifi::core::ProcessContext>& context) {
+void TestPlan::scheduleProcessor(minifi::core::Processor* processor, const std::shared_ptr<minifi::core::ProcessContext>& context) {
   if (std::find(configured_processors_.begin(), configured_processors_.end(), processor) == configured_processors_.end()) {
     // Ordering on factories and list of configured processors do not matter
     const auto factory = std::make_shared<minifi::core::ProcessSessionFactory>(context);
@@ -479,19 +491,19 @@ void TestPlan::scheduleProcessor(const std::shared_ptr<minifi::core::Processor>&
   }
 }
 
-void TestPlan::scheduleProcessor(const std::shared_ptr<minifi::core::Processor>& processor) {
+void TestPlan::scheduleProcessor(minifi::core::Processor* processor) {
   scheduleProcessor(processor, getProcessContextForProcessor(processor));
 }
 
 void TestPlan::scheduleProcessors() {
   for (std::size_t target_location = 0; target_location < processor_queue_.size(); ++target_location) {
-    std::shared_ptr<minifi::core::Processor> processor = processor_queue_.at(target_location);
+    auto processor = processor_queue_.at(target_location);
     std::shared_ptr<minifi::core::ProcessContext> context = processor_contexts_.at(target_location);
     scheduleProcessor(processor, context);
   }
 }
 
-bool TestPlan::runProcessor(const std::shared_ptr<minifi::core::Processor>& processor, const PreTriggerVerifier& verify) {
+bool TestPlan::runProcessor(minifi::core::Processor* processor, const PreTriggerVerifier& verify) {
   const auto processor_location = gsl::narrow<size_t>(std::distance(processor_queue_.begin(), getProcessorItByUuid(processor->getUUIDStr())));
   return runProcessor(processor_location, verify);
 }
@@ -518,7 +530,7 @@ bool TestPlan::runProcessor(size_t target_location, const PreTriggerVerifier& ve
   logger_->log_info("Running next processor {}, processor_queue_.size {}, processor_contexts_.size {}", target_location, processor_queue_.size(), processor_contexts_.size());
   std::lock_guard<std::recursive_mutex> guard(mutex);
 
-  std::shared_ptr<minifi::core::Processor> processor = processor_queue_.at(target_location);
+  auto processor = processor_queue_.at(target_location);
   std::shared_ptr<minifi::core::ProcessContext> context = processor_contexts_.at(target_location);
   scheduleProcessor(processor, context);
   current_flowfile_ = nullptr;
@@ -567,7 +579,7 @@ std::size_t TestPlan::getNumFlowFileProducedByCurrentProcessor() {
   return getNumFlowFileProducedByProcessor(processor);
 }
 
-std::size_t TestPlan::getNumFlowFileProducedByProcessor(const std::shared_ptr<minifi::core::Processor>& processor) {
+std::size_t TestPlan::getNumFlowFileProducedByProcessor(minifi::core::Processor* processor) {
   std::vector<minifi::Connection*> connections = getProcessorOutboundConnections(processor);
   std::size_t num_flow_files = 0;
   for (auto connection : connections) {
@@ -577,7 +589,7 @@ std::size_t TestPlan::getNumFlowFileProducedByProcessor(const std::shared_ptr<mi
 }
 
 std::shared_ptr<minifi::core::FlowFile> TestPlan::getFlowFileProducedByCurrentProcessor() {
-  const std::shared_ptr<minifi::core::Processor>& processor = processor_queue_.at(location);
+  minifi::core::Processor* processor = processor_queue_.at(location);
   std::vector<minifi::Connection*> connections = getProcessorOutboundConnections(processor);
   for (auto connection : connections) {
     std::set<std::shared_ptr<minifi::core::FlowFile>> expiredFlowRecords;
@@ -607,7 +619,7 @@ std::shared_ptr<minifi::core::FlowFile> TestPlan::getCurrentFlowFile() {
   return current_flowfile_;
 }
 
-std::vector<minifi::Connection*> TestPlan::getProcessorOutboundConnections(const std::shared_ptr<minifi::core::Processor>& processor) {
+std::vector<minifi::Connection*> TestPlan::getProcessorOutboundConnections(minifi::core::Processor* processor) {
   const auto is_processor_outbound_connection = [&processor] (const std::unique_ptr<minifi::Connection>& connection) {
     // A connection is outbound from a processor if its source uuid matches the processor
     return connection->getSource()->getUUIDStr() == processor->getUUIDStr();
@@ -626,7 +638,7 @@ std::shared_ptr<minifi::core::ProcessContext> TestPlan::getCurrentContext() {
   return processor_contexts_.at(location);
 }
 
-std::unique_ptr<minifi::Connection> TestPlan::buildFinalConnection(const std::shared_ptr<minifi::core::Processor>& processor, bool setDest) {
+std::unique_ptr<minifi::Connection> TestPlan::buildFinalConnection(minifi::core::Processor* processor, bool setDest) {
   gsl_Expects(termination_);
   std::stringstream connection_name;
   connection_name << processor->getUUIDStr() << "-to-" << processor->getUUIDStr();
@@ -634,9 +646,9 @@ std::unique_ptr<minifi::Connection> TestPlan::buildFinalConnection(const std::sh
   connection->addRelationship(termination_.value());
 
   // link the connections so that we can test results at the end for this
-  connection->setSource(processor.get());
+  connection->setSource(processor);
   if (setDest)
-    connection->setDestination(processor.get());
+    connection->setDestination(processor);
 
   minifi::utils::Identifier uuid_copy = processor->getUUID();
   connection->setSourceUUID(uuid_copy);

--- a/libminifi/test/libtest/unit/TestBase.h
+++ b/libminifi/test/libtest/unit/TestBase.h
@@ -40,6 +40,7 @@
 #include "core/repository/VolatileContentRepository.h"
 #include "utils/file/FileUtils.h"
 #include "properties/Configuration.h"
+#include "core/Processor.h"
 
 namespace minifi = org::apache::nifi::minifi;
 namespace utils = minifi::utils;
@@ -208,25 +209,25 @@ class TestPlan {
 
   virtual ~TestPlan();
 
-  std::shared_ptr<minifi::core::Processor> addProcessor(const std::shared_ptr<minifi::core::Processor> &processor, const std::string &name,
+  minifi::core::Processor* addProcessor(std::unique_ptr<minifi::core::Processor> processor, const std::string &name,
       const minifi::core::Relationship& relationship = minifi::core::Relationship("success", "description"), bool linkToPrevious = false) {
-    return addProcessor(processor, name, { relationship }, linkToPrevious);
+    return addProcessor(std::move(processor), name, { relationship }, linkToPrevious);
   }
-  std::shared_ptr<minifi::core::Processor> addProcessor(const std::string &processor_name, const std::string &name,
+  minifi::core::Processor* addProcessor(const std::string &processor_name, const std::string &name,
       const minifi::core::Relationship& relationship = minifi::core::Relationship("success", "description"), bool linkToPrevious = false) {
     return addProcessor(processor_name, name, { relationship }, linkToPrevious);
   }
-  std::shared_ptr<minifi::core::Processor> addProcessor(const std::shared_ptr<minifi::core::Processor> &processor, const std::string &name, const std::initializer_list<minifi::core::Relationship>& relationships, bool linkToPrevious = false); // NOLINT
-  std::shared_ptr<minifi::core::Processor> addProcessor(const std::string &processor_name, const std::string &name, const std::initializer_list<minifi::core::Relationship>& relationships, bool linkToPrevious = false); // NOLINT
-  std::shared_ptr<minifi::core::Processor> addProcessor(const std::string &processor_name, const minifi::utils::Identifier& uuid, const std::string &name, const std::initializer_list<minifi::core::Relationship>& relationships, bool linkToPrevious = false); // NOLINT
+  minifi::core::Processor* addProcessor(std::unique_ptr<minifi::core::Processor> processor, const std::string &name, const std::initializer_list<minifi::core::Relationship>& relationships, bool linkToPrevious = false); // NOLINT
+  minifi::core::Processor* addProcessor(const std::string &processor_name, const std::string &name, const std::initializer_list<minifi::core::Relationship>& relationships, bool linkToPrevious = false); // NOLINT
+  minifi::core::Processor* addProcessor(const std::string &processor_name, const minifi::utils::Identifier& uuid, const std::string &name, const std::initializer_list<minifi::core::Relationship>& relationships, bool linkToPrevious = false); // NOLINT
 
-  minifi::Connection* addConnection(const std::shared_ptr<minifi::core::Processor>& source_proc, const minifi::core::Relationship& source_relationship, const std::shared_ptr<minifi::core::Processor>& destination_proc); // NOLINT
+  minifi::Connection* addConnection(minifi::core::Processor* source_proc, const minifi::core::Relationship& source_relationship, minifi::core::Processor* destination_proc); // NOLINT
 
   std::shared_ptr<minifi::core::controller::ControllerServiceNode> addController(const std::string &controller_name, const std::string &name);
 
-  bool setProperty(const std::shared_ptr<minifi::core::Processor>& processor, const core::PropertyReference& property, std::string_view value);
-  bool setProperty(const std::shared_ptr<minifi::core::Processor>& processor, std::string_view property, std::string_view value);
-  bool setDynamicProperty(const std::shared_ptr<minifi::core::Processor>& processor, std::string_view property, std::string_view value);
+  bool setProperty(minifi::core::Processor* processor, const core::PropertyReference& property, std::string_view value);
+  bool setProperty(minifi::core::Processor* processor, std::string_view property, std::string_view value);
+  bool setDynamicProperty(minifi::core::Processor* processor, std::string_view property, std::string_view value);
 
   static bool setProperty(const std::shared_ptr<minifi::core::controller::ControllerServiceNode>& controller_service_node, const core::PropertyReference& property, std::string_view value);
   static bool setProperty(const std::shared_ptr<minifi::core::controller::ControllerServiceNode>& controller_service_node, std::string_view property, std::string_view value);
@@ -238,14 +239,14 @@ class TestPlan {
 
   using PreTriggerVerifier = std::function<void(const std::shared_ptr<minifi::core::ProcessContext>, const std::shared_ptr<minifi::core::ProcessSession>)>;
 
-  std::vector<std::shared_ptr<minifi::core::Processor>>::iterator getProcessorItByUuid(const std::string& uuid);
-  std::shared_ptr<minifi::core::ProcessContext> getProcessContextForProcessor(const std::shared_ptr<minifi::core::Processor>& processor);
+  std::vector<minifi::core::Processor*>::iterator getProcessorItByUuid(const std::string& uuid);
+  std::shared_ptr<minifi::core::ProcessContext> getProcessContextForProcessor(minifi::core::Processor* processor);
 
-  void scheduleProcessor(const std::shared_ptr<minifi::core::Processor>& processor, const std::shared_ptr<minifi::core::ProcessContext>& context);
-  void scheduleProcessor(const std::shared_ptr<minifi::core::Processor>& processor);
+  void scheduleProcessor(minifi::core::Processor* processor, const std::shared_ptr<minifi::core::ProcessContext>& context);
+  void scheduleProcessor(minifi::core::Processor* processor);
   void scheduleProcessors();
 
-  bool runProcessor(const std::shared_ptr<minifi::core::Processor>& processor, const PreTriggerVerifier& verify = nullptr);
+  bool runProcessor(minifi::core::Processor* processor, const PreTriggerVerifier& verify = nullptr);
   bool runProcessor(size_t target_location, const PreTriggerVerifier& verify = nullptr);
   bool runNextProcessor(const PreTriggerVerifier& verify = nullptr);
   bool runCurrentProcessor();
@@ -254,8 +255,8 @@ class TestPlan {
   std::set<std::shared_ptr<minifi::provenance::ProvenanceEventRecord>> getProvenanceRecords();
 
   std::shared_ptr<minifi::core::FlowFile> getCurrentFlowFile();
-  std::vector<minifi::Connection*> getProcessorOutboundConnections(const std::shared_ptr<minifi::core::Processor>& processor);
-  std::size_t getNumFlowFileProducedByProcessor(const std::shared_ptr<minifi::core::Processor>& processor);
+  std::vector<minifi::Connection*> getProcessorOutboundConnections(minifi::core::Processor* processor);
+  std::size_t getNumFlowFileProducedByProcessor(minifi::core::Processor* processor);
   std::size_t getNumFlowFileProducedByCurrentProcessor();
   std::shared_ptr<minifi::core::FlowFile> getFlowFileProducedByCurrentProcessor();
 
@@ -296,7 +297,7 @@ class TestPlan {
  protected:
   std::unique_ptr<TempDirectory> state_dir_;
 
-  std::unique_ptr<minifi::Connection> buildFinalConnection(const std::shared_ptr<minifi::core::Processor>& processor, bool setDest = false);
+  std::unique_ptr<minifi::Connection> buildFinalConnection(minifi::core::Processor* processor, bool setDest = false);
 
   std::shared_ptr<minifi::Configure> configuration_;
 
@@ -319,18 +320,19 @@ class TestPlan {
 
   std::shared_ptr<minifi::state::response::FlowVersion> flow_version_;
   std::vector<std::shared_ptr<minifi::core::controller::ControllerServiceNode>> controller_service_nodes_;
-  std::map<minifi::utils::Identifier, std::shared_ptr<minifi::core::Processor>> processor_mapping_;
-  std::vector<std::shared_ptr<minifi::core::Processor>> processor_queue_;
-  std::vector<std::shared_ptr<minifi::core::Processor>> configured_processors_;  // Do not assume ordering
+  std::map<minifi::utils::Identifier, minifi::core::Processor*> processor_mapping_;
+  std::vector<minifi::core::Processor*> processor_queue_;
+  std::vector<minifi::core::Processor*> configured_processors_;  // Do not assume ordering
   std::vector<std::shared_ptr<minifi::core::ProcessorNode>> processor_nodes_;
   std::vector<std::shared_ptr<minifi::core::ProcessContext>> processor_contexts_;
   std::vector<std::shared_ptr<minifi::core::ProcessSession>> process_sessions_;
   std::vector<std::shared_ptr<minifi::core::ProcessSessionFactory>> factories_;  // Do not assume ordering
   std::vector<std::unique_ptr<minifi::Connection>> relationships_;
   std::optional<minifi::core::Relationship> termination_;
+  std::unique_ptr<minifi::core::ProcessGroup> root_process_group_;
 
  private:
-  bool setProperty(const std::shared_ptr<minifi::core::Processor>& processor, const std::string& property, const std::string& value, bool dynamic);
+  bool setProperty(minifi::core::Processor* processor, const std::string& property, const std::string& value, bool dynamic);
   static bool setProperty(const std::shared_ptr<minifi::core::controller::ControllerServiceNode>& controller_service_node, const std::string& property, const std::string& value, bool dynamic);
 
   std::shared_ptr<logging::Logger> logger_;

--- a/libminifi/test/libtest/unit/TestUtils.h
+++ b/libminifi/test/libtest/unit/TestUtils.h
@@ -217,7 +217,7 @@ concept NetworkingProcessor = std::derived_from<T, minifi::core::Processor>
     };  // NOLINT(readability/braces)
 
 template<NetworkingProcessor T>
-uint16_t scheduleProcessorOnRandomPort(const std::shared_ptr<TestPlan>& test_plan, const std::shared_ptr<T>& processor) {
+uint16_t scheduleProcessorOnRandomPort(const std::shared_ptr<TestPlan>& test_plan, T* processor) {
   REQUIRE(processor->setProperty(T::Port, "0"));
   test_plan->scheduleProcessor(processor);
   REQUIRE(verifyEventHappenedInPollTime(250ms, [&processor] { return processor->getPort() != 0; }, 20ms));

--- a/libminifi/test/resources/TestControllerServices.yml
+++ b/libminifi/test/resources/TestControllerServices.yml
@@ -17,64 +17,116 @@
 # under the License.
 #
 Flow Controller:
-    name: MiNiFi Flow
-    id: 2438e3c8-015a-1000-79ca-83af40ec1990
-    
-Processors: 
-    - name: MockProcessorIto
-      id: 1438e3c8-015a-1000-79ca-83af40ec1991
-      class: org.apache.nifi.processors.standard.MockProcessor
-      max concurrent tasks: 1
-      scheduling strategy: TIMER_DRIVEN
-      scheduling period: 1 sec
-      penalization period: 30 sec
-      yield period: 1 sec
-      run duration nanos: 0
-      auto-terminated relationships list:
-      Properties:
-        linkedService: MockItLikeIts1995
-
-Connections:
-    - name: TransferFilesToRPG
-      id: 1438e3c8-015a-1000-79ca-83af40ec1997
-      source name: MockProcessorIto
-      source id: 1438e3c8-015a-1000-79ca-83af40ec1991
-      source relationship name: success
-      destination name: MockProcessorIto
-      destination id: 1438e3c8-015a-1000-79ca-83af40ec1991
-      destination relationship name: success
-      max work queue size: 0
-      max work queue data size: 1 MB
-      flowfile expiration: 60 sec
-      
-Controller Services:
-    - name: MockItLikeIts1995
-      id: 2438e3c8-015a-1000-79ca-83af40ec1991
-      class: MockControllerService
-      Properties:
-          Linked Services: 
+  name: MiNiFi Flow
+  id: 2438e3c8-015a-1000-79ca-83af40ec1990
+Process Groups:
+  - id: 0a3aaf32-8574-4fa7-b720-84001f8dd71a
+    name: Sub Process Group
+    Processors:
+      - name: SubMockProcessor
+        id: 3458e3c8-015a-1000-79ca-83af40ec1992
+        class: org.apache.nifi.processors.standard.MockProcessor
+        max concurrent tasks: 1
+        scheduling strategy: EVENT_DRIVEN
+        penalization period: 30 sec
+        yield period: 1 sec
+        run duration nanos: 0
+        auto-terminated relationships list:
+            - success
+        Properties:
+          linkedService: ID
+          InSubProcessGroup: true
+    Input Ports:
+      - id: 012fc536-3137-4360-be65-3e3b47e05941
+        name: in
+    Controller Services:
+      - name: SubMockController
+        id: 1248e3c8-015a-1000-79ca-83af40ec1993
+        class: MockControllerService
+        Properties:
+          Linked Services:
+            - value: SubSSLClientServiceTest
             - value: ID
-    - name: SSLClientServiceTest
-      id: 2438e3c8-015a-1000-79ca-83af40ec1994
-      class: SSLContextService
-      Properties:
-        Client Certificate:
+      - name: SubSSLClientServiceTest
+        id: 2438e3c8-015a-1000-79ca-83af40ec1922
+        class: SSLContextService
+        Properties:
+          Client Certificate:
             - value: cn.crt.pem
-        Private Key:
+          Private Key:
             - value: cn.ckey.pem
-        Passphrase:
+          Passphrase:
             - value: cn.pass
-        CA Certificate:
+          CA Certificate:
             - value: nifi-cert.pem
-    - name: ID
-      id: 2438e3c8-015a-1000-79ca-83af40ec1992
-      class: MockControllerService
-      Properties:
-          Linked Services: 
-    - name: MockItLikeItsWrong
-      id: 2438e3c8-015a-1000-79ca-83af40ec1993
-      class: MockControllerSer
-      Properties:
-          Linked Services: 
-            - value: ID
-
+    Connections:
+      - name: Input/success/SubMockProcessor
+        id: 1238e3c8-015a-1000-79ca-83af40ec1997
+        source name: in
+        source id: 012fc536-3137-4360-be65-3e3b47e05941
+        source relationship name: success
+        destination name: SubMockProcessor
+        destination id: 3458e3c8-015a-1000-79ca-83af40ec1992
+        max work queue size: 0
+        max work queue data size: 1 MB
+        flowfile expiration: 60 sec
+Processors:
+  - name: MockProcessorIto
+    id: 1438e3c8-015a-1000-79ca-83af40ec1991
+    class: org.apache.nifi.processors.standard.MockProcessor
+    max concurrent tasks: 1
+    scheduling strategy: TIMER_DRIVEN
+    scheduling period: 10 sec
+    penalization period: 30 sec
+    yield period: 1 sec
+    run duration nanos: 0
+    auto-terminated relationships list: null
+    Properties:
+      linkedService: MockItLikeIts1995
+Connections:
+  - name: TransferFilesToRPG
+    id: 1438e3c8-015a-1000-79ca-83af40ec1997
+    source name: MockProcessorIto
+    source id: 1438e3c8-015a-1000-79ca-83af40ec1991
+    source relationship name: success
+    destination name: in
+    destination id: 012fc536-3137-4360-be65-3e3b47e05941
+    max work queue size: 0
+    max work queue data size: 1 MB
+    flowfile expiration: 60 sec
+Controller Services:
+  - name: MockItLikeIts1995
+    id: 2438e3c8-015a-1000-79ca-83af40ec1991
+    class: MockControllerService
+    Properties:
+      Linked Services:
+        - value: ID
+        - value: SubSSLClientServiceTest
+  - name: SSLClientServiceTest
+    id: 2438e3c8-015a-1000-79ca-83af40ec1994
+    class: SSLContextService
+    Properties:
+      Client Certificate:
+        - value: cn.crt.pem
+      Private Key:
+        - value: cn.ckey.pem
+      Passphrase:
+        - value: cn.pass
+      CA Certificate:
+        - value: nifi-cert.pem
+  - name: ID
+    id: 2438e3c8-015a-1000-79ca-83af40ec1992
+    class: MockControllerService
+    Properties:
+      Linked Services:
+  - name: MockItLikeItsWrong
+    id: 2438e3c8-015a-1000-79ca-83af40ec1993
+    class: MockControllerSer
+    Properties:
+      Linked Services:
+        - value: ID
+  - name: LinkSubService
+    id: 7538e3c8-015a-1000-79ca-83af40ec1996
+    class: MockControllerService
+    Properties:
+      linkedService: SubSSLClientServiceTest

--- a/libminifi/test/unit/ProcessSessionTests.cpp
+++ b/libminifi/test/unit/ProcessSessionTests.cpp
@@ -40,7 +40,7 @@ class Fixture {
   TestController test_controller_;
   TestController::PlanConfig plan_config_;
   std::shared_ptr<TestPlan> test_plan_ = test_controller_.createPlan(plan_config_);
-  std::shared_ptr<minifi::core::Processor> dummy_processor_ = test_plan_->addProcessor("DummyProcessor", "dummyProcessor");
+  minifi::core::Processor* dummy_processor_ = test_plan_->addProcessor("DummyProcessor", "dummyProcessor");
   std::shared_ptr<minifi::core::ProcessContext> context_ = [this] { test_plan_->runNextProcessor(); return test_plan_->getCurrentContext(); }();
   std::unique_ptr<minifi::core::ProcessSession> process_session_ = std::make_unique<core::ProcessSession>(context_);
 };


### PR DESCRIPTION
- Controller services are only found if they are in the scope of the processor or controller that tries to get it (in the same process group or in a parent group)
- Tests are modified to use a single root ProcessGroup that contains the used processors and processor handles are only stored as raw pointers
- Processor start and shutdown is changed to avoid deadlock when a findProcessor call is running on the same process group

https://issues.apache.org/jira/browse/MINIFICPP-2377

-------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
