### PR TITLE
MINIFICPP-2636 update ExecutePythonProcessor description

### DIFF
--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -722,7 +722,7 @@ In the list below, the names of required properties appear in bold. Any other pr
 
 ### Description
 
-Executes a script given the flow file and a process session. The script is responsible for handling the incoming flow file (transfer to SUCCESS or remove, e.g.) as well as any flow files created by the script. If the handling is incomplete or incorrect, the session will be rolled back.Scripts must define an onTrigger function which accepts NiFi Context and Property objects. For efficiency, scripts are executed once when the processor is run, then the onTrigger method is called for each incoming flowfile. This enables scripts to keep state if they wish, although there will be a script context per concurrent task of the processor. In order to, e.g., compute an arithmetic sum based on incoming flow file information, set the concurrent tasks to 1. The python script files are expected to contain `describe(procesor)` and `onTrigger(context, session)`.
+Executes a script given the flow file and a process session. The script is responsible for handling the incoming flow file (transfer to SUCCESS or remove, e.g.) as well as any flow files created by the script. If the handling is incomplete or incorrect, the session will be rolled back. Scripts must define an onTrigger function which accepts NiFi Context and ProcessSession objects. Scripts are executed once when the processor is run, then the onTrigger method is called for each incoming flowfile. This enables scripts to keep state if they wish. The python script files are expected to contain `describe(processor)` and `onTrigger(context, session)`.
 
 ### Properties
 

--- a/extensions/python/ExecutePythonProcessor.h
+++ b/extensions/python/ExecutePythonProcessor.h
@@ -50,10 +50,9 @@ class ExecutePythonProcessor : public core::ProcessorImpl {
 
   EXTENSIONAPI static constexpr const char* Description = "Executes a script given the flow file and a process session. "
       "The script is responsible for handling the incoming flow file (transfer to SUCCESS or remove, e.g.) as well as "
-      "any flow files created by the script. If the handling is incomplete or incorrect, the session will be rolled back.Scripts must define an onTrigger function which accepts NiFi Context "
-      "and Property objects. For efficiency, scripts are executed once when the processor is run, then the onTrigger method is called for each incoming flowfile. This enables scripts to keep state "
-      "if they wish, although there will be a script context per concurrent task of the processor. In order to, e.g., compute an arithmetic sum based on incoming flow file information, set the "
-      "concurrent tasks to 1. The python script files are expected to contain `describe(procesor)` and `onTrigger(context, session)`.";
+      "any flow files created by the script. If the handling is incomplete or incorrect, the session will be rolled back. Scripts must define an onTrigger function which accepts NiFi Context "
+      "and ProcessSession objects. Scripts are executed once when the processor is run, then the onTrigger method is called for each incoming flowfile. This enables scripts to keep state "
+      "if they wish. The python script files are expected to contain `describe(processor)` and `onTrigger(context, session)`.";
 
   EXTENSIONAPI static constexpr auto ScriptFile = core::PropertyDefinitionBuilder<>::createProperty("Script File")
       .withDescription("Path to script file to execute. Only one of Script File or Script Body may be used")


### PR DESCRIPTION
- onTrigger accepts session, not property
- justifying basic behavior with efficiency seems weird, removed
- remove the sentence about concurrency, since the processor is single threaded

On a somewhat unrelated note, should we drop this API in favor of the newer NiFi-compatible python scripting API, or is it still useful to maintain? I guess it's easier to write processors for the legacy API, but the new API seems better designed, plus it handles dependencies. If we drop it, it should be done before 1.0.

-----
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
