### PR TITLE
MINIFICPP-2495 change default logging settings

### DIFF
--- a/conf/minifi-log.properties
+++ b/conf/minifi-log.properties
@@ -28,8 +28,8 @@ spdlog.pattern=[%Y-%m-%d %H:%M:%S.%e] [%n] [%l] %v
 appender.rolling=rollingappender
 #appender.rolling.directory=${MINIFI_HOME}/logs
 appender.rolling.file_name=minifi-app.log
-appender.rolling.max_files=3
-appender.rolling.max_file_size=5 MB
+appender.rolling.max_files=1
+appender.rolling.max_file_size=20 MB
 
 #Other possible appenders
 #appender.stdout=stdout

--- a/extensions/rocksdb-repos/database/RocksDbUtils.cpp
+++ b/extensions/rocksdb-repos/database/RocksDbUtils.cpp
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "Exception.h"
+#include "utils/Literals.h"
 
 namespace org::apache::nifi::minifi::internal {
 
@@ -56,7 +57,8 @@ void setCommonRocksDbOptions(Writable<rocksdb::DBOptions>& db_opts) {
   db_opts.set(&rocksdb::DBOptions::create_if_missing, true);
   db_opts.set(&rocksdb::DBOptions::use_direct_io_for_flush_and_compaction, true);
   db_opts.set(&rocksdb::DBOptions::use_direct_reads, true);
-  db_opts.set(&rocksdb::DBOptions::keep_log_file_num, 5);
+  db_opts.set(&rocksdb::DBOptions::keep_log_file_num, 1);
+  db_opts.set(&rocksdb::DBOptions::max_log_file_size, 1_MiB);
 }
 
 std::unordered_map<std::string, std::string> getRocksDbOptionsToOverride(const std::shared_ptr<Configure> &configuration, std::string_view custom_db_prefix) {


### PR DESCRIPTION
  - max minifi log size: 20MiB (from 5MiB)
  - max rotations: 1 (from 3)
  - rocksdb max log size: 1MiB (from unlimited)
  - rocksdb max log rotations: 1 (from 5)

----

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
