### PR TITLE
MINIFICPP-2480 workaround python version incompatibilities around 3.6 vs 3.11

### DIFF
--- a/extensions/python/PythonInterpreter.cpp
+++ b/extensions/python/PythonInterpreter.cpp
@@ -54,7 +54,7 @@ std::optional<version> getPythonVersion() {
   //                  "3.12.6 (main, Sep  8 2024, 13:18:56) [GCC 14.2.1 20240805]"
   std::string ver_str = Py_GetVersion();
   std::smatch match;
-  if (std::regex_search(ver_str, match, std::regex{"^(\\d+)\\.(\\d+)"})) {
+  if (std::regex_search(ver_str, match, std::regex{R"(^(\d+)\.(\d+))"})) {
     return version{std::stoi(match[1]), std::stoi(match[2])};
   } else {
     return std::nullopt;
@@ -69,7 +69,10 @@ std::optional<version> getPythonVersion() {
 // This can be removed if we drop the support for Python 3.6
 void initThreads() {
   using namespace std::literals;
-  if (const auto version = getPythonVersion(); version->major == 3 && version->minor <= 6) { return; }
+  // early return (skip workaround) above Python 3.6
+  if (const auto version = getPythonVersion(); !version || (version->major == 3 && version->minor > 6) || version->major > 3) {
+    return;
+  }
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/extensions/python/PythonInterpreter.cpp
+++ b/extensions/python/PythonInterpreter.cpp
@@ -18,6 +18,14 @@
 
 #include "PythonBindings.h"
 
+#ifndef WIN32
+#if !defined(__APPLE__) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE  // NOLINT: for RTLD_DEFAULT (source: `man dlsym` on linux)
+#endif  // !__APPLE__ && !_GNU_SOURCE
+// on Apple, RTLD_DEFAULT is defined without needing any macros (source: `man dlsym` on macOS)
+#include <dlfcn.h>
+#endif  // !WIN32
+
 namespace org::apache::nifi::minifi::extensions::python {
 
 Interpreter* Interpreter::getInterpreter() {
@@ -35,29 +43,37 @@ GlobalInterpreterLock::~GlobalInterpreterLock() {
 
 namespace {
 // PyEval_InitThreads might be marked deprecated (depending on the version of Python.h)
-// Python <= 3.6: This needs to be called manually after Py_Initialize to initialize threads
+// Python <= 3.6: This needs to be called manually after Py_Initialize to initialize threads (python < 3.6 is unsupported by us)
 // Python >= 3.7: Noop function since its functionality is included in Py_Initialize
 // Python >= 3.9: Marked as deprecated (still noop)
+// Python >= 3.11: removed
 // This can be removed if we drop the support for Python 3.6
 void initThreads() {
+  using namespace std::literals;
+  // ignoring versions 3.60+, hopefully we can remove this hack by the time they are relevant
+  // Example version string: "3.0a5+ (py3k:63103M, May 12 2008, 00:53:55) \n[GCC 4.2.3]"
+  if (const auto version = Py_GetVersion(); std::string_view{version}.starts_with("3.6")) { return; }
 #if defined(__clang__)
   #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(WIN32)
-  #pragma warning(push)
-#pragma warning(disable: 4996)
 #endif
-  if (!PyEval_ThreadsInitialized())
-    PyEval_InitThreads();
+#ifndef WIN32  // dlsym hack, doesn't work on windows
+  // dlsym hack: allows us to build with python 3.11+, where these were removed (so no header declarations), and run with python 3.6 (e.g. RHEL8)
+  // the dlsym hack doesn't work on Windows, we'll drop python 3.6 support there
+  // lowercase, to avoid name conflicts with the header declaration, in case we're using an old enough python to build
+  const auto pyeval_threads_initialized = (int (*)())dlsym(RTLD_DEFAULT, "PyEval_ThreadsInitialized");  // NOLINT: C-style cast for POSIX-guaranteed dataptr -> funcptr conversion in dlsym
+  const auto pyeval_initthreads = (void (*)())dlsym(RTLD_DEFAULT, "PyEval_InitThreads");  // NOLINT: C-style cast for POSIX-guaranteed dataptr -> funcptr conversion in dlsym
+  gsl_Assert(pyeval_threads_initialized && pyeval_initthreads && "We're on python 3.6, yet we couldn't load PyEval_ThreadsInitialized and/or PyEval_InitThreads");
+  if (!pyeval_threads_initialized())
+    pyeval_initthreads();
+#endif  // !WIN32
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #elif defined(__GNUC__)
 #pragma GCC diagnostic pop
-#elif defined(WIN32)
-#pragma warning(pop)
 #endif
 }
 


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
