### PR TITLE
MINIFICPP-2899 procfs: Fix CpuStat and CPUStatTests inaccuracy

### DIFF
--- a/extensions/procfs/CpuStat.h
+++ b/extensions/procfs/CpuStat.h
@@ -51,7 +51,7 @@ class CpuStatData {
   [[nodiscard]] SystemClockDuration getIdleAll() const noexcept { return idle_ + io_wait_; }
   [[nodiscard]] SystemClockDuration getSystemAll() const noexcept { return system_ + irq_ + soft_irq_; }
   [[nodiscard]] SystemClockDuration getVirtAll() const noexcept { return guest_ + guest_nice_; }
-  [[nodiscard]] std::chrono::duration<double> getTotal() const noexcept { return user_ + nice_ + getSystemAll() + getIdleAll() + steal_; }  // VirtAll is already included in User and Nice
+  [[nodiscard]] SystemClockDuration getTotal() const noexcept { return user_ + nice_ + getSystemAll() + getIdleAll() + steal_; }  // VirtAll is already included in User and Nice
 
  private:
   SystemClockDuration user_;

--- a/extensions/procfs/tests/CPUStatTests.cpp
+++ b/extensions/procfs/tests/CPUStatTests.cpp
@@ -25,6 +25,7 @@
 namespace org::apache::nifi::minifi::extensions::procfs::tests {
 
 void cpu_stat_period_total_should_be_one(const CpuStatData& cpu_stat) {
+  // according to the comment of getTotal, User and Nice already includes VirtAll (Guest + GuestNice), so adding them again would push us above 1
   const auto sum_of_parts = cpu_stat.getUser()
       + cpu_stat.getNice()
       + cpu_stat.getSystem()
@@ -32,11 +33,7 @@ void cpu_stat_period_total_should_be_one(const CpuStatData& cpu_stat) {
       + cpu_stat.getIoWait()
       + cpu_stat.getIrq()
       + cpu_stat.getSoftIrq()
-      + cpu_stat.getSteal()
-      // according to the comment of getTotal, User and Nice already includes VirtAll (Guest + GuestNice), so adding them again would push us above 1
-      //+ cpu_stat.getGuest()
-      //+ cpu_stat.getGuestNice()
-  ;
+      + cpu_stat.getSteal();
   REQUIRE(sum_of_parts == cpu_stat.getTotal());
 }
 

--- a/extensions/procfs/tests/CPUStatTests.cpp
+++ b/extensions/procfs/tests/CPUStatTests.cpp
@@ -25,18 +25,19 @@
 namespace org::apache::nifi::minifi::extensions::procfs::tests {
 
 void cpu_stat_period_total_should_be_one(const CpuStatData& cpu_stat) {
-  double percentage = 0;
-  percentage += cpu_stat.getUser() / cpu_stat.getTotal();
-  percentage += cpu_stat.getNice() / cpu_stat.getTotal();
-  percentage += cpu_stat.getSystem() / cpu_stat.getTotal();
-  percentage += cpu_stat.getIdle() / cpu_stat.getTotal();
-  percentage += cpu_stat.getIoWait() / cpu_stat.getTotal();
-  percentage += cpu_stat.getIrq() / cpu_stat.getTotal();
-  percentage += cpu_stat.getSoftIrq() / cpu_stat.getTotal();
-  percentage += cpu_stat.getSteal() / cpu_stat.getTotal();
-  percentage += cpu_stat.getGuest() / cpu_stat.getTotal();
-  percentage += cpu_stat.getGuestNice() / cpu_stat.getTotal();
-  REQUIRE(percentage == Catch::Approx(1.0));
+  const auto sum_of_parts = cpu_stat.getUser()
+      + cpu_stat.getNice()
+      + cpu_stat.getSystem()
+      + cpu_stat.getIdle()
+      + cpu_stat.getIoWait()
+      + cpu_stat.getIrq()
+      + cpu_stat.getSoftIrq()
+      + cpu_stat.getSteal()
+      // according to the comment of getTotal, User and Nice already includes VirtAll (Guest + GuestNice), so adding them again would push us above 1
+      //+ cpu_stat.getGuest()
+      //+ cpu_stat.getGuestNice()
+  ;
+  REQUIRE(sum_of_parts == cpu_stat.getTotal());
 }
 
 TEST_CASE("ProcFSTest stat test with mock", "[procfsstatmockabsolutetest]") {


### PR DESCRIPTION
These tests have been failing on my home PC ever since they were introduced. It looks like the tests have double counted 
Guest + GuestNice, while also introducing floating point inaccuracy. This small change fixes both.

-------

Thank you for submitting a contribution to Apache NiFi - MiNiFi C++.

In order to streamline the review of the contribution we ask you to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with MINIFICPP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file?
- [x] If applicable, have you updated the NOTICE file?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI results for build issues and submit an update to your PR as soon as possible.
