### PR TITLE
MINIFICPP-2843 Retry downloading test llamacpp models in case of failure

### DIFF
--- a/extensions/llamacpp/tests/features/environment.py
+++ b/extensions/llamacpp/tests/features/environment.py
@@ -31,8 +31,14 @@ def before_all(context: MinifiTestContext):
     dockerfile = dedent("""\
                 FROM {base_image}
                 RUN mkdir {models_path}
-                RUN wget https://huggingface.co/bartowski/Qwen2-VL-2B-Instruct-GGUF/resolve/main/Qwen2-VL-2B-Instruct-Q3_K_M.gguf --directory-prefix={models_path}
-                RUN wget https://huggingface.co/bartowski/Qwen2-VL-2B-Instruct-GGUF/resolve/main/mmproj-Qwen2-VL-2B-Instruct-f16.gguf --directory-prefix={models_path}
+                RUN for i in 1 2 3 4 5 6; do \\
+                    wget https://huggingface.co/bartowski/Qwen2-VL-2B-Instruct-GGUF/resolve/main/Qwen2-VL-2B-Instruct-Q3_K_M.gguf --directory-prefix={models_path} && break \\
+                        || ([ $i -lt 6 ] && sleep $((i * 5)) && echo "Attempt $i failed, retrying in $((i * 5))s..."); \\
+                    done && [ -f {models_path}/Qwen2-VL-2B-Instruct-Q3_K_M.gguf ] || exit 1
+                RUN for i in 1 2 3 4 5 6; do \\
+                    wget https://huggingface.co/bartowski/Qwen2-VL-2B-Instruct-GGUF/resolve/main/mmproj-Qwen2-VL-2B-Instruct-f16.gguf --directory-prefix={models_path} && break \\
+                        || ([ $i -lt 6 ] && sleep $((i * 5)) && echo "Attempt $i failed, retrying in $((i * 5))s..."); \\
+                    done && [ -f {models_path}/mmproj-Qwen2-VL-2B-Instruct-f16.gguf ] || exit 1
         """.format(base_image=minifi_container_image, models_path='/tmp/models'))
 
     builder = DockerImageBuilder(

--- a/extensions/llamacpp/tests/features/environment.py
+++ b/extensions/llamacpp/tests/features/environment.py
@@ -28,22 +28,25 @@ from minifi_behave.core.minifi_test_context import MinifiTestContext
 def before_all(context: MinifiTestContext):
     minifi_container_image = get_minifi_container_image()
 
+    wget_with_retry_path = Path(__file__).resolve().parent / "resources" / "wget_with_retry.sh"
+    wget_with_retry_content = None
+    with open(wget_with_retry_path, "rb") as f:
+        wget_with_retry_content = f.read()
+
     dockerfile = dedent("""\
                 FROM {base_image}
-                RUN mkdir {models_path}
-                RUN for i in 1 2 3 4 5 6; do \\
-                    wget https://huggingface.co/bartowski/Qwen2-VL-2B-Instruct-GGUF/resolve/main/Qwen2-VL-2B-Instruct-Q3_K_M.gguf --directory-prefix={models_path} && break \\
-                        || ([ $i -lt 6 ] && sleep $((i * 5)) && echo "Attempt $i failed, retrying in $((i * 5))s..."); \\
-                    done && [ -f {models_path}/Qwen2-VL-2B-Instruct-Q3_K_M.gguf ] || exit 1
-                RUN for i in 1 2 3 4 5 6; do \\
-                    wget https://huggingface.co/bartowski/Qwen2-VL-2B-Instruct-GGUF/resolve/main/mmproj-Qwen2-VL-2B-Instruct-f16.gguf --directory-prefix={models_path} && break \\
-                        || ([ $i -lt 6 ] && sleep $((i * 5)) && echo "Attempt $i failed, retrying in $((i * 5))s..."); \\
-                    done && [ -f {models_path}/mmproj-Qwen2-VL-2B-Instruct-f16.gguf ] || exit 1
+                USER root
+                COPY wget_with_retry.sh /scripts/wget_with_retry.sh
+                RUN chmod 755 /scripts/wget_with_retry.sh && mkdir {models_path} && \\
+                    /scripts/wget_with_retry.sh https://huggingface.co/bartowski/Qwen2-VL-2B-Instruct-GGUF/resolve/main/Qwen2-VL-2B-Instruct-Q3_K_M.gguf {models_path} && \\
+                    /scripts/wget_with_retry.sh https://huggingface.co/bartowski/Qwen2-VL-2B-Instruct-GGUF/resolve/main/mmproj-Qwen2-VL-2B-Instruct-f16.gguf {models_path}
+                USER minificpp
         """.format(base_image=minifi_container_image, models_path='/tmp/models'))
 
     builder = DockerImageBuilder(
         image_tag="apacheminificpp:llama",
-        dockerfile_content=dockerfile
+        dockerfile_content=dockerfile,
+        files_on_context={"wget_with_retry.sh": wget_with_retry_content}
     )
     builder.build()
 

--- a/extensions/llamacpp/tests/features/resources/wget_with_retry.sh
+++ b/extensions/llamacpp/tests/features/resources/wget_with_retry.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -u
+
+URL=$1
+DEST=$2
+
+for i in 1 2 3 4 5 6; do
+    if wget "${URL}" --directory-prefix="${DEST}"; then
+        break
+    elif [ $i -lt 6 ]; then
+        sleep $((i * 5))
+        echo "Attempt $i failed, retrying in $((i * 5))s..."
+    fi
+done
+
+[ -f "${DEST}/$(basename "${URL}")" ] || exit 1


### PR DESCRIPTION
Add exponential backoff to llamacpp model download in docker tests to elmininate transient download failures in test setup hook

https://issues.apache.org/jira/browse/MINIFICPP-2843

-------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
