### PR TITLE
MINIFICPP-2619 Fix deadlock of ThreadPool shutdown

### DIFF
--- a/core-framework/include/utils/ThreadPool.h
+++ b/core-framework/include/utils/ThreadPool.h
@@ -271,7 +271,6 @@ class ThreadPool {
   std::vector<std::shared_ptr<WorkerThread>> thread_queue_;
   std::thread manager_thread_;
   std::thread delayed_scheduler_thread_;
-  std::atomic<bool> adjust_threads_;
   std::atomic<bool> running_;
   core::controller::ControllerServiceLookup* controller_service_provider_;
   std::shared_ptr<controllers::ThreadManagementService> thread_manager_;

--- a/core-framework/src/utils/ThreadPool.cpp
+++ b/core-framework/src/utils/ThreadPool.cpp
@@ -98,8 +98,11 @@ void ThreadPool::run_tasks(const std::shared_ptr<WorkerThread>& thread) {
 }
 
 void ThreadPool::manage_delayed_queue() {
-  while (running_) {
+  while (true) {
     std::unique_lock<std::mutex> lock(worker_queue_mutex_);
+    if (!running_) {
+      return;
+    }
 
     // Put the tasks ready to run in the worker queue
     while (!delayed_worker_queue_.empty() && delayed_worker_queue_.top().getNextExecutionTime() <= std::chrono::steady_clock::now()) {

--- a/core-framework/src/utils/ThreadPool.cpp
+++ b/core-framework/src/utils/ThreadPool.cpp
@@ -26,7 +26,6 @@ ThreadPool::ThreadPool(int max_worker_threads, core::controller::ControllerServi
     : thread_reduction_count_(0),
       max_worker_threads_(max_worker_threads),
       current_workers_(0),
-      adjust_threads_(false),
       running_(false),
       controller_service_provider_(controller_service_provider),
       name_(std::move(name)),


### PR DESCRIPTION
The test case "Timer driven should respect both yield and run schedule" of SchedulingAgentTests hung sometimes due to a race condition in the ThreadPool class. It could occur that while shutting down, the notify_all call would go out and after that the delayed scheduler thread would still try to process the worker queue one more time then wait for the notify forever. Moving the running_ variable check under the mutual mutex solves the issue.

https://issues.apache.org/jira/browse/MINIFICPP-2619

---------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
