### PR TITLE
MINIFICPP-2576 Improve the performance of ConsumeWindowsEventLog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ assemblies
 CMakeCache.txt
 CMakeFiles
 CMakeScripts
+CMakeSettings.json
 cmake_install.cmake
 install_manifest.txt
 CTestTestfile.cmake

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
@@ -323,7 +323,7 @@ wel::WindowsEventLogHandler& ConsumeWindowsEventLog::getEventLogHandler(const st
   auto opened_publisher_metadata_provider = EvtOpenPublisherMetadata(nullptr, widechar, nullptr, 0, 0);
   if (!opened_publisher_metadata_provider)
     logger_->log_warn("EvtOpenPublisherMetadata failed due to {}", utils::OsUtils::windowsErrorToErrorCode(GetLastError()).message());
-  providers_[name] = wel::WindowsEventLogHandler(opened_publisher_metadata_provider);
+  providers_.emplace(name, opened_publisher_metadata_provider);
   logger_->log_info("Handler not found for {}, creating. Number of cached handlers: {}", name, providers_.size());
   return providers_[name];
 }
@@ -459,7 +459,7 @@ nonstd::expected<cwel::EventRender, std::string> ConsumeWindowsEventLog::createE
 
   // this is a well known path.
   std::string provider_name = doc.child("Event").child("System").child("Provider").attribute("Name").value();
-  wel::WindowsEventLogMetadataImpl metadata{getEventLogHandler(provider_name).getMetadata(), hEvent};
+  wel::WindowsEventLogMetadataImpl metadata{getEventLogHandler(provider_name), hEvent};
   wel::MetadataWalker walker{metadata, path_.str(), !resolve_as_attributes_, apply_identifier_function_, regex_ ? &*regex_ : nullptr, userIdToUsernameFunction()};
 
   // resolve the event metadata

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.cpp
@@ -23,15 +23,10 @@
 #include <vector>
 #include <tuple>
 #include <utility>
-#include <queue>
 #include <map>
-#include <set>
 #include <sstream>
 #include <string>
-#include <iostream>
 #include <memory>
-#include <regex>
-#include <cinttypes>
 
 #include "wel/LookupCacher.h"
 #include "wel/MetadataWalker.h"
@@ -49,6 +44,8 @@
 
 #include "utils/gsl.h"
 #include "utils/OsUtils.h"
+#include "utils/RegexUtils.h"
+#include "utils/StringUtils.h"
 #include "utils/UnicodeConversion.h"
 #include "utils/ProcessorConfigUtils.h"
 
@@ -140,11 +137,7 @@ void ConsumeWindowsEventLog::onSchedule(core::ProcessContext& context, core::Pro
     }
   }
 
-  regex_.reset();
-  if (auto identifier_matcher = context.getProperty(IdentifierMatcher); identifier_matcher && !identifier_matcher->empty()) {
-    regex_.emplace(*identifier_matcher);
-  }
-
+  sid_matcher_ = cwel::parseSidMatcher(utils::parseOptionalProperty(context, IdentifierMatcher));
   output_format_ = utils::parseEnumProperty<cwel::OutputFormat>(context, OutputFormatProperty);
   json_format_ = utils::parseEnumProperty<cwel::JsonFormat>(context, JsonFormatProperty);
 
@@ -193,6 +186,20 @@ void ConsumeWindowsEventLog::onSchedule(core::ProcessContext& context, core::Pro
 
   provenanceUri_ = "winlog://" + computerName_ + "/" + path_.str() + "?" + query;
   logger_->log_trace("Successfully configured CWEL");
+}
+
+std::function<bool(std::string_view)> cwel::parseSidMatcher(const std::optional<std::string>& sid_matcher) {
+  if (!sid_matcher || sid_matcher->empty()) {
+    return [](std::string_view){ return false; };
+  }
+
+  if (std::smatch match; utils::regexMatch(*sid_matcher, match, utils::Regex{R"_(\.\*(\w+))_"})) {
+    std::string suffix = match[1];
+    return [suffix](std::string_view field_name) { return utils::string::endsWith(field_name, suffix); };
+  }
+
+  utils::Regex sid_matcher_regex{*sid_matcher};
+  return [sid_matcher_regex](std::string_view field_name) { return utils::regexMatch(field_name, sid_matcher_regex); };
 }
 
 bool ConsumeWindowsEventLog::commitAndSaveBookmark(const std::wstring &bookmark_xml, core::ProcessContext& context, core::ProcessSession& session) {
@@ -460,7 +467,7 @@ nonstd::expected<cwel::EventRender, std::string> ConsumeWindowsEventLog::createE
   // this is a well known path.
   std::string provider_name = doc.child("Event").child("System").child("Provider").attribute("Name").value();
   wel::WindowsEventLogMetadataImpl metadata{getEventLogHandler(provider_name), hEvent};
-  wel::MetadataWalker walker{metadata, path_.str(), !resolve_as_attributes_, apply_identifier_function_, regex_ ? &*regex_ : nullptr, userIdToUsernameFunction()};
+  wel::MetadataWalker walker{metadata, path_.str(), !resolve_as_attributes_, apply_identifier_function_, sid_matcher_, userIdToUsernameFunction()};
 
   // resolve the event metadata
   doc.traverse(walker);

--- a/extensions/windows-event-log/ConsumeWindowsEventLog.h
+++ b/extensions/windows-event-log/ConsumeWindowsEventLog.h
@@ -74,6 +74,8 @@ enum class JsonFormat {
   Simple,
   Flattened,
 };
+
+std::function<bool(std::string_view)> parseSidMatcher(const std::optional<std::string>& sid_matcher);
 }  // namespace cwel
 
 class Bookmark;
@@ -242,7 +244,7 @@ class ConsumeWindowsEventLog : public core::ProcessorImpl {
   std::optional<std::string> header_delimiter_;
   wel::EventPath path_;
   std::wstring wstr_query_;
-  std::optional<utils::Regex> regex_;
+  std::function<bool(std::string_view)> sid_matcher_;
   bool resolve_as_attributes_{false};
   bool apply_identifier_function_{false};
   std::string provenanceUri_;

--- a/extensions/windows-event-log/tests/ConsumeWindowsEventLogTests.cpp
+++ b/extensions/windows-event-log/tests/ConsumeWindowsEventLogTests.cpp
@@ -541,4 +541,28 @@ TEST_CASE("ConsumeWindowsEventLog can process events from a log file", "[cwel][l
   )json");
 }
 
+TEST_CASE("ConsumeWindowsEventLog::parseSidMatcher works correctly") {
+  const auto verify = [](const std::optional<std::string>& sid_matcher, std::string_view field_name, bool result) {
+    const auto matcher_function = minifi::processors::cwel::parseSidMatcher(sid_matcher);
+    CHECK(matcher_function(field_name) == result);
+  };
+
+  verify(std::nullopt, "UserSid", false);
+  verify(std::nullopt, "WidthOfSidewalk", false);
+  verify(std::nullopt, "Channel", false);
+
+  verify(".*Sid", "UserSid", true);
+  verify(".*Sid", "WidthOfSidewalk", false);
+  verify(".*Sid", "Channel", false);
+
+  verify(".*Sid.*", "UserSid", true);
+  verify(".*Sid.*", "WidthOfSidewalk", true);
+  verify(".*Sid.*", "Channel", false);
+
+  verify("Sid", "UserSid", false);
+  verify("Sid", "WidthOfSidewalk", false);
+  verify("Sid", "Channel", false);
+  verify("Sid", "Sid", true);
+}
+
 }  // namespace org::apache::nifi::minifi::test

--- a/extensions/windows-event-log/wel/MetadataWalker.cpp
+++ b/extensions/windows-event-log/wel/MetadataWalker.cpp
@@ -20,7 +20,6 @@
 
 #include <map>
 #include <functional>
-#include <codecvt>
 #include <regex>
 #include <string>
 #include <utility>
@@ -44,7 +43,7 @@ bool MetadataWalker::for_each(pugi::xml_node &node) {
     return input;
   };
   for (pugi::xml_attribute attr : node.attributes())  {
-    if (regex_ && utils::regexMatch(attr.name(), *regex_)) {
+    if (sid_matcher_(attr.name())) {
       updateAttributeValue(attr, attr.name(), idUpdate);
     }
   }
@@ -52,11 +51,11 @@ bool MetadataWalker::for_each(pugi::xml_node &node) {
   const std::string node_name = node.name();
   if (node_name == "Data") {
     for (pugi::xml_attribute attr : node.attributes())  {
-      if (regex_ && utils::regexMatch(attr.name(), *regex_)) {
+      if (sid_matcher_(attr.name())) {
         updateText(node, attr.name(), idUpdate);
       }
 
-      if (regex_ && utils::regexMatch(attr.value(), *regex_)) {
+      if (sid_matcher_(attr.value())) {
         updateText(node, attr.value(), idUpdate);
       }
     }

--- a/extensions/windows-event-log/wel/MetadataWalker.cpp
+++ b/extensions/windows-event-log/wel/MetadataWalker.cpp
@@ -90,7 +90,7 @@ bool MetadataWalker::for_each(pugi::xml_node &node) {
     if (it != formatFlagMap.end()) {
       std::function<std::string(const std::string &)> updateFunc = [&](const std::string &input) -> std::string {
         if (resolve_) {
-          auto resolved = windows_event_log_metadata_.getEventData(it->second);
+          auto resolved = windows_event_log_metadata_.getEventData(it->second, input);
           if (!resolved.empty()) {
             return resolved;
           }

--- a/extensions/windows-event-log/wel/MetadataWalker.h
+++ b/extensions/windows-event-log/wel/MetadataWalker.h
@@ -49,11 +49,12 @@ namespace org::apache::nifi::minifi::wel {
  */
 class MetadataWalker : public pugi::xml_tree_walker {
  public:
-  MetadataWalker(const WindowsEventLogMetadata& windows_event_log_metadata, std::string log_name, bool update_xml, bool resolve, utils::Regex const* regex,
+  MetadataWalker(const WindowsEventLogMetadata& windows_event_log_metadata, std::string log_name, bool update_xml, bool resolve,
+      std::function<bool(std::string_view)> sid_matcher,
       std::function<std::string(std::string)> user_id_to_username_fn)
       : windows_event_log_metadata_(windows_event_log_metadata),
         log_name_(std::move(log_name)),
-        regex_(regex),
+        sid_matcher_(std::move(sid_matcher)),
         update_xml_(update_xml),
         resolve_(resolve),
         user_id_to_username_fn_(std::move(user_id_to_username_fn)) {
@@ -82,8 +83,6 @@ class MetadataWalker : public pugi::xml_tree_walker {
     return "N/A";
   }
 
-  static std::string to_string(const wchar_t* pChar);
-
   /**
    * Updates text within the XML representation
    */
@@ -96,7 +95,7 @@ class MetadataWalker : public pugi::xml_tree_walker {
 
   const WindowsEventLogMetadata& windows_event_log_metadata_;
   const std::string log_name_;
-  utils::Regex const * const regex_;
+  std::function<bool(std::string_view)> sid_matcher_;
   const bool update_xml_;
   const bool resolve_;
   std::function<std::string(const std::string&)> user_id_to_username_fn_;

--- a/extensions/windows-event-log/wel/WindowsEventLog.h
+++ b/extensions/windows-event-log/wel/WindowsEventLog.h
@@ -72,9 +72,7 @@ class EventDataCache {
     EVT_FORMAT_MESSAGE_FLAGS field;
     std::string key;
 
-    [[nodiscard]] bool operator==(const CacheKey& other) const noexcept {
-      return field == other.field && key == other.key;
-    }
+    [[nodiscard]] bool operator==(const CacheKey&) const noexcept = default;
   };
   struct CacheKeyHash {
     [[nodiscard]] size_t operator()(const CacheKey& cache_key) const noexcept {

--- a/extensions/windows-event-log/wel/WindowsEventLog.h
+++ b/extensions/windows-event-log/wel/WindowsEventLog.h
@@ -58,7 +58,6 @@ enum METADATA {
   COMPUTER,
   UNKNOWN
 };
-// this is a continuous enum, so we can rely on the array
 using METADATA_NAMES = std::vector<std::pair<METADATA, std::string>>;
 
 class EventDataCache {

--- a/extensions/windows-event-log/wel/WindowsEventLog.h
+++ b/extensions/windows-event-log/wel/WindowsEventLog.h
@@ -58,11 +58,39 @@ enum METADATA {
   COMPUTER,
   UNKNOWN
 };
-
-
 // this is a continuous enum, so we can rely on the array
-
 using METADATA_NAMES = std::vector<std::pair<METADATA, std::string>>;
+
+class EventDataCache {
+ public:
+  explicit EventDataCache(std::chrono::milliseconds lifetime = std::chrono::hours{24})
+      : lifetime_(lifetime) {}
+  [[nodiscard]] std::optional<std::string> get(EVT_FORMAT_MESSAGE_FLAGS field, const std::string& key) const;
+  void set(EVT_FORMAT_MESSAGE_FLAGS field, const std::string& key, std::string value);
+
+ private:
+  struct CacheKey {
+    EVT_FORMAT_MESSAGE_FLAGS field;
+    std::string key;
+
+    [[nodiscard]] bool operator==(const CacheKey& other) const noexcept {
+      return field == other.field && key == other.key;
+    }
+  };
+  struct CacheKeyHash {
+    [[nodiscard]] size_t operator()(const CacheKey& cache_key) const noexcept {
+      return utils::hash_combine(std::hash<EVT_FORMAT_MESSAGE_FLAGS>{}(cache_key.field), std::hash<std::string>{}(cache_key.key));
+    }
+  };
+  struct CacheItem {
+    std::string value;
+    std::chrono::system_clock::time_point expiry;
+  };
+
+  mutable std::mutex mutex_;
+  std::chrono::milliseconds lifetime_;
+  std::unordered_map<CacheKey, CacheItem, CacheKeyHash> cache_;
+};
 
 class WindowsEventLogHandler {
  public:
@@ -74,16 +102,19 @@ class WindowsEventLogHandler {
 
   nonstd::expected<std::string, std::error_code> getEventMessage(EVT_HANDLE eventHandle) const;
 
-  [[nodiscard]] EVT_HANDLE getMetadata() const;
+  [[nodiscard]] std::string getEventData(EVT_FORMAT_MESSAGE_FLAGS field, const std::string& key, EVT_HANDLE event_ptr) const;
 
  private:
+  [[nodiscard]] std::string getEventDataImpl(EVT_FORMAT_MESSAGE_FLAGS field, EVT_HANDLE event_ptr) const;
+
   unique_evt_handle metadata_provider_;
+  mutable EventDataCache event_data_cache_;
 };
 
 class WindowsEventLogMetadata {
  public:
   virtual ~WindowsEventLogMetadata() = default;
-  [[nodiscard]] virtual std::string getEventData(EVT_FORMAT_MESSAGE_FLAGS flags) const = 0;
+  [[nodiscard]] virtual std::string getEventData(EVT_FORMAT_MESSAGE_FLAGS field, const std::string& key) const = 0;
   [[nodiscard]] virtual std::string getEventTimestamp() const = 0;
   virtual short getEventTypeIndex() const = 0;  // NOLINT short comes from WINDOWS API
 
@@ -147,11 +178,11 @@ class WindowsEventLogMetadata {
 
 class WindowsEventLogMetadataImpl : public WindowsEventLogMetadata {
  public:
-  WindowsEventLogMetadataImpl(EVT_HANDLE metadataProvider, EVT_HANDLE event_ptr) : metadata_ptr_(metadataProvider), event_ptr_(event_ptr) {
+  WindowsEventLogMetadataImpl(const WindowsEventLogHandler& metadataProvider, EVT_HANDLE event_ptr) : metadata_ptr_(metadataProvider), event_ptr_(event_ptr) {
     renderMetadata();
   }
 
-  [[nodiscard]] std::string getEventData(EVT_FORMAT_MESSAGE_FLAGS flags) const override;
+  [[nodiscard]] std::string getEventData(EVT_FORMAT_MESSAGE_FLAGS field, const std::string& key) const override;
 
   [[nodiscard]] std::string getEventTimestamp() const override { return event_timestamp_str_; }
 
@@ -164,7 +195,7 @@ class WindowsEventLogMetadataImpl : public WindowsEventLogMetadata {
   short event_type_index_ = 0;  // NOLINT short comes from WINDOWS API
   std::string event_timestamp_str_;
   EVT_HANDLE event_ptr_;
-  EVT_HANDLE metadata_ptr_;
+  const WindowsEventLogHandler& metadata_ptr_;
 };
 
 class WindowsEventLogHeader {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-2576

This PR contains two changes, both affecting the same files, so it is probably easiest to review the two commits separately.

change 1: Cache the results of `getEventData()` in `MetadataWalker::for_each()`. Previously, this typically did five Windows API calls to `EvtFormatMessage` per event.

change 2: If the value of the `Identifier Match Regex` property is of the form `.*something` (in particular, if the default value of `.*Sid` is used), then the calls to `regexMatch()` are replaced with calls to `endsWith()`.

Before these changes, processing took around 1.1 ms per event.  After change one, this got reduced to 0.5 ms per event; after both changes, the processing time is around 0.4 ms per event (as measured by the `"processed {} Events in {}"` log line in `ConsumeWindowsEventLog.cpp`).

--- 

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
