### PR TITLE
MINIFICPP-2520 Expand the CPACK_SOURCE_IGNORE_FILES list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,7 @@ extensions/windows-event-log/tests/custom-provider/unit-test-provider.man
 extensions/windows-event-log/tests/custom-provider/unit-test-provider.rc
 extensions/windows-event-log/tests/custom-provider/unit-test-provider.res
 extensions/windows-event-log/tests/custom-provider/unit-test-providerTEMP.BIN
+
+##################################################################################################
+#  If you add anything here, consider adding it to the CPACK_SOURCE_IGNORE_FILES list, as well.  #
+##################################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,8 +545,8 @@ else()
 endif(WIN32)
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "${ASSEMBLY_BASE_NAME}-source")
 set(CPACK_SOURCE_IGNORE_FILES
-    "/build/"
-    "/cmake-build-"
+    "/.*build.*/"
+    "/build_description\\\\.cpp"
     "~"
     "\\\\.git/"
     "\\\\.idea"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,7 +544,49 @@ else()
     set(CPACK_SOURCE_GENERATOR "TGZ")
 endif(WIN32)
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "${ASSEMBLY_BASE_NAME}-source")
-set(CPACK_SOURCE_IGNORE_FILES "/docs/generated/;${CMAKE_SOURCE_DIR}/build/;~$;${CPACK_SOURCE_IGNORE_FILES};${CMAKE_SOURCE_DIR}/.git/;${CMAKE_SOURCE_DIR}/.idea/;${CMAKE_SOURCE_DIR}/cmake-build-debug/")
+set(CPACK_SOURCE_IGNORE_FILES
+    "/build/"
+    "/cmake-build-"
+    "~"
+    "\\\\.git/"
+    "\\\\.idea"
+    "\\\\.kdev4"
+    "\\\\.project"
+    "\\\\.vscode"
+    "\\\\.swp"
+    "thirdparty/uuid/tst_uuid"
+    "assemblies"
+    "CMakeCache\\\\.txt"
+    "CMakeFiles"
+    "CMakeScripts"
+    "cmake_install\\\\.cmake"
+    "install_manifest\\\\.txt"
+    "CTestTestfile\\\\.cmake"
+    "\\\\.o\\$"
+    "\\\\.a\\$"
+    "/docs/generated/"
+    "flowfile_checkpoint"
+    "flowfile_repository"
+    "content_repository"
+    "provenance_repository"
+    "corecomponentstate"
+    "thirdparty/apache-rat/apache-rat"
+    "compile_commands\\\\.json"
+    "/venv/"
+    "__pycache__"
+    "\\\\.pyc"
+    "/logs/"
+    "behavex_output"
+    "\\\\.device_id"
+    "\\\\.cache"
+    "\\\\.ccache"
+    "\\\\.cproject"
+    "\\\\.settings"
+    "profraw"
+    "bootstrap/option_state\\\\.json"
+    "docker/test-env-py3"
+    "\\\\.ropeproject"
+)
 
 # Generate binary assembly. Exclude conf for windows since we'll be doing the work in the WiX template
 if (NOT WIN32)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-2520

This helps to avoid including generated files in the source package. However, to be safe, it's best to run `make package_source` in a freshly checked out source tree, which does not contain generated files.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
