### PR TITLE
MINIFICPP-2456 Remove curl output from Elasticsearch responses

### DIFF
--- a/docker/test/integration/cluster/checkers/ElasticSearchChecker.py
+++ b/docker/test/integration/cluster/checkers/ElasticSearchChecker.py
@@ -39,7 +39,6 @@ class ElasticSearchChecker:
         if code != 0:
             return None
         output_lines = output.splitlines()
-        print(output_lines)
         result = json.loads(output_lines[-1])
         return result["encoded"]
 

--- a/docker/test/integration/cluster/checkers/ElasticSearchChecker.py
+++ b/docker/test/integration/cluster/checkers/ElasticSearchChecker.py
@@ -20,27 +20,30 @@ class ElasticSearchChecker:
         self.container_communicator = container_communicator
 
     def is_elasticsearch_empty(self, container_name):
-        (code, output) = self.container_communicator.execute_command(container_name, ["curl", "-u", "elastic:password", "-k", "-XGET", "https://localhost:9200/_search"])
+        (code, output) = self.container_communicator.execute_command(container_name, ["curl", "-s", "-u", "elastic:password", "-k", "-XGET", "https://localhost:9200/_search"])
         return code == 0 and '"hits":[]' in output
 
     def create_doc_elasticsearch(self, container_name, index_name, doc_id):
         (code, output) = self.container_communicator.execute_command(container_name, ["/bin/bash", "-c",
-                                                                                      "curl -u elastic:password -k -XPUT https://localhost:9200/" + index_name + "/_doc/" + doc_id + " -H Content-Type:application/json -d'{\"field1\":\"value1\"}'"])
+                                                                                      "curl -s -u elastic:password -k -XPUT https://localhost:9200/" + index_name + "/_doc/" + doc_id + " -H Content-Type:application/json -d'{\"field1\":\"value1\"}'"])
         return code == 0 and ('"_id":"' + doc_id + '"') in output
 
     def check_elastic_field_value(self, container_name, index_name, doc_id, field_name, field_value):
         (code, output) = self.container_communicator.execute_command(container_name, ["/bin/bash", "-c",
-                                                                                      "curl -u elastic:password -k -XGET https://localhost:9200/" + index_name + "/_doc/" + doc_id])
+                                                                                      "curl -s -u elastic:password -k -XGET https://localhost:9200/" + index_name + "/_doc/" + doc_id])
         return code == 0 and (field_name + '":"' + field_value) in output
 
     def elastic_generate_apikey(self, elastic_container_name):
-        (_, output) = self.container_communicator.execute_command(elastic_container_name, ["/bin/bash", "-c",
-                                                                                           "curl -u elastic:password -k -XPOST https://localhost:9200/_security/api_key -H Content-Type:application/json -d'{\"name\":\"my-api-key\",\"expiration\":\"1d\",\"role_descriptors\":{\"role-a\": {\"cluster\": [\"all\"],\"index\": [{\"names\": [\"my_index\"],\"privileges\": [\"all\"]}]}}}'"])
+        (code, output) = self.container_communicator.execute_command(elastic_container_name, ["/bin/bash", "-c",
+                                                                                              "curl -s -u elastic:password -k -XPOST https://localhost:9200/_security/api_key -H Content-Type:application/json -d'{\"name\":\"my-api-key\",\"expiration\":\"1d\",\"role_descriptors\":{\"role-a\": {\"cluster\": [\"all\"],\"index\": [{\"names\": [\"my_index\"],\"privileges\": [\"all\"]}]}}}'"])
+        if code != 0:
+            return None
         output_lines = output.splitlines()
+        print(output_lines)
         result = json.loads(output_lines[-1])
         return result["encoded"]
 
     def add_elastic_user_to_opensearch(self, container_name):
         (code, output) = self.container_communicator.execute_command(container_name, ["/bin/bash", "-c",
-                                                                                      'curl -u admin:admin -k -XPUT https://{hostname}:9200/_plugins/_security/api/internalusers/elastic -H Content-Type:application/json -d\'{{"password":"password","backend_roles":["admin"]}}\''.format(hostname=container_name)])
+                                                                                      'curl -s -u admin:admin -k -XPUT https://{hostname}:9200/_plugins/_security/api/internalusers/elastic -H Content-Type:application/json -d\'{{"password":"password","backend_roles":["admin"]}}\''.format(hostname=container_name)])
         return code == 0 and '"status":"CREATED"' in output

--- a/docker/test/integration/features/utils.py
+++ b/docker/test/integration/features/utils.py
@@ -25,7 +25,7 @@ def retry_check(max_tries=5, retry_interval=1):
     def retry_check_func(func):
         @functools.wraps(func)
         def retry_wrapper(*args, **kwargs):
-            for i in range(max_tries):
+            for _ in range(max_tries):
                 if func(*args, **kwargs):
                     return True
                 time.sleep(retry_interval)


### PR DESCRIPTION
Curl debug output in could get into the response of the Elasticsearch API key generation request, which caused json parsing failure in the tests. Adding the silent option for the curl calls resolves this issue.

https://issues.apache.org/jira/browse/MINIFICPP-2456

-------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
