### PR TITLE
MINIFICPP-2529 Upgrade expected_lite to v0.8.0

### DIFF
--- a/cmake/ExpectedLite.cmake
+++ b/cmake/ExpectedLite.cmake
@@ -18,7 +18,7 @@
 include(FetchContent)
 
 FetchContent_Declare(expected-lite
-    URL      https://github.com/martinmoene/expected-lite/archive/refs/tags/v0.6.0.tar.gz
-    URL_HASH SHA256=90478ff7345100bf7539b12ea2c5ff04a7b6290bc5c280f02b473d5c65165342
+    URL      https://github.com/martinmoene/expected-lite/archive/refs/tags/v0.8.0.tar.gz
+    URL_HASH SHA256=27649f30bd9d4fe7b193ab3eb6f78c64d0f585c24c085f340b4722b3d0b5e701
 )
 FetchContent_MakeAvailable(expected-lite)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-2529

Visual Studio 17.13 (finally) provides the C++23 feature std::expected, so expected_lite tries to use it and act as a wrapper around it. However, the old version we use, v0.6.0, only wraps std::expected, so the compilation fails.
https://github.com/martinmoene/expected-lite/blob/v0.6.0/include/nonstd/expected.hpp#L216-L220

The latest release, v0.8.0, wraps all required symbols including std::unexpect and std::unexpected_type etc:
https://github.com/martinmoene/expected-lite/blob/v0.8.0/include/nonstd/expected.hpp#L231-L251

---

This is needed to support compilers which provide std::expected.

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
