### PR TITLE
MINIFICPP-2796 Remove workIsAvailable from C API

### DIFF
--- a/extension-framework/cpp-extension-lib/include/api/core/ProcessorImpl.h
+++ b/extension-framework/cpp-extension-lib/include/api/core/ProcessorImpl.h
@@ -67,8 +67,6 @@ class ProcessorImpl {
 
   virtual void onUnSchedule() {}
 
-  virtual bool isWorkAvailable();
-
   static constexpr auto DynamicProperties = std::array<minifi::core::DynamicPropertyDefinition, 0>{};
 
   static constexpr auto OutputAttributes = std::array<minifi::core::OutputAttributeReference, 0>{};

--- a/extension-framework/cpp-extension-lib/include/api/core/Resource.h
+++ b/extension-framework/cpp-extension-lib/include/api/core/Resource.h
@@ -106,7 +106,7 @@ void useProcessorClassDescription(Fn&& fn) {
       .getTriggerWhenEmpty = [] (void* self) -> MinifiBool {
         return static_cast<Class*>(self)->getTriggerWhenEmpty();
       },
-      .trigger = [] (void* self, MinifiProcessContext* context, MinifiProcessSession* session) -> MinifiStatus {
+      .onTrigger = [] (void* self, MinifiProcessContext* context, MinifiProcessSession* session) -> MinifiStatus {
         ProcessContext context_wrapper(context);
         ProcessSession session_wrapper(session);
         try {
@@ -115,7 +115,7 @@ void useProcessorClassDescription(Fn&& fn) {
           return MINIFI_STATUS_UNKNOWN_ERROR;
         }
       },
-      .schedule = [] (void* self, MinifiProcessContext* context) -> MinifiStatus {
+      .onSchedule = [] (void* self, MinifiProcessContext* context) -> MinifiStatus {
         ProcessContext context_wrapper(context);
         try {
           return static_cast<Class*>(self)->onSchedule(context_wrapper);
@@ -123,7 +123,7 @@ void useProcessorClassDescription(Fn&& fn) {
           return MINIFI_STATUS_UNKNOWN_ERROR;
         }
       },
-      .unSchedule = [] (void* self) -> void {
+      .onUnSchedule = [] (void* self) -> void {
         static_cast<Class*>(self)->onUnSchedule();
       },
       .calculateMetrics = [] (void* self) -> MINIFI_OWNED MinifiPublishedMetrics* {

--- a/extension-framework/cpp-extension-lib/include/api/core/Resource.h
+++ b/extension-framework/cpp-extension-lib/include/api/core/Resource.h
@@ -103,13 +103,10 @@ void useProcessorClassDescription(Fn&& fn) {
       .destroy = [] (MINIFI_OWNED void* self) -> void {
         delete static_cast<Class*>(self);
       },
-      .isWorkAvailable = [] (void* self) -> MinifiBool {
-        return static_cast<Class*>(self)->isWorkAvailable();
-      },
       .getTriggerWhenEmpty = [] (void* self) -> MinifiBool {
         return static_cast<Class*>(self)->getTriggerWhenEmpty();
       },
-      .onTrigger = [] (void* self, MinifiProcessContext* context, MinifiProcessSession* session) -> MinifiStatus {
+      .trigger = [] (void* self, MinifiProcessContext* context, MinifiProcessSession* session) -> MinifiStatus {
         ProcessContext context_wrapper(context);
         ProcessSession session_wrapper(session);
         try {
@@ -118,7 +115,7 @@ void useProcessorClassDescription(Fn&& fn) {
           return MINIFI_STATUS_UNKNOWN_ERROR;
         }
       },
-      .onSchedule = [] (void* self, MinifiProcessContext* context) -> MinifiStatus {
+      .schedule = [] (void* self, MinifiProcessContext* context) -> MinifiStatus {
         ProcessContext context_wrapper(context);
         try {
           return static_cast<Class*>(self)->onSchedule(context_wrapper);
@@ -126,7 +123,7 @@ void useProcessorClassDescription(Fn&& fn) {
           return MINIFI_STATUS_UNKNOWN_ERROR;
         }
       },
-      .onUnSchedule = [] (void* self) -> void {
+      .unSchedule = [] (void* self) -> void {
         static_cast<Class*>(self)->onUnSchedule();
       },
       .calculateMetrics = [] (void* self) -> MINIFI_OWNED MinifiPublishedMetrics* {

--- a/extension-framework/cpp-extension-lib/src/core/ProcessorImpl.cpp
+++ b/extension-framework/cpp-extension-lib/src/core/ProcessorImpl.cpp
@@ -40,10 +40,6 @@ ProcessorImpl::~ProcessorImpl() {
   logger_->log_debug("Destroying processor {} with uuid {}", getName(), getUUIDStr());
 }
 
-bool ProcessorImpl::isWorkAvailable() {
-  return false;
-}
-
 std::string ProcessorImpl::getName() const {
   return metadata_.name;
 }

--- a/libminifi/include/utils/CProcessor.h
+++ b/libminifi/include/utils/CProcessor.h
@@ -80,6 +80,7 @@ class CProcessor : public minifi::core::ProcessorApi {
     class_description_.callbacks.destroy(impl_);
   }
 
+  // C API doesnt yet expose isWorkAvailable
   bool isWorkAvailable() override {
     return false;
   }
@@ -118,7 +119,7 @@ class CProcessor : public minifi::core::ProcessorApi {
 
   void onTrigger(minifi::core::ProcessContext& process_context, minifi::core::ProcessSession& process_session) override {
     std::optional<std::string> error;
-    auto status = class_description_.callbacks.trigger(impl_, reinterpret_cast<MinifiProcessContext*>(&process_context), reinterpret_cast<MinifiProcessSession*>(&process_session));
+    auto status = class_description_.callbacks.onTrigger(impl_, reinterpret_cast<MinifiProcessContext*>(&process_context), reinterpret_cast<MinifiProcessSession*>(&process_session));
     if (status == MINIFI_STATUS_PROCESSOR_YIELD) {
       process_context.yield();
       return;
@@ -130,18 +131,18 @@ class CProcessor : public minifi::core::ProcessorApi {
 
   void onSchedule(minifi::core::ProcessContext& process_context, minifi::core::ProcessSessionFactory& /*process_session_factory*/) override {
     std::optional<std::string> error;
-    auto status = class_description_.callbacks.schedule(impl_, reinterpret_cast<MinifiProcessContext*>(&process_context));
+    auto status = class_description_.callbacks.onSchedule(impl_, reinterpret_cast<MinifiProcessContext*>(&process_context));
     if (status != MINIFI_STATUS_SUCCESS) {
       throw minifi::Exception(minifi::ExceptionType::PROCESS_SCHEDULE_EXCEPTION, "Error while scheduling processor");
     }
   }
 
   void onUnSchedule() override {
-    class_description_.callbacks.unSchedule(impl_);
+    class_description_.callbacks.onUnSchedule(impl_);
   }
 
   void notifyStop() override {
-    class_description_.callbacks.unSchedule(impl_);
+    class_description_.callbacks.onUnSchedule(impl_);
   }
 
   minifi::core::annotation::Input getInputRequirement() const override {

--- a/libminifi/include/utils/CProcessor.h
+++ b/libminifi/include/utils/CProcessor.h
@@ -81,7 +81,7 @@ class CProcessor : public minifi::core::ProcessorApi {
   }
 
   bool isWorkAvailable() override {
-    return static_cast<bool>(class_description_.callbacks.isWorkAvailable(impl_));
+    return false;
   }
 
   void restore(const std::shared_ptr<minifi::core::FlowFile>& /*file*/) override {
@@ -118,7 +118,7 @@ class CProcessor : public minifi::core::ProcessorApi {
 
   void onTrigger(minifi::core::ProcessContext& process_context, minifi::core::ProcessSession& process_session) override {
     std::optional<std::string> error;
-    auto status = class_description_.callbacks.onTrigger(impl_, reinterpret_cast<MinifiProcessContext*>(&process_context), reinterpret_cast<MinifiProcessSession*>(&process_session));
+    auto status = class_description_.callbacks.trigger(impl_, reinterpret_cast<MinifiProcessContext*>(&process_context), reinterpret_cast<MinifiProcessSession*>(&process_session));
     if (status == MINIFI_STATUS_PROCESSOR_YIELD) {
       process_context.yield();
       return;
@@ -130,18 +130,18 @@ class CProcessor : public minifi::core::ProcessorApi {
 
   void onSchedule(minifi::core::ProcessContext& process_context, minifi::core::ProcessSessionFactory& /*process_session_factory*/) override {
     std::optional<std::string> error;
-    auto status = class_description_.callbacks.onSchedule(impl_, reinterpret_cast<MinifiProcessContext*>(&process_context));
+    auto status = class_description_.callbacks.schedule(impl_, reinterpret_cast<MinifiProcessContext*>(&process_context));
     if (status != MINIFI_STATUS_SUCCESS) {
       throw minifi::Exception(minifi::ExceptionType::PROCESS_SCHEDULE_EXCEPTION, "Error while scheduling processor");
     }
   }
 
   void onUnSchedule() override {
-    class_description_.callbacks.onUnSchedule(impl_);
+    class_description_.callbacks.unSchedule(impl_);
   }
 
   void notifyStop() override {
-    class_description_.callbacks.onUnSchedule(impl_);
+    class_description_.callbacks.unSchedule(impl_);
   }
 
   minifi::core::annotation::Input getInputRequirement() const override {

--- a/minifi-api/include/minifi-c/minifi-c.h
+++ b/minifi-api/include/minifi-c/minifi-c.h
@@ -157,9 +157,9 @@ typedef struct MinifiProcessorCallbacks {
   MINIFI_OWNED void*(*create)(MinifiProcessorMetadata);
   void(*destroy)(MINIFI_OWNED void*);
   MinifiBool(*getTriggerWhenEmpty)(void*);
-  MinifiStatus(*trigger)(void*, MinifiProcessContext*, MinifiProcessSession*);
-  MinifiStatus(*schedule)(void*, MinifiProcessContext*);
-  void(*unSchedule)(void*);
+  MinifiStatus(*onTrigger)(void*, MinifiProcessContext*, MinifiProcessSession*);
+  MinifiStatus(*onSchedule)(void*, MinifiProcessContext*);
+  void(*onUnSchedule)(void*);
   MINIFI_OWNED MinifiPublishedMetrics*(*calculateMetrics)(void*);
 } MinifiProcessorCallbacks;
 

--- a/minifi-api/include/minifi-c/minifi-c.h
+++ b/minifi-api/include/minifi-c/minifi-c.h
@@ -42,7 +42,7 @@ extern "C" {
 #endif
 
 enum : uint32_t {
-  MINIFI_API_VERSION = 2
+  MINIFI_API_VERSION = 3
 };
 
 typedef bool MinifiBool;
@@ -156,11 +156,10 @@ typedef struct MinifiProcessorMetadata {
 typedef struct MinifiProcessorCallbacks {
   MINIFI_OWNED void*(*create)(MinifiProcessorMetadata);
   void(*destroy)(MINIFI_OWNED void*);
-  MinifiBool(*isWorkAvailable)(void*);
   MinifiBool(*getTriggerWhenEmpty)(void*);
-  MinifiStatus(*onTrigger)(void*, MinifiProcessContext*, MinifiProcessSession*);
-  MinifiStatus(*onSchedule)(void*, MinifiProcessContext*);
-  void(*onUnSchedule)(void*);
+  MinifiStatus(*trigger)(void*, MinifiProcessContext*, MinifiProcessSession*);
+  MinifiStatus(*schedule)(void*, MinifiProcessContext*);
+  void(*unSchedule)(void*);
   MINIFI_OWNED MinifiPublishedMetrics*(*calculateMetrics)(void*);
 } MinifiProcessorCallbacks;
 


### PR DESCRIPTION
workIsAvailable is currently only used in ListenHTTP (and tbh triggerWhenEmpty would be better in that case aswell)
and if it comes to that it can be reintroduced later, meanwhile we can further reduce the api before the upcoming 1.0 release

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
