### PR TITLE
MINIFICPP-2806 Fix verify package test issues

### DIFF
--- a/behave_framework/src/minifi_behave/containers/minifi_linux_container.py
+++ b/behave_framework/src/minifi_behave/containers/minifi_linux_container.py
@@ -31,6 +31,13 @@ from .minifi_controller import MinifiController
 from .minifi_protocol import MinifiProtocol
 
 
+CA_CERT_PATHS = [
+    "/usr/local/share/certs/ca-root-nss.crt",
+    "/etc/ssl/certs/ca-certificates.crt",
+    "/etc/pki/tls/certs/ca-bundle.crt"
+]
+
+
 class NormalDeployment:
     def __init__(self):
         self.conf_path = "/opt/minifi/minifi-current/conf"
@@ -67,9 +74,10 @@ class MinifiLinuxContainer(LinuxContainer, MinifiProtocol):
         minifi_client_cert, minifi_client_key = make_cert_without_extended_usage(common_name=self.container_name,
                                                                                  ca_cert=test_context.root_ca_cert,
                                                                                  ca_key=test_context.root_ca_key)
-        self.files.append(File("/usr/local/share/certs/ca-root-nss.crt", dump_cert(test_context.root_ca_cert)))
         self.files.append(File("/tmp/resources/root_ca.crt", dump_cert(test_context.root_ca_cert)))
-        self.files.append(File("/etc/ssl/certs/ca-certificates.crt", dump_cert(test_context.root_ca_cert)))
+        if test_context.override_default_ca_cert_files:
+            for ca_cert_path in CA_CERT_PATHS:
+                self.files.append(File(ca_cert_path, dump_cert(test_context.root_ca_cert)))
         self.files.append(File("/tmp/resources/minifi_client.crt", dump_cert(minifi_client_cert)))
         self.files.append(File("/tmp/resources/minifi_client.key", dump_key(minifi_client_key)))
         self.files.append(
@@ -143,5 +151,5 @@ class MinifiLinuxContainer(LinuxContainer, MinifiProtocol):
         return "\n".join(lines)
 
     def add_example_python_processors(self):
-        run_minifi_cmd = f'{self.deployment_type.bin_path}/minifi.sh run'
+        run_minifi_cmd = f'{self.deployment_type.bin_path}/minifi'
         self.command = f'sh -c "cp -r {self.deployment_type.minifi_python_examples_path} {self.deployment_type.minifi_python_path}/examples && {run_minifi_cmd}"'

--- a/behave_framework/src/minifi_behave/core/hooks.py
+++ b/behave_framework/src/minifi_behave/core/hooks.py
@@ -78,6 +78,7 @@ def common_before_scenario(context: Context, scenario: Scenario):
     context.containers = {}
     context.resource_dir = None
     context.root_ca_cert, context.root_ca_key = make_self_signed_cert("root CA")
+    context.override_default_ca_cert_files = True
 
     for step in scenario.steps:
         inject_scenario_id(context, step)

--- a/behave_framework/src/minifi_behave/core/minifi_test_context.py
+++ b/behave_framework/src/minifi_behave/core/minifi_test_context.py
@@ -43,6 +43,7 @@ class MinifiTestContext(Context):
     resource_dir: str | None
     root_ca_key: RSAPrivateKey
     root_ca_cert: Certificate
+    override_default_ca_cert_files: bool
 
     def get_or_create_minifi_container(self, container_name: str) -> MinifiContainer:
         if container_name not in self.containers:

--- a/extensions/python/tests/features/environment.py
+++ b/extensions/python/tests/features/environment.py
@@ -118,6 +118,7 @@ def before_scenario(context, scenario):
 
     common_before_scenario(context, scenario)
     context.minifi_container_image = "apacheminificpp-python:latest"
+    context.override_default_ca_cert_files = False
 
 
 def after_scenario(context, scenario):


### PR DESCRIPTION
- Override default CA paths to use test generated root CA in tests, or leave the default CA when need external SSL communication
- Fix minifi binary path when using RPM package

🟢 https://github.com/lordgamez/nifi-minifi-cpp/actions/runs/25425552526

https://issues.apache.org/jira/browse/MINIFICPP-2806

--------------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
