### PR TITLE
MINIFICPP-2823 Fix build with gcc 16

### DIFF
--- a/core-framework/include/core/RepositoryMetricsSource.h
+++ b/core-framework/include/core/RepositoryMetricsSource.h
@@ -20,6 +20,7 @@
 
 #include <string>
 #include <optional>
+#include <cstdint>
 
 #include "minifi-cpp/core/RepositoryMetricsSource.h"
 

--- a/extensions/systemd/libwrapper/LibWrapper.h
+++ b/extensions/systemd/libwrapper/LibWrapper.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <memory>
+#include <cstdint>
 
 #include "../Common.h"
 #include "minifi-cpp/utils/gsl.h"

--- a/minifi-api/include/minifi-cpp/core/RepositoryMetricsSource.h
+++ b/minifi-api/include/minifi-cpp/core/RepositoryMetricsSource.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <optional>
 


### PR DESCRIPTION
Fixes:
  extensions/systemd/libwrapper/LibWrapper.h:38:31: error: 'uint64_t' has not been declared
   38 |   virtual int getRealtimeUsec(uint64_t* usec_out) noexcept = 0;
      |                               ^~~~~~~~

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
