### PR TITLE
MINIFICPP-2724 C API small changes

### DIFF
--- a/extension-framework/cpp-extension-lib/include/api/core/ProcessContext.h
+++ b/extension-framework/cpp-extension-lib/include/api/core/ProcessContext.h
@@ -37,8 +37,6 @@ class ProcessContext {
 
   bool hasNonEmptyProperty(std::string_view name) const;
 
-  std::string getProcessorName() const;
-
  private:
   MinifiProcessContext* impl_;
 };

--- a/extension-framework/cpp-extension-lib/include/api/utils/ProcessorConfigUtils.h
+++ b/extension-framework/cpp-extension-lib/include/api/utils/ProcessorConfigUtils.h
@@ -33,37 +33,37 @@ namespace org::apache::nifi::minifi::api::utils {
 
 inline std::string parseProperty(const core::ProcessContext& ctx, const minifi::core::PropertyReference& property, const core::FlowFile* flow_file = nullptr) {
   return ctx.getProperty(property.name, flow_file)
-      | minifi::utils::orThrow(fmt::format("Expected valid value from \"{}::{}\"", ctx.getProcessorName(), property.name));
+      | minifi::utils::orThrow(fmt::format("Expected valid value from \"{}\"", property.name));
 }
 
 inline bool parseBoolProperty(const core::ProcessContext& ctx, const minifi::core::PropertyReference& property, const core::FlowFile* flow_file = nullptr) {
   return ctx.getProperty(property.name, flow_file)
       | minifi::utils::andThen(parsing::parseBool)
-      | minifi::utils::orThrow(fmt::format("Expected parsable bool from \"{}::{}\"", ctx.getProcessorName(), property.name));
+      | minifi::utils::orThrow(fmt::format("Expected parsable bool from \"{}\"", property.name));
 }
 
 inline uint64_t parseU64Property(const core::ProcessContext& ctx, const minifi::core::PropertyReference& property, const core::FlowFile* flow_file = nullptr) {
   return ctx.getProperty(property.name, flow_file)
       | minifi::utils::andThen(parsing::parseIntegral<uint64_t>)
-      | minifi::utils::orThrow(fmt::format("Expected parsable uint64_t from \"{}::{}\"", ctx.getProcessorName(), property.name));
+      | minifi::utils::orThrow(fmt::format("Expected parsable uint64_t from \"{}\"", property.name));
 }
 
 inline int64_t parseI64Property(const core::ProcessContext& ctx, const minifi::core::PropertyReference& property, const core::FlowFile* flow_file = nullptr) {
   return ctx.getProperty(property.name, flow_file)
       | minifi::utils::andThen(parsing::parseIntegral<int64_t>)
-      | minifi::utils::orThrow(fmt::format("Expected parsable int64_t from \"{}::{}\"", ctx.getProcessorName(), property.name));
+      | minifi::utils::orThrow(fmt::format("Expected parsable int64_t from \"{}\"", property.name));
 }
 
 inline std::chrono::milliseconds parseDurationProperty(const core::ProcessContext& ctx, const minifi::core::PropertyReference& property, const core::FlowFile* flow_file = nullptr) {
   return ctx.getProperty(property.name, flow_file)
       | minifi::utils::andThen(parsing::parseDuration<std::chrono::milliseconds>)
-      | minifi::utils::orThrow(fmt::format("Expected parsable duration from \"{}::{}\"", ctx.getProcessorName(), property.name));
+      | minifi::utils::orThrow(fmt::format("Expected parsable duration from \"{}\"", property.name));
 }
 
 inline uint64_t parseDataSizeProperty(const core::ProcessContext& ctx, const minifi::core::PropertyReference& property, const core::FlowFile* flow_file = nullptr) {
   return ctx.getProperty(property.name, flow_file)
       | minifi::utils::andThen(parsing::parseDataSize)
-      | minifi::utils::orThrow(fmt::format("Expected parsable data size from \"{}::{}\"", ctx.getProcessorName(), property.name));
+      | minifi::utils::orThrow(fmt::format("Expected parsable data size from \"{}\"", property.name));
 }
 
 inline std::optional<std::string> parseOptionalProperty(const core::ProcessContext& ctx, const minifi::core::PropertyReference& property, const core::FlowFile* flow_file = nullptr) {
@@ -74,7 +74,7 @@ inline std::optional<std::string> parseOptionalProperty(const core::ProcessConte
 inline std::optional<bool> parseOptionalBoolProperty(const core::ProcessContext& ctx, const minifi::core::PropertyReference& property, const core::FlowFile* flow_file = nullptr) {
   if (const auto property_str = ctx.getProperty(property.name, flow_file)) {
     return parsing::parseBool(*property_str)
-        | minifi::utils::orThrow(fmt::format("Expected parsable bool from \"{}::{}\"", ctx.getProcessorName(), property.name));
+        | minifi::utils::orThrow(fmt::format("Expected parsable bool from \"{}\"", property.name));
   }
   return std::nullopt;
 }
@@ -85,7 +85,7 @@ inline std::optional<uint64_t> parseOptionalU64Property(const core::ProcessConte
       return std::nullopt;
     }
     return parsing::parseIntegral<uint64_t>(*property_str)
-        | minifi::utils::orThrow(fmt::format("Expected parsable uint64_t from \"{}::{}\"", ctx.getProcessorName(), property.name));
+        | minifi::utils::orThrow(fmt::format("Expected parsable uint64_t from \"{}\"", property.name));
   }
 
   return std::nullopt;
@@ -97,7 +97,7 @@ inline std::optional<int64_t> parseOptionalI64Property(const core::ProcessContex
       return std::nullopt;
     }
     return parsing::parseIntegral<int64_t>(*property_str)
-        | minifi::utils::orThrow(fmt::format("Expected parsable int64_t from \"{}::{}\"", ctx.getProcessorName(), property.name));
+        | minifi::utils::orThrow(fmt::format("Expected parsable int64_t from \"{}\"", property.name));
   }
 
   return std::nullopt;
@@ -111,7 +111,7 @@ inline std::optional<std::chrono::milliseconds> parseOptionalDurationProperty(co
       return std::nullopt;
     }
     return parsing::parseDuration(*property_str)
-        | minifi::utils::orThrow(fmt::format("Expected parsable duration from \"{}::{}\"", ctx.getProcessorName(), property.name));
+        | minifi::utils::orThrow(fmt::format("Expected parsable duration from \"{}\"", property.name));
   }
 
   return std::nullopt;
@@ -123,7 +123,7 @@ inline std::optional<uint64_t> parseOptionalDataSizeProperty(const core::Process
       return std::nullopt;
     }
     return parsing::parseDataSize(*property_str)
-        | minifi::utils::orThrow(fmt::format("Expected parsable data size from \"{}::{}\"", ctx.getProcessorName(), property.name));
+        | minifi::utils::orThrow(fmt::format("Expected parsable data size from \"{}\"", property.name));
   }
 
   return std::nullopt;
@@ -135,7 +135,7 @@ inline std::optional<float> parseOptionalFloatProperty(const core::ProcessContex
       return std::nullopt;
     }
     return parsing::parseFloat(*property_str)
-        | minifi::utils::orThrow(fmt::format("Expected parsable float from {}::{}", ctx.getProcessorName(), property.name));
+        | minifi::utils::orThrow(fmt::format("Expected parsable float from \"{}\"", property.name));
   }
   return std::nullopt;
 }

--- a/extension-framework/cpp-extension-lib/src/core/ProcessContext.cpp
+++ b/extension-framework/cpp-extension-lib/src/core/ProcessContext.cpp
@@ -38,14 +38,4 @@ bool ProcessContext::hasNonEmptyProperty(std::string_view name) const {
   return MinifiProcessContextHasNonEmptyProperty(impl_, utils::toStringView(name));
 }
 
-std::string ProcessContext::getProcessorName() const {
-  std::string result;
-  MinifiProcessContextGetProcessorName(impl_, [] (void* data, MinifiStringView name) {
-    *static_cast<std::string*>(data) = std::string(name.data, name.length);
-  }, &result);
-  return result;
-}
-
-
-
 }  // namespace org::apache::nifi::minifi::api::core

--- a/extension-framework/include/utils/ProcessorConfigUtils.h
+++ b/extension-framework/include/utils/ProcessorConfigUtils.h
@@ -34,37 +34,37 @@ namespace org::apache::nifi::minifi::utils {
 
 inline std::string parseProperty(const core::ProcessContext& ctx, const core::PropertyReference& property, const core::FlowFile* flow_file = nullptr) {
   return ctx.getProperty(property.name, flow_file)
-      | orThrow(fmt::format("Expected valid value from \"{}::{}\"", ctx.getProcessorInfo().getName(), property.name));
+      | orThrow(fmt::format("Expected valid value from \"{}\"", property.name));
 }
 
 inline bool parseBoolProperty(const core::ProcessContext& ctx, const core::PropertyReference& property, const core::FlowFile* flow_file = nullptr) {
   return ctx.getProperty(property.name, flow_file)
       | andThen(parsing::parseBool)
-      | orThrow(fmt::format("Expected parsable bool from \"{}::{}\"", ctx.getProcessorInfo().getName(), property.name));
+      | orThrow(fmt::format("Expected parsable bool from \"{}\"", property.name));
 }
 
 inline uint64_t parseU64Property(const core::ProcessContext& ctx, const core::PropertyReference& property, const core::FlowFile* flow_file = nullptr) {
   return ctx.getProperty(property.name, flow_file)
       | andThen(parsing::parseIntegral<uint64_t>)
-      | orThrow(fmt::format("Expected parsable uint64_t from \"{}::{}\"", ctx.getProcessorInfo().getName(), property.name));
+      | orThrow(fmt::format("Expected parsable uint64_t from \"{}\"", property.name));
 }
 
 inline int64_t parseI64Property(const core::ProcessContext& ctx, const core::PropertyReference& property, const core::FlowFile* flow_file = nullptr) {
   return ctx.getProperty(property.name, flow_file)
       | andThen(parsing::parseIntegral<int64_t>)
-      | orThrow(fmt::format("Expected parsable int64_t from \"{}::{}\"", ctx.getProcessorInfo().getName(), property.name));
+      | orThrow(fmt::format("Expected parsable int64_t from \"{}\"", property.name));
 }
 
 inline std::chrono::milliseconds parseDurationProperty(const core::ProcessContext& ctx, const core::PropertyReference& property, const core::FlowFile* flow_file = nullptr) {
   return ctx.getProperty(property.name, flow_file)
       | andThen(parsing::parseDuration<std::chrono::milliseconds>)
-      | orThrow(fmt::format("Expected parsable duration from \"{}::{}\"", ctx.getProcessorInfo().getName(), property.name));
+      | orThrow(fmt::format("Expected parsable duration from \"{}\"", property.name));
 }
 
 inline uint64_t parseDataSizeProperty(const core::ProcessContext& ctx, const core::PropertyReference& property, const core::FlowFile* flow_file = nullptr) {
   return ctx.getProperty(property.name, flow_file)
       | andThen(parsing::parseDataSize)
-      | orThrow(fmt::format("Expected parsable data size from \"{}::{}\"", ctx.getProcessorInfo().getName(), property.name));
+      | orThrow(fmt::format("Expected parsable data size from \"{}\"", property.name));
 }
 
 inline std::optional<std::string> parseOptionalProperty(const core::ProcessContext& ctx, const core::PropertyReference& property, const core::FlowFile* flow_file = nullptr) {
@@ -75,7 +75,7 @@ inline std::optional<std::string> parseOptionalProperty(const core::ProcessConte
 inline std::optional<bool> parseOptionalBoolProperty(const core::ProcessContext& ctx, const core::PropertyReference& property, const core::FlowFile* flow_file = nullptr) {
   if (const auto property_str = ctx.getProperty(property.name, flow_file)) {
     return parsing::parseBool(*property_str)
-        | utils::orThrow(fmt::format("Expected parsable bool from \"{}::{}\"", ctx.getProcessorInfo().getName(), property.name));
+        | utils::orThrow(fmt::format("Expected parsable bool from \"{}\"", property.name));
   }
   return std::nullopt;
 }
@@ -86,7 +86,7 @@ inline std::optional<uint64_t> parseOptionalU64Property(const core::ProcessConte
       return std::nullopt;
     }
     return parsing::parseIntegral<uint64_t>(*property_str)
-        | utils::orThrow(fmt::format("Expected parsable uint64_t from \"{}::{}\"", ctx.getProcessorInfo().getName(), property.name));
+        | utils::orThrow(fmt::format("Expected parsable uint64_t from \"{}\"", property.name));
   }
 
   return std::nullopt;
@@ -98,7 +98,7 @@ inline std::optional<int64_t> parseOptionalI64Property(const core::ProcessContex
       return std::nullopt;
     }
     return parsing::parseIntegral<int64_t>(*property_str)
-        | utils::orThrow(fmt::format("Expected parsable int64_t from \"{}::{}\"", ctx.getProcessorInfo().getName(), property.name));
+        | utils::orThrow(fmt::format("Expected parsable int64_t from \"{}\"", property.name));
   }
 
   return std::nullopt;
@@ -110,7 +110,7 @@ inline std::optional<std::chrono::milliseconds> parseOptionalDurationProperty(co
       return std::nullopt;
     }
     return parsing::parseDuration(*property_str)
-        | utils::orThrow(fmt::format("Expected parsable duration from \"{}::{}\"", ctx.getProcessorInfo().getName(), property.name));
+        | utils::orThrow(fmt::format("Expected parsable duration from \"{}\"", property.name));
   }
 
   return std::nullopt;
@@ -122,7 +122,7 @@ inline std::optional<uint64_t> parseOptionalDataSizeProperty(const core::Process
       return std::nullopt;
     }
     return parsing::parseDataSize(*property_str)
-        | utils::orThrow(fmt::format("Expected parsable data size from \"{}::{}\"", ctx.getProcessorInfo().getName(), property.name));
+        | utils::orThrow(fmt::format("Expected parsable data size from \"{}\"", property.name));
   }
 
   return std::nullopt;
@@ -134,7 +134,7 @@ inline std::optional<float> parseOptionalFloatProperty(const core::ProcessContex
       return std::nullopt;
     }
     return parsing::parseFloat(*property_str)
-        | utils::orThrow(fmt::format("Expected parsable float from {}::{}", ctx.getProcessorInfo().getName(), property.name));
+        | utils::orThrow(fmt::format("Expected parsable float from \"{}\"", property.name));
   }
   return std::nullopt;
 }

--- a/extensions/azure/tests/FetchAzureDataLakeStorageTests.cpp
+++ b/extensions/azure/tests/FetchAzureDataLakeStorageTests.cpp
@@ -157,7 +157,7 @@ TEST_CASE_METHOD(FetchAzureDataLakeStorageTestsFixture, "Valid Number of Retries
 
 TEST_CASE_METHOD(FetchAzureDataLakeStorageTestsFixture, "Invalid Number of Retries is set via EL", "[azureDataLakeStorageFetch]") {
   plan_->setProperty(azure_data_lake_storage_, minifi::azure::processors::FetchAzureDataLakeStorage::NumberOfRetries, "${literal(\"asd\")}");
-  REQUIRE_THROWS_WITH(test_controller_.runSession(plan_, true), "Expected parsable uint64_t from \"AzureDataLakeStorageProcessor::Number of Retries\", but got GeneralParsingError (Parsing Error:0)");
+  REQUIRE_THROWS_WITH(test_controller_.runSession(plan_, true), "Expected parsable uint64_t from \"Number of Retries\", but got GeneralParsingError (Parsing Error:0)");
   CHECK_FALSE(mock_data_lake_storage_client_ptr_->getPassedFetchParams().number_of_retries);
 }
 

--- a/extensions/llamacpp/tests/RunLlamaCppInferenceTests.cpp
+++ b/extensions/llamacpp/tests/RunLlamaCppInferenceTests.cpp
@@ -229,7 +229,7 @@ TEST_CASE("Invalid values for optional double type properties throw exception") 
 
   REQUIRE_THROWS(controller.trigger(minifi::test::InputFlowFileData{.content = "42", .attributes = {}}));
   CHECK(minifi::test::utils::verifyLogLinePresenceInPollTime(1s,
-      fmt::format("Expected parsable float from RunLlamaCppInference::{}, but got GeneralParsingError (Parsing Error:0)", property_name)));
+      fmt::format("Expected parsable float from \"{}\", but got GeneralParsingError (Parsing Error:0)", property_name)));
 }
 
 TEST_CASE("Top K property empty and invalid values are handled properly") {
@@ -252,7 +252,7 @@ TEST_CASE("Top K property empty and invalid values are handled properly") {
     REQUIRE(controller.getProcessor()->setProperty(processors::RunLlamaCppInference::TopK.name, "invalid_value"));
     REQUIRE_THROWS(controller.trigger(minifi::test::InputFlowFileData{.content = "42", .attributes = {}}));
     CHECK(minifi::test::utils::verifyLogLinePresenceInPollTime(1s,
-                        "Expected parsable int64_t from \"RunLlamaCppInference::Top K\", but got GeneralParsingError (Parsing Error:0)"));
+                        "Expected parsable int64_t from \"Top K\", but got GeneralParsingError (Parsing Error:0)"));
   }
 }
 

--- a/extensions/mqtt/tests/ConsumeMQTTTests.cpp
+++ b/extensions/mqtt/tests/ConsumeMQTTTests.cpp
@@ -120,13 +120,13 @@ using namespace std::literals::chrono_literals;
 TEST_CASE_METHOD(ConsumeMqttTestFixture, "ConsumeMQTTTest_EmptyTopic", "[consumeMQTTTest]") {
   REQUIRE(test_controller_.plan->setProperty(consume_mqtt_processor_, minifi::processors::AbstractMQTTProcessor::BrokerURI.name, "127.0.0.1:1883"));
   REQUIRE_THROWS_WITH(test_controller_.plan->scheduleProcessor(consume_mqtt_processor_),
-      Catch::Matchers::EndsWith("Expected valid value from \"TestConsumeMQTTProcessor::Topic\", but got PropertyNotSet (Property Error:2)"));
+      Catch::Matchers::EndsWith("Expected valid value from \"Topic\", but got PropertyNotSet (Property Error:2)"));
 }
 
 TEST_CASE_METHOD(ConsumeMqttTestFixture, "ConsumeMQTTTest_EmptyBrokerURI", "[consumeMQTTTest]") {
   REQUIRE(test_controller_.plan->setProperty(consume_mqtt_processor_, minifi::processors::ConsumeMQTT::Topic.name, "mytopic"));
   REQUIRE_THROWS_WITH(test_controller_.plan->scheduleProcessor(consume_mqtt_processor_),
-      Catch::Matchers::EndsWith("Expected valid value from \"TestConsumeMQTTProcessor::Broker URI\", but got PropertyNotSet (Property Error:2)"));
+      Catch::Matchers::EndsWith("Expected valid value from \"Broker URI\", but got PropertyNotSet (Property Error:2)"));
 }
 
 TEST_CASE_METHOD(ConsumeMqttTestFixture, "ConsumeMQTTTest_DurableSessionWithID", "[consumeMQTTTest]") {

--- a/extensions/mqtt/tests/PublishMQTTTests.cpp
+++ b/extensions/mqtt/tests/PublishMQTTTests.cpp
@@ -80,7 +80,7 @@ TEST_CASE_METHOD(PublishMQTTTestFixture, "PublishMQTTTest_EmptyTopic", "[publish
 TEST_CASE_METHOD(PublishMQTTTestFixture, "PublishMQTTTest_EmptyBrokerURI", "[publishMQTTTest]") {
   REQUIRE(test_controller_.plan->setProperty(publish_mqtt_processor_, minifi::processors::PublishMQTT::Topic.name, "mytopic"));
   REQUIRE_THROWS_WITH(test_controller_.plan->scheduleProcessor(publish_mqtt_processor_),
-      Catch::Matchers::EndsWith("Expected valid value from \"TestPublishMQTTProcessor::Broker URI\", but got PropertyNotSet (Property Error:2)"));
+      Catch::Matchers::EndsWith("Expected valid value from \"Broker URI\", but got PropertyNotSet (Property Error:2)"));
 }
 
 TEST_CASE_METHOD(PublishMQTTTestFixture, "PublishMQTTTest_EmptyClientID_V_3", "[publishMQTTTest]") {

--- a/extensions/standard-processors/tests/unit/SegmentContentTests.cpp
+++ b/extensions/standard-processors/tests/unit/SegmentContentTests.cpp
@@ -62,11 +62,11 @@ TEST_CASE("Invalid segmentSize tests") {
 
   SECTION("foo") {
     REQUIRE(segment_content->setProperty(SegmentContent::SegmentSize.name, "foo"));
-    REQUIRE_THROWS_WITH(controller.trigger("bar"), "Expected parsable data size from \"SegmentContent::Segment Size\", but got GeneralParsingError (Parsing Error:0)");
+    REQUIRE_THROWS_WITH(controller.trigger("bar"), "Expected parsable data size from \"Segment Size\", but got GeneralParsingError (Parsing Error:0)");
   }
   SECTION("10 foo") {
     REQUIRE(segment_content->setProperty(SegmentContent::SegmentSize.name, "10 foo"));
-    REQUIRE_THROWS_WITH(controller.trigger("bar"), "Expected parsable data size from \"SegmentContent::Segment Size\", but got GeneralParsingError (Parsing Error:0)");
+    REQUIRE_THROWS_WITH(controller.trigger("bar"), "Expected parsable data size from \"Segment Size\", but got GeneralParsingError (Parsing Error:0)");
   }
   SECTION("0") {
     REQUIRE(segment_content->setProperty(SegmentContent::SegmentSize.name, "0"));

--- a/extensions/standard-processors/tests/unit/SplitContentTests.cpp
+++ b/extensions/standard-processors/tests/unit/SplitContentTests.cpp
@@ -39,7 +39,7 @@ TEST_CASE("WithoutByteSequence") {
   REQUIRE(split_content->setProperty(SplitContent::KeepByteSequence.name, "true"));
   REQUIRE(split_content->setProperty(SplitContent::ByteSequenceLocationProperty.name, std::string{magic_enum::enum_name(SplitContent::ByteSequenceLocation::Leading)}));
 
-  REQUIRE_THROWS_WITH(controller.trigger("rub-a-dub-dub"), "Expected valid value from \"SplitContent::Byte Sequence\", but got PropertyNotSet (Property Error:2)");
+  REQUIRE_THROWS_WITH(controller.trigger("rub-a-dub-dub"), "Expected valid value from \"Byte Sequence\", but got PropertyNotSet (Property Error:2)");
 }
 
 TEST_CASE("EmptyFlowFile") {

--- a/extensions/standard-processors/tests/unit/SplitTextTests.cpp
+++ b/extensions/standard-processors/tests/unit/SplitTextTests.cpp
@@ -193,7 +193,7 @@ void runSplitTextTest(const std::string& input, const std::vector<ExpectedSplitT
 
 TEST_CASE("Line Split Count property is required") {
 SingleProcessorTestController controller{minifi::test::utils::make_processor<processors::SplitText>("SplitText")};
-  REQUIRE_THROWS_WITH(controller.trigger("", {}), "Expected parsable uint64_t from \"SplitText::Line Split Count\", but got PropertyNotSet (Property Error:2)");
+  REQUIRE_THROWS_WITH(controller.trigger("", {}), "Expected parsable uint64_t from \"Line Split Count\", but got PropertyNotSet (Property Error:2)");
 }
 
 TEST_CASE("Line Split Count property can only be 0 if Maximum Fragment Size is set") {

--- a/libminifi/src/minifi-c.cpp
+++ b/libminifi/src/minifi-c.cpp
@@ -340,22 +340,24 @@ MINIFI_OWNED MinifiFlowFile* MinifiProcessSessionCreate(MinifiProcessSession* se
 }
 
 MinifiStatus MinifiProcessSessionTransfer(MinifiProcessSession* session, MINIFI_OWNED MinifiFlowFile* flowfile, MinifiStringView relationship_name) {
+  gsl_Assert(session != MINIFI_NULL);
   gsl_Assert(flowfile !=  MINIFI_NULL);
   try {
     reinterpret_cast<minifi::core::ProcessSession*>(session)->transfer(
         *reinterpret_cast<std::shared_ptr<minifi::core::FlowFile>*>(flowfile), minifi::core::Relationship{toString(relationship_name), ""});
     return MINIFI_STATUS_SUCCESS;
-  } catch (std::exception&) {
+  } catch (...) {
     return MINIFI_STATUS_UNKNOWN_ERROR;
   }
 }
 
 MinifiStatus MinifiProcessSessionRemove(MinifiProcessSession* session, MINIFI_OWNED MinifiFlowFile* flowfile) {
+  gsl_Assert(session != MINIFI_NULL);
   gsl_Assert(flowfile != MINIFI_NULL);
   try {
     reinterpret_cast<minifi::core::ProcessSession*>(session)->remove(*reinterpret_cast<std::shared_ptr<minifi::core::FlowFile>*>(flowfile));
     return MINIFI_STATUS_SUCCESS;
-  } catch (std::exception&) {
+  } catch (...) {
     return MINIFI_STATUS_UNKNOWN_ERROR;
   }
 }

--- a/libminifi/src/minifi-c.cpp
+++ b/libminifi/src/minifi-c.cpp
@@ -267,12 +267,6 @@ MinifiStatus MinifiProcessContextGetProperty(MinifiProcessContext* context, Mini
   }
 }
 
-void MinifiProcessContextGetProcessorName(MinifiProcessContext* context, void(*cb)(void* user_ctx, MinifiStringView result), void* user_ctx) {
-  gsl_Assert(context != MINIFI_NULL);
-  auto name = reinterpret_cast<minifi::core::ProcessContext*>(context)->getProcessorInfo().getName();
-  cb(user_ctx, MinifiStringView{.data = name.data(), .length = name.length()});
-}
-
 MinifiBool MinifiProcessContextHasNonEmptyProperty(MinifiProcessContext* context, MinifiStringView property_name) {
   gsl_Assert(context != MINIFI_NULL);
   return reinterpret_cast<minifi::core::ProcessContext*>(context)->hasNonEmptyProperty(toString(property_name));
@@ -345,15 +339,25 @@ MINIFI_OWNED MinifiFlowFile* MinifiProcessSessionCreate(MinifiProcessSession* se
   return MINIFI_NULL;
 }
 
-void MinifiProcessSessionTransfer(MinifiProcessSession* session, MINIFI_OWNED MinifiFlowFile* flowfile, MinifiStringView relationship_name) {
+MinifiStatus MinifiProcessSessionTransfer(MinifiProcessSession* session, MINIFI_OWNED MinifiFlowFile* flowfile, MinifiStringView relationship_name) {
   gsl_Assert(flowfile !=  MINIFI_NULL);
-  reinterpret_cast<minifi::core::ProcessSession*>(session)->transfer(
-      *reinterpret_cast<std::shared_ptr<minifi::core::FlowFile>*>(flowfile), minifi::core::Relationship{toString(relationship_name), ""});
+  try {
+    reinterpret_cast<minifi::core::ProcessSession*>(session)->transfer(
+        *reinterpret_cast<std::shared_ptr<minifi::core::FlowFile>*>(flowfile), minifi::core::Relationship{toString(relationship_name), ""});
+    return MINIFI_STATUS_SUCCESS;
+  } catch (std::exception&) {
+    return MINIFI_STATUS_UNKNOWN_ERROR;
+  }
 }
 
-void MinifiProcessSessionRemove(MinifiProcessSession* session, MINIFI_OWNED MinifiFlowFile* flowfile) {
+MinifiStatus MinifiProcessSessionRemove(MinifiProcessSession* session, MINIFI_OWNED MinifiFlowFile* flowfile) {
   gsl_Assert(flowfile != MINIFI_NULL);
-  reinterpret_cast<minifi::core::ProcessSession*>(session)->remove(*reinterpret_cast<std::shared_ptr<minifi::core::FlowFile>*>(flowfile));
+  try {
+    reinterpret_cast<minifi::core::ProcessSession*>(session)->remove(*reinterpret_cast<std::shared_ptr<minifi::core::FlowFile>*>(flowfile));
+    return MINIFI_STATUS_SUCCESS;
+  } catch (std::exception&) {
+    return MINIFI_STATUS_UNKNOWN_ERROR;
+  }
 }
 
 MinifiStatus MinifiProcessSessionRead(MinifiProcessSession* session, MinifiFlowFile* flowfile, int64_t(*cb)(void* user_ctx, MinifiInputStream*), void* user_ctx) {
@@ -412,7 +416,7 @@ void MinifiStatusToString(MinifiStatus status, void(*cb)(void* user_ctx, MinifiS
   cb(user_ctx, MinifiStringView{.data = message.data(), .length = message.size()});
 }
 
-void MinifiFlowFileSetAttribute(MinifiProcessSession* session, MinifiFlowFile* flowfile, MinifiStringView attribute_name, const MinifiStringView* attribute_value) {
+MinifiStatus MinifiFlowFileSetAttribute(MinifiProcessSession* session, MinifiFlowFile* flowfile, MinifiStringView attribute_name, const MinifiStringView* attribute_value) {
   gsl_Assert(session != MINIFI_NULL);
   gsl_Assert(flowfile != MINIFI_NULL);
   if (attribute_value == nullptr) {
@@ -421,6 +425,7 @@ void MinifiFlowFileSetAttribute(MinifiProcessSession* session, MinifiFlowFile* f
     reinterpret_cast<minifi::core::ProcessSession*>(session)->putAttribute(
         **reinterpret_cast<std::shared_ptr<minifi::core::FlowFile>*>(flowfile), toString(attribute_name), toString(*attribute_value));
   }
+  return MINIFI_STATUS_SUCCESS;
 }
 
 MinifiBool MinifiFlowFileGetAttribute(MinifiProcessSession* session, MinifiFlowFile* flowfile, MinifiStringView attribute_name,

--- a/minifi-api/include/minifi-c/minifi-c.h
+++ b/minifi-api/include/minifi-c/minifi-c.h
@@ -190,7 +190,6 @@ MINIFI_OWNED MinifiPublishedMetrics* MinifiPublishedMetricsCreate(size_t count, 
 
 MinifiStatus MinifiProcessContextGetProperty(MinifiProcessContext* context, MinifiStringView property_name, MinifiFlowFile* flowfile,
                                              void(*cb)(void* user_ctx, MinifiStringView property_value), void* user_ctx);
-void MinifiProcessContextGetProcessorName(MinifiProcessContext* context, void(*cb)(void* user_ctx, MinifiStringView processor_name), void* user_ctx);
 MinifiBool MinifiProcessContextHasNonEmptyProperty(MinifiProcessContext* context, MinifiStringView property_name);
 
 void MinifiLoggerSetMaxLogSize(MinifiLogger*, int32_t);
@@ -201,8 +200,8 @@ MinifiLogLevel MinifiLoggerLevel(MinifiLogger*);
 MINIFI_OWNED MinifiFlowFile* MinifiProcessSessionGet(MinifiProcessSession*);
 MINIFI_OWNED MinifiFlowFile* MinifiProcessSessionCreate(MinifiProcessSession* session, MinifiFlowFile* parent_flowfile);
 
-void MinifiProcessSessionTransfer(MinifiProcessSession* session, MINIFI_OWNED MinifiFlowFile* flowfile, MinifiStringView relationship_name);
-void MinifiProcessSessionRemove(MinifiProcessSession* session, MINIFI_OWNED MinifiFlowFile* flowfile);
+MinifiStatus MinifiProcessSessionTransfer(MinifiProcessSession* session, MINIFI_OWNED MinifiFlowFile* flowfile, MinifiStringView relationship_name);
+MinifiStatus MinifiProcessSessionRemove(MinifiProcessSession* session, MINIFI_OWNED MinifiFlowFile* flowfile);
 
 MinifiStatus MinifiProcessSessionRead(MinifiProcessSession*, MinifiFlowFile*, int64_t(*cb)(void* user_ctx, MinifiInputStream*), void* user_ctx);
 MinifiStatus MinifiProcessSessionWrite(MinifiProcessSession*, MinifiFlowFile*, int64_t(*cb)(void* user_ctx, MinifiOutputStream*), void* user_ctx);
@@ -216,7 +215,7 @@ int64_t MinifiOutputStreamWrite(MinifiOutputStream* stream, const char* data, si
 
 void MinifiStatusToString(MinifiStatus, void(*cb)(void* user_ctx, MinifiStringView str), void* user_ctx);
 
-void MinifiFlowFileSetAttribute(MinifiProcessSession* session, MinifiFlowFile* flowfile, MinifiStringView attribute_name, const MinifiStringView* attribute_value);
+MinifiStatus MinifiFlowFileSetAttribute(MinifiProcessSession* session, MinifiFlowFile* flowfile, MinifiStringView attribute_name, const MinifiStringView* attribute_value);
 MinifiBool MinifiFlowFileGetAttribute(MinifiProcessSession* session, MinifiFlowFile* flowfile, MinifiStringView attribute_name,
                                       void(*cb)(void* user_ctx, MinifiStringView attribute_value), void* user_ctx);
 void MinifiFlowFileGetAttributes(MinifiProcessSession* session, MinifiFlowFile* flowfile, void(*cb)(void* user_ctx, MinifiStringView attribute_name, MinifiStringView attribute_value), void* user_ctx);

--- a/minifi-api/minifi-c-api.def
+++ b/minifi-api/minifi-c-api.def
@@ -3,7 +3,6 @@ EXPORTS
   MinifiCreateExtension
   MinifiPublishedMetricsCreate
   MinifiProcessContextGetProperty
-  MinifiProcessContextGetProcessorName
   MinifiProcessContextHasNonEmptyProperty
   MinifiLoggerSetMaxLogSize
   MinifiLoggerLogString


### PR DESCRIPTION
Added MinifiStatus return to MinifiProcessSessionTransfer, MinifiProcessSessionRemove, MinifiFlowFileSetAttribute,
since these might(or might in the future) fail I think its best if we could signal failure back to the extensions.

Removed MinifiProcessContextGetProcessorName since it was only used in the parseProperty helper function so they can include the ProcessorName in the exception message, but these calls are already try-d and any failure logged with the processor name already included so we can further reduce the API


---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
