### PR TITLE
MINIFICPP-2787 Do not encrypt empty properties and parameters

### DIFF
--- a/core-framework/src/utils/crypto/property_encryption/PropertyEncryptionUtils.cpp
+++ b/core-framework/src/utils/crypto/property_encryption/PropertyEncryptionUtils.cpp
@@ -39,7 +39,7 @@ std::string decrypt(std::string_view input, const utils::crypto::EncryptionProvi
 }
 
 std::string encrypt(std::string_view input, const utils::crypto::EncryptionProvider& encryption_provider) {
-  if (isEncrypted(input)) {
+  if (input.empty() || isEncrypted(input)) {
     return std::string{input};
   }
   return utils::string::join_pack("enc{", encryption_provider.encrypt(input), "}");

--- a/libminifi/src/core/yaml/YamlFlowSerializer.cpp
+++ b/libminifi/src/core/yaml/YamlFlowSerializer.cpp
@@ -65,7 +65,7 @@ void YamlFlowSerializer::addProviderCreatedParameterContexts(YAML::Node flow_def
 
     int64_t index = -1;
     for (int64_t i = 0; i < gsl::narrow<int64_t>(parameter_contexts_node.size()); ++i) {
-      if (parameter_contexts_node[i][schema.name[0]].as<std::string>() == parameter_context->getName()) {
+      if (parameter_contexts_node[i][schema.name[0]].Scalar() == parameter_context->getName()) {
         index = i;
         break;
       }
@@ -85,7 +85,7 @@ void YamlFlowSerializer::encryptSensitiveProperties(YAML::Node property_yamls,
   std::unordered_set<std::string> processed_property_names;
 
   for (auto kv : property_yamls) {
-    auto name = kv.first.as<std::string>();
+    auto name = kv.first.Scalar();
     if (!properties.contains(name)) {
       logger_->log_warn("Property {} found in flow definition does not exist!", name);
       continue;
@@ -94,12 +94,12 @@ void YamlFlowSerializer::encryptSensitiveProperties(YAML::Node property_yamls,
       if (kv.second.IsSequence()) {
         for (auto property_item : kv.second) {
           const auto override_value = overrides.get(name);
-          auto value = override_value ? *override_value : property_item["value"].as<std::string>();
+          auto value = override_value ? *override_value : property_item["value"].Scalar();
           property_item["value"] = utils::crypto::property_encryption::encrypt(value, encryption_provider);
         }
       } else {
         const auto override_value = overrides.get(name);
-        auto value = override_value ? *override_value : kv.second.as<std::string>();
+        auto value = override_value ? *override_value : kv.second.Scalar();
         property_yamls[name] = utils::crypto::property_encryption::encrypt(value, encryption_provider);
       }
       processed_property_names.insert(name);

--- a/libminifi/test/libtest/unit/Catch.h
+++ b/libminifi/test/libtest/unit/Catch.h
@@ -17,9 +17,11 @@
 
 #pragma once
 
+#include <chrono>
+#include <expected>
 #include <optional>
 #include <string>
-#include <chrono>
+
 #include "fmt/format.h"
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/catch_tostring.hpp"
@@ -54,6 +56,19 @@ template <>
 struct StringMaker<std::chrono::file_clock::duration> {
   static std::string convert(const std::chrono::file_clock::duration& duration) {
     return fmt::format("{} {} s", duration.count(), Catch::ratio_string<std::chrono::file_clock::duration::period>::symbol());
+  }
+};
+
+template <typename T, typename E>
+struct StringMaker<std::expected<T, E>> {
+  static std::string convert(const std::expected<T, E>& expected) {
+    if (!expected) {
+      return "error: " + Catch::Detail::stringify(expected.error());
+    }
+    if constexpr (!std::is_void_v<T>) {
+      return Catch::Detail::stringify(*expected);
+    }
+    return "OK";
   }
 };
 }  // namespace Catch

--- a/libminifi/test/libtest/unit/Catch.h
+++ b/libminifi/test/libtest/unit/Catch.h
@@ -63,12 +63,12 @@ template <typename T, typename E>
 struct StringMaker<std::expected<T, E>> {
   static std::string convert(const std::expected<T, E>& expected) {
     if (!expected) {
-      return "error: " + Catch::Detail::stringify(expected.error());
+      return fmt::format("unexpected({})", Catch::Detail::stringify(expected.error()));
     }
     if constexpr (!std::is_void_v<T>) {
-      return Catch::Detail::stringify(*expected);
+      return fmt::format("expected({})", Catch::Detail::stringify(*expected));
     }
-    return "OK";
+    return "expected(void)";
   }
 };
 }  // namespace Catch

--- a/libminifi/test/libtest/unit/TestUtils.h
+++ b/libminifi/test/libtest/unit/TestUtils.h
@@ -266,4 +266,15 @@ struct StringMaker<std::unordered_map<std::string_view, std::string_view>> {
     }) + "}";
   }
 };
+
+template <typename T, typename E>
+struct StringMaker<std::expected<T, E>> {
+  static std::string convert(const std::expected<T, E>& expected) {
+    if (expected.has_value()) {
+      return fmt::format(R"("{}")", expected.value());
+    } else {
+      return fmt::format(R"(error: "{}")", expected.error());
+    }
+  }
+};
 }  // namespace Catch

--- a/libminifi/test/libtest/unit/TestUtils.h
+++ b/libminifi/test/libtest/unit/TestUtils.h
@@ -266,15 +266,4 @@ struct StringMaker<std::unordered_map<std::string_view, std::string_view>> {
     }) + "}";
   }
 };
-
-template <typename T, typename E>
-struct StringMaker<std::expected<T, E>> {
-  static std::string convert(const std::expected<T, E>& expected) {
-    if (expected.has_value()) {
-      return fmt::format(R"("{}")", expected.value());
-    } else {
-      return fmt::format(R"(error: "{}")", expected.error());
-    }
-  }
-};
 }  // namespace Catch

--- a/libminifi/test/unit/ExpectedTest.cpp
+++ b/libminifi/test/unit/ExpectedTest.cpp
@@ -580,10 +580,10 @@ TEST_CASE("This fails to compile with std::expected on GCC 15.1 due to https://g
 }
 
 TEST_CASE("Test Catch2 stringification of expected") {
-  CHECK(Catch::Detail::stringify(std::expected<int, std::string>{123}) == "123");
-  CHECK(Catch::Detail::stringify(std::expected<std::string, std::string>{"hello"}) == R"("hello")");
-  CHECK(Catch::Detail::stringify(std::expected<std::string, std::error_code>{"hello"}) == R"("hello")");
-  CHECK(Catch::Detail::stringify(std::expected<std::string, std::unique_ptr<int>>{"hello"}) == R"("hello")");
-  CHECK(Catch::Detail::stringify(std::expected<void, std::string>{}) == "OK");
-  CHECK(Catch::Detail::stringify(std::expected<std::string, std::string>{std::unexpect, "doesn't compute"}) == R"(error: "doesn't compute")");
+  CHECK(Catch::Detail::stringify(std::expected<int, std::string>{123}) == "expected(123)");
+  CHECK(Catch::Detail::stringify(std::expected<std::string, std::string>{"hello"}) == R"(expected("hello"))");
+  CHECK(Catch::Detail::stringify(std::expected<std::string, std::error_code>{"hello"}) == R"(expected("hello"))");
+  CHECK(Catch::Detail::stringify(std::expected<std::string, std::unique_ptr<int>>{"hello"}) == R"(expected("hello"))");
+  CHECK(Catch::Detail::stringify(std::expected<void, std::string>{}) == "expected(void)");
+  CHECK(Catch::Detail::stringify(std::expected<std::string, std::string>{std::unexpect, "doesn't compute"}) == R"(unexpected("doesn't compute"))");
 }

--- a/libminifi/test/unit/ExpectedTest.cpp
+++ b/libminifi/test/unit/ExpectedTest.cpp
@@ -578,3 +578,12 @@ TEST_CASE("This fails to compile with std::expected on GCC 15.1 due to https://g
 
   CHECK(a == b);
 }
+
+TEST_CASE("Test Catch2 stringification of expected") {
+  CHECK(Catch::Detail::stringify(std::expected<int, std::string>{123}) == "123");
+  CHECK(Catch::Detail::stringify(std::expected<std::string, std::string>{"hello"}) == R"("hello")");
+  CHECK(Catch::Detail::stringify(std::expected<std::string, std::error_code>{"hello"}) == R"("hello")");
+  CHECK(Catch::Detail::stringify(std::expected<std::string, std::unique_ptr<int>>{"hello"}) == R"("hello")");
+  CHECK(Catch::Detail::stringify(std::expected<void, std::string>{}) == "OK");
+  CHECK(Catch::Detail::stringify(std::expected<std::string, std::string>{std::unexpect, "doesn't compute"}) == R"(error: "doesn't compute")");
+}

--- a/libminifi/test/unit/JsonFlowSerializerTests.cpp
+++ b/libminifi/test/unit/JsonFlowSerializerTests.cpp
@@ -749,6 +749,46 @@ TEST_CASE("The encrypted flow configuration cannot be decrypted with an incorrec
   REQUIRE_THROWS_AS(json_configuration_after.getRootFromPayload(config_json_encrypted), minifi::utils::crypto::EncryptionError);
 }
 
+TEST_CASE("Empty sensitive properties and parameters are not encrypted and round-trip as empty") {
+  ConfigurationTestController test_controller;
+  auto configuration_context = test_controller.getContext();
+  configuration_context.sensitive_values_encryptor = encryption_provider;
+
+  const auto schema = core::flow::FlowSchema::getNiFiFlowJson();
+  std::string config_json_with_empty_passphrase_and_parameter = minifi::utils::string::join_pack(config_json_with_nifi_schema_part_1, config_json_with_nifi_schema_part_2);
+  minifi::utils::string::replaceAll(config_json_with_empty_passphrase_and_parameter, "very_secure_passphrase", "");
+  minifi::utils::string::replaceAll(config_json_with_empty_passphrase_and_parameter, "param_value_1", "");
+
+  core::flow::AdaptiveConfiguration json_configuration_before{configuration_context};
+  const auto process_group_before = json_configuration_before.getRootFromPayload(config_json_with_empty_passphrase_and_parameter);
+  REQUIRE(process_group_before);
+
+  rapidjson::Document doc;
+  rapidjson::ParseResult res = doc.Parse(config_json_with_empty_passphrase_and_parameter.data(), config_json_with_empty_passphrase_and_parameter.size());
+  REQUIRE(res);
+  const auto flow_serializer = core::json::JsonFlowSerializer{std::move(doc)};
+
+  const auto processor_id = minifi::utils::Identifier::parse("469617f1-3898-4bbf-91fe-27d8f4dd2a75").value();
+  const OverridesMap overrides{{processor_id, core::flow::Overrides{}.add("invokehttp-proxy-password", "")}};
+  const std::string serialized = flow_serializer.serialize(*process_group_before, schema, encryption_provider, overrides, {});
+  CHECK_FALSE(serialized.contains("enc{"));
+
+  core::flow::AdaptiveConfiguration json_configuration_after{configuration_context};
+  const auto process_group_after = json_configuration_after.getRootFromPayload(serialized);
+  REQUIRE(process_group_after);
+
+  const auto* processor_after = process_group_after->findProcessorById(processor_id);
+  REQUIRE(processor_after);
+  CHECK(processor_after->getProperty("invokehttp-proxy-password") == "");
+
+  const auto* const controller_service_node_after = process_group_after->findControllerService("b9801278-7b5d-4314-aed6-713fd4b5f933");
+  REQUIRE(controller_service_node_after);
+  CHECK(controller_service_node_after->getControllerServiceImplementation()->getProperty("Passphrase") == "");
+
+  const auto& param_contexts = json_configuration_after.getParameterContexts();
+  CHECK(param_contexts.at("my-context")->getParameter("secret_parameter").value().value.empty());
+}
+
 TEST_CASE("Parameter provider generated parameter context is serialized correctly") {
   ConfigurationTestController test_controller;
   auto configuration_context = test_controller.getContext();

--- a/libminifi/test/unit/PropertyEncryptionUtilsTests.cpp
+++ b/libminifi/test/unit/PropertyEncryptionUtilsTests.cpp
@@ -31,11 +31,6 @@ const crypto::Bytes secret_key = crypto::generateKey();
 const crypto::EncryptionProvider property_encryptor{secret_key};
 
 TEST_CASE("A property value can be encrypted") {
-  std::string encrypted_blank = property_encryption::encrypt("", property_encryptor);
-  CHECK(encrypted_blank.starts_with("enc{"));
-  CHECK(encrypted_blank.ends_with("}"));
-  CHECK(encrypted_blank.size() == 63);
-
   std::string encrypted_foo = property_encryption::encrypt("foo", property_encryptor);
   CHECK(encrypted_foo.starts_with("enc{"));
   CHECK(encrypted_foo.ends_with("}"));
@@ -48,6 +43,10 @@ TEST_CASE("A property value can be encrypted") {
   CHECK(encrypted_long_text.size() == 283);
 }
 
+TEST_CASE("An empty property value is not encrypted") {
+  CHECK(property_encryption::encrypt("", property_encryptor).empty());
+}
+
 TEST_CASE("Encrypting the same value a second time doesn't change its value") {
   std::string encrypted_foo = property_encryption::encrypt("foo", property_encryptor);
   std::string re_encrypted_foo = property_encryption::encrypt(encrypted_foo, property_encryptor);
@@ -58,9 +57,6 @@ TEST_CASE("Encrypting the same value a second time doesn't change its value") {
 }
 
 TEST_CASE("We can decrypt an encrypted value") {
-  std::string encrypted_blank = property_encryption::encrypt("", property_encryptor);
-  CHECK(property_encryption::decrypt(encrypted_blank, property_encryptor).empty());
-
   std::string encrypted_foo = property_encryption::encrypt("foo", property_encryptor);
   CHECK(property_encryption::decrypt(encrypted_foo, property_encryptor) == "foo");
 

--- a/libminifi/test/unit/YamlFlowSerializerTests.cpp
+++ b/libminifi/test/unit/YamlFlowSerializerTests.cpp
@@ -19,6 +19,7 @@
 
 #include "unit/Catch.h"
 #include "unit/ConfigurationTestController.h"
+#include "unit/TestUtils.h"
 #include "catch2/generators/catch_generators.hpp"
 #include "core/flow/FlowSchema.h"
 #include "core/yaml/YamlFlowSerializer.h"
@@ -26,7 +27,6 @@
 #include "utils/crypto/EncryptionProvider.h"
 #include "utils/crypto/property_encryption/PropertyEncryptionUtils.h"
 #include "utils/StringUtils.h"
-#include "core/Resource.h"
 #include "utils/Environment.h"
 
 namespace org::apache::nifi::minifi::test {
@@ -338,6 +338,44 @@ TEST_CASE("The encrypted flow configuration can be decrypted with the correct ke
 
   const auto& param_contexts = yaml_configuration_after.getParameterContexts();
   CHECK(param_contexts.at("my-context")->getParameter("secret_parameter")->value == "param_value_1");
+}
+
+TEST_CASE("Empty sensitive properties and parameters are not encrypted and round-trip as empty") {
+  ConfigurationTestController test_controller;
+  auto configuration_context = test_controller.getContext();
+  configuration_context.sensitive_values_encryptor = encryption_provider;
+
+  std::string config_yaml_with_empty_passphrase_and_parameter{config_yaml};
+  minifi::utils::string::replaceAll(config_yaml_with_empty_passphrase_and_parameter, "very_secure_passphrase", "");
+  minifi::utils::string::replaceAll(config_yaml_with_empty_passphrase_and_parameter, "param_value_1", "");
+
+  core::flow::AdaptiveConfiguration yaml_configuration_before{configuration_context};
+  const auto process_group_before = yaml_configuration_before.getRootFromPayload(config_yaml_with_empty_passphrase_and_parameter);
+  REQUIRE(process_group_before);
+
+  const auto schema = core::flow::FlowSchema::getDefault();
+  YAML::Node root_yaml_node = YAML::Load(config_yaml_with_empty_passphrase_and_parameter);
+  const auto flow_serializer = core::yaml::YamlFlowSerializer{root_yaml_node};
+
+  const auto processor_id = minifi::utils::Identifier::parse("469617f1-3898-4bbf-91fe-27d8f4dd2a75").value();
+  const OverridesMap overrides{{processor_id, core::flow::Overrides{}.add("invokehttp-proxy-password", "")}};
+  const std::string serialized = flow_serializer.serialize(*process_group_before, schema, encryption_provider, overrides, {});
+  CHECK_FALSE(serialized.contains("enc{"));
+
+  core::flow::AdaptiveConfiguration yaml_configuration_after{configuration_context};
+  const auto process_group_after = yaml_configuration_after.getRootFromPayload(serialized);
+  REQUIRE(process_group_after);
+
+  const auto* processor_after = process_group_after->findProcessorById(processor_id);
+  REQUIRE(processor_after);
+  CHECK(processor_after->getProperty("invokehttp-proxy-password") == "");
+
+  const auto* const controller_service_node_after = process_group_after->findControllerService("b9801278-7b5d-4314-aed6-713fd4b5f933");
+  REQUIRE(controller_service_node_after);
+  CHECK(controller_service_node_after->getControllerServiceImplementation()->getProperty("Passphrase") == "");
+
+  const auto& param_contexts = yaml_configuration_after.getParameterContexts();
+  CHECK(param_contexts.at("my-context")->getParameter("secret_parameter").value().value.empty());
 }
 
 TEST_CASE("The encrypted flow configuration cannot be decrypted with an incorrect key") {

--- a/libminifi/test/unit/YamlFlowSerializerTests.cpp
+++ b/libminifi/test/unit/YamlFlowSerializerTests.cpp
@@ -19,7 +19,6 @@
 
 #include "unit/Catch.h"
 #include "unit/ConfigurationTestController.h"
-#include "unit/TestUtils.h"
 #include "catch2/generators/catch_generators.hpp"
 #include "core/flow/FlowSchema.h"
 #include "core/yaml/YamlFlowSerializer.h"


### PR DESCRIPTION
This also fixes a bug: if a sensitive value was set as
```
  sensitive_property:
```
instead of
```
  sensitive_property: ""
```
in a YAML flow configuration, then the value was null instead of an empty string, and it got expanded to the string "null", and then encrypted.

https://issues.apache.org/jira/browse/MINIFICPP-2787

---

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file?
- [ ] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
