### PR TITLE
MINIFICPP-2620 DatabaseContentRepository should be the default

### DIFF
--- a/docker/test/integration/resources/minifi/minifi.properties
+++ b/docker/test/integration/resources/minifi/minifi.properties
@@ -7,7 +7,6 @@ nifi.provenance.repository.max.storage.time=1 MIN
 nifi.provenance.repository.max.storage.size=1 MB
 nifi.flowfile.repository.directory.default=${MINIFI_HOME}/flowfile_repository
 nifi.database.content.repository.directory.default=${MINIFI_HOME}/content_repository
-nifi.content.repository.class.name=DatabaseContentRepository
 
 nifi.python.processor.dir=${MINIFI_HOME}/minifi-python/
 nifi.flow.engine.threads=5

--- a/minifi_main/MiNiFiMain.cpp
+++ b/minifi_main/MiNiFiMain.cpp
@@ -64,12 +64,12 @@
 #include "AgentDocs.h"
 #include "MainHelper.h"
 #include "agent/JsonSchema.h"
-#include "core/state/nodes/ResponseNodeLoader.h"
 #include "core/state/MetricsPublisherStore.h"
 #include "argparse/argparse.hpp"
 #include "agent/agent_version.h"
 #include "Fips.h"
 #include "core/BulletinStore.h"
+#include "range/v3/algorithm/min_element.hpp"
 
 namespace minifi = org::apache::nifi::minifi;
 namespace core = minifi::core;
@@ -84,7 +84,7 @@ static std::atomic_flag process_running;
  *
  * Semaphores are a portable choice when using signal handlers. Threads,
  * mutexes, and condition variables are not guaranteed to work within
- * a signal handler. Consequently we will use the semaphore to avoid thread
+ * a signal handler. Consequently, we will use the semaphore to avoid thread
  * safety issues.
  */
 
@@ -303,7 +303,6 @@ int main(int argc, char **argv) {
   do {
     flow_controller_running.test_and_set();
 
-    std::string graceful_shutdown_seconds;
     std::string prov_repo_class = "provenancerepository";
     std::string flow_repo_class = "flowfilerepository";
     std::string nifi_configuration_class_name = "adaptiveconfiguration";
@@ -423,22 +422,22 @@ int main(int argc, char **argv) {
     if (disk_space_watchdog_enable) {
       try {
         const auto repo_paths = [&] {
-          std::vector<std::string> repo_paths;
-          repo_paths.reserve(3);
+          std::vector<std::string> paths;
+          paths.reserve(3);
           // REPOSITORY_DIRECTORY is a dummy path used by noop repositories
           const auto path_valid = [](const std::string& p) { return !p.empty() && p != org::apache::nifi::minifi::core::REPOSITORY_DIRECTORY; };
           auto prov_repo_path = prov_repo->getDirectory();
           auto flow_repo_path = flow_repo->getDirectory();
           auto content_repo_storage_path = content_repo->getStoragePath();
-          if (!prov_repo->isNoop() && path_valid(prov_repo_path)) { repo_paths.push_back(std::move(prov_repo_path)); }
-          if (!flow_repo->isNoop() && path_valid(flow_repo_path)) { repo_paths.push_back(std::move(flow_repo_path)); }
-          if (path_valid(content_repo_storage_path)) { repo_paths.push_back(std::move(content_repo_storage_path)); }
-          return repo_paths;
+          if (!prov_repo->isNoop() && path_valid(prov_repo_path)) { paths.push_back(std::move(prov_repo_path)); }
+          if (!flow_repo->isNoop() && path_valid(flow_repo_path)) { paths.push_back(std::move(flow_repo_path)); }
+          if (path_valid(content_repo_storage_path)) { paths.push_back(std::move(content_repo_storage_path)); }
+          return paths;
         }();
         const auto available_spaces = minifi::disk_space_watchdog::check_available_space(repo_paths, logger.get());
         const auto config = minifi::disk_space_watchdog::read_config(*configure);
         const auto min_space = [](const std::vector<std::uintmax_t>& spaces) {
-          const auto it = std::min_element(std::begin(spaces), std::end(spaces));
+          const auto it = ranges::min_element(spaces);
           return it != spaces.end() ? *it : (std::numeric_limits<std::uintmax_t>::max)();
         };
         if (min_space(available_spaces) <= config.stop_threshold_bytes) {

--- a/minifi_main/MiNiFiMain.cpp
+++ b/minifi_main/MiNiFiMain.cpp
@@ -41,6 +41,7 @@
 #include <csignal>
 
 #include <atomic>
+#include <algorithm>
 #include <cstdlib>
 #include <iostream>
 #include <vector>
@@ -69,7 +70,6 @@
 #include "agent/agent_version.h"
 #include "Fips.h"
 #include "core/BulletinStore.h"
-#include "range/v3/algorithm/min_element.hpp"
 
 namespace minifi = org::apache::nifi::minifi;
 namespace core = minifi::core;
@@ -437,7 +437,7 @@ int main(int argc, char **argv) {
         const auto available_spaces = minifi::disk_space_watchdog::check_available_space(repo_paths, logger.get());
         const auto config = minifi::disk_space_watchdog::read_config(*configure);
         const auto min_space = [](const std::vector<std::uintmax_t>& spaces) {
-          const auto it = ranges::min_element(spaces);
+          const auto it = std::ranges::min_element(spaces);
           return it != spaces.end() ? *it : (std::numeric_limits<std::uintmax_t>::max)();
         };
         if (min_space(available_spaces) <= config.stop_threshold_bytes) {

--- a/minifi_main/MiNiFiMain.cpp
+++ b/minifi_main/MiNiFiMain.cpp
@@ -307,7 +307,7 @@ int main(int argc, char **argv) {
     std::string prov_repo_class = "provenancerepository";
     std::string flow_repo_class = "flowfilerepository";
     std::string nifi_configuration_class_name = "adaptiveconfiguration";
-    std::string content_repo_class = "filesystemrepository";
+    std::string content_repo_class = "DatabaseContentRepository";
 
     auto log_properties = std::make_shared<core::logging::LoggerProperties>();
     log_properties->setHome(minifiHome);


### PR DESCRIPTION
Based on [CONFIGURE.md](https://github.com/apache/nifi-minifi-cpp/blob/main/CONFIGURE.md#configuring-repositories) DatabaseContentRepository should be the default.

We even had a [test](https://github.com/apache/nifi-minifi-cpp/blob/main/docker/test/integration/features/core_functionality.feature#L50-L55) to verify this, but it was explicitly set [here](https://github.com/apache/nifi-minifi-cpp/blob/main/minifi_main/MiNiFiMain.cpp#L310) so it didnt test it properly.


---
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
