### PR TITLE
MINIFICPP-2890 InputStream::read (length prefixed string) length shou…

### DIFF
--- a/controller/Controller.cpp
+++ b/controller/Controller.cpp
@@ -26,11 +26,15 @@
 #include "asio/ssl/stream.hpp"
 #include "asio/connect.hpp"
 #include "minifi-cpp/core/logging/Logger.h"
+#include "minifi-cpp/utils/Literals.h"
 #include "utils/ConfigurationUtils.h"
 #include "utils/net/AsioSocketUtils.h"
 #include "utils/file/FileUtils.h"
 
 namespace org::apache::nifi::minifi::controller {
+
+constexpr auto MAX_MANIFEST_SIZE = 10_MiB;
+constexpr auto MAX_NAME_SIZE = 1_KiB;
 
 bool sendSingleCommand(const utils::net::SocketData& socket_data, uint8_t op, const std::string& value) {
   const auto connection_stream = std::make_unique<utils::net::AsioSocketConnection>(socket_data);
@@ -74,11 +78,11 @@ bool updateFlow(const utils::net::SocketData& socket_data, std::ostream &out, co
   if (resp == static_cast<uint8_t>(c2::Operation::describe)) {
     uint16_t connections = 0;
     connection_stream->read(connections);
-    out << connections << " are full" << std::endl;
+    out << connections << " are full\n";
     for (uint16_t i = 0; i < connections; i++) {
       std::string fullcomponent;
-      connection_stream->read(fullcomponent);
-      out << fullcomponent << " is full" << std::endl;
+      connection_stream->read(fullcomponent, io::LengthPrefixSize::_16BIT, MAX_NAME_SIZE);
+      out << fullcomponent << " is full\n";
     }
   }
   return true;
@@ -102,11 +106,11 @@ bool getFullConnections(const utils::net::SocketData& socket_data, std::ostream 
   if (resp == static_cast<uint8_t>(c2::Operation::describe)) {
     uint16_t connections = 0;
     connection_stream->read(connections);
-    out << connections << " are full" << std::endl;
+    out << connections << " are full\n";
     for (uint16_t i = 0; i < connections; i++) {
       std::string fullcomponent;
-      connection_stream->read(fullcomponent);
-      out << fullcomponent << " is full" << std::endl;
+      connection_stream->read(fullcomponent, io::LengthPrefixSize::_16BIT, MAX_NAME_SIZE);
+      out << fullcomponent << " is full\n";
     }
   }
   return true;
@@ -130,8 +134,8 @@ bool getConnectionSize(const utils::net::SocketData& socket_data, std::ostream &
   connection_stream->read(resp);
   if (resp == static_cast<uint8_t>(c2::Operation::describe)) {
     std::string size;
-    connection_stream->read(size);
-    out << "Size/Max of " << connection << " " << size << std::endl;
+    connection_stream->read(size, io::LengthPrefixSize::_16BIT, MAX_NAME_SIZE);
+    out << "Size/Max of " << connection << " " << size << "\n";
   }
   return true;
 }
@@ -152,14 +156,14 @@ bool listComponents(const utils::net::SocketData& socket_data, std::ostream &out
   connection_stream->read(op);
   connection_stream->read(responses);
   if (show_header)
-    out << "Components:" << std::endl;
+    out << "Components:\n";
 
   for (uint16_t i = 0; i < responses; i++) {
     std::string name;
-    connection_stream->read(name, false);
+    connection_stream->read(name, io::LengthPrefixSize::_16BIT, MAX_NAME_SIZE);
     std::string status;
-    connection_stream->read(status, false);
-    out << name << ", running: " << status << std::endl;
+    connection_stream->read(status, io::LengthPrefixSize::_16BIT, MAX_NAME_SIZE);
+    out << name << ", running: " << status << "\n";
   }
   return true;
 }
@@ -180,12 +184,12 @@ bool listConnections(const utils::net::SocketData& socket_data, std::ostream &ou
   connection_stream->read(op);
   connection_stream->read(responses);
   if (show_header)
-    out << "Connection Names:" << std::endl;
+    out << "Connection Names:\n";
 
   for (uint16_t i = 0; i < responses; i++) {
     std::string name;
-    connection_stream->read(name, false);
-    out << name << std::endl;
+    connection_stream->read(name, io::LengthPrefixSize::_16BIT, MAX_NAME_SIZE);
+    out << name << "\n";
   }
   return true;
 }
@@ -204,8 +208,8 @@ bool printManifest(const utils::net::SocketData& socket_data, std::ostream &out)
   }
   connection_stream->read(op);
   std::string manifest;
-  connection_stream->read(manifest, true);
-  out << manifest << std::endl;
+  connection_stream->read(manifest, io::LengthPrefixSize::_32BIT, MAX_MANIFEST_SIZE);
+  out << manifest << "\n";
   return true;
 }
 
@@ -223,8 +227,8 @@ bool getJstacks(const utils::net::SocketData& socket_data, std::ostream &out) {
   }
   connection_stream->read(op);
   std::string manifest;
-  connection_stream->read(manifest, true);
-  out << manifest << std::endl;
+  connection_stream->read(manifest, io::LengthPrefixSize::_32BIT, MAX_MANIFEST_SIZE);
+  out << manifest << "\n";
   return true;
 }
 
@@ -282,8 +286,8 @@ bool getFlowStatus(const utils::net::SocketData& socket_data, const std::string&
   }
   connection_stream->read(op);
   std::string manifest;
-  connection_stream->read(manifest, true);
-  out << manifest << std::endl;
+  connection_stream->read(manifest, io::LengthPrefixSize::_32BIT, MAX_MANIFEST_SIZE);
+  out << manifest << "\n";
   return true;
 }
 

--- a/core-framework/common/src/io/InputStream.cpp
+++ b/core-framework/common/src/io/InputStream.cpp
@@ -15,10 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cstdio>
-#include <vector>
-#include <string>
 #include "io/InputStream.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
 #include "minifi-cpp/utils/gsl.h"
 
 namespace org::apache::nifi::minifi::io {
@@ -35,7 +37,7 @@ size_t InputStream::read(bool &value) {
 
 size_t InputStream::read(utils::Identifier &value) {
   std::string uuidStr;
-  const auto ret = read(uuidStr);
+  const auto ret = read(uuidStr, LengthPrefixSize::_16BIT, 36 /* characters in a UUID string */);
   if (isError(ret)) {
     return ret;
   }
@@ -47,44 +49,51 @@ size_t InputStream::read(utils::Identifier &value) {
   return ret;
 }
 
-size_t InputStream::read(std::string &str, bool widen) {
+size_t InputStream::read(std::string &str, LengthPrefixSize prefix_size, size_t max_length) {
   uint32_t string_length = 0;
-  size_t length_return = 0;
-  if (!widen) {
-    uint16_t shortLength = 0;
-    length_return = read(shortLength);
-    string_length = shortLength;
-  } else {
-    length_return = read(string_length);
+  size_t length_prefix_size_in_bytes = 0;
+  switch (prefix_size) {
+    case LengthPrefixSize::_16BIT: {
+      uint16_t out_16bit_length = 0;
+      length_prefix_size_in_bytes = read(out_16bit_length);
+      string_length = out_16bit_length;
+    } break;
+    case LengthPrefixSize::_32BIT: {
+      uint32_t out_32bit_length = 0;
+      length_prefix_size_in_bytes = read(out_32bit_length);
+      string_length = out_32bit_length;
+    } break;
   }
 
-  if (length_return == 0 || isError(length_return)) {
-    return length_return;
+  // The zero case should be impossible, read(Integral&) returns the size of the integral type,
+  // or an error code, so this handles the error case and propagates the stream error
+  if (length_prefix_size_in_bytes == 0 || isError(length_prefix_size_in_bytes)) {
+    return length_prefix_size_in_bytes;
   }
 
+  string_length = std::min(string_length, gsl::narrow<uint32_t>(max_length));
   if (string_length == 0) {
     str.clear();
-    return length_return;
+    return length_prefix_size_in_bytes;
   }
 
   str.clear();
-  str.reserve(string_length);
+  str.resize(string_length);
+  std::span<std::byte> dst_buffer = as_writable_bytes(std::span{str});
 
-  size_t bytes_to_read{string_length};
   auto zero_return_retry_count = 0;
-  while (bytes_to_read > 0) {
-    std::vector<std::byte> buffer(bytes_to_read);
-    const auto read_return = read(buffer);
-    if (io::isError(read_return))
+  while (!dst_buffer.empty()) {
+    const auto read_return = read(dst_buffer);
+    if (io::isError(read_return)) {
       return read_return;
+    }
     if (read_return == 0 && ++zero_return_retry_count > 3) {
       return STREAM_ERROR;
     }
-    bytes_to_read -= read_return;
-    str.append(std::string(reinterpret_cast<const char*>(buffer.data()), read_return));
+    dst_buffer = dst_buffer.subspan(read_return);
   }
 
-  return length_return + string_length;
+  return length_prefix_size_in_bytes + string_length;
 }
 
 std::optional<std::byte> InputStream::readByte() {

--- a/core-framework/common/src/io/InputStream.cpp
+++ b/core-framework/common/src/io/InputStream.cpp
@@ -94,15 +94,17 @@ size_t InputStream::read(std::string &str, LengthPrefixSize prefix_size, size_t 
   }
 
   // if max_length truncated the string, consume the rest of it from the stream, and throw it away, to keep subsequent reads aligned
-  for (ssize_t remaining = string_length - limited_length; remaining > 0;) {
+  // ptrdiff_t because I want currently impossible math errors to flip the remainder negative and terminate minifi
+  for (std::ptrdiff_t remaining = string_length - limited_length; remaining != 0;) {
+    gsl_Assert(remaining > 0);
     std::array<std::byte, 8192> throwaway_buf{};
     std::span<std::byte> dst_span = throwaway_buf;
-    if (remaining < gsl::narrow<ssize_t>(dst_span.size())) { dst_span = dst_span.subspan(0, remaining); }
+    if (remaining < gsl::narrow<std::ptrdiff_t>(dst_span.size())) { dst_span = dst_span.subspan(0, remaining); }
     const auto read_return = read(dst_span);
     if (io::isError(read_return)) {
       return read_return;
     }
-    remaining -= gsl::narrow<ssize_t>(read_return);
+    remaining -= gsl::narrow<std::ptrdiff_t>(read_return);
   }
 
   return length_prefix_size_in_bytes + string_length;

--- a/core-framework/common/src/io/InputStream.cpp
+++ b/core-framework/common/src/io/InputStream.cpp
@@ -37,7 +37,7 @@ size_t InputStream::read(bool &value) {
 
 size_t InputStream::read(utils::Identifier &value) {
   std::string uuidStr;
-  const auto ret = read(uuidStr, LengthPrefixSize::_16BIT, 36 /* characters in a UUID string */);
+  const auto ret = read(uuidStr, LengthPrefixSize::_16BIT, utils::Identifier::UUID_STR_LEN);
   if (isError(ret)) {
     return ret;
   }

--- a/core-framework/common/src/io/InputStream.cpp
+++ b/core-framework/common/src/io/InputStream.cpp
@@ -71,14 +71,14 @@ size_t InputStream::read(std::string &str, LengthPrefixSize prefix_size, size_t 
     return length_prefix_size_in_bytes;
   }
 
-  string_length = std::min(string_length, gsl::narrow<uint32_t>(max_length));
-  if (string_length == 0) {
+  const auto limited_length = std::min(string_length, gsl::narrow<uint32_t>(max_length));
+  if (limited_length == 0) {
     str.clear();
     return length_prefix_size_in_bytes;
   }
 
   str.clear();
-  str.resize(string_length);
+  str.resize(limited_length);
   std::span<std::byte> dst_buffer = as_writable_bytes(std::span{str});
 
   auto zero_return_retry_count = 0;
@@ -91,6 +91,18 @@ size_t InputStream::read(std::string &str, LengthPrefixSize prefix_size, size_t 
       return STREAM_ERROR;
     }
     dst_buffer = dst_buffer.subspan(read_return);
+  }
+
+  // if max_length truncated the string, consume the rest of it from the stream, and throw it away, to keep subsequent reads aligned
+  for (ssize_t remaining = string_length - limited_length; remaining > 0;) {
+    std::array<std::byte, 8192> throwaway_buf{};
+    std::span<std::byte> dst_span = throwaway_buf;
+    if (remaining < gsl::narrow<ssize_t>(dst_span.size())) { dst_span = dst_span.subspan(0, remaining); }
+    const auto read_return = read(dst_span);
+    if (io::isError(read_return)) {
+      return read_return;
+    }
+    remaining -= gsl::narrow<ssize_t>(read_return);
   }
 
   return length_prefix_size_in_bytes + string_length;

--- a/core-framework/common/src/utils/Id.cpp
+++ b/core-framework/common/src/utils/Id.cpp
@@ -19,7 +19,6 @@
 #include "minifi-cpp/utils/Id.h"
 
 #include "utils/StringUtils.h"
-#include "minifi-cpp/utils/gsl.h"
 
 namespace org::apache::nifi::minifi::utils {
 
@@ -55,8 +54,8 @@ bool Identifier::operator<(const Identifier &other) const {
   return data_ < other.data_;
 }
 
-SmallString<36> Identifier::to_string() const {
-  SmallString<36> uuidStr;
+SmallString<Identifier::UUID_STR_LEN> Identifier::to_string() const {
+  SmallString<UUID_STR_LEN> uuidStr;
   // xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx is 36 long: 16 bytes * 2 hex digits / byte + 4 hyphens
   int byteIdx = 0;
   int charIdx = 0;
@@ -92,7 +91,7 @@ SmallString<36> Identifier::to_string() const {
 std::optional<Identifier> Identifier::parse(const std::string &str) {
   Identifier id;
   // xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx is 36 long: 16 bytes * 2 hex digits / byte + 4 hyphens
-  if (str.length() != 36) return {};
+  if (str.length() != UUID_STR_LEN) return {};
   int charIdx = 0;
   int byteIdx = 0;
   auto input = reinterpret_cast<const uint8_t*>(str.c_str());

--- a/core-framework/include/core/Core.h
+++ b/core-framework/include/core/Core.h
@@ -107,7 +107,7 @@ class CoreComponentImpl : public virtual CoreComponent {
 
   [[nodiscard]] utils::Identifier getUUID() const override;
 
-  [[nodiscard]] utils::SmallString<36> getUUIDStr() const override {
+  [[nodiscard]] utils::SmallString<utils::Identifier::UUID_STR_LEN> getUUIDStr() const override {
     return uuid_.to_string();
   }
 

--- a/core-framework/include/core/ProcessorImpl.h
+++ b/core-framework/include/core/ProcessorImpl.h
@@ -114,7 +114,7 @@ class ProcessorImpl : public virtual ProcessorApi {
 
   std::string getName() const;
   utils::Identifier getUUID() const;
-  utils::SmallString<36> getUUIDStr() const;
+  utils::SmallString<utils::Identifier::UUID_STR_LEN> getUUIDStr() const;
 
  protected:
   void notifyStop() override {

--- a/core-framework/src/core/ProcessorImpl.cpp
+++ b/core-framework/src/core/ProcessorImpl.cpp
@@ -68,7 +68,7 @@ utils::Identifier ProcessorImpl::getUUID() const {
   return metadata_.uuid;
 }
 
-utils::SmallString<36> ProcessorImpl::getUUIDStr() const {
+utils::SmallString<utils::Identifier::UUID_STR_LEN> ProcessorImpl::getUUIDStr() const {
   return getUUID().to_string();
 }
 

--- a/extension-framework/cpp-extension-lib/include/api/core/ControllerServiceImpl.h
+++ b/extension-framework/cpp-extension-lib/include/api/core/ControllerServiceImpl.h
@@ -48,7 +48,7 @@ class ControllerServiceImpl {
 
   [[nodiscard]] std::string getName() const;
   [[nodiscard]] minifi::utils::Identifier getUUID() const;
-  [[nodiscard]] minifi::utils::SmallString<36> getUUIDStr() const;
+  [[nodiscard]] minifi::utils::SmallString<utils::Identifier::UUID_STR_LEN> getUUIDStr() const;
 
  protected:
   virtual minifi_status enableImpl(api::core::ControllerServiceContext&) = 0;

--- a/extension-framework/cpp-extension-lib/include/api/core/ControllerServiceImpl.h
+++ b/extension-framework/cpp-extension-lib/include/api/core/ControllerServiceImpl.h
@@ -48,7 +48,7 @@ class ControllerServiceImpl {
 
   [[nodiscard]] std::string getName() const;
   [[nodiscard]] minifi::utils::Identifier getUUID() const;
-  [[nodiscard]] minifi::utils::SmallString<utils::Identifier::UUID_STR_LEN> getUUIDStr() const;
+  [[nodiscard]] minifi::utils::SmallString<minifi::utils::Identifier::UUID_STR_LEN> getUUIDStr() const;
 
  protected:
   virtual minifi_status enableImpl(api::core::ControllerServiceContext&) = 0;

--- a/extension-framework/cpp-extension-lib/include/api/core/ProcessorImpl.h
+++ b/extension-framework/cpp-extension-lib/include/api/core/ProcessorImpl.h
@@ -63,7 +63,7 @@ class ProcessorImpl {
 
   [[nodiscard]] std::string getName() const;
   [[nodiscard]] minifi::utils::Identifier getUUID() const;
-  [[nodiscard]] minifi::utils::SmallString<utils::Identifier::UUID_STR_LEN> getUUIDStr() const;
+  [[nodiscard]] minifi::utils::SmallString<minifi::utils::Identifier::UUID_STR_LEN> getUUIDStr() const;
 
  protected:
   virtual minifi_status onTriggerImpl(ProcessContext&, ProcessSession&) {return MINIFI_STATUS_SUCCESS;}

--- a/extension-framework/cpp-extension-lib/include/api/core/ProcessorImpl.h
+++ b/extension-framework/cpp-extension-lib/include/api/core/ProcessorImpl.h
@@ -61,9 +61,9 @@ class ProcessorImpl {
 
   static constexpr auto OutputAttributes = std::array<minifi::core::OutputAttributeReference, 0>{};
 
-  std::string getName() const;
-  minifi::utils::Identifier getUUID() const;
-  minifi::utils::SmallString<36> getUUIDStr() const;
+  [[nodiscard]] std::string getName() const;
+  [[nodiscard]] minifi::utils::Identifier getUUID() const;
+  [[nodiscard]] minifi::utils::SmallString<utils::Identifier::UUID_STR_LEN> getUUIDStr() const;
 
  protected:
   virtual minifi_status onTriggerImpl(ProcessContext&, ProcessSession&) {return MINIFI_STATUS_SUCCESS;}

--- a/extension-framework/cpp-extension-lib/src/core/ControllerServiceImpl.cpp
+++ b/extension-framework/cpp-extension-lib/src/core/ControllerServiceImpl.cpp
@@ -58,7 +58,7 @@ utils::Identifier ControllerServiceImpl::getUUID() const {
   return metadata_.uuid;
 }
 
-utils::SmallString<36> ControllerServiceImpl::getUUIDStr() const {
+utils::SmallString<utils::Identifier::UUID_STR_LEN> ControllerServiceImpl::getUUIDStr() const {
   return getUUID().to_string();
 }
 

--- a/extensions/libarchive/BinFiles.h
+++ b/extensions/libarchive/BinFiles.h
@@ -101,7 +101,7 @@ class Bin {
   [[nodiscard]] int getSize() const {
     return gsl::narrow<int>(queue_.size());
   }
-  [[nodiscard]] utils::SmallString<36> getUUIDStr() const {
+  [[nodiscard]] utils::SmallString<utils::Identifier::UUID_STR_LEN> getUUIDStr() const {
     return uuid_.to_string();
   }
   [[nodiscard]] std::string getGroupId() const {

--- a/extensions/rocksdb-repos/tests/DBContentRepositoryTests.cpp
+++ b/extensions/rocksdb-repos/tests/DBContentRepositoryTests.cpp
@@ -122,7 +122,7 @@ TEST_CASE("Delete Claim", "[TestDBCR2]") {
     auto read_stream = content_repo->read(*claim);
 
     // error tells us we have an invalid stream
-    REQUIRE(minifi::io::isError(read_stream->read(readstr)));
+    REQUIRE(minifi::io::isError(read_stream->read(readstr, minifi::io::LengthPrefixSize::_16BIT, 100)));
   }
 
   SECTION("Async") {
@@ -133,10 +133,10 @@ TEST_CASE("Delete Claim", "[TestDBCR2]") {
     content_repo->remove(*claim);
 
     // an immediate read will still be able to access the content
-    REQUIRE_FALSE(minifi::io::isError(content_repo->read(*claim)->read(readstr)));
+    REQUIRE_FALSE(minifi::io::isError(content_repo->read(*claim)->read(readstr, minifi::io::LengthPrefixSize::_16BIT, 100)));
 
     REQUIRE(minifi::test::utils::verifyEventHappenedInPollTime(1s, [&] {
-      return minifi::io::isError(content_repo->read(*claim)->read(readstr));
+      return minifi::io::isError(content_repo->read(*claim)->read(readstr, minifi::io::LengthPrefixSize::_16BIT, 100));
     }));
   }
 }
@@ -214,7 +214,7 @@ TEST_CASE("Test Empty Claim", "[TestDBCR3]") {
   std::string readstr;
 
   // error tells us we have an invalid stream
-  REQUIRE(minifi::io::isError(read_stream->read(readstr)));
+  REQUIRE(minifi::io::isError(read_stream->read(readstr, minifi::io::LengthPrefixSize::_16BIT, 100)));
 }
 
 TEST_CASE("Delete NonExistent Claim", "[TestDBCR4]") {
@@ -252,7 +252,7 @@ TEST_CASE("Delete NonExistent Claim", "[TestDBCR4]") {
 
   std::string readstr;
 
-  read_stream->read(readstr);
+  read_stream->read(readstr, minifi::io::LengthPrefixSize::_16BIT, 100);
 
   REQUIRE(readstr == "well hello there");
 }
@@ -298,7 +298,7 @@ TEST_CASE("Delete Remove Count Claim", "[TestDBCR5]") {
 
   std::string readstr;
 
-  read_stream->read(readstr);
+  read_stream->read(readstr, minifi::io::LengthPrefixSize::_16BIT, 100);
 
   REQUIRE(readstr == "well hello there");
 }

--- a/extensions/rocksdb-repos/tests/RocksDBStreamTests.cpp
+++ b/extensions/rocksdb-repos/tests/RocksDBStreamTests.cpp
@@ -52,7 +52,7 @@ TEST_CASE_METHOD(RocksDBStreamTest, "Verify simple operation") {
   REQUIRE_FALSE(minifi::io::isError(second_write_result));
   minifi::io::RocksDbStream inStream("one", gsl::make_not_null(db.get()));
   std::string str;
-  inStream.read(str);
+  inStream.read(str, minifi::io::LengthPrefixSize::_16BIT, 100);
   REQUIRE(str == content);
 }
 

--- a/extensions/standard-processors/tests/unit/GenerateFlowFileTests.cpp
+++ b/extensions/standard-processors/tests/unit/GenerateFlowFileTests.cpp
@@ -85,7 +85,6 @@ TEST_CASE("GenerateFlowFileCustomTextTest") {
   minifi::test::SingleProcessorTestController test_controller{minifi::test::utils::make_processor<GenerateFlowFile>("GenerateFlowFile")};
   auto generate_flow_file = test_controller.getProcessor();
 
-  constexpr auto uuid_string_length = 36;
 
   CHECK(test_controller.plan->setProperty(generate_flow_file, GenerateFlowFile::CustomText, "${UUID()}"));
   CHECK(test_controller.plan->setProperty(generate_flow_file, GenerateFlowFile::UniqueFlowFiles, "false"));
@@ -94,7 +93,7 @@ TEST_CASE("GenerateFlowFileCustomTextTest") {
   auto result = test_controller.trigger();
   REQUIRE(result.at(GenerateFlowFile::Success).size() == 1);
   auto result_0 = test_controller.plan->getContent(result.at(GenerateFlowFile::Success)[0]);
-  CHECK(result_0.length() == uuid_string_length);
+  CHECK(result_0.length() == utils::Identifier::UUID_STR_LEN);
 }
 
 TEST_CASE("GenerateFlowFileCustomTextEmptyTest") {

--- a/libminifi/include/c2/PayloadSerializer.h
+++ b/libminifi/include/c2/PayloadSerializer.h
@@ -200,7 +200,7 @@ class PayloadSerializer {
       case 4:
       default: {
         std::string str;
-        stream->read(str);
+        stream->read(str, io::LengthPrefixSize::_16BIT, 64_KiB);
         node = str;
       }
     }
@@ -228,8 +228,8 @@ class PayloadSerializer {
     for (size_t i = 0; i < payloads; i++) {
       stream->read(op);
       stream->read(st);
-      stream->read(label);
-      stream->read(identifier);
+      stream->read(label, io::LengthPrefixSize::_16BIT, 1_KiB);
+      stream->read(identifier, io::LengthPrefixSize::_16BIT, 36);
       operation = intToOp(op);
       C2Payload subPayload(operation, st == 1 ? state::UpdateState::NESTED : state::UpdateState::READ_COMPLETE);
       subPayload.setIdentifier(identifier);
@@ -240,12 +240,12 @@ class PayloadSerializer {
         std::string content_name;
         uint32_t args = 0;
         C2ContentResponse content(operation);
-        stream->read(content_name);
+        stream->read(content_name, io::LengthPrefixSize::_16BIT, 1_KiB);
         content.name = content_name;
         stream->read(args);
         for (uint32_t j = 0; j < args; j++) {
           std::string first, second;
-          stream->read(first);
+          stream->read(first, io::LengthPrefixSize::_16BIT, 1_KiB);
           content.operation_arguments[first] = C2Value{deserializeValueNode(stream)};
         }
         subPayload.addContent(std::move(content));
@@ -266,8 +266,8 @@ class PayloadSerializer {
     stream.read(op);
     stream.read(version);
     stream.read(st);
-    stream.read(label);
-    stream.read(identifier);
+    stream.read(label, io::LengthPrefixSize::_16BIT, 1_KiB);
+    stream.read(identifier, io::LengthPrefixSize::_16BIT, 36);
 
     Operation operation = intToOp(op);
 
@@ -281,12 +281,12 @@ class PayloadSerializer {
       std::string content_name;
       uint32_t args = 0;
       C2ContentResponse content(operation);
-      stream.read(content_name);
+      stream.read(content_name, io::LengthPrefixSize::_16BIT, 1_KiB);
       content.name = content_name;
       stream.read(args);
       for (uint32_t j = 0; j < args; j++) {
         std::string first, second;
-        stream.read(first);
+        stream.read(first, io::LengthPrefixSize::_16BIT, 1_KiB);
         // stream.readUTF(second);
         content.operation_arguments[first] = C2Value{deserializeValueNode(&stream)};
       }

--- a/libminifi/include/c2/PayloadSerializer.h
+++ b/libminifi/include/c2/PayloadSerializer.h
@@ -229,7 +229,7 @@ class PayloadSerializer {
       stream->read(op);
       stream->read(st);
       stream->read(label, io::LengthPrefixSize::_16BIT, 1_KiB);
-      stream->read(identifier, io::LengthPrefixSize::_16BIT, 36);
+      stream->read(identifier, io::LengthPrefixSize::_16BIT, utils::Identifier::UUID_STR_LEN);
       operation = intToOp(op);
       C2Payload subPayload(operation, st == 1 ? state::UpdateState::NESTED : state::UpdateState::READ_COMPLETE);
       subPayload.setIdentifier(identifier);
@@ -267,7 +267,7 @@ class PayloadSerializer {
     stream.read(version);
     stream.read(st);
     stream.read(label, io::LengthPrefixSize::_16BIT, 1_KiB);
-    stream.read(identifier, io::LengthPrefixSize::_16BIT, 36);
+    stream.read(identifier, io::LengthPrefixSize::_16BIT, utils::Identifier::UUID_STR_LEN);
 
     Operation operation = intToOp(op);
 

--- a/libminifi/include/sitetosite/SiteToSite.h
+++ b/libminifi/include/sitetosite/SiteToSite.h
@@ -195,7 +195,7 @@ class Transaction {
 
   virtual ~Transaction() = default;
 
-  [[nodiscard]] utils::SmallString<36> getUUIDStr() const {
+  [[nodiscard]] utils::SmallString<utils::Identifier::UUID_STR_LEN> getUUIDStr() const {
     return uuid_.to_string();
   }
 

--- a/libminifi/src/FlowFileRecord.cpp
+++ b/libminifi/src/FlowFileRecord.cpp
@@ -230,14 +230,14 @@ std::shared_ptr<FlowFileRecord> FlowFileRecordImpl::DeSerialize(io::InputStream&
   for (uint32_t i = 0; i < numAttributes; i++) {
     std::string key;
     {
-      const auto ret = inStream.read(key, true);
+      const auto ret = inStream.read(key, io::LengthPrefixSize::_32BIT, 1_MiB);
       if (ret == 0 || io::isError(ret)) {
         return {};
       }
     }
     std::string value;
     {
-      const auto ret = inStream.read(value, true);
+      const auto ret = inStream.read(value, io::LengthPrefixSize::_32BIT, 1_MiB);
       if (ret == 0 || io::isError(ret)) {
         return {};
       }
@@ -247,7 +247,7 @@ std::shared_ptr<FlowFileRecord> FlowFileRecordImpl::DeSerialize(io::InputStream&
 
   std::string content_full_path;
   {
-    const auto ret = inStream.read(content_full_path);
+    const auto ret = inStream.read(content_full_path, io::LengthPrefixSize::_16BIT, 10_KiB);
     if (ret == 0 || io::isError(ret)) {
       return {};
     }

--- a/libminifi/src/c2/ControllerSocketProtocol.cpp
+++ b/libminifi/src/c2/ControllerSocketProtocol.cpp
@@ -36,6 +36,7 @@
 #include "utils/net/AsioSocketUtils.h"
 
 namespace org::apache::nifi::minifi::c2 {
+constexpr auto MAX_COMPONENT_NAME_LENGTH = 1_KiB;
 
 ControllerSocketProtocol::SocketRestartCommandProcessor::SocketRestartCommandProcessor(state::StateMonitor& update_sink, const std::shared_ptr<core::logging::Logger>& logger) :
     update_sink_(update_sink),
@@ -185,7 +186,7 @@ void ControllerSocketProtocol::setRoot(core::ProcessGroup* root) {
 
 void ControllerSocketProtocol::handleStart(io::BaseStream &stream) {
   std::string component_str;
-  const auto size = stream.read(component_str);
+  const auto size = stream.read(component_str, io::LengthPrefixSize::_16BIT, MAX_COMPONENT_NAME_LENGTH);
   if (!io::isError(size)) {
     if (component_str == "FlowController") {
       // Starting flow controller resets socket
@@ -202,7 +203,7 @@ void ControllerSocketProtocol::handleStart(io::BaseStream &stream) {
 
 void ControllerSocketProtocol::handleStop(io::BaseStream &stream) {
   std::string component_str;
-  const auto size = stream.read(component_str);
+  const auto size = stream.read(component_str, io::LengthPrefixSize::_16BIT, MAX_COMPONENT_NAME_LENGTH);
   if (!io::isError(size)) {
     update_sink_.executeOnComponent(component_str, [](state::StateController& component) {
       component.stop();
@@ -214,7 +215,7 @@ void ControllerSocketProtocol::handleStop(io::BaseStream &stream) {
 
 void ControllerSocketProtocol::handleClear(io::BaseStream &stream) {
   std::string connection;
-  const auto size = stream.read(connection);
+  const auto size = stream.read(connection, io::LengthPrefixSize::_16BIT, MAX_COMPONENT_NAME_LENGTH);
   if (!io::isError(size)) {
     update_sink_.clearConnection(connection);
   }
@@ -223,7 +224,7 @@ void ControllerSocketProtocol::handleClear(io::BaseStream &stream) {
 void ControllerSocketProtocol::handleUpdate(io::BaseStream &stream) {
   std::string what;
   {
-    const auto size = stream.read(what);
+    const auto size = stream.read(what, io::LengthPrefixSize::_16BIT, MAX_COMPONENT_NAME_LENGTH);
     if (io::isError(size)) {
       logger_->log_error("Connection broke");
       return;
@@ -232,7 +233,7 @@ void ControllerSocketProtocol::handleUpdate(io::BaseStream &stream) {
   if (what == "flow") {
     std::string ff_loc;
     {
-      const auto size = stream.read(ff_loc);
+      const auto size = stream.read(ff_loc, io::LengthPrefixSize::_16BIT, 1_KiB);
       if (io::isError(size)) {
         logger_->log_error("Connection broke");
         return;
@@ -247,7 +248,7 @@ void ControllerSocketProtocol::handleUpdate(io::BaseStream &stream) {
 
 void ControllerSocketProtocol::writeQueueSizesResponse(io::BaseStream &stream) {
   std::string connection;
-  const auto size_ = stream.read(connection);
+  const auto size_ = stream.read(connection, io::LengthPrefixSize::_16BIT, MAX_COMPONENT_NAME_LENGTH);
   if (io::isError(size_)) {
     logger_->log_error("Connection broke");
     return;
@@ -361,7 +362,7 @@ void ControllerSocketProtocol::writeJstackResponse(io::BaseStream &stream) {
 void ControllerSocketProtocol::writeFlowStatusResponse(io::BaseStream &stream) {
   std::string query;
   {
-    const auto size = stream.read(query);
+    const auto size = stream.read(query, io::LengthPrefixSize::_16BIT, 1_MiB);
     if (io::isError(size)) {
       logger_->log_error("Connection broke");
       return;
@@ -389,7 +390,7 @@ void ControllerSocketProtocol::writeFlowStatusResponse(io::BaseStream &stream) {
 
 void ControllerSocketProtocol::handleDescribe(io::BaseStream &stream) {
   std::string what;
-  const auto size = stream.read(what);
+  const auto size = stream.read(what, io::LengthPrefixSize::_16BIT, 1_KiB);
   if (io::isError(size)) {
     logger_->log_error("Connection broke");
     return;
@@ -442,7 +443,7 @@ void ControllerSocketProtocol::writeDebugBundleResponse(io::BaseStream &stream) 
 
 void ControllerSocketProtocol::handleTransfer(io::BaseStream &stream) {
   std::string what;
-  const auto size = stream.read(what);
+  const auto size = stream.read(what, io::LengthPrefixSize::_16BIT, 1_KiB);
   if (io::isError(size)) {
     logger_->log_error("Connection broke");
     return;

--- a/libminifi/src/provenance/Provenance.cpp
+++ b/libminifi/src/provenance/Provenance.cpp
@@ -34,6 +34,8 @@
 
 namespace org::apache::nifi::minifi::provenance {
 
+constexpr auto MAX_COMPONENT_NAME_LENGTH = 1_KiB;
+
 std::shared_ptr<utils::IdGenerator> ProvenanceEventRecordImpl::id_generator_ = utils::IdGenerator::getIdGenerator();
 std::shared_ptr<core::logging::Logger> ProvenanceEventRecordImpl::logger_ = core::logging::LoggerFactory<ProvenanceEventRecord>::getLogger();
 
@@ -300,14 +302,14 @@ bool ProvenanceEventRecordImpl::deserialize(io::InputStream &input_stream) {
   }
 
   {
-    const auto ret = input_stream.read(component_id_);
+    const auto ret = input_stream.read(component_id_, io::LengthPrefixSize::_16BIT, MAX_COMPONENT_NAME_LENGTH);
     if (ret == 0 || io::isError(ret)) {
       return false;
     }
   }
 
   {
-    const auto ret = input_stream.read(component_type_);
+    const auto ret = input_stream.read(component_type_, io::LengthPrefixSize::_16BIT, MAX_COMPONENT_NAME_LENGTH);
     if (ret == 0 || io::isError(ret)) {
       return false;
     }
@@ -321,7 +323,7 @@ bool ProvenanceEventRecordImpl::deserialize(io::InputStream &input_stream) {
   }
 
   {
-    const auto ret = input_stream.read(details_);
+    const auto ret = input_stream.read(details_, io::LengthPrefixSize::_16BIT, 1_MiB);
     if (ret == 0 || io::isError(ret)) {
       return false;
     }
@@ -339,14 +341,16 @@ bool ProvenanceEventRecordImpl::deserialize(io::InputStream &input_stream) {
   for (uint32_t i = 0; i < numAttributes; i++) {
     std::string key;
     {
-      const auto ret = input_stream.read(key);
+      // clamp attribute name / value to 64k (the 16bit length prefix maximum)
+      const auto ret = input_stream.read(key, io::LengthPrefixSize::_16BIT, 64_KiB);
       if (ret == 0 || io::isError(ret)) {
         return false;
       }
     }
     std::string value;
     {
-      const auto ret = input_stream.read(value);
+      // clamp attribute name / value to 64k (the 16bit length prefix maximum)
+      const auto ret = input_stream.read(value, io::LengthPrefixSize::_16BIT, 64_KiB);
       if (ret == 0 || io::isError(ret)) {
         return false;
       }
@@ -355,7 +359,7 @@ bool ProvenanceEventRecordImpl::deserialize(io::InputStream &input_stream) {
   }
 
   {
-    const auto ret = input_stream.read(content_full_path_);
+    const auto ret = input_stream.read(content_full_path_, io::LengthPrefixSize::_16BIT, 1_KiB);
     if (ret == 0 || io::isError(ret)) {
       return false;
     }
@@ -376,7 +380,7 @@ bool ProvenanceEventRecordImpl::deserialize(io::InputStream &input_stream) {
   }
 
   {
-    const auto ret = input_stream.read(source_queue_identifier_);
+    const auto ret = input_stream.read(source_queue_identifier_, io::LengthPrefixSize::_16BIT, MAX_COMPONENT_NAME_LENGTH);
     if (ret == 0 || io::isError(ret)) {
       return false;
     }
@@ -421,20 +425,20 @@ bool ProvenanceEventRecordImpl::deserialize(io::InputStream &input_stream) {
     }
   } else if (event_type_ == ProvenanceEventRecord::SEND || event_type_ == ProvenanceEventRecord::FETCH) {
     {
-      const auto ret = input_stream.read(transit_uri_);
+      const auto ret = input_stream.read(transit_uri_, io::LengthPrefixSize::_16BIT, 10_KiB);
       if (ret == 0 || io::isError(ret)) {
         return false;
       }
     }
   } else if (event_type_ == ProvenanceEventRecord::RECEIVE) {
     {
-      const auto ret = input_stream.read(transit_uri_);
+      const auto ret = input_stream.read(transit_uri_, io::LengthPrefixSize::_16BIT, 10_KiB);
       if (ret == 0 || io::isError(ret)) {
         return false;
       }
     }
     {
-      const auto ret = input_stream.read(source_system_flow_file_identifier_);
+      const auto ret = input_stream.read(source_system_flow_file_identifier_, io::LengthPrefixSize::_16BIT, 36);
       if (ret == 0 || io::isError(ret)) {
         return false;
       }

--- a/libminifi/src/provenance/Provenance.cpp
+++ b/libminifi/src/provenance/Provenance.cpp
@@ -341,7 +341,6 @@ bool ProvenanceEventRecordImpl::deserialize(io::InputStream &input_stream) {
   for (uint32_t i = 0; i < numAttributes; i++) {
     std::string key;
     {
-      // clamp attribute name / value to 64k (the 16bit length prefix maximum)
       const auto ret = input_stream.read(key, io::LengthPrefixSize::_16BIT, 64_KiB);
       if (ret == 0 || io::isError(ret)) {
         return false;
@@ -349,7 +348,6 @@ bool ProvenanceEventRecordImpl::deserialize(io::InputStream &input_stream) {
     }
     std::string value;
     {
-      // clamp attribute name / value to 64k (the 16bit length prefix maximum)
       const auto ret = input_stream.read(value, io::LengthPrefixSize::_16BIT, 64_KiB);
       if (ret == 0 || io::isError(ret)) {
         return false;

--- a/libminifi/src/sitetosite/RawSiteToSiteClient.cpp
+++ b/libminifi/src/sitetosite/RawSiteToSiteClient.cpp
@@ -251,7 +251,7 @@ std::optional<std::vector<PeerStatus>> RawSiteToSiteClient::getPeerList() {
 
   for (uint32_t i = 0; i < number_of_peers; i++) {
     std::string host;
-    if (const auto ret = peer_->read(host); ret == 0 || io::isError(ret)) {
+    if (const auto ret = peer_->read(host, io::LengthPrefixSize::_16BIT, 1_KiB); ret == 0 || io::isError(ret)) {
       tearDown();
       return std::nullopt;
     }

--- a/libminifi/src/sitetosite/SiteToSiteClient.cpp
+++ b/libminifi/src/sitetosite/SiteToSiteClient.cpp
@@ -61,7 +61,7 @@ std::optional<SiteToSiteResponse> SiteToSiteClient::readResponse(const std::shar
     return std::nullopt;
   }
   if (response_code_context->has_description) {
-    if (const auto ret = peer_->read(response.message); ret == 0 || io::isError(ret)) {
+    if (const auto ret = peer_->read(response.message, io::LengthPrefixSize::_16BIT, 64_KiB); ret == 0 || io::isError(ret)) {
       logger_->log_error("Site2Site read response failed: failed to read response message");
       return std::nullopt;
     }
@@ -569,11 +569,11 @@ std::expected<void, std::string> SiteToSiteClient::readFlowFileHeaderData(io::In
   for (uint64_t i = 0; i < num_attributes; i++) {
     std::string key;
     std::string value;
-    if (const auto ret = stream.read(key, true); ret == 0 || io::isError(ret)) {
+    if (const auto ret = stream.read(key, io::LengthPrefixSize::_32BIT, 1_MiB); ret == 0 || io::isError(ret)) {
       return std::unexpected{fmt::format("Site2Site transaction {} failed to read attribute key", transaction_id_str)};
     }
 
-    if (const auto ret = stream.read(value, true); ret == 0 || io::isError(ret)) {
+    if (const auto ret = stream.read(value, io::LengthPrefixSize::_32BIT, 1_MiB); ret == 0 || io::isError(ret)) {
       return std::unexpected{fmt::format("Site2Site transaction {} failed to read attribute value for key {}", transaction_id_str, key)};
     }
 

--- a/libminifi/test/libtest/integration/ConnectionCountingServer.h
+++ b/libminifi/test/libtest/integration/ConnectionCountingServer.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <set>
 #include "CivetServer.h"
+#include "utils/Id.h"
 #include "utils/SmallString.h"
 
 namespace org::apache::nifi::minifi::test {
@@ -31,7 +32,7 @@ namespace details {
 
 class NumberedMethodResponder : public CivetHandler {
  public:
-  explicit NumberedMethodResponder(std::set<minifi::utils::SmallString<36>>& connections) : connections_(connections) {}
+  explicit NumberedMethodResponder(std::set<minifi::utils::SmallString<utils::Identifier::UUID_STR_LEN>>& connections) : connections_(connections) {}
 
   bool handleGet(CivetServer*, struct mg_connection* conn) override;
   bool handlePost(CivetServer*, struct mg_connection* conn) override;
@@ -43,19 +44,19 @@ class NumberedMethodResponder : public CivetHandler {
   void saveConnectionId(struct mg_connection* conn);
 
   uint64_t response_id_ = 0;
-  std::set<minifi::utils::SmallString<36>>& connections_;
+  std::set<minifi::utils::SmallString<utils::Identifier::UUID_STR_LEN>>& connections_;
 };
 
 class ReverseBodyPostHandler : public CivetHandler {
  public:
-  explicit ReverseBodyPostHandler(std::set<minifi::utils::SmallString<36>>& connections) : connections_(connections) {}
+  explicit ReverseBodyPostHandler(std::set<minifi::utils::SmallString<utils::Identifier::UUID_STR_LEN>>& connections) : connections_(connections) {}
 
   bool handlePost(CivetServer* /*server*/, struct mg_connection* conn) override;
 
  private:
   void saveConnectionId(struct mg_connection* conn);
 
-  std::set<minifi::utils::SmallString<36>>& connections_;
+  std::set<minifi::utils::SmallString<utils::Identifier::UUID_STR_LEN>>& connections_;
 };
 
 struct AddIdToUserConnectionData : public CivetCallbacks {
@@ -78,7 +79,7 @@ class ConnectionCountingServer {
       "num_threads", "1",
       "listening_ports", "0"};
 
-  std::set<minifi::utils::SmallString<36>> connections_;
+  std::set<minifi::utils::SmallString<utils::Identifier::UUID_STR_LEN>> connections_;
   details::AddIdToUserConnectionData add_id_to_user_connection_data_;
   CivetServer server_{options, &add_id_to_user_connection_data_};
   details::ReverseBodyPostHandler reverse_body_post_handler_{connections_};

--- a/libminifi/test/libtest/integration/HTTPHandlers.cpp
+++ b/libminifi/test/libtest/integration/HTTPHandlers.cpp
@@ -160,13 +160,13 @@ bool FlowFileResponder::handlePost(CivetServer* /*server*/, struct mg_connection
       std::string name;
       std::string value;
       {
-        const auto read = stream.read(name, true);
+        const auto read = stream.read(name, io::LengthPrefixSize::_32BIT, 1_MiB);
         if (!isServerRunning()) return false;
         REQUIRE(read > 0);
         total_size += read;
       }
       {
-        const auto read = stream.read(value, true);
+        const auto read = stream.read(value, io::LengthPrefixSize::_32BIT, 1_MiB);
         if (!isServerRunning()) return false;
         REQUIRE(read > 0);
         total_size += read;

--- a/libminifi/test/unit/SerializationTests.cpp
+++ b/libminifi/test/unit/SerializationTests.cpp
@@ -32,7 +32,7 @@ TEST_CASE("TestWriteUTF", "[MINIFI193]") {
   std::string verifyString;
   baseStream.write(stringOne, false);
 
-  baseStream.read(verifyString, false);
+  baseStream.read(verifyString, minifi::io::LengthPrefixSize::_16BIT, 100);
 
   REQUIRE(verifyString == stringOne);
 }
@@ -45,7 +45,7 @@ TEST_CASE("TestWriteUTF2", "[MINIFI193]") {
   std::string verifyString;
   baseStream.write(stringOne, false);
 
-  baseStream.read(verifyString, false);
+  baseStream.read(verifyString, minifi::io::LengthPrefixSize::_16BIT, 100);
 
   REQUIRE(verifyString == stringOne);
 }
@@ -58,7 +58,7 @@ TEST_CASE("TestWriteUTF3", "[MINIFI193]") {
   std::string verifyString;
   baseStream.write(stringOne, false);
 
-  baseStream.read(verifyString, false);
+  baseStream.read(verifyString, minifi::io::LengthPrefixSize::_16BIT, 100);
 
   REQUIRE(verifyString == stringOne);
 }

--- a/libminifi/test/unit/StreamTests.cpp
+++ b/libminifi/test/unit/StreamTests.cpp
@@ -16,17 +16,18 @@
  * limitations under the License.
  */
 
-#include <thread>
-#include <random>
 #include <chrono>
-#include <vector>
-#include <string>
 #include <memory>
+#include <random>
+#include <string>
+#include <thread>
 #include <utility>
-#include "unit/TestBase.h"
-#include "unit/Catch.h"
-#include "minifi-cpp/io/BaseStream.h"
+#include <vector>
+
 #include "io/StreamSlice.h"
+#include "minifi-cpp/io/BaseStream.h"
+#include "unit/Catch.h"
+#include "unit/TestBase.h"
 #include "utils/span.h"
 
 TEST_CASE("TestReadData", "[testread]") {
@@ -104,4 +105,34 @@ TEST_CASE("StreamSliceTest1", "[teststreamslice]") {
   buffer2.resize(4);
   REQUIRE(buffer == buffer2);
   REQUIRE(utils::span_to<std::vector>(utils::as_span<uint8_t>(std::span(buffer))) == std::vector<uint8_t>({3, 4, 5, 6}));
+}
+
+TEST_CASE("InputStream max_length test", "[stream][input][maxlength]") {
+  minifi::io::BufferStream buffer_stream;
+  constexpr auto& test_str =
+      "Hello world, partial length prefixed string read from stream test, it should return the truncated string, but read the full string from the "
+      "stream";
+  constexpr auto& test_str2 = "subsequent string";
+  constexpr auto test_str_serialized_length = sizeof(test_str) + 4 /* bytes for length prefix */ - 1 /* null terminator byte */;
+  constexpr auto test_str2_serialized_length = sizeof(test_str2) + 2 /* length prefix */ - 1 /* null terminator */;
+  buffer_stream.write(test_str, /* 32bit length prefix: */ true);
+  REQUIRE(buffer_stream.size() == test_str_serialized_length);
+  buffer_stream.write(test_str2, false);
+  REQUIRE(buffer_stream.size() == test_str_serialized_length + test_str2_serialized_length);
+  {
+    // read the first test string
+    std::string out_str;
+    const auto number_of_bytes_consumed_from_the_stream = buffer_stream.read(out_str, minifi::io::LengthPrefixSize::_32BIT, /* max length: */ 20);
+    REQUIRE(!minifi::io::isError(number_of_bytes_consumed_from_the_stream));
+    REQUIRE(number_of_bytes_consumed_from_the_stream == test_str_serialized_length);
+    REQUIRE(out_str == "Hello world, partial");
+  }
+  {
+    // read the second test string, to ensure that subsequent reads/writes remain aligned
+    std::string out_str;
+    const auto number_of_bytes_consumed_from_the_stream = buffer_stream.read(out_str, minifi::io::LengthPrefixSize::_16BIT, /* max length: */ 20);
+    REQUIRE(!minifi::io::isError(number_of_bytes_consumed_from_the_stream));
+    REQUIRE(number_of_bytes_consumed_from_the_stream == test_str2_serialized_length);
+    REQUIRE(out_str == test_str2);
+  }
 }

--- a/minifi-api/common/include/minifi-cpp/io/InputStream.h
+++ b/minifi-api/common/include/minifi-cpp/io/InputStream.h
@@ -28,6 +28,11 @@
 
 namespace org::apache::nifi::minifi::io {
 
+enum class LengthPrefixSize {
+  _16BIT,
+  _32BIT
+};
+
 class InputStream : public virtual Stream {
  public:
   [[nodiscard]] virtual size_t size() const = 0;
@@ -40,11 +45,13 @@ class InputStream : public virtual Stream {
   virtual size_t read(std::span<std::byte> out_buffer) = 0;
 
   /**
-   * Read string from stream. Use isError (Stream.h) to check for errors.
+   * Read length prefixed string from stream. Use isError (Stream.h) to check for errors.
    * @param str reference string
+   * @param length_prefix_size The wideness of the length prefix, 16bit or 32bit
+   * @param max_length The max length of the string, to avoid excessive allocations
    * @return resulting read size or STREAM_ERROR on error or static_cast<size_t>(-2) on EAGAIN
    **/
-  size_t read(std::string &str, bool widen = false);
+  size_t read(std::string &str, LengthPrefixSize length_prefix_size, size_t max_length);
 
   /**
    * Read a bool from stream. Use isError (Stream.h) to check for errors.

--- a/minifi-api/common/include/minifi-cpp/io/InputStream.h
+++ b/minifi-api/common/include/minifi-cpp/io/InputStream.h
@@ -47,7 +47,7 @@ class InputStream : public virtual Stream {
   /**
    * Read length prefixed string from stream. Use isError (Stream.h) to check for errors.
    * @param str reference string
-   * @param length_prefix_size The wideness of the length prefix, 16bit or 32bit
+   * @param length_prefix_size The bit width of the length prefix, 16bit or 32bit
    * @param max_length The max length of the string, to avoid excessive allocations
    * @return resulting read size or STREAM_ERROR on error or static_cast<size_t>(-2) on EAGAIN
    **/

--- a/minifi-api/common/include/minifi-cpp/utils/Id.h
+++ b/minifi-api/common/include/minifi-cpp/utils/Id.h
@@ -16,13 +16,10 @@
  */
 #pragma once
 
-#include <atomic>
-#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
 #include <thread>
-#include <utility>
 #include <array>
 
 #include "SmallString.h"
@@ -35,6 +32,10 @@ class Identifier {
 
  public:
   using Data = std::array<uint8_t, 16>;
+
+  // xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx is 36 long: 16 bytes * 2 hex digits / byte + 4 hyphens
+  // only the string contents, excluding a null terminator
+  static constexpr auto UUID_STR_LEN = 36;
 
   Identifier() = default;
   explicit Identifier(const Data& data);
@@ -60,7 +61,7 @@ class Identifier {
   // building the representation itself takes 10ns, while
   // subsequently turning it into a std::string would take
   // 70ns more.
-  SmallString<36> to_string() const;
+  [[nodiscard]] SmallString<UUID_STR_LEN> to_string() const;
 
   static std::optional<Identifier> parse(const std::string& str);
 

--- a/minifi-api/include/minifi-cpp/core/Core.h
+++ b/minifi-api/include/minifi-cpp/core/Core.h
@@ -49,7 +49,7 @@ class CoreComponent {
   virtual void setName(std::string name) = 0;
   virtual void setUUID(const utils::Identifier& uuid) = 0;
   [[nodiscard]] virtual utils::Identifier getUUID() const = 0;
-  [[nodiscard]] virtual utils::SmallString<36> getUUIDStr() const = 0;
+  [[nodiscard]] virtual utils::SmallString<utils::Identifier::UUID_STR_LEN> getUUIDStr() const = 0;
   virtual void configure(const std::shared_ptr<Configure>& /*configuration*/) = 0;
 };
 


### PR DESCRIPTION
…ld be limited

It's used on network streams, and we want to avoid letting compromised network peers allocate large buffers on memory-constrained systems. This issue was pointed out in a security report, but given the trusted nature of the C2 server and S2S peers, we treat this as a defense-in-depth mitigation measure.

I've used symbolic constants for the limit at some but not all places. When there was no obvious place to put a constant to make it widely reusable, I've skipped them. The limits are not meant to be precise, but just a rough upper bound to the strings in that context. I've not modified the corresponding OutputStream::write overload.

This mitigation is just a "quick fix". A proper fix would involve rethinking how to manage streams in the project, and separating streams from readers/writers that serialize data from/onto them, but that would be a scary big undertaking.

Extent of AI usage: generated code reviews for handwritten code.

-----------------
Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
