### PR TITLE
MINIFICPP-2834 Fixing AwsProcessor::AWSCredentialsProviderService::wi…

### DIFF
--- a/.github/references/ubuntu_22_04_clang_arm_manifest.json
+++ b/.github/references/ubuntu_22_04_clang_arm_manifest.json
@@ -1516,9 +1516,9 @@
                 "propertyDescriptors": {
                     "AWS Credentials Provider service": {
                         "typeProvidedByValue": {
-                            "type": "org.apache.nifi.minifi.aws.AWSCredentialsProvider",
+                            "type": "org.apache.nifi.minifi.aws.controllers.AWSCredentialsService",
                             "group": "org.apache.nifi.minifi",
-                            "artifact": "minifi-system"
+                            "artifact": "minifi-aws"
                         },
                         "name": "AWS Credentials Provider service",
                         "description": "The name of the AWS Credentials Provider controller service that is used to obtain AWS credentials.",
@@ -2999,9 +2999,9 @@
                 "propertyDescriptors": {
                     "AWS Credentials Provider service": {
                         "typeProvidedByValue": {
-                            "type": "org.apache.nifi.minifi.aws.AWSCredentialsProvider",
+                            "type": "org.apache.nifi.minifi.aws.controllers.AWSCredentialsService",
                             "group": "org.apache.nifi.minifi",
-                            "artifact": "minifi-system"
+                            "artifact": "minifi-aws"
                         },
                         "name": "AWS Credentials Provider service",
                         "description": "The name of the AWS Credentials Provider controller service that is used to obtain AWS credentials.",
@@ -5186,9 +5186,9 @@
                 "propertyDescriptors": {
                     "AWS Credentials Provider service": {
                         "typeProvidedByValue": {
-                            "type": "org.apache.nifi.minifi.aws.AWSCredentialsProvider",
+                            "type": "org.apache.nifi.minifi.aws.controllers.AWSCredentialsService",
                             "group": "org.apache.nifi.minifi",
-                            "artifact": "minifi-system"
+                            "artifact": "minifi-aws"
                         },
                         "name": "AWS Credentials Provider service",
                         "description": "The name of the AWS Credentials Provider controller service that is used to obtain AWS credentials.",
@@ -7949,9 +7949,9 @@
                 "propertyDescriptors": {
                     "AWS Credentials Provider service": {
                         "typeProvidedByValue": {
-                            "type": "org.apache.nifi.minifi.aws.AWSCredentialsProvider",
+                            "type": "org.apache.nifi.minifi.aws.controllers.AWSCredentialsService",
                             "group": "org.apache.nifi.minifi",
-                            "artifact": "minifi-system"
+                            "artifact": "minifi-aws"
                         },
                         "name": "AWS Credentials Provider service",
                         "description": "The name of the AWS Credentials Provider controller service that is used to obtain AWS credentials.",
@@ -8531,9 +8531,9 @@
                 "propertyDescriptors": {
                     "AWS Credentials Provider service": {
                         "typeProvidedByValue": {
-                            "type": "org.apache.nifi.minifi.aws.AWSCredentialsProvider",
+                            "type": "org.apache.nifi.minifi.aws.controllers.AWSCredentialsService",
                             "group": "org.apache.nifi.minifi",
-                            "artifact": "minifi-system"
+                            "artifact": "minifi-aws"
                         },
                         "name": "AWS Credentials Provider service",
                         "description": "The name of the AWS Credentials Provider controller service that is used to obtain AWS credentials.",

--- a/extensions/aws/processors/AwsProcessor.h
+++ b/extensions/aws/processors/AwsProcessor.h
@@ -27,13 +27,13 @@
 #include <utility>
 
 #include "aws/core/auth/AWSCredentialsProvider.h"
-#include "AWSCredentialsProvider.h"
 #include "minifi-cpp/core/PropertyDefinition.h"
 #include "core/PropertyDefinitionBuilder.h"
 #include "minifi-cpp/core/PropertyValidator.h"
 #include "core/ProcessorImpl.h"
 #include "minifi-cpp/controllers/ProxyConfigurationServiceInterface.h"
 #include "controllers/ProxyConfiguration.h"
+#include "controllerservices/AWSCredentialsService.h"
 
 
 namespace org::apache::nifi::minifi::aws::processors {
@@ -108,7 +108,7 @@ class AwsProcessor : public core::ProcessorImpl {  // NOLINT(cppcoreguidelines-s
       .build();
   EXTENSIONAPI static constexpr auto AWSCredentialsProviderService = core::PropertyDefinitionBuilder<>::createProperty("AWS Credentials Provider service")
       .withDescription("The name of the AWS Credentials Provider controller service that is used to obtain AWS credentials.")
-      .withAllowedTypes<AWSCredentialsProvider>()
+      .withAllowedTypes<controllers::AWSCredentialsService>()
       .build();
   EXTENSIONAPI static constexpr auto Region = core::PropertyDefinitionBuilder<region::REGIONS.size()>::createProperty("Region")
       .isRequired(true)


### PR DESCRIPTION
…thAllowedTypes typo

[MINIFICPP-2602](https://issues.apache.org/jira/browse/MINIFICPP-2602) introduced withAllowedTypes to AwsProcessor::AWSCredentialsProviderService but not with the proper type, this made the manifest to be faulty (possibly causing C2 GUI-s to misbehave)

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
