### PR TITLE
MINIFICPP-2528 disable jom in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,14 +195,6 @@ jobs:
       - name: Add sccache to path
         run: '[Environment]::SetEnvironmentVariable("PATH", [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine) + ";" + (Split-Path -Path $env:SCCACHE_PATH -Parent), [EnvironmentVariableTarget]::Machine);'
         shell: powershell
-      - name: Install jom
-        run: |
-          Invoke-WebRequest -Uri "http://download.qt.io/official_releases/jom/jom_1_1_4.zip" -OutFile "jom.zip"
-          if ((Get-FileHash 'jom.zip').Hash -ne "d533c1ef49214229681e90196ed2094691e8c4a0a0bef0b2c901debcb562682b") {Write "Hash mismatch"; Exit 1}
-          New-Item -ItemType Directory -Path D:\jom
-          Expand-Archive -Path jom.zip -DestinationPath D:\jom
-          [Environment]::SetEnvironmentVariable("PATH", [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine) + ";D:\jom", [EnvironmentVariableTarget]::Machine);
-        shell: powershell
       - name: build
         run: |
           python -m venv venv & venv\Scripts\activate & pip install -r requirements.txt & python main.py --noninteractive --skip-compiler-install --minifi-options="%WINDOWS_MINIFI_OPTIONS%" --cmake-options="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"

--- a/cmake/BundledOpenSSL.cmake
+++ b/cmake/BundledOpenSSL.cmake
@@ -71,8 +71,20 @@ function(use_openssl SOURCE_DIR BINARY_DIR)
 
     # Note: when upgrading to a later release than 3.1.1 the --no-apps could be used instead of --no-tests to minimize the build size
     if (WIN32)
-        set(OPENSSL_BUILD_COMMAND nmake)
-        set(OPENSSL_WINDOWS_COMPILE_FLAGS "")
+        find_program(JOM_EXECUTABLE_PATH
+            NAMES jom.exe
+            PATHS ENV PATH
+            NO_DEFAULT_PATH)
+        if(JOM_EXECUTABLE_PATH)
+            include(ProcessorCount)
+            processorcount(jobs)
+            set(OPENSSL_BUILD_COMMAND ${JOM_EXECUTABLE_PATH} -j${jobs})
+            set(OPENSSL_WINDOWS_COMPILE_FLAGS /FS)
+        else()
+            message("Using nmake for OpenSSL build")
+            set(OPENSSL_BUILD_COMMAND nmake)
+            set(OPENSSL_WINDOWS_COMPILE_FLAGS "")
+        endif()
         ExternalProject_Add(
                 openssl-external
                 URL https://github.com/openssl/openssl/releases/download/openssl-3.3.2/openssl-3.3.2.tar.gz

--- a/cmake/BundledOpenSSL.cmake
+++ b/cmake/BundledOpenSSL.cmake
@@ -71,20 +71,8 @@ function(use_openssl SOURCE_DIR BINARY_DIR)
 
     # Note: when upgrading to a later release than 3.1.1 the --no-apps could be used instead of --no-tests to minimize the build size
     if (WIN32)
-        find_program(JOM_EXECUTABLE_PATH
-            NAMES jom.exe
-            PATHS ENV PATH
-            NO_DEFAULT_PATH)
-        if(JOM_EXECUTABLE_PATH)
-            include(ProcessorCount)
-            processorcount(jobs)
-            set(OPENSSL_BUILD_COMMAND ${JOM_EXECUTABLE_PATH} -j${jobs})
-            set(OPENSSL_WINDOWS_COMPILE_FLAGS /FS)
-        else()
-            message("Using nmake for OpenSSL build")
-            set(OPENSSL_BUILD_COMMAND nmake)
-            set(OPENSSL_WINDOWS_COMPILE_FLAGS "")
-        endif()
+        set(OPENSSL_BUILD_COMMAND nmake)
+        set(OPENSSL_WINDOWS_COMPILE_FLAGS "")
         ExternalProject_Add(
                 openssl-external
                 URL https://github.com/openssl/openssl/releases/download/openssl-3.3.2/openssl-3.3.2.tar.gz


### PR DESCRIPTION
because windows CI builds are often failing, and I suspect it's because the OpenSSL build system doesn't tolerate parallel builds well.

----

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
