### PR TITLE
MINIFICPP-2696 Add option for optimizationForSmallDB in DatabaseConte…

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -41,6 +41,7 @@
   - [Configuring Repositories](#configuring-repositories)
   - [Configuring Volatile Repositories](#configuring-volatile-repositories)
   - [Configuring Repository storage locations](#configuring-repository-storage-locations)
+  - [Configuring cache size for rocksdb content repository](#configuring-cache-size-for-rocksdb-content-repository)
   - [Configuring compression for rocksdb database](#configuring-compression-for-rocksdb-database)
   - [Configuring compaction for rocksdb database](#configuring-compaction-for-rocksdb-database)
   - [Configuring synchronous or asynchronous writes for RocksDB content repository](#configuring-synchronous-or-asynchronous-writes-for-rocksdb-content-repository)
@@ -673,6 +674,19 @@ In a Filesystem Hierarchy Standard (FHS) installation (from an RPM package), the
     nifi.provenance.repository.directory.default=/var/lib/nifi-minifi-cpp/provenance_repository
     nifi.flowfile.repository.directory.default=/var/lib/nifi-minifi-cpp/flowfile_repository
     nifi.database.content.repository.directory.default=/var/lib/nifi-minifi-cpp/content_repository
+
+### Configuring cache size for rocksdb content repository
+
+The RocksDB content repository uses a cache to limit memory usage. The cache size can be configured using the following property.
+This should limit the memory usage but may cause minimal processing overhead.
+
+    # in minifi.properties
+    nifi.database.content.repository.optimize.for.small.db.cache.size=8 MB
+
+You can disable this cache by setting it to an empty value.
+
+    # in minifi.properties
+    nifi.database.content.repository.optimize.for.small.db.cache.size=
 
 
 ### Configuring compression for rocksdb database

--- a/conf/minifi.properties.in
+++ b/conf/minifi.properties.in
@@ -52,6 +52,7 @@ nifi.content.repository.class.name=DatabaseContentRepository
 ## Relates to the internal workings of the rocksdb backend
 # nifi.flowfile.repository.rocksdb.compaction.period=2 min
 # nifi.database.content.repository.rocksdb.compaction.period=2 min
+# nifi.database.content.repository.optimize.for.small.db.cache.size=8 MB
 
 # setting this value to "0" enables synchronous deletion
 # nifi.database.content.repository.purge.period = 1 sec

--- a/extensions/rocksdb-repos/DatabaseContentRepository.cpp
+++ b/extensions/rocksdb-repos/DatabaseContentRepository.cpp
@@ -58,10 +58,14 @@ bool DatabaseContentRepository::initialize(const std::shared_ptr<minifi::Configu
 
   setCompactionPeriod(configuration);
 
-  const auto cache_size = configuration->get(Configure::nifi_dbcontent_optimize_for_small_db_cache_size).or_else([] { return std::make_optional<std::string>("8 MB"); })
-    | utils::andThen([](const auto& cache_size_str) -> std::optional<uint64_t> {
-      return parsing::parseDataSize(cache_size_str) | utils::toOptional();
-    });
+  const auto cache_size = configuration->get(Configure::nifi_dbcontent_optimize_for_small_db_cache_size)
+      | utils::orElse([] { return std::make_optional<std::string>("8 MB"); })
+      | utils::andThen([](const auto& cache_size_str) -> std::optional<uint64_t> {
+        if (cache_size_str.empty()) {
+          return std::nullopt;
+        }
+        return parsing::parseDataSize(cache_size_str) | utils::orThrow(fmt::format("{} has invalid format {}", Configure::nifi_dbcontent_optimize_for_small_db_cache_size, cache_size_str));
+      });
 
   std::shared_ptr<rocksdb::Cache> cache = nullptr;
   std::shared_ptr<rocksdb::WriteBufferManager> wbm = nullptr;

--- a/extensions/rocksdb-repos/database/OpenRocksDb.cpp
+++ b/extensions/rocksdb-repos/database/OpenRocksDb.cpp
@@ -137,20 +137,44 @@ std::optional<uint64_t> OpenRocksDb::getApproximateSizes() const {
 
 minifi::core::RepositoryMetricsSource::RocksDbStats OpenRocksDb::getStats() {
   minifi::core::RepositoryMetricsSource::RocksDbStats stats;
-  std::string table_readers;
-  GetProperty("rocksdb.estimate-table-readers-mem", &table_readers);
-  try {
-    stats.table_readers_size = std::stoull(table_readers);
-  } catch (const std::exception&) {
-    logger_->log_warn("Could not retrieve valid 'rocksdb.estimate-table-readers-mem' property value from rocksdb content repository!");
+  {
+    std::string table_readers;
+    GetProperty("rocksdb.estimate-table-readers-mem", &table_readers);
+    try {
+      stats.table_readers_size = std::stoull(table_readers);
+    } catch (const std::exception&) {
+      logger_->log_warn("Could not retrieve valid 'rocksdb.estimate-table-readers-mem' property value from rocksdb content repository!");
+    }
   }
 
-  std::string all_memtables;
-  GetProperty("rocksdb.cur-size-all-mem-tables", &all_memtables);
-  try {
-    stats.all_memory_tables_size = std::stoull(all_memtables);
-  } catch (const std::exception&) {
-    logger_->log_warn("Could not retrieve valid 'rocksdb.cur-size-all-mem-tables' property value from rocksdb content repository!");
+  {
+    std::string all_memtables;
+    GetProperty("rocksdb.cur-size-all-mem-tables", &all_memtables);
+    try {
+      stats.all_memory_tables_size = std::stoull(all_memtables);
+    } catch (const std::exception&) {
+      logger_->log_warn("Could not retrieve valid 'rocksdb.cur-size-all-mem-tables' property value from rocksdb content repository!");
+    }
+  }
+
+  {
+    std::string block_cache_usage;
+    GetProperty("rocksdb.block-cache-usage", &block_cache_usage);
+    try {
+      stats.block_cache_usage = std::stoull(block_cache_usage);
+    } catch (const std::exception&) {
+      logger_->log_warn("Could not retrieve valid 'rocksdb.block-cache-usage' property value from rocksdb content repository!");
+    }
+  }
+
+  {
+    std::string block_cache_pinned_usage;
+    GetProperty("rocksdb.block-cache-pinned-usage", &block_cache_pinned_usage);
+    try {
+      stats.block_cache_pinned_usage = std::stoull(block_cache_pinned_usage);
+    } catch (const std::exception&) {
+      logger_->log_warn("Could not retrieve valid 'rocksdb.block-cache-pinned-usage' property value from rocksdb content repository!");
+    }
   }
 
   return stats;

--- a/extensions/rocksdb-repos/database/OpenRocksDb.cpp
+++ b/extensions/rocksdb-repos/database/OpenRocksDb.cpp
@@ -135,47 +135,23 @@ std::optional<uint64_t> OpenRocksDb::getApproximateSizes() const {
   return std::nullopt;
 }
 
+void OpenRocksDb::fillU64FromProperty(uint64_t& member, std::string_view property_name) {
+  std::string property_value;
+  GetProperty(property_name, &property_value);
+  try {
+    member = std::stoull(property_value);
+  } catch (const std::exception&) {
+    logger_->log_warn("Could not retrieve valid '{}' property value from rocksdb content repository!", property_name);
+  }
+}
+
+
 minifi::core::RepositoryMetricsSource::RocksDbStats OpenRocksDb::getStats() {
   minifi::core::RepositoryMetricsSource::RocksDbStats stats;
-  {
-    std::string table_readers;
-    GetProperty("rocksdb.estimate-table-readers-mem", &table_readers);
-    try {
-      stats.table_readers_size = std::stoull(table_readers);
-    } catch (const std::exception&) {
-      logger_->log_warn("Could not retrieve valid 'rocksdb.estimate-table-readers-mem' property value from rocksdb content repository!");
-    }
-  }
-
-  {
-    std::string all_memtables;
-    GetProperty("rocksdb.cur-size-all-mem-tables", &all_memtables);
-    try {
-      stats.all_memory_tables_size = std::stoull(all_memtables);
-    } catch (const std::exception&) {
-      logger_->log_warn("Could not retrieve valid 'rocksdb.cur-size-all-mem-tables' property value from rocksdb content repository!");
-    }
-  }
-
-  {
-    std::string block_cache_usage;
-    GetProperty("rocksdb.block-cache-usage", &block_cache_usage);
-    try {
-      stats.block_cache_usage = std::stoull(block_cache_usage);
-    } catch (const std::exception&) {
-      logger_->log_warn("Could not retrieve valid 'rocksdb.block-cache-usage' property value from rocksdb content repository!");
-    }
-  }
-
-  {
-    std::string block_cache_pinned_usage;
-    GetProperty("rocksdb.block-cache-pinned-usage", &block_cache_pinned_usage);
-    try {
-      stats.block_cache_pinned_usage = std::stoull(block_cache_pinned_usage);
-    } catch (const std::exception&) {
-      logger_->log_warn("Could not retrieve valid 'rocksdb.block-cache-pinned-usage' property value from rocksdb content repository!");
-    }
-  }
+  fillU64FromProperty(stats.table_readers_size, "rocksdb.estimate-table-readers-mem");
+  fillU64FromProperty(stats.all_memory_tables_size, "rocksdb.cur-size-all-mem-tables");
+  fillU64FromProperty(stats.block_cache_usage, "rocksdb.block-cache-usage");
+  fillU64FromProperty(stats.block_cache_pinned_usage, "rocksdb.block-cache-pinned-usage");
 
   return stats;
 }

--- a/extensions/rocksdb-repos/database/OpenRocksDb.h
+++ b/extensions/rocksdb-repos/database/OpenRocksDb.h
@@ -81,6 +81,8 @@ class OpenRocksDb {
   void handleResult(const rocksdb::Status& result);
   void handleResult(const std::vector<rocksdb::Status>& results);
 
+  void fillU64FromProperty(uint64_t& member, std::string_view property_name);
+
   gsl::not_null<RocksDbInstance*> db_;
   gsl::not_null<std::shared_ptr<rocksdb::DB>> impl_;
   gsl::not_null<std::shared_ptr<ColumnHandle>> column_;

--- a/extensions/rocksdb-repos/database/RocksDbUtils.h
+++ b/extensions/rocksdb-repos/database/RocksDbUtils.h
@@ -49,6 +49,12 @@ class Writable {
     }
   }
 
+  template <typename Method, typename... Args>
+  decltype(auto) call(Method method, Args&&... args) {
+    is_modified_ = true;
+    return std::invoke(method, target_, std::forward<Args>(args)...);
+  }
+
   template<typename F>
   const F& get(F T::* member) {
     return target_.*member;

--- a/extensions/rocksdb-repos/database/RocksDbUtils.h
+++ b/extensions/rocksdb-repos/database/RocksDbUtils.h
@@ -51,8 +51,14 @@ class Writable {
 
   template <typename Method, typename... Args>
   decltype(auto) call(Method method, Args&&... args) {
-    is_modified_ = true;
     return std::invoke(method, target_, std::forward<Args>(args)...);
+  }
+
+  void optimizeForSmallDb(std::shared_ptr<rocksdb::Cache> cache, std::shared_ptr<rocksdb::WriteBufferManager> wbm) {
+    if (!cache || !wbm) { return; }
+    target_.OptimizeForSmallDb(&cache);
+    target_.write_buffer_manager = wbm;
+    target_.max_open_files = 20;
   }
 
   template<typename F>

--- a/extensions/rocksdb-repos/tests/DBContentRepositoryTests.cpp
+++ b/extensions/rocksdb-repos/tests/DBContentRepositoryTests.cpp
@@ -355,3 +355,35 @@ TEST_CASE("DBContentRepository can clear orphan entries") {
 
   REQUIRE(getDbSize(dir) == 0);
 }
+
+TEST_CASE("nifi_dbcontent_optimize_for_small_db_cache_size default") {
+  LogTestController::getInstance().setTrace<core::repository::DatabaseContentRepository>();
+
+  const auto configuration = std::make_shared<org::apache::nifi::minifi::ConfigureImpl>();
+  const auto content_repo = std::make_shared<core::repository::DatabaseContentRepository>();
+  REQUIRE(content_repo->initialize(configuration));
+
+  CHECK(LogTestController::getInstance().contains("Using 8388608 sized cache for DatabaseContentRepository"));
+}
+
+TEST_CASE("nifi_dbcontent_optimize_for_small_db_cache_size override") {
+  LogTestController::getInstance().setTrace<core::repository::DatabaseContentRepository>();
+
+  const auto configuration = std::make_shared<org::apache::nifi::minifi::ConfigureImpl>();
+  configuration->set("nifi.database.content.repository.optimize.for.small.db.cache.size", "100 MB");
+  const auto content_repo = std::make_shared<core::repository::DatabaseContentRepository>();
+  REQUIRE(content_repo->initialize(configuration));
+
+  CHECK(LogTestController::getInstance().contains("Using 104857600 sized cache for DatabaseContentRepository"));
+}
+
+TEST_CASE("nifi_dbcontent_optimize_for_small_db_cache_size disable") {
+  LogTestController::getInstance().setTrace<core::repository::DatabaseContentRepository>();
+
+  const auto configuration = std::make_shared<org::apache::nifi::minifi::ConfigureImpl>();
+  configuration->set("nifi.database.content.repository.optimize.for.small.db.cache.size", "");
+  const auto content_repo = std::make_shared<core::repository::DatabaseContentRepository>();
+  REQUIRE(content_repo->initialize(configuration));
+
+  CHECK(LogTestController::getInstance().contains("Cache limitation disabled for DatabaseContentRepository"));
+}

--- a/extensions/rocksdb-repos/tests/DBContentRepositoryTests.cpp
+++ b/extensions/rocksdb-repos/tests/DBContentRepositoryTests.cpp
@@ -387,3 +387,12 @@ TEST_CASE("nifi_dbcontent_optimize_for_small_db_cache_size disable") {
 
   CHECK(LogTestController::getInstance().contains("Cache limitation disabled for DatabaseContentRepository"));
 }
+
+TEST_CASE("nifi_dbcontent_optimize_for_small_db_cache_size invalid") {
+  LogTestController::getInstance().setTrace<core::repository::DatabaseContentRepository>();
+
+  const auto configuration = std::make_shared<org::apache::nifi::minifi::ConfigureImpl>();
+  configuration->set("nifi.database.content.repository.optimize.for.small.db.cache.size", "two million bytes");
+  const auto content_repo = std::make_shared<core::repository::DatabaseContentRepository>();
+  REQUIRE_THROWS(content_repo->initialize(configuration));
+}

--- a/libminifi/src/Configuration.cpp
+++ b/libminifi/src/Configuration.cpp
@@ -54,6 +54,7 @@ const std::unordered_map<std::string_view, gsl::not_null<const core::PropertyVal
   {Configuration::nifi_flowfile_repository_rocksdb_read_verify_checksums, gsl::make_not_null(&core::StandardPropertyValidators::BOOLEAN_VALIDATOR)},
   {Configuration::nifi_provenance_repository_rocksdb_read_verify_checksums, gsl::make_not_null(&core::StandardPropertyValidators::BOOLEAN_VALIDATOR)},
   {Configuration::nifi_rocksdb_state_storage_read_verify_checksums, gsl::make_not_null(&core::StandardPropertyValidators::BOOLEAN_VALIDATOR)},
+  {Configuration::nifi_dbcontent_optimize_for_small_db_cache_size, gsl::make_not_null(&core::StandardPropertyValidators::DATA_SIZE_VALIDATOR)},
   {Configuration::nifi_dbcontent_repository_purge_period, gsl::make_not_null(&core::StandardPropertyValidators::TIME_PERIOD_VALIDATOR)},
   {Configuration::nifi_remote_input_secure, gsl::make_not_null(&core::StandardPropertyValidators::BOOLEAN_VALIDATOR)},
   {Configuration::nifi_security_need_ClientAuth, gsl::make_not_null(&core::StandardPropertyValidators::BOOLEAN_VALIDATOR)},

--- a/libminifi/src/core/state/nodes/RepositoryMetricsSourceStore.cpp
+++ b/libminifi/src/core/state/nodes/RepositoryMetricsSourceStore.cpp
@@ -48,6 +48,8 @@ std::vector<SerializedResponseNode> RepositoryMetricsSourceStore::serialize() co
     if (auto rocksdb_stats = repo->getRocksDbStats()) {
       parent.children.push_back({.name = "rocksDbTableReadersSize", .value = rocksdb_stats->table_readers_size});
       parent.children.push_back({.name = "rocksDbAllMemoryTablesSize", .value = rocksdb_stats->all_memory_tables_size});
+      parent.children.push_back({.name = "rocksDbBlockCacheUsage", .value = rocksdb_stats->block_cache_usage});
+      parent.children.push_back({.name = "rocksDbBlockCachePinnedUsage", .value = rocksdb_stats->block_cache_pinned_usage});
     }
 
     serialized.push_back(parent);
@@ -67,6 +69,10 @@ std::vector<PublishedMetric> RepositoryMetricsSourceStore::calculateMetrics() co
       metrics.push_back({"rocksdb_table_readers_size_bytes", static_cast<double>(rocksdb_stats->table_readers_size),
         {{"metric_class", name_}, {"repository_name", repo->getRepositoryName()}}});
       metrics.push_back({"rocksdb_all_memory_tables_size_bytes", static_cast<double>(rocksdb_stats->all_memory_tables_size),
+        {{"metric_class", name_}, {"repository_name", repo->getRepositoryName()}}});
+      metrics.push_back({"rocksdb_block_cache_usage_bytes", static_cast<double>(rocksdb_stats->block_cache_usage),
+        {{"metric_class", name_}, {"repository_name", repo->getRepositoryName()}}});
+      metrics.push_back({"rocksdb_block_cache_pinned_usage_bytes", static_cast<double>(rocksdb_stats->block_cache_pinned_usage),
         {{"metric_class", name_}, {"repository_name", repo->getRepositoryName()}}});
     }
   }

--- a/libminifi/test/libtest/unit/ProvenanceTestHelper.h
+++ b/libminifi/test/libtest/unit/ProvenanceTestHelper.h
@@ -161,7 +161,9 @@ class TestRocksDbRepository : public TestThreadedRepository {
   std::optional<RocksDbStats> getRocksDbStats() const override {
     return RocksDbStats {
       .table_readers_size = 100,
-      .all_memory_tables_size = 200
+      .all_memory_tables_size = 200,
+      .block_cache_usage = 85,
+      .block_cache_pinned_usage = 50
     };
   }
 };

--- a/libminifi/test/libtest/unit/TestUtils.cpp
+++ b/libminifi/test/libtest/unit/TestUtils.cpp
@@ -262,7 +262,7 @@ std::error_code sendMessagesViaSSL(const std::vector<std::string_view>& contents
 
 std::vector<LogMessageView> extractLogMessageViews(const std::string& log_str) {
   std::vector<LogMessageView> messages;
-  const std::regex header_pattern(R"((\[[\d\-\s\:\.]+\]) (\s*\[[^\]]+\]) \[(.*)\])");
+  const std::regex header_pattern(R"(\[([\d\-\s\:\.]+)\]\s+\[(.*?)\]\s+\[(.*?)\])");
   struct HeaderMarker {
     size_t start;
     std::string_view timestamp;

--- a/libminifi/test/libtest/unit/TestUtils.h
+++ b/libminifi/test/libtest/unit/TestUtils.h
@@ -39,6 +39,7 @@
 #include "utils/net/Ssl.h"
 #include "core/Processor.h"
 #include <range/v3/all.hpp>
+#include "./ProcessorUtils.h"
 
 using namespace std::literals::chrono_literals;
 

--- a/libminifi/test/libtest/unit/TestUtils.h
+++ b/libminifi/test/libtest/unit/TestUtils.h
@@ -127,6 +127,12 @@ bool verifyLogLineVariantPresenceInPollTime(const std::chrono::duration<Rep, Per
   return verifyEventHappenedInPollTime(wait_duration, check);
 }
 
+template<class Rep, class Period>
+bool verifyLogMatchesRegexInPollTime(const std::chrono::duration<Rep, Period>& wait_duration, const std::string& regex) {
+  auto check = [&regex] { return LogTestController::getInstance().matchesRegex(regex); };
+  return verifyEventHappenedInPollTime(wait_duration, check);
+}
+
 namespace internal {
 struct JsonContext {
   const JsonContext *parent{nullptr};

--- a/libminifi/test/libtest/unit/TestUtils.h
+++ b/libminifi/test/libtest/unit/TestUtils.h
@@ -245,53 +245,7 @@ struct LogMessageView {
   std::string_view payload;
 };
 
-inline std::vector<LogMessageView> extractLogMessageViews(const std::string& log_str) {
-  std::vector<LogMessageView> messages;
-  const std::regex header_pattern(R"((\[[\d\-\s\:\.]+\]) (\s*\[[^\]]+\]) \[(.*)\])");
-  const auto search_range = std::ranges::subrange(std::sregex_iterator(log_str.begin(), log_str.end(), header_pattern), std::sregex_iterator());
-  struct MsgMarker {
-    size_t start;
-    size_t timestamp_start;
-    size_t timestamp_length;
-    size_t logger_class_start;
-    size_t logger_class_length;
-    size_t log_level_start;
-    size_t log_level_length;
-  };
-
-  std::vector<MsgMarker> markers = ranges::subrange<std::sregex_iterator>(std::sregex_iterator(log_str.begin(), log_str.end(), header_pattern),
-                                       std::sregex_iterator()) |
-      ranges::views::transform([=](const std::smatch& m) {
-        return MsgMarker{.start = static_cast<size_t>(m.position(0)),
-            .timestamp_start = static_cast<size_t>(m.position(1)),
-            .timestamp_length = static_cast<size_t>(m.length(1)),
-            .logger_class_start = static_cast<size_t>(m.position(2)),
-            .logger_class_length = static_cast<size_t>(m.length(2)),
-            .log_level_start = static_cast<size_t>(m.position(3)),
-            .log_level_length = static_cast<size_t>(m.length(3))};
-      }) |
-      ranges::to<std::vector>();
-
-  markers.push_back(MsgMarker{.start = log_str.size(),
-      .timestamp_start = log_str.size(),
-      .timestamp_length = 0,
-      .logger_class_start = log_str.size(),
-      .logger_class_length = 0,
-      .log_level_start = log_str.size(),
-      .log_level_length = 0});
-
-  for (auto window: markers | ranges::views::sliding(2)) {
-    const std::string_view timestamp{log_str.data() + window[0].timestamp_start, window[0].timestamp_length};
-    const std::string_view logger_class{log_str.data() + window[0].logger_class_start, window[0].logger_class_length};
-    const std::string_view log_level{log_str.data() + window[0].log_level_start, window[0].log_level_length};
-    const size_t msg_start_pos = window[0].log_level_start + window[0].log_level_length + 2;
-    const size_t msg_length = window[1].start >= msg_start_pos ? window[1].start - msg_start_pos : 0;
-    const std::string_view message{log_str.data() + msg_start_pos, msg_length};
-    messages.push_back(LogMessageView{.timestamp = timestamp, .logger_class = logger_class, .log_level = log_level, .payload = message});
-  }
-
-  return messages;
-}
+std::vector<LogMessageView> extractLogMessageViews(const std::string& log_str);
 
 }  // namespace org::apache::nifi::minifi::test::utils
 

--- a/libminifi/test/unit/LogMetricsPublisherTests.cpp
+++ b/libminifi/test/unit/LogMetricsPublisherTests.cpp
@@ -18,11 +18,11 @@
 #include <memory>
 #include <thread>
 
-#include "unit/TestBase.h"
-#include "unit/Catch.h"
+#include "core/RepositoryFactory.h"
 #include "core/state/LogMetricsPublisher.h"
 #include "core/state/nodes/ResponseNodeLoader.h"
-#include "core/RepositoryFactory.h"
+#include "unit/Catch.h"
+#include "unit/TestBase.h"
 #include "unit/TestUtils.h"
 #include "utils/file/FileUtils.h"
 
@@ -33,12 +33,12 @@ namespace org::apache::nifi::minifi::test {
 class LogPublisherTestFixture {
  public:
   LogPublisherTestFixture()
-    : configuration_(std::make_shared<ConfigureImpl>()),
-      provenance_repo_(core::createRepository("provenancerepository", "provenancerepository")),
-      flow_file_repo_(core::createRepository("flowfilerepository", "flowfilerepository")),
-      response_node_loader_(std::make_shared<state::response::ResponseNodeLoaderImpl>(configuration_,
-        std::vector<std::shared_ptr<core::RepositoryMetricsSource>>{provenance_repo_, flow_file_repo_}, nullptr)),
-      publisher_(std::make_unique<minifi::state::LogMetricsPublisher>("LogMetricsPublisher")) {
+      : configuration_(std::make_shared<ConfigureImpl>()),
+        provenance_repo_(core::createRepository("provenancerepository", "provenancerepository")),
+        flow_file_repo_(core::createRepository("flowfilerepository", "flowfilerepository")),
+        response_node_loader_(std::make_shared<state::response::ResponseNodeLoaderImpl>(configuration_,
+            std::vector<std::shared_ptr<core::RepositoryMetricsSource>>{provenance_repo_, flow_file_repo_}, nullptr)),
+        publisher_(std::make_unique<minifi::state::LogMetricsPublisher>("LogMetricsPublisher")) {
     provenance_repo_->initialize(configuration_);
     flow_file_repo_->initialize(configuration_);
   }
@@ -67,7 +67,8 @@ class LogPublisherTestFixture {
 TEST_CASE_METHOD(LogPublisherTestFixture, "Logging interval property is mandatory", "[LogMetricsPublisher]") {
   LogTestController::getInstance().setTrace<minifi::state::LogMetricsPublisher>();
   SECTION("No logging interval is set") {
-    REQUIRE_THROWS_WITH(publisher_->initialize(configuration_, response_node_loader_), "General Operation: Metrics logging interval not configured for log metrics publisher!");
+    REQUIRE_THROWS_WITH(publisher_->initialize(configuration_, response_node_loader_),
+        "General Operation: Metrics logging interval not configured for log metrics publisher!");
   }
   SECTION("Logging interval is set to 2 seconds") {
     configuration_->set(minifi::Configuration::nifi_metrics_publisher_log_metrics_logging_interval, "2s");
@@ -88,46 +89,40 @@ TEST_CASE_METHOD(LogPublisherTestFixture, "Verify empty metrics if no valid metr
   REQUIRE(utils::verifyLogLinePresenceInPollTime(5s, "LogMetricsPublisher is configured without any valid metrics!"));
 }
 
-std::string expectedRepositoryMetricsRegex(std::string level) {
-  std::string regex_pattern =
-      // 1. Log Header & Opening
-      R"(\[[\d\-\s\:\.]+\]\s*\[[^\]]+\]\s*\[)" + std::move(level) + R"(\]\s*\{\s*)" +
-      R"(\"LogMetrics\":\s*\{\s*)" +
+bool check_exact_metrics_value(const rapidjson::Value& repo_metrics, const std::string_view key, const std::string_view expected_value) {
+  const auto key_ref = rapidjson::StringRef(key.data(), key.size());
+  const auto member_it = repo_metrics.FindMember(key_ref);
+  if (member_it == repo_metrics.MemberEnd()) { return false; }
+  const auto actual_value = std::string_view{member_it->value.GetString(), member_it->value.GetStringLength()};
+  return actual_value == expected_value;
+}
 
-      // 2. (skips other nodes, stops if a \n[ starts (other log line))
-      R"((?:(?!\n\[)[\s\S])*?)" +
+bool isExpectedRepositoryMetricsLogMessage(const utils::LogMessageView& message_view, std::string_view log_level) {
+  if (message_view.log_level != log_level) { return false; }
+  if (message_view.logger_class != "[org::apache::nifi::minifi::state::LogMetricsPublisher]") { return false; }
+  rapidjson::Document document;
+  if (const rapidjson::ParseResult res = document.Parse(message_view.payload.data(), message_view.payload.length()); !res) { return false; }
+  if (!document.HasMember("LogMetrics")) { return false; }
+  const auto& log_metrics = document["LogMetrics"].GetObject();
+  if (!log_metrics.HasMember("RepositoryMetrics")) { return false; }
+  const auto& repository_metrics = log_metrics["RepositoryMetrics"].GetObject();
+  if (!repository_metrics.HasMember("provenancerepository") || !repository_metrics.HasMember("flowfilerepository")) { return false; }
+  const rapidjson::Value& provenance_repo_metrics = repository_metrics["provenancerepository"];
+  const rapidjson::Value& flow_file_repo_metrics = repository_metrics["flowfilerepository"];
 
-      // 3. RepositoryMetrics Node
-      R"(\"RepositoryMetrics\":\s*\{\s*)" +
+  const auto repo_is_okay = [](const rapidjson::Value& repo_metrics) -> bool {
+    return check_exact_metrics_value(repo_metrics, "full", "false")
+        && check_exact_metrics_value(repo_metrics, "running", "false")
+        && check_exact_metrics_value(repo_metrics, "size", "0")
+        && check_exact_metrics_value(repo_metrics, "maxSize", "0")
+        && check_exact_metrics_value(repo_metrics, "entryCount", "0")
+        && check_exact_metrics_value(repo_metrics, "rocksDbTableReadersSize", "0")
+        && check_exact_metrics_value(repo_metrics, "rocksDbAllMemoryTablesSize", "2048")
+        && repo_metrics.HasMember("rocksDbBlockCacheUsage")
+        && repo_metrics.HasMember("rocksDbBlockCachePinnedUsage");
+  };
 
-      // 4. Provenance Repository
-      R"(\"provenancerepository\":\s*\{\s*)" +
-      R"(\"running\":\s*\"false\",\s*)" +
-      R"(\"full\":\s*\"false\",\s*)" +
-      R"(\"size\":\s*\"0\",\s*)" +
-      R"(\s*\"maxSize\":\s*\"0\",\s*)" +
-      R"(\"entryCount\":\s*\"0\",\s*)" +
-      R"(\"rocksDbTableReadersSize\":\s*\"0\",\s*)" +
-      R"(\"rocksDbAllMemoryTablesSize\":\s*\"2048\",\s*)" +
-      R"(\"rocksDbBlockCacheUsage\":\s*\"\d+\",\s*)" +
-      R"(\"rocksDbBlockCachePinnedUsage\":\s*\"\d+\"\s*)" +
-      R"(\},\s*)" +
-
-      // 5. FlowFile Repository
-      R"(\"flowfilerepository\":\s*\{\s*)" +
-      R"(\"running\":\s*\"false\",\s*)" +
-      R"(\"full\":\s*\"false\",\s*)" +
-      R"(\"size\":\s*\"0\",\s*)" +
-      R"(\"maxSize\":\s*\"0\",\s*)" +
-      R"(\"entryCount\":\s*\"0\",\s*)" +
-      R"(\"rocksDbTableReadersSize\":\s*\"0\",\s*)" +
-      R"(\"rocksDbAllMemoryTablesSize\":\s*\"2048\",\s*)" +
-      R"(\"rocksDbBlockCacheUsage\":\s*\"\d+\",\s*)" +
-      R"(\"rocksDbBlockCachePinnedUsage\":\s*\"\d+\"\s*)" +
-
-      // 6. Final Closures
-      R"(\}\s*\}\s*\}\s*\})";
-  return regex_pattern;
+  return repo_is_okay(provenance_repo_metrics) && repo_is_okay(flow_file_repo_metrics);
 }
 
 TEST_CASE_METHOD(LogPublisherTestFixture, "Verify multiple metric nodes in logs", "[LogMetricsPublisher]") {
@@ -136,13 +131,14 @@ TEST_CASE_METHOD(LogPublisherTestFixture, "Verify multiple metric nodes in logs"
   configuration_->set(Configure::nifi_metrics_publisher_metrics, "RepositoryMetrics,DeviceInfoNode");
   publisher_->initialize(configuration_, response_node_loader_);
   publisher_->loadMetricNodes();
-  std::string expected_log_1 = R"([info] {
-    "LogMetrics": {)";
-  std::string expected_log_3 = R"("deviceInfo": {
-            "identifier":)";
-  REQUIRE(utils::verifyLogLinePresenceInPollTime(5s, expected_log_1));
-  REQUIRE(utils::verifyLogMatchesRegexInPollTime(5s, expectedRepositoryMetricsRegex("info")));
-  REQUIRE(utils::verifyLogLinePresenceInPollTime(5s, expected_log_3));
+  REQUIRE(utils::verifyEventHappenedInPollTime(
+      5s,
+      [] {
+        const auto logs = LogTestController::getInstance().getLogs();
+        const auto message_views = utils::extractLogMessageViews(logs);
+        return ranges::any_of(message_views, [](const auto& msg_view) { return isExpectedRepositoryMetricsLogMessage(msg_view, "info"); });
+      },
+      100ms));
 }
 
 TEST_CASE_METHOD(LogPublisherTestFixture, "Verify reloading different metrics", "[LogMetricsPublisher]") {
@@ -152,7 +148,14 @@ TEST_CASE_METHOD(LogPublisherTestFixture, "Verify reloading different metrics", 
   publisher_->initialize(configuration_, response_node_loader_);
   publisher_->loadMetricNodes();
 
-  REQUIRE(utils::verifyLogMatchesRegexInPollTime(5s, expectedRepositoryMetricsRegex("info")));
+  REQUIRE(utils::verifyEventHappenedInPollTime(
+      5s,
+      [] {
+        const auto logs = LogTestController::getInstance().getLogs();
+        const auto message_views = utils::extractLogMessageViews(logs);
+        return ranges::any_of(message_views, [](const auto& msg_view) { return isExpectedRepositoryMetricsLogMessage(msg_view, "info"); });
+      },
+      100ms));
   publisher_->clearMetricNodes();
   LogTestController::getInstance().reset();
   LogTestController::getInstance().setTrace<minifi::state::LogMetricsPublisher>();
@@ -180,7 +183,14 @@ TEST_CASE_METHOD(LogPublisherTestFixture, "Verify generic and publisher specific
   }
   publisher_->initialize(configuration_, response_node_loader_);
   publisher_->loadMetricNodes();
-  REQUIRE(utils::verifyLogMatchesRegexInPollTime(5s, expectedRepositoryMetricsRegex("info")));
+  REQUIRE(utils::verifyEventHappenedInPollTime(
+      5s,
+      [] {
+        const auto logs = LogTestController::getInstance().getLogs();
+        const auto message_views = utils::extractLogMessageViews(logs);
+        return ranges::any_of(message_views, [](const auto& msg_view) { return isExpectedRepositoryMetricsLogMessage(msg_view, "info"); });
+      },
+      100ms));
 }
 
 TEST_CASE_METHOD(LogPublisherTestFixture, "Verify changing log level property for logging", "[LogMetricsPublisher]") {
@@ -190,7 +200,14 @@ TEST_CASE_METHOD(LogPublisherTestFixture, "Verify changing log level property fo
   configuration_->set(Configure::nifi_metrics_publisher_metrics, "RepositoryMetrics");
   publisher_->initialize(configuration_, response_node_loader_);
   publisher_->loadMetricNodes();
-  REQUIRE(utils::verifyLogMatchesRegexInPollTime(5s, expectedRepositoryMetricsRegex("debug")));
+  REQUIRE(utils::verifyEventHappenedInPollTime(
+      5s,
+      [] {
+        const auto logs = LogTestController::getInstance().getLogs();
+        const auto message_views = utils::extractLogMessageViews(logs);
+        return ranges::any_of(message_views, [](const auto& msg_view) { return isExpectedRepositoryMetricsLogMessage(msg_view, "debug"); });
+      },
+      100ms));
 }
 
 }  // namespace org::apache::nifi::minifi::test

--- a/libminifi/test/unit/LogMetricsPublisherTests.cpp
+++ b/libminifi/test/unit/LogMetricsPublisherTests.cpp
@@ -99,7 +99,7 @@ bool check_exact_metrics_value(const rapidjson::Value& repo_metrics, const std::
 
 bool isExpectedRepositoryMetricsLogMessage(const utils::LogMessageView& message_view, std::string_view log_level) {
   if (message_view.log_level != log_level) { return false; }
-  if (message_view.logger_class != "[org::apache::nifi::minifi::state::LogMetricsPublisher]") { return false; }
+  if (message_view.logger_class != "org::apache::nifi::minifi::state::LogMetricsPublisher") { return false; }
   rapidjson::Document document;
   if (const rapidjson::ParseResult res = document.Parse(message_view.payload.data(), message_view.payload.length()); !res) { return false; }
   if (!document.HasMember("LogMetrics")) { return false; }

--- a/libminifi/test/unit/MetricsTests.cpp
+++ b/libminifi/test/unit/MetricsTests.cpp
@@ -104,7 +104,7 @@ TEST_CASE("RepositorymetricsHaveRepo", "[c2m4]") {
 
   SECTION("RocksDB repository") {
     repo = std::make_shared<TestRocksDbRepository>();
-    expected_metric_count = 7;
+    expected_metric_count = 9;
   }
 
 
@@ -125,6 +125,8 @@ TEST_CASE("RepositorymetricsHaveRepo", "[c2m4]") {
     if (expected_metric_count > 5) {
       checkSerializedValue(resp.children, "rocksDbTableReadersSize", "100");
       checkSerializedValue(resp.children, "rocksDbAllMemoryTablesSize", "200");
+      checkSerializedValue(resp.children, "rocksDbBlockCacheUsage", "85");
+      checkSerializedValue(resp.children, "rocksDbBlockCachePinnedUsage", "50");
     }
   }
 

--- a/minifi-api/include/minifi-cpp/core/RepositoryMetricsSource.h
+++ b/minifi-api/include/minifi-cpp/core/RepositoryMetricsSource.h
@@ -28,6 +28,8 @@ class RepositoryMetricsSource {
   struct RocksDbStats {
     uint64_t table_readers_size{};
     uint64_t all_memory_tables_size{};
+    uint64_t block_cache_usage{};
+    uint64_t block_cache_pinned_usage{};
   };
 
   virtual ~RepositoryMetricsSource() = default;

--- a/minifi-api/include/minifi-cpp/properties/Configuration.h
+++ b/minifi-api/include/minifi-cpp/properties/Configuration.h
@@ -76,6 +76,7 @@ class Configuration : public virtual Properties {
   static constexpr const char *nifi_flowfile_repository_rocksdb_read_verify_checksums = "nifi.flowfile.repository.rocksdb.read.verify.checksums";
   static constexpr const char *nifi_provenance_repository_rocksdb_read_verify_checksums = "nifi.provenance.repository.rocksdb.read.verify.checksums";
   static constexpr const char *nifi_rocksdb_state_storage_read_verify_checksums = "nifi.rocksdb.state.storage.read.verify.checksums";
+  static constexpr const char *nifi_dbcontent_optimize_for_small_db_cache_size = "nifi.database.content.repository.optimize.for.small.db.cache.size";
 
   static constexpr const char *nifi_remote_input_secure = "nifi.remote.input.secure";
   static constexpr const char *nifi_security_need_ClientAuth = "nifi.security.need.ClientAuth";


### PR DESCRIPTION
I’ve went ahead and this some testing so we can set a sensible default value for this new configurable value. Based on my testing it seems the processing overhead is negligible, unfortunately the memory gains are also not what one expect (flow specific)

I’ve created a bunch of flows and tried it various cache sizes.

- Simple GenerateFlowFile → LogAttribute 5MB Text (random)
  - processing throughput remained the same while achieving 10% lower memory footprint on avarage, but the memory usage was not consistent
- TailFile(30k lines) → MergeFile → LogAttribute, with GetFile → LogAttribute (to increase memory usage)
  - Processing time of the tailfile remained within run-to-run variance with 20-30% lower memory footprint

I’ve also noticed that compaction time and periodic https://man7.org/linux/man-pages/man3/malloc_trim.3.html makes memory footprint even smaller (much more noticably in some cases)

Methodology
Processing time was measured via log messages, memory footprint was measured via prometheus AgentStatus metrics
Baseline was setting the new variable to an empty string (which basically mimics the current main behaviour)

**I couldn’t measure performance losses but only tried with a small set of relatively simple flows, since this PR now changes the default behavior its important that we emphasise this change and the method to disable this in the release logs.**
