### PR TITLE
MINIFICPP-2494 windows event log: fix event message formatting, refactor

### DIFF
--- a/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
@@ -100,9 +100,9 @@ void ConsumeWindowsEventLog::initialize() {
 }
 
 bool ConsumeWindowsEventLog::insertHeaderName(wel::METADATA_NAMES &header, const std::string &key, const std::string & value) {
-  wel::METADATA name = wel::WindowsEventLogMetadata::getMetadataFromString(key);
+  wel::Metadata name = wel::WindowsEventLogMetadata::getMetadataFromString(key);
 
-  if (name != wel::METADATA::UNKNOWN) {
+  if (name != wel::Metadata::UNKNOWN) {
     header.emplace_back(std::make_pair(name, value));
     return true;
   }
@@ -488,7 +488,7 @@ nonstd::expected<cwel::EventRender, std::string> ConsumeWindowsEventLog::createE
     std::string_view payload_name = event_message ? "Message" : "Error";
 
     wel::WindowsEventLogHeader log_header(header_names_, header_delimiter_, payload_name.size());
-    result.plaintext = log_header.getEventHeader([&walker](wel::METADATA metadata) { return walker.getMetadata(metadata); });
+    result.plaintext = log_header.getEventHeader([&walker](wel::Metadata metadata) { return walker.getMetadata(metadata); });
     result.plaintext += payload_name;
     result.plaintext += log_header.getDelimiterFor(payload_name.size());
     result.plaintext += event_message.has_value() ? *event_message : event_message.error().message();

--- a/extensions/windows-event-log/tests/MetadataWalkerTests.cpp
+++ b/extensions/windows-event-log/tests/MetadataWalkerTests.cpp
@@ -27,7 +27,7 @@
 #include "wel/XMLString.h"
 #include "pugixml.hpp"
 
-using METADATA = org::apache::nifi::minifi::wel::METADATA;
+using Metadata = org::apache::nifi::minifi::wel::Metadata;
 using MetadataWalker = org::apache::nifi::minifi::wel::MetadataWalker;
 using WindowsEventLogMetadata = org::apache::nifi::minifi::wel::WindowsEventLogMetadata;
 using WindowsEventLogMetadataImpl = org::apache::nifi::minifi::wel::WindowsEventLogMetadataImpl;
@@ -74,7 +74,7 @@ const short event_type_index = 178;  // NOLINT short comes from WINDOWS API
 
 class FakeWindowsEventLogMetadata : public WindowsEventLogMetadata {
  public:
-  [[nodiscard]] std::string getEventData(EVT_FORMAT_MESSAGE_FLAGS flags) const override { return "event_data_for_flag_" + std::to_string(flags); }
+  [[nodiscard]] nonstd::expected<std::string, std::error_code> getEventData(EVT_FORMAT_MESSAGE_FLAGS flags) const noexcept override { return "event_data_for_flag_" + std::to_string(flags); }
   [[nodiscard]] std::string getEventTimestamp() const override { return "event_timestamp"; }
   short getEventTypeIndex() const override { return event_type_index; }  // NOLINT short comes from WINDOWS API
 };
@@ -149,7 +149,7 @@ void extractMappingsTestHelper(const std::string &file_name,
                                bool update_xml,
                                bool resolve,
                                const std::map<std::string, std::string>& expected_identifiers,
-                               const std::map<METADATA, std::string>& expected_metadata,
+                               const std::map<Metadata, std::string>& expected_metadata,
                                const std::map<std::string, std::string>& expected_field_values) {
   std::string input_xml = readFile(file_name);
   REQUIRE(!input_xml.empty());
@@ -175,12 +175,12 @@ TEST_CASE("MetadataWalker extracts mappings correctly when there is a single Sid
 
   const std::map<std::string, std::string> expected_identifiers{{"S-1-0-0", "S-1-0-0"}};
 
-  using org::apache::nifi::minifi::wel::METADATA;
-  const std::map<METADATA, std::string> expected_metadata{
-      {METADATA::SOURCE, "Microsoft-Windows-Security-Auditing"},
-      {METADATA::TIME_CREATED, "event_timestamp"},
-      {METADATA::EVENTID, "4672"},
-      {METADATA::EVENT_RECORDID, "2575952"}};
+  using org::apache::nifi::minifi::wel::Metadata;
+  const std::map<Metadata, std::string> expected_metadata{
+      {Metadata::SOURCE, "Microsoft-Windows-Security-Auditing"},
+      {Metadata::TIME_CREATED, "event_timestamp"},
+      {Metadata::EVENTID, "4672"},
+      {Metadata::EVENT_RECORDID, "2575952"}};
 
   const std::map<std::string, std::string> expected_field_values{};
 
@@ -198,18 +198,18 @@ TEST_CASE("MetadataWalker extracts mappings correctly when there is a single Sid
 
   const std::map<std::string, std::string> expected_identifiers{{"S-1-0-0", "Nobody"}};
 
-  using org::apache::nifi::minifi::wel::METADATA;
-  const std::map<METADATA, std::string> expected_metadata{
-      {METADATA::LOG_NAME, "MetadataWalkerTests"},
-      {METADATA::SOURCE, "Microsoft-Windows-Security-Auditing"},
-      {METADATA::TIME_CREATED, "event_timestamp"},
-      {METADATA::EVENTID, "4672"},
-      {METADATA::OPCODE, "event_data_for_flag_4"},
-      {METADATA::EVENT_RECORDID, "2575952"},
-      {METADATA::EVENT_TYPE, "178"},
-      {METADATA::TASK_CATEGORY, "event_data_for_flag_3"},
-      {METADATA::LEVEL, "event_data_for_flag_2"},
-      {METADATA::KEYWORDS, "event_data_for_flag_5"}};
+  using org::apache::nifi::minifi::wel::Metadata;
+  const std::map<Metadata, std::string> expected_metadata{
+      {Metadata::LOG_NAME, "MetadataWalkerTests"},
+      {Metadata::SOURCE, "Microsoft-Windows-Security-Auditing"},
+      {Metadata::TIME_CREATED, "event_timestamp"},
+      {Metadata::EVENTID, "4672"},
+      {Metadata::OPCODE, "event_data_for_flag_4"},
+      {Metadata::EVENT_RECORDID, "2575952"},
+      {Metadata::EVENT_TYPE, "178"},
+      {Metadata::TASK_CATEGORY, "event_data_for_flag_3"},
+      {Metadata::LEVEL, "event_data_for_flag_2"},
+      {Metadata::KEYWORDS, "event_data_for_flag_5"}};
 
   SECTION("update_xml is false => fields are collected into walker.getFieldValues()") {
     const std::map<std::string, std::string> expected_field_values{
@@ -235,12 +235,12 @@ TEST_CASE("MetadataWalker extracts mappings correctly when there are multiple Si
 
   const std::map<std::string, std::string> expected_identifiers{{"S-1-0-0", "S-1-0-0"}};
 
-  using org::apache::nifi::minifi::wel::METADATA;
-  const std::map<METADATA, std::string> expected_metadata{
-      {METADATA::SOURCE, "Microsoft-Windows-Security-Auditing"},
-      {METADATA::TIME_CREATED, "event_timestamp"},
-      {METADATA::EVENTID, "4672"},
-      {METADATA::EVENT_RECORDID, "2575952"}};
+  using org::apache::nifi::minifi::wel::Metadata;
+  const std::map<Metadata, std::string> expected_metadata{
+      {Metadata::SOURCE, "Microsoft-Windows-Security-Auditing"},
+      {Metadata::TIME_CREATED, "event_timestamp"},
+      {Metadata::EVENTID, "4672"},
+      {Metadata::EVENT_RECORDID, "2575952"}};
 
   const std::map<std::string, std::string> expected_field_values{};
 
@@ -264,18 +264,18 @@ TEST_CASE("MetadataWalker extracts mappings correctly when there are multiple Si
       {"S-1-0-0", "Nobody"},
       {"S-1-1-0", "Everyone"}};
 
-  using org::apache::nifi::minifi::wel::METADATA;
-  const std::map<METADATA, std::string> expected_metadata{
-      {METADATA::LOG_NAME, "MetadataWalkerTests"},
-      {METADATA::SOURCE, "Microsoft-Windows-Security-Auditing"},
-      {METADATA::TIME_CREATED, "event_timestamp"},
-      {METADATA::EVENTID, "4672"},
-      {METADATA::OPCODE, "event_data_for_flag_4"},
-      {METADATA::EVENT_RECORDID, "2575952"},
-      {METADATA::EVENT_TYPE, "178"},
-      {METADATA::TASK_CATEGORY, "event_data_for_flag_3"},
-      {METADATA::LEVEL, "event_data_for_flag_2"},
-      {METADATA::KEYWORDS, "event_data_for_flag_5"}};
+  using org::apache::nifi::minifi::wel::Metadata;
+  const std::map<Metadata, std::string> expected_metadata{
+      {Metadata::LOG_NAME, "MetadataWalkerTests"},
+      {Metadata::SOURCE, "Microsoft-Windows-Security-Auditing"},
+      {Metadata::TIME_CREATED, "event_timestamp"},
+      {Metadata::EVENTID, "4672"},
+      {Metadata::OPCODE, "event_data_for_flag_4"},
+      {Metadata::EVENT_RECORDID, "2575952"},
+      {Metadata::EVENT_TYPE, "178"},
+      {Metadata::TASK_CATEGORY, "event_data_for_flag_3"},
+      {Metadata::LEVEL, "event_data_for_flag_2"},
+      {Metadata::KEYWORDS, "event_data_for_flag_5"}};
 
   SECTION("update_xml is false => fields are collected into walker.getFieldValues()") {
     const std::map<std::string, std::string> expected_field_values{
@@ -301,12 +301,12 @@ TEST_CASE("MetadataWalker extracts mappings correctly when the Sid is unknown an
 
   const std::map<std::string, std::string> expected_identifiers{{"S-1-8-6-5-3-0-9", "S-1-8-6-5-3-0-9"}};
 
-  using org::apache::nifi::minifi::wel::METADATA;
-  const std::map<METADATA, std::string> expected_metadata{
-      {METADATA::SOURCE, "Microsoft-Windows-Security-Auditing"},
-      {METADATA::TIME_CREATED, "event_timestamp"},
-      {METADATA::EVENTID, "4672"},
-      {METADATA::EVENT_RECORDID, "2575952"}};
+  using org::apache::nifi::minifi::wel::Metadata;
+  const std::map<Metadata, std::string> expected_metadata{
+      {Metadata::SOURCE, "Microsoft-Windows-Security-Auditing"},
+      {Metadata::TIME_CREATED, "event_timestamp"},
+      {Metadata::EVENTID, "4672"},
+      {Metadata::EVENT_RECORDID, "2575952"}};
 
   const std::map<std::string, std::string> expected_field_values{};
 
@@ -324,18 +324,18 @@ TEST_CASE("MetadataWalker extracts mappings correctly when the Sid is unknown an
 
   const std::map<std::string, std::string> expected_identifiers{{"S-1-8-6-5-3-0-9", "S-1-8-6-5-3-0-9"}};
 
-  using org::apache::nifi::minifi::wel::METADATA;
-  const std::map<METADATA, std::string> expected_metadata{
-      {METADATA::LOG_NAME, "MetadataWalkerTests"},
-      {METADATA::SOURCE, "Microsoft-Windows-Security-Auditing"},
-      {METADATA::TIME_CREATED, "event_timestamp"},
-      {METADATA::EVENTID, "4672"},
-      {METADATA::OPCODE, "event_data_for_flag_4"},
-      {METADATA::EVENT_RECORDID, "2575952"},
-      {METADATA::EVENT_TYPE, "178"},
-      {METADATA::TASK_CATEGORY, "event_data_for_flag_3"},
-      {METADATA::LEVEL, "event_data_for_flag_2"},
-      {METADATA::KEYWORDS, "event_data_for_flag_5"}};
+  using org::apache::nifi::minifi::wel::Metadata;
+  const std::map<Metadata, std::string> expected_metadata{
+      {Metadata::LOG_NAME, "MetadataWalkerTests"},
+      {Metadata::SOURCE, "Microsoft-Windows-Security-Auditing"},
+      {Metadata::TIME_CREATED, "event_timestamp"},
+      {Metadata::EVENTID, "4672"},
+      {Metadata::OPCODE, "event_data_for_flag_4"},
+      {Metadata::EVENT_RECORDID, "2575952"},
+      {Metadata::EVENT_TYPE, "178"},
+      {Metadata::TASK_CATEGORY, "event_data_for_flag_3"},
+      {Metadata::LEVEL, "event_data_for_flag_2"},
+      {Metadata::KEYWORDS, "event_data_for_flag_5"}};
 
   SECTION("update_xml is false => fields are collected into walker.getFieldValues()") {
     const std::map<std::string, std::string> expected_field_values{

--- a/extensions/windows-event-log/wel/MetadataWalker.cpp
+++ b/extensions/windows-event-log/wel/MetadataWalker.cpp
@@ -134,9 +134,9 @@ std::string MetadataWalker::getMetadata(Metadata metadata) const {
     case KEYWORDS: return getString(metadata_, "Keywords");
     case EVENT_TYPE: return std::to_string(windows_event_log_metadata_.getEventTypeIndex());
     case COMPUTER: return WindowsEventLogMetadata::getComputerName();
-    case USER: // TODO(szaszm): unhandled before refactoring
-    case UNKNOWN: // TODO(szaszm): unhandled before refactoring
-      ;
+    case USER:  // TODO(szaszm): unhandled before refactoring
+    case UNKNOWN:  // TODO(szaszm): unhandled before refactoring
+      break;
   }
   return "N/A";
 }

--- a/extensions/windows-event-log/wel/MetadataWalker.h
+++ b/extensions/windows-event-log/wel/MetadataWalker.h
@@ -22,14 +22,12 @@
 
 #include <Windows.h>
 #include <winevt.h>
-#include <codecvt>
 #include <functional>
 #include <map>
-#include <sstream>
 #include <string>
 #include <vector>
-#include <optional>
 #include <utility>
+#include <type_traits>
 
 #include "core/Core.h"
 #include "core/Processor.h"
@@ -37,7 +35,6 @@
 #include "FlowFileRecord.h"
 #include "WindowsEventLog.h"
 
-#include "concurrentqueue.h"
 #include "pugixml.hpp"
 #include "utils/RegexUtils.h"
 
@@ -45,7 +42,6 @@ namespace org::apache::nifi::minifi::wel {
 
 /**
  * Defines a tree walker for the XML input
- *
  */
 class MetadataWalker : public pugi::xml_tree_walker {
  public:
@@ -65,11 +61,9 @@ class MetadataWalker : public pugi::xml_tree_walker {
    */
   bool for_each(pugi::xml_node &node) override;
 
-  [[nodiscard]] std::map<std::string, std::string> getFieldValues() const;
-
-  [[nodiscard]] std::map<std::string, std::string> getIdentifiers() const;
-
-  [[nodiscard]] std::string getMetadata(METADATA metadata) const;
+  [[nodiscard]] std::map<std::string, std::string> getFieldValues() const { return fields_values_; }
+  [[nodiscard]] std::map<std::string, std::string> getIdentifiers() const { return replaced_identifiers_; }
+  [[nodiscard]] std::string getMetadata(Metadata metadata) const;
 
  private:
   static std::vector<std::string> getIdentifiers(const std::string &text);

--- a/libminifi/include/utils/OsUtils.h
+++ b/libminifi/include/utils/OsUtils.h
@@ -43,7 +43,7 @@ int64_t getSystemTotalPhysicalMemory();
 /// Returns the total paging file size in bytes
 int64_t getTotalPagingFileSize();
 
-std::error_code windowsErrorToErrorCode(unsigned long error_code);  // NOLINT [runtime/int]
+std::error_code windowsErrorToErrorCode(unsigned long error_code) noexcept;  // NOLINT [runtime/int]
 #endif
 
 /// Returns the host architecture (e.g. x32, arm64)

--- a/libminifi/src/utils/OsUtils.cpp
+++ b/libminifi/src/utils/OsUtils.cpp
@@ -296,7 +296,7 @@ int64_t OsUtils::getTotalPagingFileSize() {
   return total_paging_file_size;
 }
 
-std::error_code OsUtils::windowsErrorToErrorCode(DWORD error_code) {
+std::error_code OsUtils::windowsErrorToErrorCode(DWORD error_code) noexcept {
   return {gsl::narrow_cast<int>(error_code), std::system_category()};
 }
 #endif


### PR DESCRIPTION
Changes:
- change `enum METADATA` to `enum class Metadata`
- rewrite `getEventData` and `getEventMessage`. They no longer try with a stack buffer first. That looks like a premature optimization, since there are allocations in the function either way, and a user reported issues with the call that may be resolved by this. The rewrite aims to follow modern C++ best practices, instead of the unsafe C-like code it used to be.
- remove a few unused includes
- make `getComputerName` thread-safe and simpler. The max computer name is reduced to 256, based on the MSDN example. I think the overwhelming majority of computer FQDNs will fit in that just fine. Also changed it to truncate when it's longer, instead of bailing out and returning "N/A"
- other various drive-by refactors

----------

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
