### PR TITLE
MINIFICPP-2431 Include relationship.py in the msi installer

### DIFF
--- a/msi/WixWin.wsi.in
+++ b/msi/WixWin.wsi.in
@@ -414,6 +414,7 @@ ${WIX_EXTRA_COMPONENTS}
                 <Component Id="PythonProcessorNifiApiFiles" Guid="a9cb7b7b-e66d-4e32-9115-eab4aa980124">
                   <File Id="NifiApi_flowfiletransform" Name="flowfiletransform.py" KeyPath="no" Source="pythonprocessors\nifiapi\flowfiletransform.py"/>
                   <File Id="NifiApi_properties" Name="properties.py" KeyPath="no" Source="pythonprocessors\nifiapi\properties.py"/>
+                  <File Id="NifiApi_relationship" Name="relationship.py" KeyPath="no" Source="pythonprocessors\nifiapi\relationship.py"/>
                   <File Id="NifiApi_documentation" Name="documentation.py" KeyPath="no" Source="pythonprocessors\nifiapi\documentation.py"/>
                   <File Id="NifiApi_init" Name="__init__.py" KeyPath="no" Source="pythonprocessors\nifiapi\__init__.py"/>
                 </Component>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-2431

Custom relationship support in NiFi Python processors requires the new `relationship.py` file to be present in the `minifi-python/nifiapi` directory, but `WixWin.msi` did not copy it there from the source.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
