### PR TITLE
MINIFICPP-2847 Allow nifi.c2.rest.path.base to end with slash character

### DIFF
--- a/libminifi/src/c2/C2Agent.cpp
+++ b/libminifi/src/c2/C2Agent.cpp
@@ -1005,6 +1005,9 @@ std::optional<std::string> C2Agent::resolveUrl(const std::string& url) const {
   }
   std::string base;
   if (configuration_->get(Configuration::nifi_c2_rest_path_base, base)) {
+    if (!base.empty() && base.back() == '/') {
+      base.pop_back();
+    }
     return base + url;
   }
   if (!configuration_->get(Configuration::nifi_c2_rest_url, "c2.rest.url", base)) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MINIFICPP-2847

-------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced
     in the commit message?

- [ ] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
