### PR TITLE
MINIFICPP-2599 parseOptionalControllerService should throw

### DIFF
--- a/extensions/aws/processors/AwsProcessor.cpp
+++ b/extensions/aws/processors/AwsProcessor.cpp
@@ -46,7 +46,7 @@ std::optional<Aws::Auth::AWSCredentials> AwsProcessor::getAWSCredentials(
   auto service_cred = getAWSCredentialsFromControllerService(context);
   if (service_cred) {
     logger_->log_info("AWS Credentials successfully set from controller service");
-    return service_cred.value();
+    return service_cred;
   }
 
   aws::AWSCredentialsProvider aws_credentials_provider;

--- a/extensions/aws/processors/AwsProcessor.cpp
+++ b/extensions/aws/processors/AwsProcessor.cpp
@@ -33,7 +33,7 @@
 namespace org::apache::nifi::minifi::aws::processors {
 
 std::optional<Aws::Auth::AWSCredentials> AwsProcessor::getAWSCredentialsFromControllerService(core::ProcessContext& context) const {
-  if (auto service = minifi::utils::parseOptionalControllerService<controllers::AWSCredentialsService>(context, AWSCredentialsProviderService, getUUID()); service) {
+  if (auto service = minifi::utils::parseOptionalControllerService<controllers::AWSCredentialsService>(context, AWSCredentialsProviderService, getUUID())) {
     return service->getAWSCredentials();
   }
   logger_->log_error("AWS credentials service could not be found");

--- a/extensions/aws/processors/AwsProcessor.cpp
+++ b/extensions/aws/processors/AwsProcessor.cpp
@@ -33,11 +33,10 @@
 namespace org::apache::nifi::minifi::aws::processors {
 
 std::optional<Aws::Auth::AWSCredentials> AwsProcessor::getAWSCredentialsFromControllerService(core::ProcessContext& context) const {
-  if (const auto aws_credentials_service = minifi::utils::parseOptionalControllerService<controllers::AWSCredentialsService>(context, AWSCredentialsProviderService, getUUID())) {
-    return (*aws_credentials_service)->getAWSCredentials();
+  if (auto service = minifi::utils::parseOptionalControllerService<controllers::AWSCredentialsService>(context, AWSCredentialsProviderService, getUUID()); service) {
+    return service->getAWSCredentials();
   }
   logger_->log_error("AWS credentials service could not be found");
-
   return std::nullopt;
 }
 
@@ -98,6 +97,9 @@ void AwsProcessor::onSchedule(core::ProcessContext& context, core::ProcessSessio
   if (default_ca_file) {
     client_config_->caFile = *default_ca_file;
   }
+
+  // throw here if the credentials provider service is set to an invalid value
+  std::ignore = minifi::utils::parseOptionalControllerService<controllers::AWSCredentialsService>(context, AWSCredentialsProviderService, getUUID());
 }
 
 std::optional<CommonProperties> AwsProcessor::getCommonELSupportedProperties(

--- a/extensions/couchbase/controllerservices/CouchbaseClusterService.cpp
+++ b/extensions/couchbase/controllerservices/CouchbaseClusterService.cpp
@@ -157,9 +157,11 @@ nonstd::expected<CouchbaseGetResult, CouchbaseErrorType> CouchbaseClient::get(co
       logger_->log_error("Failed to get document '{}' from collection '{}.{}.{}' due to timeout", document_id, collection.bucket_name, collection.scope_name, collection.collection_name);
       return nonstd::make_unexpected(CouchbaseErrorType::TEMPORARY);
     }
-    std::string cause = get_err.cause() ? get_err.cause()->message() : "";
     logger_->log_error("Failed to get document '{}' from collection '{}.{}.{}' with error code: '{}', message: '{}'", document_id, collection.bucket_name, collection.scope_name,
         collection.collection_name, get_err.ec(), get_err.message());
+    if (get_err.cause()) {
+      logger_->log_error("... root cause error code: '{}', message: '{}'", get_err.cause()->ec(), get_err.cause()->message());
+    }
     return nonstd::make_unexpected(CouchbaseErrorType::FATAL);
   } else {
     try {

--- a/extensions/couchbase/controllerservices/CouchbaseClusterService.cpp
+++ b/extensions/couchbase/controllerservices/CouchbaseClusterService.cpp
@@ -247,17 +247,6 @@ void CouchbaseClusterService::onEnable() {
   }
 }
 
-gsl::not_null<std::shared_ptr<CouchbaseClusterService>> CouchbaseClusterService::getFromProperty(const core::ProcessContext& context, const core::PropertyReference& property) {
-  std::shared_ptr<CouchbaseClusterService> couchbase_cluster_service;
-  if (auto connection_controller_name = context.getProperty(property)) {
-    couchbase_cluster_service = std::dynamic_pointer_cast<CouchbaseClusterService>(context.getControllerService(*connection_controller_name, context.getProcessorInfo().getUUID()));
-  }
-  if (!couchbase_cluster_service) {
-    throw minifi::Exception(ExceptionType::PROCESS_SCHEDULE_EXCEPTION, "Missing Couchbase Cluster Service");
-  }
-  return gsl::make_not_null(couchbase_cluster_service);
-}
-
 REGISTER_RESOURCE(CouchbaseClusterService, ControllerService);
 
 }  // namespace controllers

--- a/extensions/couchbase/controllerservices/CouchbaseClusterService.h
+++ b/extensions/couchbase/controllerservices/CouchbaseClusterService.h
@@ -166,8 +166,6 @@ class CouchbaseClusterService : public core::controller::ControllerServiceImpl {
     return client_->get(collection, document_id, return_type);
   }
 
-  static gsl::not_null<std::shared_ptr<CouchbaseClusterService>> getFromProperty(const core::ProcessContext& context, const core::PropertyReference& property);
-
  private:
   std::unique_ptr<CouchbaseClient> client_;
   std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<CouchbaseClusterService>::getLogger(uuid_);

--- a/extensions/couchbase/processors/GetCouchbaseKey.cpp
+++ b/extensions/couchbase/processors/GetCouchbaseKey.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "GetCouchbaseKey.h"
+#include "CouchbaseClusterService.h"
 #include "utils/gsl.h"
 #include "core/Resource.h"
 #include "utils/ProcessorConfigUtils.h"
@@ -24,7 +25,7 @@
 namespace org::apache::nifi::minifi::couchbase::processors {
 
 void GetCouchbaseKey::onSchedule(core::ProcessContext& context, core::ProcessSessionFactory&) {
-  couchbase_cluster_service_ = controllers::CouchbaseClusterService::getFromProperty(context, GetCouchbaseKey::CouchbaseClusterControllerService);
+  couchbase_cluster_service_ = utils::parseControllerService<controllers::CouchbaseClusterService>(context, GetCouchbaseKey::CouchbaseClusterControllerService, context.getProcessorInfo().getUUID());
   document_type_ = utils::parseEnumProperty<CouchbaseValueType>(context, GetCouchbaseKey::DocumentType);
 }
 

--- a/extensions/couchbase/processors/PutCouchbaseKey.cpp
+++ b/extensions/couchbase/processors/PutCouchbaseKey.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "PutCouchbaseKey.h"
+#include "CouchbaseClusterService.h"
 #include "utils/gsl.h"
 #include "core/Resource.h"
 #include "utils/ProcessorConfigUtils.h"
@@ -24,7 +25,7 @@
 namespace org::apache::nifi::minifi::couchbase::processors {
 
 void PutCouchbaseKey::onSchedule(core::ProcessContext& context, core::ProcessSessionFactory&) {
-  couchbase_cluster_service_ = controllers::CouchbaseClusterService::getFromProperty(context, PutCouchbaseKey::CouchbaseClusterControllerService);
+  couchbase_cluster_service_ = utils::parseControllerService<controllers::CouchbaseClusterService>(context, PutCouchbaseKey::CouchbaseClusterControllerService, context.getProcessorInfo().getUUID());
   document_type_ = utils::parseEnumProperty<CouchbaseValueType>(context, PutCouchbaseKey::DocumentType);
   persist_to_ = utils::parseEnumProperty<::couchbase::persist_to>(context, PutCouchbaseKey::PersistTo);
   replicate_to_ = utils::parseEnumProperty<::couchbase::replicate_to>(context, PutCouchbaseKey::ReplicateTo);

--- a/extensions/elasticsearch/PostElasticsearch.h
+++ b/extensions/elasticsearch/PostElasticsearch.h
@@ -109,8 +109,6 @@ class PostElasticsearch : public core::ProcessorImpl {
 
  private:
   std::string collectPayload(core::ProcessContext&, core::ProcessSession&, std::vector<std::shared_ptr<core::FlowFile>>&) const;
-  auto getSSLContextService(core::ProcessContext& context) const;
-  auto getCredentialsService(core::ProcessContext& context) const;
 
   uint64_t max_batch_size_ = 100;
   std::string host_url_;

--- a/extensions/gcp/processors/GCSProcessor.cpp
+++ b/extensions/gcp/processors/GCSProcessor.cpp
@@ -28,11 +28,8 @@ namespace gcs = ::google::cloud::storage;
 namespace org::apache::nifi::minifi::extensions::gcp {
 
 std::shared_ptr<google::cloud::storage::oauth2::Credentials> GCSProcessor::getCredentials(core::ProcessContext& context) const {
-  const std::string service_name = utils::parseProperty(context, GCSProcessor::GCPCredentials);
-  if (!IsNullOrEmpty(service_name)) {
-    auto gcp_credentials_controller_service = std::dynamic_pointer_cast<const GCPCredentialsControllerService>(context.getControllerService(service_name, getUUID()));
-    if (!gcp_credentials_controller_service)
-      return nullptr;
+  auto gcp_credentials_controller_service = utils::parseOptionalControllerService<GCPCredentialsControllerService>(context, GCSProcessor::GCPCredentials, getUUID());
+  if (gcp_credentials_controller_service) {
     return gcp_credentials_controller_service->getCredentials();
   }
   return nullptr;

--- a/extensions/grafana-loki/PushGrafanaLoki.cpp
+++ b/extensions/grafana-loki/PushGrafanaLoki.cpp
@@ -142,7 +142,7 @@ void PushGrafanaLoki::onSchedule(core::ProcessContext& context, core::ProcessSes
   }
 
   if (log_line_batch_wait) {
-    log_batch_.setLogLineBatchWait(*log_line_batch_wait);
+    log_batch_.setLogLineBatchWait(log_line_batch_wait);
     logger_->log_debug("PushGrafanaLoki Log Line Batch Wait is set to {} milliseconds", *log_line_batch_wait);
   }
 }

--- a/extensions/grafana-loki/PushGrafanaLoki.cpp
+++ b/extensions/grafana-loki/PushGrafanaLoki.cpp
@@ -77,13 +77,6 @@ void PushGrafanaLoki::LogBatch::setStartPushTime(std::chrono::system_clock::time
 
 const core::Relationship PushGrafanaLoki::Self("__self__", "Marks the FlowFile to be owned by this processor");
 
-std::shared_ptr<minifi::controllers::SSLContextServiceInterface> PushGrafanaLoki::getSSLContextService(core::ProcessContext& context) const {
-  if (auto ssl_context = context.getProperty(PushGrafanaLoki::SSLContextService)) {
-    return std::dynamic_pointer_cast<minifi::controllers::SSLContextServiceInterface>(context.getControllerService(*ssl_context, getUUID()));
-  }
-  return std::shared_ptr<minifi::controllers::SSLContextServiceInterface>{};
-}
-
 void PushGrafanaLoki::setUpStateManager(core::ProcessContext& context) {
   auto state_manager = context.getStateManager();
   if (state_manager == nullptr) {
@@ -110,11 +103,11 @@ std::map<std::string, std::string> PushGrafanaLoki::buildStreamLabelMap(core::Pr
       throw Exception(PROCESS_SCHEDULE_EXCEPTION, "Missing or invalid Stream Labels property");
     }
     for (const auto& label : stream_labels) {
-      auto stream_labels = utils::string::splitAndTrimRemovingEmpty(label, "=");
-      if (stream_labels.size() != 2) {
+      auto key_value = utils::string::splitAndTrimRemovingEmpty(label, "=");
+      if (key_value.size() != 2) {
         throw Exception(PROCESS_SCHEDULE_EXCEPTION, "Missing or invalid Stream Labels property");
       }
-      stream_label_map[stream_labels[0]] = stream_labels[1];
+      stream_label_map[key_value[0]] = key_value[1];
     }
   } else {
     throw Exception(PROCESS_SCHEDULE_EXCEPTION, "Missing or invalid Stream Labels property");

--- a/extensions/grafana-loki/PushGrafanaLoki.h
+++ b/extensions/grafana-loki/PushGrafanaLoki.h
@@ -21,7 +21,7 @@
 #include <vector>
 #include <map>
 
-#include "controllers/SSLContextService.h"
+#include "controllers/SSLContextServiceInterface.h"
 #include "core/ProcessorImpl.h"
 #include "core/PropertyDefinition.h"
 #include "core/PropertyDefinitionBuilder.h"

--- a/extensions/grafana-loki/PushGrafanaLoki.h
+++ b/extensions/grafana-loki/PushGrafanaLoki.h
@@ -21,7 +21,7 @@
 #include <vector>
 #include <map>
 
-#include "controllers/SSLContextServiceInterface.h"
+#include "controllers/SSLContextService.h"
 #include "core/ProcessorImpl.h"
 #include "core/PropertyDefinition.h"
 #include "core/PropertyDefinitionBuilder.h"
@@ -133,7 +133,6 @@ class PushGrafanaLoki : public core::ProcessorImpl {
 
   static std::map<std::string, std::string> buildStreamLabelMap(core::ProcessContext& context);
 
-  std::shared_ptr<minifi::controllers::SSLContextServiceInterface> getSSLContextService(core::ProcessContext& context) const;
   void processBatch(const std::vector<std::shared_ptr<core::FlowFile>>& batched_flow_files, core::ProcessSession& session);
   virtual nonstd::expected<void, std::string> submitRequest(const std::vector<std::shared_ptr<core::FlowFile>>& batched_flow_files, core::ProcessSession& session) = 0;
   void initializeHttpClient(core::ProcessContext& context);

--- a/extensions/grafana-loki/PushGrafanaLokiGrpc.cpp
+++ b/extensions/grafana-loki/PushGrafanaLokiGrpc.cpp
@@ -74,7 +74,7 @@ void PushGrafanaLokiGrpc::setUpGrpcChannel(const std::string& url, core::Process
   args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
 
   std::shared_ptr<::grpc::ChannelCredentials> creds = [&]() {
-    auto ssl_context_service = utils::parseOptionalControllerService<minifi::controllers::SSLContextService>(context, PushGrafanaLoki::SSLContextService, getUUID());
+    auto ssl_context_service = utils::parseOptionalControllerService<minifi::controllers::SSLContextServiceInterface>(context, PushGrafanaLoki::SSLContextService, getUUID());
     if (ssl_context_service) {
       ::grpc::SslCredentialsOptions ssl_credentials_options;
       ssl_credentials_options.pem_cert_chain = utils::file::FileUtils::get_content(ssl_context_service->getCertificateFile());

--- a/extensions/grafana-loki/PushGrafanaLokiREST.cpp
+++ b/extensions/grafana-loki/PushGrafanaLokiREST.cpp
@@ -82,7 +82,8 @@ void PushGrafanaLokiREST::initializeHttpClient(core::ProcessContext& context) {
     url += "/loki/api/v1/push";
   }
   logger_->log_debug("PushGrafanaLokiREST push url is set to: {}", url);
-  client_.initialize(http::HttpRequestMethod::POST, url, getSSLContextService(context));
+  auto ssl_context_service = utils::parseOptionalControllerService<minifi::controllers::SSLContextService>(context, PushGrafanaLoki::SSLContextService, getUUID());
+  client_.initialize(http::HttpRequestMethod::POST, url, ssl_context_service);
 }
 
 void PushGrafanaLokiREST::onSchedule(core::ProcessContext& context, core::ProcessSessionFactory& session_factory) {

--- a/extensions/grafana-loki/PushGrafanaLokiREST.cpp
+++ b/extensions/grafana-loki/PushGrafanaLokiREST.cpp
@@ -82,7 +82,7 @@ void PushGrafanaLokiREST::initializeHttpClient(core::ProcessContext& context) {
     url += "/loki/api/v1/push";
   }
   logger_->log_debug("PushGrafanaLokiREST push url is set to: {}", url);
-  auto ssl_context_service = utils::parseOptionalControllerService<minifi::controllers::SSLContextService>(context, PushGrafanaLoki::SSLContextService, getUUID());
+  auto ssl_context_service = utils::parseOptionalControllerService<minifi::controllers::SSLContextServiceInterface>(context, PushGrafanaLoki::SSLContextService, getUUID());
   client_.initialize(http::HttpRequestMethod::POST, url, ssl_context_service);
 }
 

--- a/extensions/kubernetes/processors/CollectKubernetesPodMetrics.cpp
+++ b/extensions/kubernetes/processors/CollectKubernetesPodMetrics.cpp
@@ -22,6 +22,7 @@
 #include "../ContainerInfo.h"
 #include "../MetricsApi.h"
 #include "../MetricsFilter.h"
+#include "utils/ProcessorConfigUtils.h"
 
 namespace org::apache::nifi::minifi::processors {
 
@@ -31,20 +32,7 @@ void CollectKubernetesPodMetrics::initialize() {
 }
 
 void CollectKubernetesPodMetrics::onSchedule(core::ProcessContext& context, core::ProcessSessionFactory&) {
-  const auto controller_service_name = context.getProperty(KubernetesControllerService);
-  if (!controller_service_name || controller_service_name->empty()) {
-    throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, utils::string::join_pack("Missing '", KubernetesControllerService.name, "' property")};
-  }
-
-  std::shared_ptr<core::controller::ControllerService> controller_service = context.getControllerService(*controller_service_name, getUUID());
-  if (!controller_service) {
-    throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, utils::string::join_pack("Controller service '", *controller_service_name, "' not found")};
-  }
-
-  kubernetes_controller_service_ = std::dynamic_pointer_cast<minifi::controllers::KubernetesControllerService>(controller_service);
-  if (!kubernetes_controller_service_) {
-    throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, utils::string::join_pack("Controller service '", *controller_service_name, "' is not a KubernetesControllerService")};
-  }
+  kubernetes_controller_service_ = utils::parseControllerService<controllers::KubernetesControllerService>(context, KubernetesControllerService, getUUID());
 }
 
 void CollectKubernetesPodMetrics::onTrigger(core::ProcessContext&, core::ProcessSession& session) {

--- a/extensions/smb/FetchSmb.cpp
+++ b/extensions/smb/FetchSmb.cpp
@@ -19,6 +19,7 @@
 #include "core/Resource.h"
 #include "utils/ConfigurationUtils.h"
 #include "utils/file/FileReaderCallback.h"
+#include "utils/ProcessorConfigUtils.h"
 
 namespace org::apache::nifi::minifi::extensions::smb {
 
@@ -28,7 +29,7 @@ void FetchSmb::initialize() {
 }
 
 void FetchSmb::onSchedule(core::ProcessContext& context, core::ProcessSessionFactory&) {
-  smb_connection_controller_service_ = SmbConnectionControllerService::getFromProperty(context, FetchSmb::ConnectionControllerService);
+  smb_connection_controller_service_ = utils::parseControllerService<SmbConnectionControllerService>(context, FetchSmb::ConnectionControllerService, getUUID());
   buffer_size_ = utils::configuration::getBufferSize(*context.getConfiguration());
 }
 

--- a/extensions/smb/ListSmb.cpp
+++ b/extensions/smb/ListSmb.cpp
@@ -33,7 +33,7 @@ void ListSmb::initialize() {
 }
 
 void ListSmb::onSchedule(core::ProcessContext& context, core::ProcessSessionFactory&) {
-  smb_connection_controller_service_ = SmbConnectionControllerService::getFromProperty(context, ListSmb::ConnectionControllerService);
+  smb_connection_controller_service_ = utils::parseControllerService<SmbConnectionControllerService>(context, ListSmb::ConnectionControllerService, getUUID());
 
   auto state_manager = context.getStateManager();
   if (state_manager == nullptr) {

--- a/extensions/smb/PutSmb.cpp
+++ b/extensions/smb/PutSmb.cpp
@@ -32,7 +32,7 @@ void PutSmb::initialize() {
 }
 
 void PutSmb::onSchedule(core::ProcessContext& context, core::ProcessSessionFactory&) {
-  smb_connection_controller_service_ = SmbConnectionControllerService::getFromProperty(context, PutSmb::ConnectionControllerService);
+  smb_connection_controller_service_ = utils::parseControllerService<SmbConnectionControllerService>(context, PutSmb::ConnectionControllerService, getUUID());
   create_missing_dirs_ = utils::parseBoolProperty(context, PutSmb::CreateMissingDirectories);
   conflict_resolution_strategy_ = utils::parseEnumProperty<FileExistsResolutionStrategy>(context, ConflictResolution);
 }

--- a/extensions/smb/SmbConnectionControllerService.cpp
+++ b/extensions/smb/SmbConnectionControllerService.cpp
@@ -58,17 +58,6 @@ void SmbConnectionControllerService::notifyStop() {
     logger_->log_error("Error while disconnecting from SMB: {}", disconnection_result.error().message());
 }
 
-gsl::not_null<std::shared_ptr<SmbConnectionControllerService>> SmbConnectionControllerService::getFromProperty(const core::ProcessContext& context, const core::PropertyReference& property) {
-  std::shared_ptr<SmbConnectionControllerService> smb_connection_controller_service;
-  if (auto connection_controller_name = context.getProperty(property)) {
-    smb_connection_controller_service = std::dynamic_pointer_cast<SmbConnectionControllerService>(context.getControllerService(*connection_controller_name, context.getProcessorInfo().getUUID()));
-  }
-  if (!smb_connection_controller_service) {
-    throw minifi::Exception(ExceptionType::PROCESS_SCHEDULE_EXCEPTION, "Missing SMB Connection Controller Service");
-  }
-  return gsl::make_not_null(smb_connection_controller_service);
-}
-
 nonstd::expected<void, std::error_code> SmbConnectionControllerService::connect() {
   auto connection_result = WNetAddConnection2A(&net_resource_,
       credentials_ ? credentials_->password.c_str() : nullptr,

--- a/extensions/smb/SmbConnectionControllerService.h
+++ b/extensions/smb/SmbConnectionControllerService.h
@@ -87,8 +87,6 @@ class SmbConnectionControllerService : public core::controller::ControllerServic
   virtual std::error_code validateConnection();
   virtual std::filesystem::path getPath() const { return server_path_; }
 
-  static gsl::not_null<std::shared_ptr<SmbConnectionControllerService>> getFromProperty(const core::ProcessContext& context, const core::PropertyReference& property);
-
  private:
   nonstd::expected<void, std::error_code> connect();
   nonstd::expected<void, std::error_code> disconnect();

--- a/extensions/splunk/PutSplunkHTTP.cpp
+++ b/extensions/splunk/PutSplunkHTTP.cpp
@@ -113,7 +113,7 @@ void setFlowFileAsPayload(core::ProcessSession& session,
 
 void PutSplunkHTTP::onSchedule(core::ProcessContext& context, core::ProcessSessionFactory& session_factory) {
   SplunkHECProcessor::onSchedule(context, session_factory);
-  ssl_context_service_ = getSSLContextService(context);
+  ssl_context_service_ = utils::parseOptionalControllerService<minifi::controllers::SSLContextService>(context, SSLContext, getUUID());
   auto create_client = [this]() -> std::unique_ptr<minifi::http::HTTPClient> {
     auto client = std::make_unique<http::HTTPClient>();
     initializeClient(*client, getNetworkLocation().append(getEndpoint(*client)), ssl_context_service_);

--- a/extensions/splunk/PutSplunkHTTP.cpp
+++ b/extensions/splunk/PutSplunkHTTP.cpp
@@ -113,7 +113,7 @@ void setFlowFileAsPayload(core::ProcessSession& session,
 
 void PutSplunkHTTP::onSchedule(core::ProcessContext& context, core::ProcessSessionFactory& session_factory) {
   SplunkHECProcessor::onSchedule(context, session_factory);
-  ssl_context_service_ = utils::parseOptionalControllerService<minifi::controllers::SSLContextService>(context, SSLContext, getUUID());
+  ssl_context_service_ = utils::parseOptionalControllerService<minifi::controllers::SSLContextServiceInterface>(context, SSLContext, getUUID());
   auto create_client = [this]() -> std::unique_ptr<minifi::http::HTTPClient> {
     auto client = std::make_unique<http::HTTPClient>();
     initializeClient(*client, getNetworkLocation().append(getEndpoint(*client)), ssl_context_service_);

--- a/extensions/splunk/QuerySplunkIndexingStatus.cpp
+++ b/extensions/splunk/QuerySplunkIndexingStatus.cpp
@@ -141,7 +141,8 @@ void QuerySplunkIndexingStatus::onSchedule(core::ProcessContext& context, core::
   SplunkHECProcessor::onSchedule(context, session_factory);
   max_age_ = utils::parseDurationProperty(context, MaximumWaitingTime);
   batch_size_ = utils::parseU64Property(context, MaxQuerySize);
-  initializeClient(client_, getNetworkLocation().append(getEndpoint()), getSSLContextService(context));
+  auto ssl_context_service = utils::parseOptionalControllerService<minifi::controllers::SSLContextService>(context, SSLContext, getUUID());
+  initializeClient(client_, getNetworkLocation().append(getEndpoint()), ssl_context_service);
 }
 
 void QuerySplunkIndexingStatus::onTrigger(core::ProcessContext&, core::ProcessSession& session) {

--- a/extensions/splunk/QuerySplunkIndexingStatus.cpp
+++ b/extensions/splunk/QuerySplunkIndexingStatus.cpp
@@ -146,8 +146,6 @@ void QuerySplunkIndexingStatus::onSchedule(core::ProcessContext& context, core::
 }
 
 void QuerySplunkIndexingStatus::onTrigger(core::ProcessContext&, core::ProcessSession& session) {
-  std::string ack_request;
-
   auto undetermined_flow_files = getUndeterminedFlowFiles(session, batch_size_);
   if (undetermined_flow_files.empty())
     return;

--- a/extensions/splunk/QuerySplunkIndexingStatus.cpp
+++ b/extensions/splunk/QuerySplunkIndexingStatus.cpp
@@ -141,7 +141,7 @@ void QuerySplunkIndexingStatus::onSchedule(core::ProcessContext& context, core::
   SplunkHECProcessor::onSchedule(context, session_factory);
   max_age_ = utils::parseDurationProperty(context, MaximumWaitingTime);
   batch_size_ = utils::parseU64Property(context, MaxQuerySize);
-  auto ssl_context_service = utils::parseOptionalControllerService<minifi::controllers::SSLContextService>(context, SSLContext, getUUID());
+  auto ssl_context_service = utils::parseOptionalControllerService<minifi::controllers::SSLContextServiceInterface>(context, SSLContext, getUUID());
   initializeClient(client_, getNetworkLocation().append(getEndpoint()), ssl_context_service);
 }
 

--- a/extensions/splunk/SplunkHECProcessor.cpp
+++ b/extensions/splunk/SplunkHECProcessor.cpp
@@ -40,7 +40,7 @@ std::string SplunkHECProcessor::getNetworkLocation() const {
   return hostname_ + ":" + port_;
 }
 
-void SplunkHECProcessor::initializeClient(http::HTTPClient& client, const std::string &url, std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service) const {
+void SplunkHECProcessor::initializeClient(http::HTTPClient& client, const std::string &url, std::shared_ptr<minifi::controllers::SSLContextServiceInterface> ssl_context_service) const {
   client.initialize(http::HttpRequestMethod::POST, url, std::move(ssl_context_service));
   client.setRequestHeader("Authorization", token_);
   client.setRequestHeader("X-Splunk-Request-Channel", request_channel_);

--- a/extensions/splunk/SplunkHECProcessor.cpp
+++ b/extensions/splunk/SplunkHECProcessor.cpp
@@ -40,13 +40,7 @@ std::string SplunkHECProcessor::getNetworkLocation() const {
   return hostname_ + ":" + port_;
 }
 
-std::shared_ptr<minifi::controllers::SSLContextServiceInterface> SplunkHECProcessor::getSSLContextService(core::ProcessContext& context) const {
-  if (const auto context_name = context.getProperty(SSLContext); context_name && !IsNullOrEmpty(*context_name))
-    return std::dynamic_pointer_cast<minifi::controllers::SSLContextServiceInterface>(context.getControllerService(*context_name, getUUID()));
-  return nullptr;
-}
-
-void SplunkHECProcessor::initializeClient(http::HTTPClient& client, const std::string &url, std::shared_ptr<minifi::controllers::SSLContextServiceInterface> ssl_context_service) const {
+void SplunkHECProcessor::initializeClient(http::HTTPClient& client, const std::string &url, std::shared_ptr<minifi::controllers::SSLContextService> ssl_context_service) const {
   client.initialize(http::HttpRequestMethod::POST, url, std::move(ssl_context_service));
   client.setRequestHeader("Authorization", token_);
   client.setRequestHeader("X-Splunk-Request-Channel", request_channel_);

--- a/extensions/splunk/SplunkHECProcessor.h
+++ b/extensions/splunk/SplunkHECProcessor.h
@@ -77,7 +77,6 @@ class SplunkHECProcessor : public core::ProcessorImpl {
 
  protected:
   std::string getNetworkLocation() const;
-  std::shared_ptr<minifi::controllers::SSLContextServiceInterface> getSSLContextService(core::ProcessContext& context) const;
   void initializeClient(http::HTTPClient& client, const std::string &url, std::shared_ptr<minifi::controllers::SSLContextServiceInterface> ssl_context_service) const;
 
   std::string token_;

--- a/extensions/sql/processors/SQLProcessor.cpp
+++ b/extensions/sql/processors/SQLProcessor.cpp
@@ -24,21 +24,12 @@
 #include "core/ProcessContext.h"
 #include "core/ProcessSession.h"
 #include "Exception.h"
+#include "utils/ProcessorConfigUtils.h"
 
 namespace org::apache::nifi::minifi::processors {
 
 void SQLProcessor::onSchedule(core::ProcessContext& context, core::ProcessSessionFactory&) {
-  std::string controllerService = context.getProperty(DBControllerService).value_or("");
-
-  if (auto service = context.getControllerService(controllerService, getUUID())) {
-    db_service_ = std::dynamic_pointer_cast<sql::controllers::DatabaseService>(service);
-    if (!db_service_) {
-      throw minifi::Exception(PROCESSOR_EXCEPTION, "'" + controllerService + "' is not a DatabaseService");
-    }
-  } else {
-    throw minifi::Exception(PROCESSOR_EXCEPTION, "Could not find controller service '" + controllerService + "'");
-  }
-
+  db_service_ = utils::parseControllerService<sql::controllers::DatabaseService>(context, DBControllerService, getUUID());
   processOnSchedule(context);
 }
 

--- a/extensions/standard-processors/modbus/FetchModbusTcp.cpp
+++ b/extensions/standard-processors/modbus/FetchModbusTcp.cpp
@@ -203,7 +203,6 @@ auto FetchModbusTcp::sendRequestsAndReadResponses(utils::net::ConnectionHandlerB
 
 auto FetchModbusTcp::sendRequestAndReadResponse(utils::net::ConnectionHandlerBase& connection_handler,
     const ReadModbusFunction& read_modbus_function) -> asio::awaitable<nonstd::expected<core::RecordField, std::error_code>> {
-  std::string result;
   if (auto connection_error = co_await connection_handler.setupUsableSocket(io_context_)) {  // NOLINT (clang tidy doesnt like coroutines)
     co_return nonstd::make_unexpected(connection_error);
   }

--- a/extensions/standard-processors/processors/GetTCP.cpp
+++ b/extensions/standard-processors/processors/GetTCP.cpp
@@ -83,7 +83,7 @@ void GetTCP::onSchedule(core::ProcessContext& context, core::ProcessSessionFacto
   auto connections_to_make = parseEndpointList(context);
   auto delimiter = parseDelimiter(context);
   auto ssl_context = [&]() -> std::optional<asio::ssl::context> {
-    if (auto ssl_context_service = utils::parseOptionalControllerService<minifi::controllers::SSLContextServiceInterface>(context, SSLContextService, getUUID()); ssl_context_service) {
+    if (auto ssl_context_service = utils::parseOptionalControllerService<minifi::controllers::SSLContextServiceInterface>(context, SSLContextService, getUUID())) {
       return {utils::net::getSslContext(*ssl_context_service)};
     }
     return std::nullopt;

--- a/extensions/standard-processors/processors/GetTCP.cpp
+++ b/extensions/standard-processors/processors/GetTCP.cpp
@@ -71,22 +71,6 @@ char GetTCP::parseDelimiter(core::ProcessContext& context) {
   return delimiter;
 }
 
-std::optional<asio::ssl::context> GetTCP::parseSSLContext(core::ProcessContext& context) const {
-  std::optional<asio::ssl::context> ssl_context;
-  if (auto context_name = context.getProperty(SSLContextService)) {
-    if (auto controller_service = context.getControllerService(*context_name, getUUID())) {
-      if (auto ssl_context_service = std::dynamic_pointer_cast<minifi::controllers::SSLContextServiceInterface>(context.getControllerService(*context_name, getUUID()))) {
-        ssl_context = utils::net::getSslContext(*ssl_context_service);
-      } else {
-        throw Exception(PROCESS_SCHEDULE_EXCEPTION, *context_name + " is not an SSL Context Service");
-      }
-    } else {
-      throw Exception(PROCESS_SCHEDULE_EXCEPTION, "Invalid controller service: " + *context_name);
-    }
-  }
-  return ssl_context;
-}
-
 uint64_t GetTCP::parseMaxBatchSize(core::ProcessContext& context) {
   const auto max_batch_size = utils::parseU64Property(context, MaxBatchSize);
   if (max_batch_size == 0) {
@@ -98,7 +82,12 @@ uint64_t GetTCP::parseMaxBatchSize(core::ProcessContext& context) {
 void GetTCP::onSchedule(core::ProcessContext& context, core::ProcessSessionFactory&) {
   auto connections_to_make = parseEndpointList(context);
   auto delimiter = parseDelimiter(context);
-  auto ssl_context = parseSSLContext(context);
+  auto ssl_context = [&]() -> std::optional<asio::ssl::context> {
+    if (auto ssl_context_service = utils::parseOptionalControllerService<minifi::controllers::SSLContextServiceInterface>(context, SSLContextService, getUUID()); ssl_context_service) {
+      return {utils::net::getSslContext(*ssl_context_service)};
+    }
+    return std::nullopt;
+  }();
 
   std::optional<size_t> max_queue_size = utils::parseOptionalU64Property(context, MaxQueueSize);
   std::optional<size_t> max_message_size = utils::parseOptionalU64Property(context, MaxMessageSize);

--- a/extensions/standard-processors/processors/GetTCP.h
+++ b/extensions/standard-processors/processors/GetTCP.h
@@ -137,7 +137,6 @@ class GetTCP : public core::ProcessorImpl {
 
   std::vector<utils::net::ConnectionId> parseEndpointList(core::ProcessContext& context);
   static char parseDelimiter(core::ProcessContext& context);
-  std::optional<asio::ssl::context> parseSSLContext(core::ProcessContext& context) const;
   static uint64_t parseMaxBatchSize(core::ProcessContext& context);
 
   class TcpClient {

--- a/extensions/standard-processors/processors/InvokeHTTP.cpp
+++ b/extensions/standard-processors/processors/InvokeHTTP.cpp
@@ -159,7 +159,6 @@ void InvokeHTTP::setupMembersFromProperties(const core::ProcessContext& context)
 
   proxy_.host = context.getProperty(InvokeHTTP::ProxyHost).value_or("");
   proxy_.port = (context.getProperty(InvokeHTTP::ProxyPort) | utils::andThen(parsing::parseIntegral<int>)).value_or(0);
-  std::string port_str;
   proxy_.username = context.getProperty(InvokeHTTP::ProxyUsername).value_or("");
   proxy_.password = context.getProperty(InvokeHTTP::ProxyPassword).value_or("");
 

--- a/extensions/standard-processors/processors/InvokeHTTP.cpp
+++ b/extensions/standard-processors/processors/InvokeHTTP.cpp
@@ -166,15 +166,7 @@ void InvokeHTTP::setupMembersFromProperties(const core::ProcessContext& context)
   follow_redirects_ = utils::parseBoolProperty(context, FollowRedirects);  // Shouldn't fail due to default value;
   content_type_ = utils::parseProperty(context, InvokeHTTP::ContentType);  // Shouldn't fail due to default value;
 
-  if (auto ssl_context_name = context.getProperty(SSLContext)) {
-    if (auto service = context.getControllerService(*ssl_context_name, getUUID())) {
-      ssl_context_service_ = std::dynamic_pointer_cast<minifi::controllers::SSLContextServiceInterface>(service);
-      if (!ssl_context_service_)
-        logger_->log_error("Controller service '{}' is not an SSLContextService", *ssl_context_name);
-    } else {
-      logger_->log_error("Couldn't find controller service with name '{}'", *ssl_context_name);
-    }
-  }
+  ssl_context_service_ = utils::parseOptionalControllerService<minifi::controllers::SSLContextServiceInterface>(context, SSLContext, getUUID());
 }
 
 gsl::not_null<std::unique_ptr<http::HTTPClient>> InvokeHTTP::createHTTPClientFromMembers(const std::string& url) const {

--- a/extensions/standard-processors/processors/PutTCP.cpp
+++ b/extensions/standard-processors/processors/PutTCP.cpp
@@ -70,7 +70,7 @@ void PutTCP::onSchedule(core::ProcessContext& context, core::ProcessSessionFacto
   else
     connections_.emplace();
 
-  if (auto ssl_context_service = utils::parseOptionalControllerService<minifi::controllers::SSLContextServiceInterface>(context, SSLContextService, getUUID()); ssl_context_service) {
+  if (auto ssl_context_service = utils::parseOptionalControllerService<minifi::controllers::SSLContextServiceInterface>(context, SSLContextService, getUUID())) {
     ssl_context_ = {utils::net::getSslContext(*ssl_context_service)};
   }
 

--- a/extensions/standard-processors/processors/PutTCP.cpp
+++ b/extensions/standard-processors/processors/PutTCP.cpp
@@ -70,17 +70,8 @@ void PutTCP::onSchedule(core::ProcessContext& context, core::ProcessSessionFacto
   else
     connections_.emplace();
 
-  ssl_context_.reset();
-  if (const auto context_name = context.getProperty(SSLContextService); context_name && !IsNullOrEmpty(*context_name)) {
-    if (auto controller_service = context.getControllerService(*context_name, getUUID())) {
-      if (const auto ssl_context_service = std::dynamic_pointer_cast<minifi::controllers::SSLContextServiceInterface>(context.getControllerService(*context_name, getUUID()))) {
-        ssl_context_ = utils::net::getSslContext(*ssl_context_service);
-      } else {
-        throw Exception(PROCESS_SCHEDULE_EXCEPTION, *context_name + " is not an SSL Context Service");
-      }
-    } else {
-      throw Exception(PROCESS_SCHEDULE_EXCEPTION, "Invalid controller service: " + *context_name);
-    }
+  if (auto ssl_context_service = utils::parseOptionalControllerService<minifi::controllers::SSLContextServiceInterface>(context, SSLContextService, getUUID()); ssl_context_service) {
+    ssl_context_ = {utils::net::getSslContext(*ssl_context_service)};
   }
 
   const auto delimiter_str = context.getProperty(OutgoingMessageDelimiter).value_or(std::string{});

--- a/extensions/standard-processors/processors/SplitRecord.cpp
+++ b/extensions/standard-processors/processors/SplitRecord.cpp
@@ -29,7 +29,7 @@ void SplitRecord::onSchedule(core::ProcessContext& context, core::ProcessSession
 
 nonstd::expected<std::size_t, std::string> SplitRecord::readRecordsPerSplit(core::ProcessContext& context, const core::FlowFile& original_flow_file) {
   return context.getProperty(RecordsPerSplit, &original_flow_file)
-      | utils::andThen([](const auto records_per_split_str) {
+      | utils::andThen([](const auto& records_per_split_str) {
             return parsing::parseIntegralMinMax<std::size_t>(records_per_split_str, 1, std::numeric_limits<std::size_t>::max());
           })
       | utils::transformError([](std::error_code) -> std::string { return std::string{"Records Per Split should be set to a number larger than 0"}; });

--- a/extensions/standard-processors/processors/TailFile.cpp
+++ b/extensions/standard-processors/processors/TailFile.cpp
@@ -44,10 +44,10 @@
 
 namespace org::apache::nifi::minifi::processors {
 
-const char *TailFile::CURRENT_STR = "CURRENT.";
-const char *TailFile::POSITION_STR = "POSITION.";
-
 namespace {
+inline constexpr std::string_view CURRENT_STR = "CURRENT.";
+inline constexpr std::string_view POSITION_STR = "POSITION.";
+
 template<typename Container, typename Key>
 bool containsKey(const Container &container, const Key &key) {
   return container.find(key) != container.end();
@@ -364,8 +364,8 @@ void TailFile::parseStateFileLine(char *buf, std::map<std::filesystem::path, Tai
     logger_->log_debug("Received position {}", position);
     state.begin()->second.position_ = gsl::narrow<uint64_t>(position);
   }
-  if (key.find(CURRENT_STR) == 0) {
-    const auto file = key.substr(strlen(CURRENT_STR));
+  if (key.starts_with(CURRENT_STR)) {
+    const auto file = key.substr(CURRENT_STR.size());
     std::filesystem::path file_path = value;
     if (file_path.has_filename() && file_path.has_parent_path()) {
       state[file].path_ = file_path.parent_path();
@@ -375,8 +375,8 @@ void TailFile::parseStateFileLine(char *buf, std::map<std::filesystem::path, Tai
     }
   }
 
-  if (key.find(POSITION_STR) == 0) {
-    const auto file = key.substr(strlen(POSITION_STR));
+  if (key.starts_with(POSITION_STR)) {
+    const auto file = key.substr(POSITION_STR.size());
     state[file].position_ = std::stoull(value);
   }
 }

--- a/extensions/standard-processors/processors/TailFile.cpp
+++ b/extensions/standard-processors/processors/TailFile.cpp
@@ -269,7 +269,7 @@ void TailFile::onSchedule(core::ProcessContext& context, core::ProcessSessionFac
     tail_mode_ = Mode::MULTIPLE;
     pattern_regex_ = utils::Regex(file_name_str);
 
-    if (auto service = utils::parseOptionalControllerService<minifi::controllers::AttributeProviderService>(context, AttributeProviderService, getUUID()); service) {
+    if (auto service = utils::parseOptionalControllerService<minifi::controllers::AttributeProviderService>(context, AttributeProviderService, getUUID())) {
       // we drop ownership of the service here -- in the long term, getControllerService/parseControllerService should return a non-owning pointer or optional reference
       attribute_provider_service_ = service.get();
     }

--- a/extensions/standard-processors/processors/TailFile.h
+++ b/extensions/standard-processors/processors/TailFile.h
@@ -283,8 +283,6 @@ class TailFile : public core::ProcessorImpl {
   static void updateStateAttributes(TailState &state, uint64_t size, uint64_t checksum);
   bool isOldFileInitiallyRead(const TailState &state) const;
 
-  static const char *CURRENT_STR;
-  static const char *POSITION_STR;
   static constexpr int BUFFER_SIZE = 512;
 
   std::optional<char> delimiter_;  // Delimiter for the data incoming from the tailed file.

--- a/extensions/standard-processors/processors/TailFile.h
+++ b/extensions/standard-processors/processors/TailFile.h
@@ -256,7 +256,6 @@ class TailFile : public core::ProcessorImpl {
     TimePoint mtime_;
   };
 
-  void parseAttributeProviderServiceProperty(const core::ProcessContext& context);
   void parseStateFileLine(char *buf, std::map<std::filesystem::path, TailState> &state) const;
   void processAllRotatedFiles(core::ProcessSession& session, TailState &state);
   void processRotatedFiles(core::ProcessSession& session, TailState &state, std::vector<TailState> &rotated_file_states);


### PR DESCRIPTION
Modified `parseOptionalControllerService()` to throw when the value of the property is not a controller service, or its type does not match.

Also removed some helper functions which basically did the same thing, and replaced them with uses of `parse[Optional]ControllerService`.

https://issues.apache.org/jira/browse/MINIFICPP-2599

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
