### PR TITLE
MINIFICPP-2772 README.md img source has been moved

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -28,7 +28,7 @@ github:
   enabled_merge_buttons:
     squash:  true
     merge:   false
-    rebase:  true
+    rebase:  false
   ghp_branch: main
   ghp_path: /docs
 notifications:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,12 +27,11 @@ github:
     projects: false
   enabled_merge_buttons:
     squash:  true
-    merge:   true
+    merge:   false
     rebase:  true
+  ghp_branch: main
+  ghp_path: /docs
 notifications:
     commits:      commits@nifi.apache.org
     issues:       issues@nifi.apache.org
     jira_options: link label worklog
-github:
-  ghp_branch:  main
-  ghp_path:    /docs

--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@
   limitations under the License.
 -->
 
-[<img src="https://nifi.apache.org/assets/images/minifi/minifi-logo.svg" width="300" height="126" alt="Apache NiFi MiNiFi"/>](https://nifi.apache.org/minifi/)
+[<img src="https://nifi.apache.org/images/minifi-logo.svg" width="300" height="126" alt="Apache NiFi MiNiFi"/>](https://nifi.apache.org/minifi/)
 
 # Apache NiFi -  MiNiFi - C++
-[![MiNiFi-CPP CI](https://github.com/apache/nifi-minifi-cpp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/apache/nifi-minifi-cpp/actions/workflows/ci.yml?query=workflow%3A%22MiNiFi-CPP+CI%22+branch%3Amain)<br>[![Check Supported Compilers](https://github.com/apache/nifi-minifi-cpp/actions/workflows/compiler-support.yml/badge.svg?branch=main)](https://github.com/apache/nifi-minifi-cpp/actions/workflows/compiler-support.yml?query=branch%3Amain)<br>[![MiNiFi-CPP Memcheck](https://github.com/apache/nifi-minifi-cpp/actions/workflows/memcheck_ci.yml/badge.svg?branch=main)](https://github.com/apache/nifi-minifi-cpp/actions/workflows/memcheck_ci.yml?query=branch%3Amain)<br>[![MiNiFi-CPP Verify Package](https://github.com/apache/nifi-minifi-cpp/actions/workflows/verify-package.yml/badge.svg?branch=main)](https://github.com/apache/nifi-minifi-cpp/actions/workflows/verify-package.yml?query=branch%3Amain)<br>[![Status Page](https://img.shields.io/website?url=https%3A%2F%2Fapache.github.io%2Fnifi-minifi-cpp%2Fstatus%2F&label=Status%20Page)](https://apache.github.io/nifi-minifi-cpp/status/)
+[![MiNiFi-CPP CI](https://github.com/apache/nifi-minifi-cpp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/apache/nifi-minifi-cpp/actions/workflows/ci.yml?query=workflow%3A%22MiNiFi-CPP+CI%22+branch%3Amain)<br>
+[![Check Supported Compilers](https://github.com/apache/nifi-minifi-cpp/actions/workflows/compiler-support.yml/badge.svg?branch=main)](https://github.com/apache/nifi-minifi-cpp/actions/workflows/compiler-support.yml?query=branch%3Amain)<br>
+[![MiNiFi-CPP Memcheck](https://github.com/apache/nifi-minifi-cpp/actions/workflows/memcheck_ci.yml/badge.svg?branch=main)](https://github.com/apache/nifi-minifi-cpp/actions/workflows/memcheck_ci.yml?query=branch%3Amain)<br>
+[![MiNiFi-CPP Verify Package](https://github.com/apache/nifi-minifi-cpp/actions/workflows/verify-package.yml/badge.svg?branch=main)](https://github.com/apache/nifi-minifi-cpp/actions/workflows/verify-package.yml?query=branch%3Amain)<br>
+[![Status Page](https://img.shields.io/website?url=https%3A%2F%2Fapache.github.io%2Fnifi-minifi-cpp%2Fstatus%2F&label=Status%20Page)](https://apache.github.io/nifi-minifi-cpp/status/)
 
 MiNiFi is a child project effort of Apache NiFi.  This repository is for a native implementation in C++.
 


### PR DESCRIPTION
Also the asf.yaml contained duplicate entries for the github key, hopefully this caused the 404 on the status page (cant test it locally only after this been merged to main)

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
