### PR TITLE
MINIFICPP-2797 Extend C Api with sslcontext, penalize, dynamic properties, flowfile id and size

### DIFF
--- a/extension-framework/cpp-extension-lib/src/core/ProcessSession.cpp
+++ b/extension-framework/cpp-extension-lib/src/core/ProcessSession.cpp
@@ -118,20 +118,20 @@ void ProcessSession::read(FlowFile& flow_file, const io::InputStreamCallback& ca
 
 void ProcessSession::setAttribute(FlowFile& ff, const std::string_view key, std::string value) {  // NOLINT(performance-unnecessary-value-param)
   const MinifiStringView value_ref = utils::toStringView(value);
-  if (MINIFI_STATUS_SUCCESS != MinifiFlowFileSetAttribute(impl_, ff.get(), utils::toStringView(key), &value_ref)) {
+  if (MINIFI_STATUS_SUCCESS != MinifiProcessSessionSetFlowFileAttribute(impl_, ff.get(), utils::toStringView(key), &value_ref)) {
     throw minifi::Exception(minifi::FILE_OPERATION_EXCEPTION, "Failed to set attribute");
   }
 }
 
 void ProcessSession::removeAttribute(FlowFile& ff, const std::string_view key) {
-  if (MINIFI_STATUS_SUCCESS != MinifiFlowFileSetAttribute(impl_, ff.get(), utils::toStringView(key), nullptr)) {
+  if (MINIFI_STATUS_SUCCESS != MinifiProcessSessionSetFlowFileAttribute(impl_, ff.get(), utils::toStringView(key), nullptr)) {
     throw minifi::Exception(minifi::FILE_OPERATION_EXCEPTION, "Failed to remove attribute");
   }
 }
 
 std::optional<std::string> ProcessSession::getAttribute(FlowFile& ff, std::string_view key) {
   std::optional<std::string> result;
-  MinifiFlowFileGetAttribute(impl_, ff.get(), utils::toStringView(key), [] (void* user_ctx, MinifiStringView value) {
+  MinifiProcessSessionGetFlowFileAttribute(impl_, ff.get(), utils::toStringView(key), [] (void* user_ctx, MinifiStringView value) {
     *static_cast<std::optional<std::string>*>(user_ctx) = std::string{value.data, value.length};
   }, &result);
   return result;
@@ -139,8 +139,8 @@ std::optional<std::string> ProcessSession::getAttribute(FlowFile& ff, std::strin
 
 std::map<std::string, std::string> ProcessSession::getAttributes(FlowFile& ff) {
   std::map<std::string, std::string> result;
-  MinifiFlowFileGetAttributes(impl_, ff.get(), [] (void* user_ctx, MinifiStringView value, MinifiStringView key) {
-    static_cast<std::map<std::string, std::string>*>(user_ctx)->insert({std::string{value.data, value.length}, std::string{key.data, key.length}});
+  MinifiProcessSessionGetFlowFileAttributes(impl_, ff.get(), [] (void* user_ctx, const MinifiStringView key, const MinifiStringView value) {
+    static_cast<std::map<std::string, std::string>*>(user_ctx)->insert({std::string{key.data, key.length}, std::string{value.data, value.length}});
   }, &result);
   return result;
 }

--- a/libminifi/src/minifi-c.cpp
+++ b/libminifi/src/minifi-c.cpp
@@ -627,7 +627,7 @@ MinifiStatus MinifiProcessContextGetSslData(MinifiProcessContext* process_contex
 
     MinifiSslData ssl_data{
         .version = 1,
-        .ca_certificate = minifiStringView(ca_cert_file),
+        .ca_certificate_file = minifiStringView(ca_cert_file),
         .certificate_file = minifiStringView(cert_file),
         .private_key_file = minifiStringView(private_key_file),
         .passphrase = minifiStringView(passphrase),

--- a/libminifi/src/minifi-c.cpp
+++ b/libminifi/src/minifi-c.cpp
@@ -193,7 +193,7 @@ void useCProcessorClassDescription(const MinifiProcessorClassDefinition& class_d
   std::vector<minifi::core::DynamicProperty> dynamic_properties;
   dynamic_properties.reserve(class_description.dynamic_properties_count);
   for (size_t i = 0; i < class_description.dynamic_properties_count; ++i) {
-    dynamic_properties.emplace_back(minifi::core::DynamicPropertyDefinition{
+    dynamic_properties.push_back(minifi::core::DynamicPropertyDefinition{
       .name = toStringView(class_description.dynamic_properties_ptr[i].name),
       .value = toStringView(class_description.dynamic_properties_ptr[i].value),
       .description = toStringView(class_description.dynamic_properties_ptr[i].description),
@@ -203,9 +203,10 @@ void useCProcessorClassDescription(const MinifiProcessorClassDefinition& class_d
   std::vector<minifi::core::Relationship> relationships;
   relationships.reserve(class_description.class_relationships_count);
   for (size_t i = 0; i < class_description.class_relationships_count; ++i) {
-    relationships.emplace_back(
+    relationships.push_back(minifi::core::Relationship{
       toString(class_description.class_relationships_ptr[i].name),
-      toString(class_description.class_relationships_ptr[i].description));
+      toString(class_description.class_relationships_ptr[i].description)
+    });
   }
   std::vector<minifi::core::OutputAttribute> output_attributes;
   for (size_t attribute_idx = 0; attribute_idx < class_description.output_attributes_count; ++attribute_idx) {
@@ -265,7 +266,7 @@ void useCControllerServiceClassDescription(const MinifiControllerServiceClassDef
   auto name_segments = minifi::utils::string::split(toStringView(class_description.full_name), "::");
   gsl_Assert(!name_segments.empty());
 
-  const minifi::ClassDescription description{
+  minifi::ClassDescription description{
     .type_ = minifi::ResourceType::ControllerService,
     .short_name_ = name_segments.back(),
     .full_name_ = minifi::utils::string::join(".", name_segments),

--- a/libminifi/src/minifi-c.cpp
+++ b/libminifi/src/minifi-c.cpp
@@ -24,6 +24,7 @@
 #include "core/ProcessorMetrics.h"
 #include "core/extension/ExtensionManager.h"
 #include "minifi-cpp/Exception.h"
+#include "minifi-cpp/controllers/SSLContextServiceInterface.h"
 #include "minifi-cpp/core/Annotation.h"
 #include "minifi-cpp/core/ClassLoader.h"
 #include "minifi-cpp/core/ProcessContext.h"
@@ -35,8 +36,8 @@
 #include "minifi-cpp/core/PropertyValidator.h"
 #include "minifi-cpp/core/logging/Logger.h"
 #include "minifi-cpp/core/state/PublishedMetricProvider.h"
-#include "utils/CProcessor.h"
 #include "utils/CControllerService.h"
+#include "utils/CProcessor.h"
 #include "utils/PropertyErrors.h"
 
 namespace minifi = org::apache::nifi::minifi;
@@ -192,7 +193,7 @@ void useCProcessorClassDescription(const MinifiProcessorClassDefinition& class_d
   std::vector<minifi::core::DynamicProperty> dynamic_properties;
   dynamic_properties.reserve(class_description.dynamic_properties_count);
   for (size_t i = 0; i < class_description.dynamic_properties_count; ++i) {
-    dynamic_properties.push_back(minifi::core::DynamicPropertyDefinition{
+    dynamic_properties.emplace_back(minifi::core::DynamicPropertyDefinition{
       .name = toStringView(class_description.dynamic_properties_ptr[i].name),
       .value = toStringView(class_description.dynamic_properties_ptr[i].value),
       .description = toStringView(class_description.dynamic_properties_ptr[i].description),
@@ -202,10 +203,9 @@ void useCProcessorClassDescription(const MinifiProcessorClassDefinition& class_d
   std::vector<minifi::core::Relationship> relationships;
   relationships.reserve(class_description.class_relationships_count);
   for (size_t i = 0; i < class_description.class_relationships_count; ++i) {
-    relationships.push_back(minifi::core::Relationship{
+    relationships.emplace_back(
       toString(class_description.class_relationships_ptr[i].name),
-      toString(class_description.class_relationships_ptr[i].description)
-    });
+      toString(class_description.class_relationships_ptr[i].description));
   }
   std::vector<minifi::core::OutputAttribute> output_attributes;
   for (size_t attribute_idx = 0; attribute_idx < class_description.output_attributes_count; ++attribute_idx) {
@@ -265,7 +265,7 @@ void useCControllerServiceClassDescription(const MinifiControllerServiceClassDef
   auto name_segments = minifi::utils::string::split(toStringView(class_description.full_name), "::");
   gsl_Assert(!name_segments.empty());
 
-  minifi::ClassDescription description{
+  const minifi::ClassDescription description{
     .type_ = minifi::ResourceType::ControllerService,
     .short_name_ = name_segments.back(),
     .full_name_ = minifi::utils::string::join(".", name_segments),
@@ -435,6 +435,18 @@ MINIFI_OWNED MinifiFlowFile* MinifiProcessSessionCreate(MinifiProcessSession* se
   return MINIFI_NULL;
 }
 
+MinifiStatus MinifiProcessSessionPenalize(MinifiProcessSession* session, MinifiFlowFile* flowfile) {
+  gsl_Assert(session != MINIFI_NULL);
+  gsl_Assert(flowfile !=  MINIFI_NULL);
+  try {
+    reinterpret_cast<minifi::core::ProcessSession*>(session)->penalize(
+        *reinterpret_cast<std::shared_ptr<minifi::core::FlowFile>*>(flowfile));
+    return MINIFI_STATUS_SUCCESS;
+  } catch (...) {
+    return MINIFI_STATUS_UNKNOWN_ERROR;
+  }
+}
+
 MinifiStatus MinifiProcessSessionTransfer(MinifiProcessSession* session, MINIFI_OWNED MinifiFlowFile* flowfile, MinifiStringView relationship_name) {
   gsl_Assert(session != MINIFI_NULL);
   gsl_Assert(flowfile !=  MINIFI_NULL);
@@ -501,7 +513,7 @@ int64_t MinifiOutputStreamWrite(MinifiOutputStream* stream, const char* data, si
   return gsl::narrow<int64_t>(reinterpret_cast<minifi::io::OutputStream*>(stream)->write(as_bytes(std::span(data, size))));
 }
 
-MinifiStatus MinifiFlowFileSetAttribute(MinifiProcessSession* session, MinifiFlowFile* flowfile, MinifiStringView attribute_name, const MinifiStringView* attribute_value) {
+MinifiStatus MinifiProcessSessionSetFlowFileAttribute(MinifiProcessSession* session, MinifiFlowFile* flowfile, MinifiStringView attribute_name, const MinifiStringView* attribute_value) {
   gsl_Assert(session != MINIFI_NULL);
   gsl_Assert(flowfile != MINIFI_NULL);
   if (attribute_value == nullptr) {
@@ -513,7 +525,7 @@ MinifiStatus MinifiFlowFileSetAttribute(MinifiProcessSession* session, MinifiFlo
   return MINIFI_STATUS_SUCCESS;
 }
 
-MinifiBool MinifiFlowFileGetAttribute(MinifiProcessSession* session, MinifiFlowFile* flowfile, MinifiStringView attribute_name,
+MinifiBool MinifiProcessSessionGetFlowFileAttribute(MinifiProcessSession* session, MinifiFlowFile* flowfile, MinifiStringView attribute_name,
                                       void(*cb)(void* user_ctx, MinifiStringView attribute_value), void* user_ctx) {
   gsl_Assert(session != MINIFI_NULL);
   gsl_Assert(flowfile != MINIFI_NULL);
@@ -525,13 +537,27 @@ MinifiBool MinifiFlowFileGetAttribute(MinifiProcessSession* session, MinifiFlowF
   return true;
 }
 
-void MinifiFlowFileGetAttributes(MinifiProcessSession* session, MinifiFlowFile* flowfile,
+void MinifiProcessSessionGetFlowFileAttributes(MinifiProcessSession* session, MinifiFlowFile* flowfile,
                                  void(*cb)(void* user_ctx, MinifiStringView attribute_name, MinifiStringView attribute_value), void* user_ctx) {
   gsl_Assert(session != MINIFI_NULL);
   gsl_Assert(flowfile != MINIFI_NULL);
   for (auto& [key, value] : (*reinterpret_cast<std::shared_ptr<minifi::core::FlowFile>*>(flowfile))->getAttributes()) {
     cb(user_ctx, minifiStringView(key), minifiStringView(value));
   }
+}
+
+uint64_t MinifiProcessSessionGetFlowFileSize(MinifiProcessSession* session, MinifiFlowFile* flowfile) {
+  gsl_Assert(session != MINIFI_NULL);
+  gsl_Assert(flowfile != MINIFI_NULL);
+  return (*reinterpret_cast<std::shared_ptr<minifi::core::FlowFile>*>(flowfile))->getSize();
+}
+
+MinifiStatus MinifiProcessSessionGetFlowFileId(MinifiProcessSession* session, MinifiFlowFile* flowfile, void(*cb)(void* user_ctx, MinifiStringView flow_file_id), void* user_ctx) {
+  gsl_Assert(session != MINIFI_NULL);
+  gsl_Assert(flowfile != MINIFI_NULL);
+  const auto uuid_small_str = (*reinterpret_cast<std::shared_ptr<minifi::core::FlowFile>*>(flowfile))->getUUIDStr();
+  cb(user_ctx, minifiStringView(uuid_small_str.view()));
+  return MINIFI_STATUS_SUCCESS;
 }
 
 MinifiStatus MinifiControllerServiceContextGetProperty(MinifiControllerServiceContext* context, MinifiStringView property_name,
@@ -550,7 +576,6 @@ MinifiStatus MinifiControllerServiceContextGetProperty(MinifiControllerServiceCo
     default: return MINIFI_STATUS_UNKNOWN_ERROR;
   }
 }
-
 
 MinifiStatus MinifiProcessContextGetControllerService(
     MinifiProcessContext* process_context,
@@ -574,6 +599,41 @@ MinifiStatus MinifiProcessContextGetControllerService(
       *controller_service_out = static_cast<MinifiControllerService*>(c_controller_service->getImpl());
       return MINIFI_STATUS_SUCCESS;
     }
+  }
+  return MINIFI_STATUS_VALIDATION_FAILED;
+}
+
+void MinifiProcessContextGetDynamicProperties(MinifiProcessContext* context, MinifiFlowFile* minifi_flow_file,
+    void (*cb)(void* user_ctx, MinifiStringView dynamic_property_name, MinifiStringView dynamic_property_value), void* user_ctx) {
+  gsl_Assert(context != MINIFI_NULL);
+  auto flow_file = minifi_flow_file != MINIFI_NULL ? reinterpret_cast<std::shared_ptr<minifi::core::FlowFile>*>(minifi_flow_file)->get() : nullptr;
+  for (auto& [key, value] : reinterpret_cast<minifi::core::ProcessContext*>(context)->getDynamicProperties(flow_file)) {
+    cb(user_ctx, minifiStringView(key), minifiStringView(value));
+  }
+}
+
+MinifiStatus MinifiProcessContextGetSslData(MinifiProcessContext* process_context, MinifiStringView controller_service_name,
+    void (*cb)(void* user_ctx, const MinifiSslData* ssl_data), void* user_ctx) {
+  gsl_Assert(process_context != MINIFI_NULL);
+  const auto context = reinterpret_cast<minifi::core::ProcessContext*>(process_context);
+  const auto name_str = std::string{toStringView(controller_service_name)};
+  const auto service_shared_ptr = context->getControllerService(name_str, context->getProcessorInfo().getUUID());
+  if (!service_shared_ptr) { return MINIFI_STATUS_VALIDATION_FAILED; }
+  if (const auto ssl_context_service = dynamic_cast<minifi::controllers::SSLContextServiceInterface*>(service_shared_ptr.get())) {
+    const std::string ca_cert_file = ssl_context_service->getCACertificate().string();
+    const std::string passphrase = ssl_context_service->getPassphrase();
+    const std::string cert_file = ssl_context_service->getCertificateFile().string();
+    const std::string private_key_file = ssl_context_service->getPrivateKeyFile().string();
+
+    MinifiSslData ssl_data{
+        .version = 1,
+        .ca_certificate = minifiStringView(ca_cert_file),
+        .certificate_file = minifiStringView(cert_file),
+        .private_key_file = minifiStringView(private_key_file),
+        .passphrase = minifiStringView(passphrase),
+    };
+    cb(user_ctx, &ssl_data);
+    return MINIFI_STATUS_SUCCESS;
   }
   return MINIFI_STATUS_VALIDATION_FAILED;
 }

--- a/libminifi/src/minifi-c.cpp
+++ b/libminifi/src/minifi-c.cpp
@@ -616,27 +616,30 @@ void MinifiProcessContextGetDynamicProperties(MinifiProcessContext* context, Min
 MinifiStatus MinifiProcessContextGetSslData(MinifiProcessContext* process_context, MinifiStringView controller_service_name,
     void (*cb)(void* user_ctx, const MinifiSslData* ssl_data), void* user_ctx) {
   gsl_Assert(process_context != MINIFI_NULL);
-  const auto context = reinterpret_cast<minifi::core::ProcessContext*>(process_context);
-  const auto name_str = std::string{toStringView(controller_service_name)};
-  const auto service_shared_ptr = context->getControllerService(name_str, context->getProcessorInfo().getUUID());
-  if (!service_shared_ptr) { return MINIFI_STATUS_VALIDATION_FAILED; }
-  if (const auto ssl_context_service = dynamic_cast<minifi::controllers::SSLContextServiceInterface*>(service_shared_ptr.get())) {
-    const std::string ca_cert_file = ssl_context_service->getCACertificate().string();
-    const std::string passphrase = ssl_context_service->getPassphrase();
-    const std::string cert_file = ssl_context_service->getCertificateFile().string();
-    const std::string private_key_file = ssl_context_service->getPrivateKeyFile().string();
+  try {
+    const auto context = reinterpret_cast<minifi::core::ProcessContext*>(process_context);
+    const auto name_str = std::string{toStringView(controller_service_name)};
+    const auto service_shared_ptr = context->getControllerService(name_str, context->getProcessorInfo().getUUID());
+    if (!service_shared_ptr) { return MINIFI_STATUS_VALIDATION_FAILED; }
+    if (const auto ssl_context_service = dynamic_cast<minifi::controllers::SSLContextServiceInterface*>(service_shared_ptr.get())) {
+      const std::string ca_cert_file = ssl_context_service->getCACertificate().string();
+      const std::string passphrase = ssl_context_service->getPassphrase();
+      const std::string cert_file = ssl_context_service->getCertificateFile().string();
+      const std::string private_key_file = ssl_context_service->getPrivateKeyFile().string();
 
-    MinifiSslData ssl_data{
-        .version = 1,
+      MinifiSslData ssl_data{
         .ca_certificate_file = minifiStringView(ca_cert_file),
         .certificate_file = minifiStringView(cert_file),
         .private_key_file = minifiStringView(private_key_file),
         .passphrase = minifiStringView(passphrase),
     };
-    cb(user_ctx, &ssl_data);
-    return MINIFI_STATUS_SUCCESS;
+      cb(user_ctx, &ssl_data);
+      return MINIFI_STATUS_SUCCESS;
+    }
+    return MINIFI_STATUS_VALIDATION_FAILED;
+  } catch (...) {
+    return MINIFI_STATUS_UNKNOWN_ERROR;
   }
-  return MINIFI_STATUS_VALIDATION_FAILED;
 }
 
 

--- a/libminifi/src/minifi-c.cpp
+++ b/libminifi/src/minifi-c.cpp
@@ -632,7 +632,7 @@ MinifiStatus MinifiProcessContextGetSslData(MinifiProcessContext* process_contex
         .certificate_file = minifiStringView(cert_file),
         .private_key_file = minifiStringView(private_key_file),
         .passphrase = minifiStringView(passphrase),
-    };
+      };
       cb(user_ctx, &ssl_data);
       return MINIFI_STATUS_SUCCESS;
     }

--- a/minifi-api/include/minifi-c/minifi-c.h
+++ b/minifi-api/include/minifi-c/minifi-c.h
@@ -41,6 +41,8 @@ extern "C" {
 #define MINIFI_REGISTER_EXTENSION_FN MinifiRegisterExtension
 #endif
 
+#define MINIFI_SSL_CONTEXT_SERVICE_API "org.apache.nifi.minifi.controllers.SSLContextServiceInterface"
+
 enum : uint32_t {
   MINIFI_API_VERSION = 3
 };
@@ -231,6 +233,8 @@ MinifiBool MinifiProcessContextHasNonEmptyProperty(MinifiProcessContext* context
 
 MinifiStatus MinifiProcessContextGetControllerService(
     MinifiProcessContext* process_context, MinifiStringView controller_service_name, MinifiStringView controller_service_type, MinifiControllerService** controller_service_out);
+void MinifiProcessContextGetDynamicProperties(MinifiProcessContext* context, MinifiFlowFile* minifi_flow_file,
+    void (*cb)(void* user_ctx, MinifiStringView dynamic_property_name, MinifiStringView dynamic_property_value), void* user_ctx);
 
 void MinifiLoggerSetMaxLogSize(MinifiLogger*, int32_t);
 void MinifiLoggerLogString(MinifiLogger*, MinifiLogLevel, MinifiStringView);
@@ -240,6 +244,7 @@ MinifiLogLevel MinifiLoggerLevel(MinifiLogger*);
 MINIFI_OWNED MinifiFlowFile* MinifiProcessSessionGet(MinifiProcessSession*);
 MINIFI_OWNED MinifiFlowFile* MinifiProcessSessionCreate(MinifiProcessSession* session, MinifiFlowFile* parent_flowfile);
 
+MinifiStatus MinifiProcessSessionPenalize(MinifiProcessSession* session, MinifiFlowFile* flowfile);
 MinifiStatus MinifiProcessSessionTransfer(MinifiProcessSession* session, MINIFI_OWNED MinifiFlowFile* flowfile, MinifiStringView relationship_name);
 MinifiStatus MinifiProcessSessionRemove(MinifiProcessSession* session, MINIFI_OWNED MinifiFlowFile* flowfile);
 
@@ -253,15 +258,29 @@ size_t MinifiInputStreamSize(MinifiInputStream*);
 int64_t MinifiInputStreamRead(MinifiInputStream* stream, char* buffer, size_t size);
 int64_t MinifiOutputStreamWrite(MinifiOutputStream* stream, const char* data, size_t size);
 
-MinifiStatus MinifiFlowFileSetAttribute(MinifiProcessSession* session, MinifiFlowFile* flowfile, MinifiStringView attribute_name, const MinifiStringView* attribute_value);
-MinifiBool MinifiFlowFileGetAttribute(MinifiProcessSession* session, MinifiFlowFile* flowfile, MinifiStringView attribute_name,
+MinifiStatus MinifiProcessSessionSetFlowFileAttribute(MinifiProcessSession* session, MinifiFlowFile* flowfile, MinifiStringView attribute_name, const MinifiStringView* attribute_value);
+MinifiBool MinifiProcessSessionGetFlowFileAttribute(MinifiProcessSession* session, MinifiFlowFile* flowfile, MinifiStringView attribute_name,
                                       void(*cb)(void* user_ctx, MinifiStringView attribute_value), void* user_ctx);
-void MinifiFlowFileGetAttributes(MinifiProcessSession* session, MinifiFlowFile* flowfile, void(*cb)(void* user_ctx, MinifiStringView attribute_name, MinifiStringView attribute_value), void* user_ctx);
+void MinifiProcessSessionGetFlowFileAttributes(MinifiProcessSession* session, MinifiFlowFile* flowfile,
+    void (*cb)(void* user_ctx, MinifiStringView attribute_name, MinifiStringView attribute_value), void* user_ctx);
+uint64_t MinifiProcessSessionGetFlowFileSize(MinifiProcessSession* session, MinifiFlowFile* flowfile);
+MinifiStatus MinifiProcessSessionGetFlowFileId(MinifiProcessSession* session, MinifiFlowFile* flowfile, void(*cb)(void* user_ctx, MinifiStringView flow_file_id), void* user_ctx);
 
 MinifiStatus MinifiControllerServiceContextGetProperty(MinifiControllerServiceContext* context,
     MinifiStringView property_name,
     void(*cb)(void* user_ctx, MinifiStringView property_value),
     void* user_ctx);
+
+struct MinifiSslData {
+  uint8_t version;
+  MinifiStringView ca_certificate;
+  MinifiStringView certificate_file;
+  MinifiStringView private_key_file;
+  MinifiStringView passphrase;
+};
+
+MinifiStatus MinifiProcessContextGetSslData(MinifiProcessContext* process_context, MinifiStringView controller_service_name,
+    void (*cb)(void* user_ctx, const MinifiSslData* ssl_data), void* user_ctx);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/minifi-api/include/minifi-c/minifi-c.h
+++ b/minifi-api/include/minifi-c/minifi-c.h
@@ -273,7 +273,7 @@ MinifiStatus MinifiControllerServiceContextGetProperty(MinifiControllerServiceCo
 
 struct MinifiSslData {
   uint8_t version;
-  MinifiStringView ca_certificate;
+  MinifiStringView ca_certificate_file;
   MinifiStringView certificate_file;
   MinifiStringView private_key_file;
   MinifiStringView passphrase;

--- a/minifi-api/include/minifi-c/minifi-c.h
+++ b/minifi-api/include/minifi-c/minifi-c.h
@@ -272,13 +272,13 @@ MinifiStatus MinifiControllerServiceContextGetProperty(MinifiControllerServiceCo
     void(*cb)(void* user_ctx, MinifiStringView property_value),
     void* user_ctx);
 
-struct MinifiSslData {
+typedef struct MinifiSslData {
   uint8_t version;
   MinifiStringView ca_certificate_file;
   MinifiStringView certificate_file;
   MinifiStringView private_key_file;
   MinifiStringView passphrase;
-};
+} MinifiSslData;
 
 MinifiStatus MinifiProcessContextGetSslData(MinifiProcessContext* process_context, MinifiStringView controller_service_name,
     void (*cb)(void* user_ctx, const MinifiSslData* ssl_data), void* user_ctx);

--- a/minifi-api/include/minifi-c/minifi-c.h
+++ b/minifi-api/include/minifi-c/minifi-c.h
@@ -41,7 +41,8 @@ extern "C" {
 #define MINIFI_REGISTER_EXTENSION_FN MinifiRegisterExtension
 #endif
 
-/// To allow the proper usage of SSLContextServices set the MinifiPropertyDefinition::type to MINIFI_SSL_CONTEXT_SERVICE_PROPERTY_TYPE
+/// To declare a processor property that expects an SSLContextService,
+/// use MINIFI_SSL_CONTEXT_SERVICE_PROPERTY_TYPE in the type field of the property definition (MinifiPropertyDefinition::type)
 #define MINIFI_SSL_CONTEXT_SERVICE_PROPERTY_TYPE "org.apache.nifi.minifi.controllers.SSLContextServiceInterface"
 
 enum : uint32_t {
@@ -273,7 +274,6 @@ MinifiStatus MinifiControllerServiceContextGetProperty(MinifiControllerServiceCo
     void* user_ctx);
 
 typedef struct MinifiSslData {
-  uint8_t version;
   MinifiStringView ca_certificate_file;
   MinifiStringView certificate_file;
   MinifiStringView private_key_file;

--- a/minifi-api/include/minifi-c/minifi-c.h
+++ b/minifi-api/include/minifi-c/minifi-c.h
@@ -41,7 +41,8 @@ extern "C" {
 #define MINIFI_REGISTER_EXTENSION_FN MinifiRegisterExtension
 #endif
 
-#define MINIFI_SSL_CONTEXT_SERVICE_API "org.apache.nifi.minifi.controllers.SSLContextServiceInterface"
+/// To allow the proper usage of SSLContextServices set the MinifiPropertyDefinition::type to MINIFI_SSL_CONTEXT_SERVICE_PROPERTY_TYPE
+#define MINIFI_SSL_CONTEXT_SERVICE_PROPERTY_TYPE "org.apache.nifi.minifi.controllers.SSLContextServiceInterface"
 
 enum : uint32_t {
   MINIFI_API_VERSION = 3

--- a/minifi-api/minifi-c-api.def
+++ b/minifi-api/minifi-c-api.def
@@ -16,12 +16,17 @@ EXPORTS
   MinifiProcessSessionCreate
   MinifiProcessSessionTransfer
   MinifiProcessSessionRemove
+  MinifiProcessSessionPenalize
   MinifiProcessSessionRead
   MinifiProcessSessionWrite
   MinifiConfigGet
   MinifiInputStreamSize
   MinifiInputStreamRead
   MinifiOutputStreamWrite
-  MinifiFlowFileSetAttribute
-  MinifiFlowFileGetAttribute
-  MinifiFlowFileGetAttributes
+  MinifiProcessSessionSetFlowFileAttribute
+  MinifiProcessSessionGetFlowFileAttribute
+  MinifiProcessSessionGetFlowFileAttributes
+  MinifiProcessSessionGetFlowFileSize
+  MinifiProcessSessionGetFlowFileId
+  MinifiProcessContextGetDynamicProperties
+  MinifiProcessContextGetSslData


### PR DESCRIPTION
[MINIFICPP-2797](https://issues.apache.org/jira/browse/MINIFICPP-2797)
There are a couple functions missing from the stable API that prevents us to migrate Kafka,
namely penalize, sslcontext functionality, dynamic property handling, flowfile id and flowfile size

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
