### PR TITLE
MINIFICPP-2523 Fix Chocolatey package name for m4

### DIFF
--- a/bootstrap/package_manager.py
+++ b/bootstrap/package_manager.py
@@ -277,6 +277,7 @@ class ChocolateyPackageManager(PackageManager):
                                     "autoconf": set(),
                                     "libtool": set(),
                                     "make": set(),
+                                    "m4": {"gnuwin32-m4"},
                                     "perl": {"strawberryperl", "NASM"}})
         return True
 


### PR DESCRIPTION
If you run the (python) bootstrap script on Windows, and m4 is not already installed, the script tries to install it using Chocolatey. But it used to fail, because the package is called "gnuwin32-m4", not "m4".

https://issues.apache.org/jira/browse/MINIFICPP-2523

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
