### PR TITLE
MINIFICPP-2562 Readd setting current working directory at startup

### DIFF
--- a/minifi_main/MiNiFiMain.cpp
+++ b/minifi_main/MiNiFiMain.cpp
@@ -282,6 +282,7 @@ int main(int argc, char **argv) {
   }
   // chdir to MINIFI_HOME
   std::error_code current_path_error;
+  std::filesystem::current_path(minifiHome, current_path_error);
   if (current_path_error) {
     logger->log_error("Failed to change working directory to MINIFI_HOME ({})", minifiHome);
     return -1;


### PR DESCRIPTION
Previously removed in 14096e2879b26feabd54fe7e1118e613b79cf9ed which causes issues with relative paths set in minifi.properties.

https://issues.apache.org/jira/browse/MINIFICPP-2562

------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
