### PR TITLE
MINIFICPP-2492 Free up disk space for docker tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,6 +553,16 @@ jobs:
           restore-keys: |
             docker-ccache-${{github.ref}}-
             docker-ccache-refs/heads/main
+      - id: free_disk_space
+        run: |
+          # We can gain additional disk space on the Ubuntu runners thanks to these suggestions:
+          # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+          # https://github.com/actions/runner-images/issues/2606#issuecomment-772683150
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - id: build
         run: |
           mkdir build
@@ -599,6 +609,16 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y python3-virtualenv
+      - id: free_disk_space
+        run: |
+          # We can gain additional disk space on the Ubuntu runners thanks to these suggestions:
+          # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+          # https://github.com/actions/runner-images/issues/2606#issuecomment-772683150
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - id: test
         name: Docker Verify
         working-directory: ./build


### PR DESCRIPTION
It seems Elasticsearch tests were transiently failing due to insufficient disk space to start the Elasticsearch node. Freeing up some additional disk space solves this issue.

https://issues.apache.org/jira/browse/MINIFICPP-2492

------------------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
