### PR TITLE
MINIFICPP-2472 msi: fix install scope, should be per machine

### DIFF
--- a/msi/WixWin.wsi.in
+++ b/msi/WixWin.wsi.in
@@ -29,7 +29,7 @@ Licensed to the Apache Software Foundation (ASF) under one or more
       Manufacturer="$(var.CPACK_PACKAGE_VENDOR)">
 
 
-    <Package InstallerVersion="301" Compressed="yes"/>
+    <Package InstallScope="perMachine" InstallerVersion="301" Compressed="yes"/>
 
     <MajorUpgrade DowngradeErrorMessage="A newer version of Apache NiFi MiNiFi C++ is already installed." />
 


### PR DESCRIPTION
The current MSI is buggy: if one user installs it, another user will not see the installation in their "Programs and features" list, and upgrades are similarly expected to fail. This PR fixes the issue by marking the package "perMachine", as documented here: https://wixtoolset.org/docs/v3/xsd/wix/package/

I tested it manually.

----


Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
