### PR TITLE
MINIFICPP-2508 Generate PARAMETER_PROVIDERS.md

### DIFF
--- a/PARAMETER_PROVIDERS.md
+++ b/PARAMETER_PROVIDERS.md
@@ -12,26 +12,28 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
 ## Table of Contents
 
 - [EnvironmentVariableParameterProvider](#EnvironmentVariableParameterProvider)
+
 
 ## EnvironmentVariableParameterProvider
 
 ### Description
 
-Fetches parameters from environment variables
+Fetches parameters from environment variables.
+
+This provider generates a single Parameter Context with the name specified in the `Parameter Group Name` property. The parameters generated match the name of the environment variables that are included.
 
 ### Properties
 
-In the list below, the names of required properties appear in bold. Any other properties (not in bold) are considered optional. The table also indicates any default values.
+In the list below, the names of required properties appear in bold. Any other properties (not in bold) are considered optional. The table also indicates any default values, and whether a property supports the NiFi Expression Language.
 
 | Name                                        | Default Value | Allowable Values                                       | Description                                                                                                                                                                               |
 |---------------------------------------------|---------------|--------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Sensitive Parameter Scope**               | none          | none<br/>all<br/>selected                              | Define which parameters are considered sensitive. If 'selected' is chosen, the 'Sensitive Parameter List' property must be set.                                                           |
+| Sensitive Parameter List                    |               |                                                        | List of sensitive parameters, if 'Sensitive Parameter Scope' is set to 'selected'.                                                                                                        |
 | **Environment Variable Inclusion Strategy** | Include All   | Include All<br/>Comma-Separated<br/>Regular Expression | Indicates how Environment Variables should be included                                                                                                                                    |
 | Include Environment Variables               |               |                                                        | Specifies comma separated environment variable names or regular expression (depending on the Environment Variable Inclusion Strategy) that should be used to fetch environment variables. |
 | **Parameter Group Name**                    |               |                                                        | The name of the parameter group that will be fetched. This indicates the name of the Parameter Context that may receive the fetched parameters.                                           |
-
-### Generated Parameter Contexts
-
-This provider generates a single Parameter Context with the name specified in the `Parameter Group Name` property. The parameters generated match the name of the environment variables that are included.

--- a/libminifi/include/core/ParameterProvider.h
+++ b/libminifi/include/core/ParameterProvider.h
@@ -57,7 +57,7 @@ class ParameterProvider : public ConfigurableComponentImpl, public CoreComponent
   ParameterProvider &operator=(const ParameterProvider &other) = delete;
 
   MINIFIAPI static constexpr auto SensitiveParameterScope = core::PropertyDefinitionBuilder<magic_enum::enum_count<SensitiveParameterScopeOptions>()>::createProperty("Sensitive Parameter Scope")
-      .withDescription("Define which parameters are considered sensitive, being either 'none', 'all' or 'selected'. If 'selected' is chosen, the 'Sensitive Parameter List' property must be set.")
+      .withDescription("Define which parameters are considered sensitive. If 'selected' is chosen, the 'Sensitive Parameter List' property must be set.")
       .isRequired(true)
       .withDefaultValue(magic_enum::enum_name(SensitiveParameterScopeOptions::none))
       .withAllowedValues(magic_enum::enum_names<SensitiveParameterScopeOptions>())

--- a/libminifi/include/parameter-providers/EnvironmentVariableParameterProvider.h
+++ b/libminifi/include/parameter-providers/EnvironmentVariableParameterProvider.h
@@ -52,7 +52,9 @@ class EnvironmentVariableParameterProvider final : public core::ParameterProvide
  public:
   using ParameterProvider::ParameterProvider;
 
-  MINIFIAPI static constexpr const char* Description = "Fetches parameters from environment variables";
+  MINIFIAPI static constexpr const char* Description = "Fetches parameters from environment variables.\n\n"
+          "This provider generates a single Parameter Context with the name specified in the `Parameter Group Name` property. "
+          "The parameters generated match the name of the environment variables that are included.";
 
   MINIFIAPI static constexpr auto EnvironmentVariableInclusionStrategy =
     core::PropertyDefinitionBuilder<magic_enum::enum_count<EnvironmentVariableInclusionStrategyOptions>()>::createProperty("Environment Variable Inclusion Strategy")
@@ -70,9 +72,11 @@ class EnvironmentVariableParameterProvider final : public core::ParameterProvide
       .isRequired(true)
       .build();
 
+  MINIFIAPI static constexpr auto Properties = minifi::utils::array_cat(core::ParameterProvider::Properties,
+          std::to_array<core::PropertyReference>({EnvironmentVariableInclusionStrategy, IncludeEnvironmentVariables, ParameterGroupName}));
+
   void initialize() override {
-    setSupportedProperties(minifi::utils::array_cat(core::ParameterProvider::Properties,
-      std::to_array<core::PropertyReference>({EnvironmentVariableInclusionStrategy, IncludeEnvironmentVariables, ParameterGroupName})));
+    setSupportedProperties(Properties);
   }
 
  private:

--- a/minifi-api/include/minifi-cpp/agent/agent_docs.h
+++ b/minifi-api/include/minifi-cpp/agent/agent_docs.h
@@ -52,10 +52,11 @@ struct ClassDescription {
 struct Components {
   std::vector<ClassDescription> processors_;
   std::vector<ClassDescription> controller_services_;
+  std::vector<ClassDescription> parameter_providers_;
   std::vector<ClassDescription> other_components_;
 
   [[nodiscard]] bool empty() const noexcept {
-    return processors_.empty() && controller_services_.empty() && other_components_.empty();
+    return processors_.empty() && controller_services_.empty() && parameter_providers_.empty() && other_components_.empty();
   }
 };
 

--- a/utils/include/agent/agent_docs.h
+++ b/utils/include/agent/agent_docs.h
@@ -80,6 +80,14 @@ void AgentDocs::createClassDescription(const std::string& group, const std::stri
         .class_properties_ = detail::toVector(Class::Properties),
         .supports_dynamic_properties_ = Class::SupportsDynamicProperties,
     });
+  } else if constexpr (Type == ResourceType::ParameterProvider) {
+    components.parameter_providers_.push_back(ClassDescription{
+        .type_ = Type,
+        .short_name_ = name,
+        .full_name_ = detail::classNameWithDots<Class>(),
+        .description_ = Class::Description,
+        .class_properties_ = detail::toVector(Class::Properties)
+    });
   } else if constexpr (Type == ResourceType::DescriptionOnly) {
     components.other_components_.push_back(ClassDescription{
         .type_ = Type,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-2508

`minifi --docs` now generates PARAMETER_PROVIDERS.md in the same way as CONTROLLERS.md and PROCESSORS.md.

Depends on #1895.
Will conflict with #1915.

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
