### PR TITLE
MINIFICPP-2835 Fix skipping Splunk tests on ARM64

### DIFF
--- a/extensions/splunk/tests/features/environment.py
+++ b/extensions/splunk/tests/features/environment.py
@@ -26,6 +26,7 @@ def before_feature(context, feature):
         is_x86 = platform.machine() in ("i386", "AMD64", "x86_64")
         if not is_x86:
             feature.skip("This feature is only x86/x64 compatible")
+            return
 
     docker.from_env().images.pull(SplunkContainer.IMAGE)
 


### PR DESCRIPTION
Successful verify package run: https://github.com/lordgamez/nifi-minifi-cpp/actions/runs/26638802749

https://issues.apache.org/jira/browse/MINIFICPP-2835

There is no splunk/splunk docker image for ARM, so we need to skip the feature, and the image pull command, too.

-----------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
