### PR TITLE
MINIFICPP-2735 Fix protobuf compilation on GCC 15

### DIFF
--- a/cmake/Protobuf.cmake
+++ b/cmake/Protobuf.cmake
@@ -18,10 +18,16 @@ include(FetchContent)
 
 set(protobuf_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 
+set(PATCH_FILE_1 "${CMAKE_SOURCE_DIR}/thirdparty/protobuf/gcc-15-musttail.patch")
+
+set(PC ${Bash_EXECUTABLE}  -c "set -x &&\
+        (\\\"${Patch_EXECUTABLE}\\\" -p1 -R -s -f --dry-run -i \\\"${PATCH_FILE_1}\\\" || \\\"${Patch_EXECUTABLE}\\\" -p1 -N -i \\\"${PATCH_FILE_1}\\\")")
+
 FetchContent_Declare(
     protobuf
     URL      https://github.com/protocolbuffers/protobuf/archive/refs/tags/v31.1.tar.gz
     URL_HASH SHA256=c3a0a9ece8932e31c3b736e2db18b1c42e7070cd9b881388b26d01aa71e24ca2
+    PATCH_COMMAND "${PC}"
 )
 FetchContent_MakeAvailable(protobuf)
 

--- a/thirdparty/protobuf/gcc-15-musttail.patch
+++ b/thirdparty/protobuf/gcc-15-musttail.patch
@@ -1,0 +1,18 @@
+# workaround for issue https://github.com/protocolbuffers/protobuf/issues/21333
+diff -ur a/src/google/protobuf/port_def.inc b/src/google/protobuf/port_def.inc
+--- a/src/google/protobuf/port_def.inc	2025-05-28 18:52:59.000000000 +0200
++++ b/src/google/protobuf/port_def.inc	2026-02-27 12:02:46.212814246 +0100
+@@ -234,7 +234,12 @@
+ #ifdef PROTOBUF_TAILCALL
+ #error PROTOBUF_TAILCALL was previously defined
+ #endif
+-#if ABSL_HAVE_CPP_ATTRIBUTE(clang::musttail) && !defined(__arm__) &&  \
++
++// See https://github.com/protocolbuffers/protobuf/issues/21333
++#if defined(__GNUC__) && __GNUC__ >= 15
++#define PROTOBUF_MUSTTAIL
++#define PROTOBUF_TAILCALL false
++#elif ABSL_HAVE_CPP_ATTRIBUTE(clang::musttail) && !defined(__arm__) &&  \
+     !defined(_ARCH_PPC) && !defined(__wasm__) &&                      \
+     !(defined(_MSC_VER) && defined(_M_IX86)) && !defined(__i386__)
+ // Compilation fails on ARM32: b/195943306


### PR DESCRIPTION
Workaround for issue https://github.com/protocolbuffers/protobuf/issues/21333

https://issues.apache.org/jira/browse/MINIFICPP-2735

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
