### PR TITLE
MINIFICPP-2483 Unify buffer sizes

### DIFF
--- a/conf/minifi.properties
+++ b/conf/minifi.properties
@@ -131,6 +131,9 @@ nifi.c2.full.heartbeat=false
 ## specify the destination of c2 directed assets
 #nifi.asset.directory=${MINIFI_HOME}/asset
 
+## You probably don't need to touch this, but you can if you want to
+# nifi.default.internal.buffer.size=4096
+
 # Publish metrics to external consumers
 # nifi.metrics.publisher.agent.identifier=
 # nifi.metrics.publisher.class=PrometheusMetricsPublisher

--- a/controller/Controller.cpp
+++ b/controller/Controller.cpp
@@ -26,6 +26,7 @@
 #include "asio/ssl/stream.hpp"
 #include "asio/connect.hpp"
 #include "core/logging/Logger.h"
+#include "utils/ConfigurationUtils.h"
 #include "utils/net/AsioSocketUtils.h"
 #include "utils/file/FileUtils.h"
 
@@ -255,7 +256,7 @@ nonstd::expected<void, std::string> getDebugBundle(const utils::net::SocketData&
   }
 
   std::ofstream out_file(target_dir / "debug.tar.gz");
-  const size_t BUFFER_SIZE = 4096;
+  static constexpr auto BUFFER_SIZE = utils::configuration::DEFAULT_BUFFER_SIZE;
   std::array<char, BUFFER_SIZE> out_buffer{};
   while (bundle_size > 0) {
     const auto next_read_size = (std::min)(bundle_size, BUFFER_SIZE);

--- a/encrypt-config/tests/ConfigFileEncryptorTests.cpp
+++ b/encrypt-config/tests/ConfigFileEncryptorTests.cpp
@@ -74,10 +74,10 @@ TEST_CASE("ConfigFileEncryptor can encrypt the sensitive properties", "[encrypt-
     ConfigFile test_file{std::ifstream{"resources/minifi.properties"}};
     std::string original_password = test_file.getValue(Configuration::nifi_rest_api_password).value();
 
-    uint32_t num_properties_encrypted = encryptSensitivePropertiesInFile(test_file, KEY);
+    uint32_t initial_num_properties_encrypted = encryptSensitivePropertiesInFile(test_file, KEY);
 
-    REQUIRE(num_properties_encrypted == 1);
-    REQUIRE(test_file.size() == 104);
+    REQUIRE(initial_num_properties_encrypted == 1);
+    REQUIRE(test_file.size() == 110);
     REQUIRE(check_encryption(test_file, Configuration::nifi_rest_api_password, original_password.length()));
 
     SECTION("calling encryptSensitiveValuesInMinifiProperties a second time does nothing") {

--- a/encrypt-config/tests/ConfigFileTests.cpp
+++ b/encrypt-config/tests/ConfigFileTests.cpp
@@ -90,7 +90,7 @@ TEST_CASE("ConfigFile creates an empty object from a nonexistent file", "[encryp
 
 TEST_CASE("ConfigFile can parse a simple config file", "[encrypt-config][constructor]") {
   ConfigFile test_file{std::ifstream{"resources/minifi.properties"}};
-  REQUIRE(test_file.size() == 103);
+  REQUIRE(test_file.size() == 109);
 }
 
 TEST_CASE("ConfigFile can test whether a key is present", "[encrypt-config][hasValue]") {
@@ -143,7 +143,7 @@ TEST_CASE("ConfigFile can add a new setting after an existing setting", "[encryp
 
   SECTION("valid key") {
     test_file.insertAfter(Configuration::nifi_rest_api_password, "nifi.rest.api.password.protected", "my-cipher-name");
-    REQUIRE(test_file.size() == 104);
+    REQUIRE(test_file.size() == 110);
     REQUIRE(test_file.getValue("nifi.rest.api.password.protected") == "my-cipher-name");
   }
 
@@ -158,7 +158,7 @@ TEST_CASE("ConfigFile can add a new setting at the end", "[encrypt-config][appen
   const std::string KEY = "nifi.bootstrap.sensitive.key";
   const std::string VALUE = "aa411f289c91685ef9d5a9e5a4fad9393ff4c7a78ab978484323488caed7a9ab";
   test_file.append(KEY, VALUE);
-  REQUIRE(test_file.size() == 104);
+  REQUIRE(test_file.size() == 110);
   REQUIRE(test_file.getValue(KEY) == std::make_optional(VALUE));
 }
 

--- a/encrypt-config/tests/resources/minifi.properties
+++ b/encrypt-config/tests/resources/minifi.properties
@@ -83,6 +83,12 @@ nifi.c2.agent.identifier=EncryptConfigTester-001
 #controller.socket.local.any.interface=false
 #controller.ssl.context.service=SSLContextService
 
+## specify the destination of c2 directed assets
+#nifi.asset.directory=${MINIFI_HOME}/asset
+
+## You probably don't need to touch this, but you can if you want to
+# nifi.default.internal.buffer.size=4096
+
 # must be comma separated
 nifi.c2.flow.id=
 nifi.c2.flow.url=

--- a/extension-utils/include/utils/file/FileReaderCallback.h
+++ b/extension-utils/include/utils/file/FileReaderCallback.h
@@ -32,11 +32,12 @@ namespace org::apache::nifi::minifi::utils {
  */
 class FileReaderCallback {
  public:
-  explicit FileReaderCallback(std::filesystem::path file_path);
+  explicit FileReaderCallback(std::filesystem::path file_path, size_t buffer_size);
   int64_t operator()(const std::shared_ptr<io::OutputStream>& output_stream) const;
 
  private:
   std::filesystem::path file_path_;
+  size_t buffer_size_;
   std::shared_ptr<core::logging::Logger> logger_;
 };
 

--- a/extensions/aws/s3/S3Wrapper.cpp
+++ b/extensions/aws/s3/S3Wrapper.cpp
@@ -74,7 +74,7 @@ std::shared_ptr<Aws::StringStream> S3Wrapper::readFlowFileStream(const std::shar
   auto data_stream = std::make_shared<Aws::StringStream>();
   uint64_t read_size = 0;
   while (read_size < read_limit) {
-    const auto next_read_size = (std::min)(read_limit - read_size, BUFFER_SIZE);
+    const auto next_read_size = (std::min)(read_limit - read_size, uint64_t{BUFFER_SIZE});
     const auto read_ret = stream->read(std::span(buffer).subspan(0, next_read_size));
     if (io::isError(read_ret)) {
       throw StreamReadException("Reading flow file inputstream failed!");
@@ -229,11 +229,11 @@ bool S3Wrapper::deleteObject(const DeleteObjectRequestParameters& params) {
 }
 
 int64_t S3Wrapper::writeFetchedBody(Aws::IOStream& source, const int64_t data_size, io::OutputStream& output) {
-  std::vector<uint8_t> buffer(4096);
+  std::vector<uint8_t> buffer(BUFFER_SIZE);
   size_t write_size = 0;
   if (data_size < 0) return 0;
   while (write_size < gsl::narrow<uint64_t>(data_size)) {
-    const auto next_write_size = (std::min)(gsl::narrow<size_t>(data_size) - write_size, size_t{4096});
+    const auto next_write_size = (std::min)(gsl::narrow<size_t>(data_size) - write_size, BUFFER_SIZE);
     if (!source.read(reinterpret_cast<char*>(buffer.data()), gsl::narrow<std::streamsize>(next_write_size))) {
       return -1;
     }

--- a/extensions/aws/s3/S3Wrapper.h
+++ b/extensions/aws/s3/S3Wrapper.h
@@ -37,6 +37,7 @@
 #include "core/logging/Logger.h"
 #include "core/logging/LoggerFactory.h"
 #include "utils/AWSInitializer.h"
+#include "utils/ConfigurationUtils.h"
 #include "utils/OptionalUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/ListingStateManager.h"
@@ -249,7 +250,7 @@ class StreamReadException : public Exception {
 
 class S3Wrapper {
  public:
-  static constexpr uint64_t BUFFER_SIZE = 4_KiB;
+  static constexpr auto BUFFER_SIZE = minifi::utils::configuration::DEFAULT_BUFFER_SIZE;
 
   S3Wrapper();
   explicit S3Wrapper(std::unique_ptr<S3RequestSender>&& request_sender);

--- a/extensions/execute-process/ExecuteProcess.h
+++ b/extensions/execute-process/ExecuteProcess.h
@@ -122,6 +122,7 @@ class ExecuteProcess final : public core::ProcessorImpl {
   std::string full_command_;
   int pipefd_[2]{};
   pid_t pid_{};
+  size_t buffer_size_{};
 };
 
 }  // namespace org::apache::nifi::minifi::processors

--- a/extensions/libarchive/ReadArchiveStream.h
+++ b/extensions/libarchive/ReadArchiveStream.h
@@ -25,10 +25,10 @@
 #include "io/ArchiveStream.h"
 #include "io/InputStream.h"
 #include "core/logging/LoggerFactory.h"
-
 #include "archive_entry.h"
 #include "archive.h"
 #include "SmartArchivePtrs.h"
+#include "utils/ConfigurationUtils.h"
 
 namespace org::apache::nifi::minifi::io {
 
@@ -47,7 +47,7 @@ class ReadArchiveStreamImpl final : public InputStreamImpl, public ReadArchiveSt
 
    private:
     std::shared_ptr<InputStream> input_;
-    std::array<std::byte, 4096> buffer_{};
+    std::array<std::byte, utils::configuration::DEFAULT_BUFFER_SIZE> buffer_{};
   };
 
   processors::archive_read_unique_ptr createReadArchive();

--- a/extensions/libarchive/UnfocusArchiveEntry.cpp
+++ b/extensions/libarchive/UnfocusArchiveEntry.cpp
@@ -30,7 +30,12 @@
 #include "core/ProcessContext.h"
 #include "core/ProcessSession.h"
 #include "core/Resource.h"
+#include "utils/ConfigurationUtils.h"
 #include "utils/gsl.h"
+
+namespace {
+inline constexpr auto BUFFER_SIZE = org::apache::nifi::minifi::utils::configuration::DEFAULT_BUFFER_SIZE;
+}  // namespace
 
 namespace org::apache::nifi::minifi::processors {
 
@@ -157,7 +162,7 @@ int64_t UnfocusArchiveEntry::WriteCallback::operator()(const std::shared_ptr<io:
   archive_write_open(output_archive.get(), &data, ok_cb, write_cb, ok_cb);
 
   // Iterate entries & write from tmp file to archive
-  std::array<char, 8192> buf{};
+  std::array<char, BUFFER_SIZE> buf{};
   struct stat st{};
   auto entry = archive_entry_unique_ptr{archive_entry_new()};
 

--- a/extensions/rocksdb-repos/tests/ContentSessionTests.cpp
+++ b/extensions/rocksdb-repos/tests/ContentSessionTests.cpp
@@ -28,7 +28,7 @@
 #include "FlowFileRecord.h"
 #include "unit/TestBase.h"
 #include "unit/Catch.h"
-#include "utils/gsl.h"
+#include "utils/ConfigurationUtils.h"
 
 template<typename ContentRepositoryClass>
 class ContentSessionController : public TestController {
@@ -61,7 +61,7 @@ const std::shared_ptr<minifi::io::OutputStream>& operator<<(const std::shared_pt
 
 const std::shared_ptr<minifi::io::InputStream>& operator>>(const std::shared_ptr<minifi::io::InputStream>& stream, std::string& str) {
   str = "";
-  std::array<std::byte, 4096> buffer{};
+  std::array<std::byte, utils::configuration::DEFAULT_BUFFER_SIZE> buffer{};
   while (true) {
     const auto ret = stream->read(buffer);
     REQUIRE_FALSE(minifi::io::isError(ret));

--- a/extensions/sftp/client/SFTPClient.cpp
+++ b/extensions/sftp/client/SFTPClient.cpp
@@ -16,7 +16,6 @@
  */
 #include "SFTPClient.h"
 #include <algorithm>
-#include <array>
 #include <exception>
 #include <memory>
 #include <optional>

--- a/extensions/sftp/client/SFTPClient.cpp
+++ b/extensions/sftp/client/SFTPClient.cpp
@@ -1,5 +1,4 @@
 /**
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -17,6 +16,7 @@
  */
 #include "SFTPClient.h"
 #include <algorithm>
+#include <array>
 #include <exception>
 #include <memory>
 #include <optional>
@@ -24,9 +24,9 @@
 #include <sstream>
 #include <string>
 #include <tuple>
-#include <utility>
 #include <vector>
 
+#include "utils/ConfigurationUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/gsl.h"
 #include "minifi-cpp/io/OutputStream.h"
@@ -719,8 +719,8 @@ bool SFTPClient::listDirectory(const std::string& path, bool follow_symlinks,
   });
 
   LIBSSH2_SFTP_ATTRIBUTES attrs;
-  std::vector<char> filename(4096U);
-  std::vector<char> longentry(4096U);
+  std::array<char, utils::configuration::DEFAULT_BUFFER_SIZE> filename{};
+  std::array<char, utils::configuration::DEFAULT_BUFFER_SIZE> longentry{};
   do {
     int ret = libssh2_sftp_readdir_ex(dir_handle,
                                       filename.data(),

--- a/extensions/sftp/client/SFTPClient.h
+++ b/extensions/sftp/client/SFTPClient.h
@@ -111,7 +111,7 @@ class LastSFTPError {
 
 class SFTPClient {
  public:
-  SFTPClient(std::string hostname, uint16_t port, std::string username);
+  SFTPClient(std::string hostname, uint16_t port, std::string username, size_t buffer_size);
 
   ~SFTPClient();
 
@@ -196,9 +196,10 @@ class SFTPClient {
 
   std::shared_ptr<core::logging::Logger> logger_;
 
-  const std::string hostname_;
-  const uint16_t port_;
-  const std::string username_;
+  std::string hostname_;
+  uint16_t port_;
+  std::string username_;
+  size_t buffer_size_;
 
   LIBSSH2_KNOWNHOSTS *ssh_known_hosts_ = nullptr;
   bool strict_host_checking_ = false;

--- a/extensions/sftp/processors/FetchSFTP.cpp
+++ b/extensions/sftp/processors/FetchSFTP.cpp
@@ -27,6 +27,7 @@
 #include "core/Relationship.h"
 #include "core/Resource.h"
 #include "io/BufferStream.h"
+#include "utils/ConfigurationUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/file/FileUtils.h"
 #include "utils/ProcessorConfigUtils.h"
@@ -89,11 +90,13 @@ void FetchSFTP::onTrigger(core::ProcessContext& context, core::ProcessSession& s
                                                                       common_properties.proxy_host,
                                                                       common_properties.proxy_port,
                                                                       common_properties.proxy_username};
+  const auto buffer_size = utils::configuration::getBufferSize(*context.getConfiguration());
   auto client = getOrCreateConnection(connection_cache_key,
                                       common_properties.password,
                                       common_properties.private_key_path,
                                       common_properties.private_key_passphrase,
-                                      common_properties.proxy_password);
+                                      common_properties.proxy_password,
+                                      buffer_size);
   if (client == nullptr) {
     context.yield();
     return;

--- a/extensions/sftp/processors/ListSFTP.cpp
+++ b/extensions/sftp/processors/ListSFTP.cpp
@@ -36,6 +36,7 @@
 #include "core/Resource.h"
 #include "io/BufferStream.h"
 #include "rapidjson/ostreamwrapper.h"
+#include "utils/ConfigurationUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/TimeUtil.h"
 #include "utils/file/FileUtils.h"
@@ -821,11 +822,13 @@ void ListSFTP::onTrigger(core::ProcessContext& context, core::ProcessSession& se
                                                                       common_properties.proxy_host,
                                                                       common_properties.proxy_port,
                                                                       common_properties.proxy_username};
+  const auto buffer_size = utils::configuration::getBufferSize(*context.getConfiguration());
   auto client = getOrCreateConnection(connection_cache_key,
                                       common_properties.password,
                                       common_properties.private_key_path,
                                       common_properties.private_key_passphrase,
-                                      common_properties.proxy_password);
+                                      common_properties.proxy_password,
+                                      buffer_size);
   if (client == nullptr) {
     context.yield();
     return;

--- a/extensions/sftp/processors/PutSFTP.cpp
+++ b/extensions/sftp/processors/PutSFTP.cpp
@@ -28,6 +28,7 @@
 #include "core/Resource.h"
 #include "core/logging/Logger.h"
 #include "io/BufferStream.h"
+#include "utils/ConfigurationUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/file/FileUtils.h"
 #include "utils/ProcessorConfigUtils.h"
@@ -120,11 +121,13 @@ bool PutSFTP::processOne(core::ProcessContext& context, core::ProcessSession& se
                                                                       common_properties.proxy_host,
                                                                       common_properties.proxy_port,
                                                                       common_properties.proxy_username};
+  const auto buffer_size = utils::configuration::getBufferSize(*context.getConfiguration());
   auto client = getOrCreateConnection(connection_cache_key,
                                       common_properties.password,
                                       common_properties.private_key_path,
                                       common_properties.private_key_passphrase,
-                                      common_properties.proxy_password);
+                                      common_properties.proxy_password,
+                                      buffer_size);
   if (client == nullptr) {
     context.yield();
     return false;

--- a/extensions/sftp/processors/SFTPProcessorBase.cpp
+++ b/extensions/sftp/processors/SFTPProcessorBase.cpp
@@ -237,12 +237,14 @@ std::unique_ptr<utils::SFTPClient> SFTPProcessorBase::getOrCreateConnection(
     const std::string& password,
     const std::string& private_key_path,
     const std::string& private_key_passphrase,
-    const std::string& proxy_password) {
+    const std::string& proxy_password,
+    const size_t buffer_size) {
   auto client = getConnectionFromCache(connection_cache_key);
   if (client == nullptr) {
     client = std::make_unique<utils::SFTPClient>(connection_cache_key.hostname,
                                                  connection_cache_key.port,
-                                                 connection_cache_key.username);
+                                                 connection_cache_key.username,
+                                                 buffer_size);
     if (!IsNullOrEmpty(host_key_file_)) {
       if (!client->setHostKeyFile(host_key_file_, strict_host_checking_)) {
         logger_->log_error("Cannot set host key file");

--- a/extensions/sftp/processors/SFTPProcessorBase.h
+++ b/extensions/sftp/processors/SFTPProcessorBase.h
@@ -217,7 +217,8 @@ class SFTPProcessorBase : public core::ProcessorImpl {
       const std::string& password,
       const std::string& private_key_path,
       const std::string& private_key_passphrase,
-      const std::string& proxy_password);
+      const std::string& proxy_password,
+      size_t buffer_size);
 
   enum class CreateDirectoryHierarchyError : uint8_t {
     CREATE_DIRECTORY_HIERARCHY_ERROR_OK = 0,

--- a/extensions/smb/FetchSmb.h
+++ b/extensions/smb/FetchSmb.h
@@ -83,6 +83,7 @@ class FetchSmb final : public core::ProcessorImpl {
 
  private:
   std::shared_ptr<SmbConnectionControllerService> smb_connection_controller_service_;
+  size_t buffer_size_{};
   std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<FetchSmb>::getLogger(uuid_);
 };
 

--- a/extensions/standard-processors/processors/ExtractText.h
+++ b/extensions/standard-processors/processors/ExtractText.h
@@ -110,12 +110,12 @@ class ExtractText : public core::ProcessorImpl {
 
   class ReadCallback {
    public:
-    ReadCallback(std::shared_ptr<core::FlowFile> flowFile, core::ProcessContext *ct, std::shared_ptr<core::logging::Logger> lgr);
+    ReadCallback(std::shared_ptr<core::FlowFile> flowFile, core::ProcessContext& ctx, std::shared_ptr<core::logging::Logger> lgr);
     int64_t operator()(const std::shared_ptr<io::InputStream>& stream) const;
 
    private:
     std::shared_ptr<core::FlowFile> flowFile_;
-    core::ProcessContext *ctx_;
+    gsl::not_null<core::ProcessContext*> ctx_;
     std::shared_ptr<core::logging::Logger> logger_;
   };
 

--- a/extensions/standard-processors/processors/FetchFile.h
+++ b/extensions/standard-processors/processors/FetchFile.h
@@ -176,6 +176,7 @@ class FetchFile final : public core::ProcessorImpl {
   fetch_file::MoveConflictStrategyOption move_conflict_strategy_{};
   utils::LogUtils::LogLevelOption log_level_when_file_not_found_{};
   utils::LogUtils::LogLevelOption log_level_when_permission_denied_{};
+  size_t buffer_size_{};
   std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<FetchFile>::getLogger(uuid_);
 };
 

--- a/extensions/standard-processors/processors/GetFile.h
+++ b/extensions/standard-processors/processors/GetFile.h
@@ -195,6 +195,7 @@ class GetFile : public core::ProcessorImpl {
   std::queue<std::filesystem::path> directory_listing_;
   mutable std::mutex directory_listing_mutex_;
   std::atomic<std::chrono::time_point<std::chrono::system_clock>> last_listing_time_{};
+  size_t buffer_size_{};
   std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<GetFile>::getLogger(uuid_);
 };
 

--- a/extensions/standard-processors/processors/SegmentContent.h
+++ b/extensions/standard-processors/processors/SegmentContent.h
@@ -73,6 +73,7 @@ class SegmentContent final : public core::ProcessorImpl {
   void initialize() override;
 
  private:
+  size_t buffer_size_{};
   std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<SegmentContent>::getLogger(uuid_);
 };
 

--- a/extensions/standard-processors/processors/SplitContent.h
+++ b/extensions/standard-processors/processors/SplitContent.h
@@ -96,8 +96,6 @@ class SplitContent final : public core::ProcessorImpl {
   EXTENSIONAPI static constexpr bool IsSingleThreaded = true;
   ADD_COMMON_VIRTUAL_FUNCTIONS_FOR_PROCESSORS
 
-  static constexpr size_type BUFFER_TARGET_SIZE = 4096;
-
   void onSchedule(core::ProcessContext& context, core::ProcessSessionFactory& session_factory) override;
   void onTrigger(core::ProcessContext& context, core::ProcessSession& session) override;
   void initialize() override;
@@ -124,6 +122,7 @@ class SplitContent final : public core::ProcessorImpl {
   std::optional<ByteSequenceMatcher> byte_sequence_matcher_;
   bool keep_byte_sequence = false;
   ByteSequenceLocation byte_sequence_location_ = ByteSequenceLocation::Trailing;
+  size_t buffer_size_{};
   std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<SplitContent>::getLogger(uuid_);
 };
 

--- a/extensions/standard-processors/processors/SplitText.h
+++ b/extensions/standard-processors/processors/SplitText.h
@@ -45,8 +45,6 @@ struct SplitTextConfiguration {
 
 namespace detail {
 
-inline constexpr size_t SPLIT_TEXT_BUFFER_SIZE = 8192;
-
 enum class StreamReadState {
   Ok,
   StreamReadError,
@@ -64,9 +62,9 @@ class LineReader {
     bool operator==(const LineInfo& line_info) const = default;
   };
 
-  explicit LineReader(const std::shared_ptr<io::InputStream>& stream);
+  explicit LineReader(const std::shared_ptr<io::InputStream>& stream, size_t buffer_size);
   std::optional<LineInfo> readNextLine(const std::optional<std::string>& starts_with = std::nullopt);
-  StreamReadState getState() const { return state_; }
+  [[nodiscard]] StreamReadState getState() const { return state_; }
 
  private:
   uint8_t getEndLineSize(size_t newline_position);
@@ -78,8 +76,9 @@ class LineReader {
   uint64_t current_buffer_count_ = 0;
   size_t last_read_size_ = 0;
   uint64_t read_size_ = 0;
-  std::array<char, SPLIT_TEXT_BUFFER_SIZE> buffer_{};
   std::shared_ptr<io::InputStream> stream_;
+  size_t buffer_size_;
+  std::vector<char> buffer_ = std::vector<char>(buffer_size_);
   std::optional<LineInfo> last_line_info_;
   StreamReadState state_ = StreamReadState::Ok;
 };
@@ -174,6 +173,7 @@ class SplitText : public core::ProcessorImpl {
 
  private:
   SplitTextConfiguration split_text_config_;
+  size_t buffer_size_{};
   std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<SplitText>::getLogger(uuid_);
 };
 

--- a/extensions/standard-processors/processors/TailFile.h
+++ b/extensions/standard-processors/processors/TailFile.h
@@ -283,6 +283,7 @@ class TailFile : public core::ProcessorImpl {
   controllers::AttributeProviderService* attribute_provider_service_ = nullptr;
   std::unordered_map<std::string, controllers::AttributeProviderService::AttributeMap> extra_attributes_;
   std::optional<uint32_t> batch_size_;
+  size_t buffer_size_{};
   std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<TailFile>::getLogger(uuid_);
 };
 

--- a/extensions/standard-processors/tests/unit/SplitContentTests.cpp
+++ b/extensions/standard-processors/tests/unit/SplitContentTests.cpp
@@ -22,6 +22,7 @@
 #include "unit/Catch.h"
 #include "unit/SingleProcessorTestController.h"
 #include "unit/TestBase.h"
+#include "utils/ConfigurationUtils.h"
 
 namespace org::apache::nifi::minifi::processors::test {
 
@@ -418,7 +419,8 @@ TEST_CASE("ByteSequenceAtBufferTargetSize") {
   minifi::test::SingleProcessorTestController controller{std::make_unique<SplitContent>("SplitContent")};
   const auto split_content = controller.getProcessor();
 
-  auto x = SplitContent::BUFFER_TARGET_SIZE-10;
+  static_assert(utils::configuration::DEFAULT_BUFFER_SIZE >= 10);
+  auto x = utils::configuration::DEFAULT_BUFFER_SIZE - 10;
 
   auto [pre_fix_size, separator_size, post_fix_size] = GENERATE_COPY(
     std::make_tuple(x, x, x),

--- a/libminifi/include/core/logging/LoggerBase.h
+++ b/libminifi/include/core/logging/LoggerBase.h
@@ -30,6 +30,7 @@
 #include "spdlog/common.h"
 #include "spdlog/logger.h"
 #include "utils/gsl.h"
+#include "utils/ConfigurationUtils.h"
 #include "utils/Enum.h"
 #include "utils/GeneralUtils.h"
 #include "fmt/chrono.h"
@@ -39,7 +40,7 @@
 
 namespace org::apache::nifi::minifi::core::logging {
 
-inline constexpr size_t LOG_BUFFER_SIZE = 4096;
+inline constexpr size_t LOG_BUFFER_SIZE = utils::configuration::DEFAULT_BUFFER_SIZE;
 
 class LoggerControl {
  public:

--- a/libminifi/src/Configuration.cpp
+++ b/libminifi/src/Configuration.cpp
@@ -51,6 +51,7 @@ const std::unordered_map<std::string_view, gsl::not_null<const core::PropertyVal
   {Configuration::nifi_provenance_repository_directory_default, gsl::make_not_null(&core::StandardPropertyValidators::ALWAYS_VALID_VALIDATOR)},
   {Configuration::nifi_flowfile_repository_directory_default, gsl::make_not_null(&core::StandardPropertyValidators::ALWAYS_VALID_VALIDATOR)},
   {Configuration::nifi_dbcontent_repository_directory_default, gsl::make_not_null(&core::StandardPropertyValidators::ALWAYS_VALID_VALIDATOR)},
+  {Configuration::nifi_default_internal_buffer_size, gsl::make_not_null(&core::StandardPropertyValidators::ALWAYS_VALID_VALIDATOR)},
   {Configuration::nifi_flowfile_repository_rocksdb_compaction_period, gsl::make_not_null(&core::StandardPropertyValidators::TIME_PERIOD_VALIDATOR)},
   {Configuration::nifi_dbcontent_repository_rocksdb_compaction_period, gsl::make_not_null(&core::StandardPropertyValidators::TIME_PERIOD_VALIDATOR)},
   {Configuration::nifi_content_repository_rocksdb_use_synchronous_writes, gsl::make_not_null(&core::StandardPropertyValidators::BOOLEAN_VALIDATOR)},

--- a/libminifi/src/Configure.cpp
+++ b/libminifi/src/Configure.cpp
@@ -135,8 +135,8 @@ bool ConfigureImpl::commitChanges() {
   return success;
 }
 
-std::shared_ptr<Configure> Configure::create() {
-  return std::make_shared<ConfigureImpl>();
+gsl::not_null<std::shared_ptr<Configure>> Configure::create() {
+  return gsl::make_not_null<std::shared_ptr<Configure>>(std::make_shared<ConfigureImpl>());
 }
 
 }  // namespace org::apache::nifi::minifi

--- a/libminifi/src/c2/ControllerSocketProtocol.cpp
+++ b/libminifi/src/c2/ControllerSocketProtocol.cpp
@@ -30,6 +30,7 @@
 #include "io/AsioStream.h"
 #include "asio/ssl/stream.hpp"
 #include "asio/detached.hpp"
+#include "utils/ConfigurationUtils.h"
 #include "utils/net/AsioSocketUtils.h"
 #include "c2/C2Utils.h"
 
@@ -396,7 +397,7 @@ void ControllerSocketProtocol::writeDebugBundleResponse(io::BaseStream &stream) 
 
   size_t bundle_size = bundle.value()->size();
   resp.write(bundle_size);
-  const size_t BUFFER_SIZE = 4096;
+  static constexpr auto BUFFER_SIZE = utils::configuration::DEFAULT_BUFFER_SIZE;
   std::array<std::byte, BUFFER_SIZE> out_buffer{};
   while (bundle_size > 0) {
     const auto next_write_size = (std::min)(bundle_size, BUFFER_SIZE);

--- a/libminifi/test/unit/ConfigurationUtilsTests.cpp
+++ b/libminifi/test/unit/ConfigurationUtilsTests.cpp
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "unit/Catch.h"
+#include "unit/TestBase.h"
+#include "properties/Configure.h"
+#include "utils/ConfigurationUtils.h"
+
+TEST_CASE("getBufferSize() returns the default buffer size by default", "[utils::configuration]") {
+  minifi::ConfigureImpl configuration;
+  CHECK(minifi::utils::configuration::getBufferSize(configuration) == minifi::utils::configuration::DEFAULT_BUFFER_SIZE);
+}
+
+TEST_CASE("getBufferSize() returns the configured buffer size if it exists", "[utils::configuration]") {
+  minifi::ConfigureImpl configuration;
+  configuration.set(minifi::Configure::nifi_default_internal_buffer_size, "12345");
+  CHECK(minifi::utils::configuration::getBufferSize(configuration) == 12345);
+}
+
+TEST_CASE("getBufferSize() throws if an invalid buffer size is set in the configuration", "[utils::configuration]") {
+  minifi::ConfigureImpl configuration;
+  configuration.set(minifi::Configure::nifi_default_internal_buffer_size, "as large as possible");
+  CHECK_THROWS(minifi::utils::configuration::getBufferSize(configuration));
+}

--- a/minifi-api/include/minifi-cpp/core/ProcessContext.h
+++ b/minifi-api/include/minifi-cpp/core/ProcessContext.h
@@ -67,7 +67,7 @@ class ProcessContext : public virtual core::VariableRegistry, public virtual uti
 
   virtual StateManager* getStateManager() = 0;
   virtual bool hasStateManager() const = 0;
-  virtual std::shared_ptr<Configure> getConfiguration() const = 0;
+  virtual gsl::not_null<Configure*> getConfiguration() const = 0;
 };
 
 }  // namespace org::apache::nifi::minifi::core

--- a/minifi-api/include/minifi-cpp/properties/Configuration.h
+++ b/minifi-api/include/minifi-cpp/properties/Configuration.h
@@ -41,8 +41,6 @@ class Configuration : public virtual Properties {
   static constexpr const char *nifi_content_repository_rocksdb_options = "nifi.content.repository.rocksdb.options.";
   static constexpr const char *nifi_provenance_repository_rocksdb_options = "nifi.provenance.repository.rocksdb.options.";
   static constexpr const char *nifi_state_storage_rocksdb_options = "nifi.state.storage.rocksdb.options.";
-
-  // nifi.flow.configuration.file
   static constexpr const char *nifi_default_directory = "nifi.default.directory";
   static constexpr const char *nifi_flow_configuration_file = "nifi.flow.configuration.file";
   static constexpr const char *nifi_flow_configuration_encrypt = "nifi.flow.configuration.encrypt";
@@ -72,6 +70,7 @@ class Configuration : public virtual Properties {
   static constexpr const char *nifi_provenance_repository_directory_default = "nifi.provenance.repository.directory.default";
   static constexpr const char *nifi_flowfile_repository_directory_default = "nifi.flowfile.repository.directory.default";
   static constexpr const char *nifi_dbcontent_repository_directory_default = "nifi.database.content.repository.directory.default";
+  static constexpr const char *nifi_default_internal_buffer_size = "nifi.default.internal.buffer.size";
 
   // these are internal properties related to the rocksdb backend
   static constexpr const char *nifi_flowfile_repository_rocksdb_compaction_period = "nifi.flowfile.repository.rocksdb.compaction.period";

--- a/minifi-api/include/minifi-cpp/properties/Configure.h
+++ b/minifi-api/include/minifi-cpp/properties/Configure.h
@@ -23,6 +23,7 @@
 
 #include "Configuration.h"
 #include "minifi-cpp/core/AgentIdentificationProvider.h"
+#include "utils/gsl.h"
 
 struct ConfigTestAccessor;
 
@@ -40,10 +41,10 @@ class Configure : public virtual Configuration, public virtual core::AgentIdenti
   virtual void setFallbackAgentIdentifier(const std::string& id) = 0;
 
   using Configuration::set;
-  virtual void set(const std::string& key, const std::string& value, PropertyChangeLifetime lifetime) override = 0;
-  virtual bool commitChanges() override = 0;
+  void set(const std::string& key, const std::string& value, PropertyChangeLifetime lifetime) override = 0;
+  bool commitChanges() override = 0;
 
-  static std::shared_ptr<Configure> create();
+  static gsl::not_null<std::shared_ptr<Configure>> create();
 };
 
 }  // namespace org::apache::nifi::minifi

--- a/utils/include/io/StreamPipe.h
+++ b/utils/include/io/StreamPipe.h
@@ -26,13 +26,14 @@
 #include "InputStream.h"
 #include "OutputStream.h"
 #include "minifi-cpp/io/StreamCallback.h"
+#include "utils/ConfigurationUtils.h"
 
 namespace org::apache::nifi::minifi {
 namespace internal {
 
 inline int64_t pipe(io::InputStream& src, io::OutputStream& dst) {
-  std::array<std::byte, 4096> buffer{};
-  int64_t totalTransferred = 0;
+  std::array<std::byte, utils::configuration::DEFAULT_BUFFER_SIZE> buffer{};
+  size_t totalTransferred = 0;
   while (true) {
     const auto readRet = src.read(buffer);
     if (io::isError(readRet)) return -1;
@@ -54,7 +55,7 @@ inline int64_t pipe(io::InputStream& src, io::OutputStream& dst) {
     }
     totalTransferred += transferred;
   }
-  return totalTransferred;
+  return gsl::narrow<int64_t>(totalTransferred);
 }
 
 }  // namespace internal

--- a/utils/include/utils/ConfigurationUtils.h
+++ b/utils/include/utils/ConfigurationUtils.h
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+
+namespace org::apache::nifi::minifi {
+
+class Configure;
+
+namespace utils::configuration {
+
+inline constexpr size_t DEFAULT_BUFFER_SIZE = 4096;
+size_t getBufferSize(const Configure& configuration);
+
+}  // namespace utils::configuration
+}  // namespace org::apache::nifi::minifi

--- a/utils/src/utils/ConfigurationUtils.cpp
+++ b/utils/src/utils/ConfigurationUtils.cpp
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "utils/ConfigurationUtils.h"
+
+#include "minifi-cpp/properties/Configure.h"
+#include "utils/ParsingUtils.h"
+
+namespace org::apache::nifi::minifi::utils::configuration {
+
+size_t getBufferSize(const Configure& configuration) {
+  if (const auto buffer_size = configuration.get(Configure::nifi_default_internal_buffer_size); buffer_size && !buffer_size->empty()) {
+    return parsing::parseIntegral<size_t>(*buffer_size) | utils::orThrow(fmt::format("Invalid value '{}' for {}", *buffer_size, Configure::nifi_default_internal_buffer_size));
+  } else {
+    return DEFAULT_BUFFER_SIZE;
+  }
+}
+
+}  // namespace org::apache::nifi::minifi::utils::configuration

--- a/utils/src/utils/file/FileUtils.cpp
+++ b/utils/src/utils/file/FileUtils.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <iostream>
 
+#include "utils/ConfigurationUtils.h"
 #include "utils/Literals.h"
 #include "utils/Searcher.h"
 
@@ -32,8 +33,8 @@
 namespace org::apache::nifi::minifi::utils::file {
 
 uint64_t computeChecksum(const std::filesystem::path& file_name, uint64_t up_to_position) {
-  constexpr uint64_t BUFFER_SIZE = 4096U;
-  std::array<char, std::size_t{BUFFER_SIZE}> buffer{};
+  static constexpr auto BUFFER_SIZE = utils::configuration::DEFAULT_BUFFER_SIZE;
+  std::array<char, BUFFER_SIZE> buffer{};
 
   std::ifstream stream{file_name, std::ios::in | std::ios::binary};
 
@@ -41,7 +42,7 @@ uint64_t computeChecksum(const std::filesystem::path& file_name, uint64_t up_to_
   uint64_t remaining_bytes_to_be_read = up_to_position;
 
   while (stream && remaining_bytes_to_be_read > 0) {
-    stream.read(buffer.data(), gsl::narrow<std::streamsize>(std::min(BUFFER_SIZE, remaining_bytes_to_be_read)));
+    stream.read(buffer.data(), gsl::narrow<std::streamsize>((std::min)(uint64_t{BUFFER_SIZE}, remaining_bytes_to_be_read)));
     uInt bytes_read = gsl::narrow<uInt>(stream.gcount());
     checksum = crc32(checksum, reinterpret_cast<unsigned char*>(buffer.data()), bytes_read);
     remaining_bytes_to_be_read -= bytes_read;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-2483

Unify buffer sizes and make them configurable in most places.

I'm not sure if making it configurable (in processors) was a good idea, because this meant that we have to use vectors instead of arrays. I can undo this part of the PR if requested.

Depends on #1926 

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
