### PR TITLE
MINIFICPP-2533 Fix librdkafka compilation on Windows

### DIFF
--- a/cmake/Fetchlibrdkafka.cmake
+++ b/cmake/Fetchlibrdkafka.cmake
@@ -30,8 +30,11 @@ set(RDKAFKA_BUILD_EXAMPLES "OFF" CACHE STRING "" FORCE)
 set(RDKAFKA_BUILD_TESTS "OFF" CACHE STRING "" FORCE)
 set(LIBRDKAFKA_STATICLIB "1" CACHE STRING "" FORCE)
 
-set(PATCH_FILE "${CMAKE_SOURCE_DIR}/thirdparty/librdkafka/0001-remove-findLZ4-and-findZSTD.patch")
-set(PC "${Patch_EXECUTABLE}" -p1 -i "${PATCH_FILE}")
+set(PATCH_FILE_1 "${CMAKE_SOURCE_DIR}/thirdparty/librdkafka/0001-remove-findLZ4-and-findZSTD.patch")
+set(PATCH_FILE_2 "${CMAKE_SOURCE_DIR}/thirdparty/librdkafka/0002-undef-X509_NAME.patch")
+set(PC ${Bash_EXECUTABLE}  -c "set -x &&\
+        (\\\"${Patch_EXECUTABLE}\\\" -p1 -R -s -f --dry-run -i \\\"${PATCH_FILE_1}\\\" || \\\"${Patch_EXECUTABLE}\\\" -p1 -N -i \\\"${PATCH_FILE_1}\\\") &&\
+        (\\\"${Patch_EXECUTABLE}\\\" -p1 -R -s -f --dry-run -i \\\"${PATCH_FILE_2}\\\" || \\\"${Patch_EXECUTABLE}\\\" -p1 -N -i \\\"${PATCH_FILE_2}\\\")")
 
 FetchContent_Declare(libkafka
         URL https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.8.0.tar.gz

--- a/thirdparty/librdkafka/0002-undef-X509_NAME.patch
+++ b/thirdparty/librdkafka/0002-undef-X509_NAME.patch
@@ -1,0 +1,11 @@
+diff -rupN old/src/rdkafka_ssl.c new/src/rdkafka_ssl.c
+--- old/src/rdkafka_ssl.c	2025-03-14 11:17:53.053817600 +0100
++++ new/src/rdkafka_ssl.c	2025-03-14 11:18:42.118319700 +0100
+@@ -39,6 +39,7 @@
+ 
+ #ifdef _WIN32
+ #include <wincrypt.h>
++#undef X509_NAME
+ #pragma comment(lib, "crypt32.lib")
+ #pragma comment(lib, "libcrypto.lib")
+ #pragma comment(lib, "libssl.lib")


### PR DESCRIPTION
A new function in librdkafka 2.8.0 uses the symbol X509_NAME which is also defined as a macro in <wincrypt.h>. This patch undefines the macro after the #include of <wincrypt.h>.

https://issues.apache.org/jira/browse/MINIFICPP-2533

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
