### PR TITLE
MINIFICPP-2544 extend and fix FIPS docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -595,7 +595,7 @@ if (NOT WIN32)
         DESTINATION conf
         COMPONENT bin)
 
-    install(FILES fips/openssl.cnf
+    install(FILES fips/openssl.cnf fips/README.md
         DESTINATION fips
         COMPONENT bin)
 

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -61,6 +61,7 @@
   - [Disk space watchdog](#disk-space-watchdog)
   - [Extension configuration](#extension-configuration)
   - [Python processors](#python-processors)
+  - [Enabling FIPS support](#enabling-fips-support)
 - [Log configuration](#log-configuration)
   - [Log appenders](#log-appenders)
   - [Log levels](#log-levels)

--- a/fips/README.md
+++ b/fips/README.md
@@ -15,4 +15,4 @@
 
 # Apache NiFi - MiNiFi C++ - FIPS subdirectory
 
-The files in this directory are used if and only if FIPS support is enabled via the `nifi.openssl.fips.support.enable` property in minifi.properties. For more info about configuring FIPS support in MiNiFi C++, see the [FIPS section](../CONFIGURE.md#enabling-fips-support) in CONFIGURE.md.
+The files in this directory are used if and only if FIPS support is enabled via the `nifi.openssl.fips.support.enable` property in minifi.properties. By default, FIPS support is disabled. For more info about configuring FIPS support in MiNiFi C++, see the [FIPS section](../CONFIGURE.md#enabling-fips-support) in CONFIGURE.md.

--- a/fips/README.md
+++ b/fips/README.md
@@ -1,0 +1,18 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Apache NiFi - MiNiFi C++ - FIPS subdirectory
+
+The files in this directory are used if and only if FIPS support is enabled via the `nifi.openssl.fips.support.enable` property in minifi.properties. For more info about configuring FIPS support in MiNiFi C++, see the [FIPS section](../CONFIGURE.md#enabling-fips-support) in CONFIGURE.md.

--- a/minifi_main/Fips.cpp
+++ b/minifi_main/Fips.cpp
@@ -67,6 +67,7 @@ bool replaceMinifiHomeVariable(const std::filesystem::path& file_path, const std
 
 void initializeFipsMode(const std::shared_ptr<minifi::Configure>& configure, const std::filesystem::path& minifi_home, const std::shared_ptr<core::logging::Logger>& logger) {
   if (!(configure->get(minifi::Configure::nifi_openssl_fips_support_enable) | utils::andThen(utils::string::toBool)).value_or(false)) {
+    logger->log_info("FIPS mode is disabled. FIPS configs and modules will NOT be loaded.");
     return;
   }
 


### PR DESCRIPTION
Added a local README in the subdirectory, to prevent user confusion, especially with the binary package: If a user doesn't want FIPS modules, they might be surprised to see a `fips` subdirectory in their installation and go investigate. Adding a message and reassuring them that it's unused until they explicitly enable it could prevent user confusion and build goodwill.

------

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
